### PR TITLE
Fix DI core factory registration and make ExtensibleEnum thread-safe

### DIFF
--- a/UniversalToolchain/BasicTypesExtensions/EnumGenerator.cs
+++ b/UniversalToolchain/BasicTypesExtensions/EnumGenerator.cs
@@ -1,12 +1,12 @@
 ﻿using ExceptionsManager;
+using System.Collections.Concurrent;
 
 namespace BasicTypesExtensions;
 
 public class EnumGenerator
 {
-    private static readonly Dictionary<Type, EnumGenerator> _dict = [];
+    private static readonly ConcurrentDictionary<Type, EnumGenerator> _dict = [];
     private readonly SetAndList<string> _setAndList = new();
-    private int _num;
 
     private EnumGenerator()
     {
@@ -16,9 +16,7 @@ public class EnumGenerator
     {
         Thrower.AssertAlways(!typeof(T).Name.Contains("ExtensibleEnum"));
 
-        return _dict.TryGetValue(typeof(T), out var value)
-            ? value
-            : _dict[typeof(T)] = new EnumGenerator();
+        return _dict.GetOrAdd(typeof(T), _ => new EnumGenerator());
     }
 
     public ExtensibleEnum<T> Get<T>(string name)
@@ -31,9 +29,8 @@ public class EnumGenerator
 
     public ExtensibleEnum<T> CreateOrGet<T>(string name)
     {
-        if (_setAndList.IndexOf(name) != -1) return Get<T>(name);
-        _setAndList.Add(name);
-        return new ExtensibleEnum<T>(_num++);
+        var index = _setAndList.GetOrAdd(name);
+        return new ExtensibleEnum<T>(index);
     }
 
     public string GetName(int value) => _setAndList[value];
@@ -43,14 +40,43 @@ public class SetAndList<T> where T : notnull
 {
     private readonly List<T> _list = [];
     private readonly Dictionary<T, int> _valueToIndex = [];
+    private readonly Lock _lock = new();
 
-    public T this[int value] => _list[value];
+    public T this[int value]
+    {
+        get
+        {
+            lock (_lock)
+                return _list[value];
+        }
+    }
 
-    public int IndexOf(T name) => _valueToIndex.GetValueOrDefault(name, -1);
+    public int IndexOf(T name)
+    {
+        lock (_lock)
+            return _valueToIndex.GetValueOrDefault(name, -1);
+    }
 
     public void Add(T name)
     {
-        _list.Add(name);
-        _valueToIndex[name] = _list.Count - 1;
+        lock (_lock)
+        {
+            _list.Add(name);
+            _valueToIndex[name] = _list.Count - 1;
+        }
+    }
+
+    public int GetOrAdd(T name)
+    {
+        lock (_lock)
+        {
+            if (_valueToIndex.TryGetValue(name, out var existingIndex))
+                return existingIndex;
+
+            var newIndex = _list.Count;
+            _list.Add(name);
+            _valueToIndex[name] = newIndex;
+            return newIndex;
+        }
     }
 }

--- a/UniversalToolchain/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/UniversalToolchain/DependencyInjection/ServiceCollectionExtensions.cs
@@ -242,61 +242,59 @@ public static class ServiceCollectionExtensions
 
     private static void RegisterCoreRunnables(IServiceCollection services)
     {
-        var cores = (List<Func<IServiceProvider, ICoreRunnable>>)
+        var cores = new List<CoreFactory>
         [
-            (Func<IServiceProvider, BasicCoreImpl<DynamicMethod>>)(provider =>
-            {
-                var modules = provider.GetServices<IFrontendCoreModule>().ToList();
-                var irProcessors = provider.GetServices<IIRProcessingModule>().ToList();
+            new(typeof(DynamicMethod), provider =>
+                {
+                    var modules = provider.GetServices<IFrontendCoreModule>().ToList();
+                    var irProcessors = provider.GetServices<IIRProcessingModule>().ToList();
 
-                return new BasicCoreImpl<DynamicMethod>(
-                    provider.GetRequiredService<Func<ILexer>>(),
-                    provider.GetRequiredService<Func<IParser>>(),
-                    provider.GetRequiredService<Func<IAstToBytecodeTranslator>>(),
-                    provider.GetRequiredService<Func<IAbstractMethodsTranslator>>(),
-                    () => provider.GetRequiredService<AbstractMethodsCompilerImpl>(),
-                    provider.GetRequiredService<Func<IExecutor<DynamicMethod>>>(),
-                    modules,
-                    irProcessors,
-                    []
-                );
-            }),
-            (Func<IServiceProvider, BasicCoreImpl<IAbstractIR>>)(provider =>
-            {
-                var modules = provider.GetServices<IFrontendCoreModule>().ToList();
-                var irProcessors = provider.GetServices<IIRProcessingModule>().ToList();
+                    return new BasicCoreImpl<DynamicMethod>(
+                        provider.GetRequiredService<Func<ILexer>>(),
+                        provider.GetRequiredService<Func<IParser>>(),
+                        provider.GetRequiredService<Func<IAstToBytecodeTranslator>>(),
+                        provider.GetRequiredService<Func<IAbstractMethodsTranslator>>(),
+                        () => provider.GetRequiredService<AbstractMethodsCompilerImpl>(),
+                        provider.GetRequiredService<Func<IExecutor<DynamicMethod>>>(),
+                        modules,
+                        irProcessors,
+                        []
+                    );
+                }
+            ),
+            new(typeof(IAbstractIR), provider =>
+                {
+                    var modules = provider.GetServices<IFrontendCoreModule>().ToList();
+                    var irProcessors = provider.GetServices<IIRProcessingModule>().ToList();
 
-                return new BasicCoreImpl<IAbstractIR>(
-                    provider.GetRequiredService<Func<ILexer>>(),
-                    provider.GetRequiredService<Func<IParser>>(),
-                    provider.GetRequiredService<Func<IAstToBytecodeTranslator>>(),
-                    provider.GetRequiredService<Func<IAbstractMethodsTranslator>>(),
-                    () => provider.GetRequiredService<AbstractIrToAbstractIrStub>(),
-                    provider.GetRequiredService<Func<IExecutor<IAbstractIR>>>(),
-                    modules,
-                    irProcessors,
-                    []
-                );
-            })
+                    return new BasicCoreImpl<IAbstractIR>(
+                        provider.GetRequiredService<Func<ILexer>>(),
+                        provider.GetRequiredService<Func<IParser>>(),
+                        provider.GetRequiredService<Func<IAstToBytecodeTranslator>>(),
+                        provider.GetRequiredService<Func<IAbstractMethodsTranslator>>(),
+                        () => provider.GetRequiredService<AbstractIrToAbstractIrStub>(),
+                        provider.GetRequiredService<Func<IExecutor<IAbstractIR>>>(),
+                        modules,
+                        irProcessors,
+                        []
+                    );
+                }
+            )
         ];
 
         RegisterWithInterface<ICoreRunnable>(services, cores);
         RegisterWithInterface<ICoreOptimizedRunnable>(services, cores);
-        RegisterWithInterface<IExecutableGiver<IAbstractIR>>(
-            services,
-            cores.Where(x => x.GetType() == typeof(Func<IServiceProvider, BasicCoreImpl<IAbstractIR>>))
-        );
-        RegisterWithInterface<IExecutableGiver<DynamicMethod>>(
-            services,
-            cores.Where(x => x.GetType() == typeof(Func<IServiceProvider, BasicCoreImpl<DynamicMethod>>))
-        );
+        RegisterWithInterface<IExecutableGiver<IAbstractIR>>(services, cores.Where(x => x.CompilationType == typeof(IAbstractIR)));
+        RegisterWithInterface<IExecutableGiver<DynamicMethod>>(services, cores.Where(x => x.CompilationType == typeof(DynamicMethod)));
     }
 
-    private static void RegisterWithInterface<T>(IServiceCollection services, IEnumerable<Func<IServiceProvider, ICoreRunnable>> cores) where T : class
+    private static void RegisterWithInterface<T>(IServiceCollection services, IEnumerable<CoreFactory> cores) where T : class
     {
         foreach (var core in cores)
-            services.AddTransient<T>(provider => (T)core(provider));
+            services.AddTransient<T>(provider => (T)core.Factory(provider));
     }
+
+    private sealed record CoreFactory(Type CompilationType, Func<IServiceProvider, ICoreRunnable> Factory);
 }
 
 /// <summary>

--- a/UniversalToolchain/Tests/DependencyInjectionRegistrationTests.cs
+++ b/UniversalToolchain/Tests/DependencyInjectionRegistrationTests.cs
@@ -1,0 +1,26 @@
+using BasicCore;
+using DependencyInjection;
+using IntermediateRepresentationAbstractions;
+using Microsoft.Extensions.DependencyInjection;
+using System.Reflection.Emit;
+
+namespace Tests;
+
+[TestFixture]
+public class DependencyInjectionRegistrationTests
+{
+    [Test]
+    public void AddWistServices_RegistersExecutableGiversForDynamicMethodAndAbstractIr()
+    {
+        var services = new ServiceCollection();
+        services.AddWistServices();
+
+        using var provider = services.BuildServiceProvider();
+
+        var dynamicMethodExecutableGivers = provider.GetServices<IExecutableGiver<DynamicMethod>>().ToList();
+        var abstractIrExecutableGivers = provider.GetServices<IExecutableGiver<IAbstractIR>>().ToList();
+
+        Assert.That(dynamicMethodExecutableGivers, Is.Not.Empty);
+        Assert.That(abstractIrExecutableGivers, Is.Not.Empty);
+    }
+}

--- a/UniversalToolchain/Tests/ExtensibleEnumTests.cs
+++ b/UniversalToolchain/Tests/ExtensibleEnumTests.cs
@@ -35,4 +35,27 @@ public class ExtensibleEnumTests
 
         Assert.That(name, Is.EqualTo("TestName"));
     }
+
+    [Test]
+    public void CreateOrGet_ConcurrentAccess_DoesNotBreakNameToIdMapping()
+    {
+        var names = Enumerable.Range(0, 100)
+            .Select(x => $"ConcurrentType_{Guid.NewGuid()}_{x}")
+            .ToArray();
+
+        Parallel.ForEach(
+            names,
+            name =>
+            {
+                for (var i = 0; i < 20; i++)
+                    _ = ExtensibleEnum<object>.CreateOrGet(name);
+            }
+        );
+
+        foreach (var name in names)
+        {
+            var enumValue = ExtensibleEnum<object>.CreateOrGet(name);
+            Assert.That(enumValue.GetName(), Is.EqualTo(name));
+        }
+    }
 }


### PR DESCRIPTION
### Motivation
- Delegate covariance caused the existing `cores.Where(x => x.GetType() == typeof(Func<...>))` filter to almost always return empty, so implementations of `IExecutableGiver<DynamicMethod>`/`IExecutableGiver<IAbstractIR>` were not being registered.
- `EnumGenerator`/`SetAndList` were not safe for concurrent access, allowing `CreateOrGet` to produce duplicate entries or corrupt the name->id mapping under parallel calls.

### Description
- Reworked core runnable registration in `ServiceCollectionExtensions`: introduced a `CoreFactory` record containing `CompilationType` and `Factory`, replaced the fragile delegate-type filtering with selection by `CompilationType`, and updated `RegisterWithInterface` to use the factory correctly.
- Made `EnumGenerator` concurrency-safe by switching `_dict` to `ConcurrentDictionary<Type, EnumGenerator>` and by delegating name insertion to a synchronized `SetAndList.GetOrAdd` path used from `CreateOrGet`.
- Hardened `SetAndList<T>` with an internal lock for all accesses, added `GetOrAdd` to atomically read-or-create mappings, and protected indexer/lookup operations.
- Added tests: `DependencyInjectionRegistrationTests` to assert that `IExecutableGiver<DynamicMethod>` and `IExecutableGiver<IAbstractIR>` are registered after `AddWistServices()`, and a concurrent `ExtensibleEnum` test to validate `CreateOrGet` under parallel load.

### Testing
- Added unit tests under `UniversalToolchain/Tests` (`DependencyInjectionRegistrationTests` and a concurrent `ExtensibleEnum` test) but did not run the test suite due to missing SDK: attempted `dotnet test UniversalToolchain/Tests/Tests.csproj --no-restore` failed with `bash: command not found: dotnet` in the environment.
- Basic repository checks (file updates and new tests added) were performed locally; the new tests are ready to run in a CI or local environment with the .NET SDK installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69920705a7708324b026464d2d5b0e0d)