### PR TITLE
Add safe boolean peephole and literal folding optimizations

### DIFF
--- a/UniversalToolchain/ConditionsModule/Optimizers/BooleanOptimizer.cs
+++ b/UniversalToolchain/ConditionsModule/Optimizers/BooleanOptimizer.cs
@@ -26,7 +26,8 @@ public class BooleanOptimizerModule : IIRProcessingModule
             return current;
 
         InitializeAirTypes();
-        return OptimizeNativeLoads(current);
+        var optimized = OptimizeNativeLoads(current);
+        return OptimizeBooleanPeepholes(optimized);
     }
 
     private void InitializeAirTypes()
@@ -76,14 +77,14 @@ public class BooleanOptimizerModule : IIRProcessingModule
             var instruction = instructions[i];
 
             if (instruction.UOpCode == UOpCode.Intrinsic)
-                if (instruction.Operands.Count >= 2 && instruction.Operands[0] == "call C#")
+                if (instruction.Operands.Count >= 2 && instruction.Operands[0] is string intrinsicName && intrinsicName == "call C#")
                 {
                     var m = instruction.Operands[1].Get<MethodInfo>();
 
                     if (m.DeclaringType == typeof(BooleanVisitor.BooleanOperations))
-                        if (methodToIntrinsic.TryGetValue(m.Name, out var intrinsicName))
+                        if (methodToIntrinsic.TryGetValue(m.Name, out var mappedIntrinsicName))
                         {
-                            context.NewInstructions.Add(new Instruction(UOpCode.Intrinsic, [intrinsicName]));
+                            context.NewInstructions.Add(new Instruction(UOpCode.Intrinsic, [mappedIntrinsicName]));
                             continue;
                         }
                 }
@@ -94,6 +95,116 @@ public class BooleanOptimizerModule : IIRProcessingModule
         var result = new AbstractIR();
         result.AppendInstructions(context.NewInstructions);
         return result;
+    }
+
+    private static IAbstractIR OptimizeBooleanPeepholes(IAbstractIR air)
+    {
+        var instructions = air.Instructions.ToList();
+        var optimized = new List<Instruction>();
+
+        for (var i = 0; i < instructions.Count; i++)
+        {
+            if (TryFoldBooleanNot(instructions, i, out var foldedNot))
+            {
+                optimized.Add(foldedNot);
+                i += 1;
+                continue;
+            }
+
+            if (TryFoldBooleanBinaryLiterals(instructions, i, out var foldedBinary))
+            {
+                optimized.Add(foldedBinary);
+                i += 2;
+                continue;
+            }
+
+            if (TryApplyIdentityLaw(instructions, i, out var replacement))
+            {
+                optimized.Add(replacement);
+                i += 2;
+                continue;
+            }
+
+            optimized.Add(instructions[i]);
+        }
+
+        var result = new AbstractIR();
+        result.AppendInstructions(optimized);
+        return result;
+    }
+
+    private static bool TryFoldBooleanNot(IReadOnlyList<Instruction> instructions, int start, out Instruction folded)
+    {
+        folded = null!;
+        if (start + 1 >= instructions.Count)
+            return false;
+
+        if (!TryGetBoolPush(instructions[start], out var value) || !IsBooleanIntrinsic(instructions[start + 1], "boolean_not"))
+            return false;
+
+        folded = new Instruction(UOpCode.Push, [!value]);
+        return true;
+    }
+
+    private static bool TryFoldBooleanBinaryLiterals(IReadOnlyList<Instruction> instructions, int start, out Instruction folded)
+    {
+        folded = null!;
+        if (start + 2 >= instructions.Count)
+            return false;
+
+        if (!TryGetBoolPush(instructions[start], out var left) || !TryGetBoolPush(instructions[start + 1], out var right))
+            return false;
+
+        if (IsBooleanIntrinsic(instructions[start + 2], "boolean_and"))
+        {
+            folded = new Instruction(UOpCode.Push, [left && right]);
+            return true;
+        }
+
+        if (IsBooleanIntrinsic(instructions[start + 2], "boolean_or"))
+        {
+            folded = new Instruction(UOpCode.Push, [left || right]);
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool TryApplyIdentityLaw(IReadOnlyList<Instruction> instructions, int start, out Instruction replacement)
+    {
+        replacement = null!;
+        if (start + 2 >= instructions.Count)
+            return false;
+
+        if (IsBooleanIntrinsic(instructions[start + 2], "boolean_and") && TryGetBoolPush(instructions[start + 1], out var andRight) && andRight)
+        {
+            replacement = instructions[start];
+            return true;
+        }
+
+        if (IsBooleanIntrinsic(instructions[start + 2], "boolean_or") && TryGetBoolPush(instructions[start + 1], out var orRight) && !orRight)
+        {
+            replacement = instructions[start];
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool IsBooleanIntrinsic(Instruction instruction, string intrinsicName) =>
+        instruction.UOpCode == UOpCode.Intrinsic &&
+        instruction.Operands.Count > 0 &&
+        instruction.Operands[0] is string name &&
+        name == intrinsicName;
+
+    private static bool TryGetBoolPush(Instruction instruction, out bool value)
+    {
+        value = false;
+        if (instruction.UOpCode != UOpCode.Push || instruction.Operands.Count != 1 || instruction.Operands[0] is not bool boolValue)
+            return false;
+
+        value = boolValue;
+        return true;
     }
 
     private class CompilationContext

--- a/UniversalToolchain/Tests/Infrastructure/OptimizerRegressionTests.cs
+++ b/UniversalToolchain/Tests/Infrastructure/OptimizerRegressionTests.cs
@@ -27,6 +27,74 @@ public class OptimizerRegressionTests
     }
 
     [Test]
+    public void BooleanOptimizer_ShouldFoldLiteralNotToPush()
+    {
+        var module = new BooleanOptimizerModule();
+        var compiler = new FakeCompiler(["boolean_and", "boolean_or", "boolean_not"]);
+        var ir = BuildIr(
+            new Instruction(UOpCode.Push, [true]),
+            new Instruction(UOpCode.Intrinsic, ["boolean_not"])
+        );
+
+        var optimized = module.ProcessIr(ir, compiler);
+
+        Assert.That(optimized.Instructions, Has.Count.EqualTo(1));
+        Assert.That(optimized.Instructions[0].UOpCode, Is.EqualTo(UOpCode.Push));
+        Assert.That(optimized.Instructions[0].Operands[0], Is.EqualTo(false));
+    }
+
+    [Test]
+    public void BooleanOptimizer_ShouldFoldLiteralAndAndOr()
+    {
+        var module = new BooleanOptimizerModule();
+        var compiler = new FakeCompiler(["boolean_and", "boolean_or", "boolean_not"]);
+        var andIr = BuildIr(
+            new Instruction(UOpCode.Push, [true]),
+            new Instruction(UOpCode.Push, [false]),
+            new Instruction(UOpCode.Intrinsic, ["boolean_and"])
+        );
+        var orIr = BuildIr(
+            new Instruction(UOpCode.Push, [false]),
+            new Instruction(UOpCode.Push, [true]),
+            new Instruction(UOpCode.Intrinsic, ["boolean_or"])
+        );
+
+        var andOptimized = module.ProcessIr(andIr, compiler);
+        var orOptimized = module.ProcessIr(orIr, compiler);
+
+        Assert.That(andOptimized.Instructions, Has.Count.EqualTo(1));
+        Assert.That(andOptimized.Instructions[0].Operands[0], Is.EqualTo(false));
+        Assert.That(orOptimized.Instructions, Has.Count.EqualTo(1));
+        Assert.That(orOptimized.Instructions[0].Operands[0], Is.EqualTo(true));
+    }
+
+    [Test]
+    public void BooleanOptimizer_ShouldApplyOnlySafeIdentityRules()
+    {
+        var module = new BooleanOptimizerModule();
+        var compiler = new FakeCompiler(["boolean_and", "boolean_or", "boolean_not"]);
+        var andTrueIr = BuildIr(
+            new Instruction(UOpCode.Intrinsic, ["load_local", "flag", typeof(bool)]),
+            new Instruction(UOpCode.Push, [true]),
+            new Instruction(UOpCode.Intrinsic, ["boolean_and"])
+        );
+        var andFalseIr = BuildIr(
+            new Instruction(UOpCode.Intrinsic, ["load_local", "flag", typeof(bool)]),
+            new Instruction(UOpCode.Push, [false]),
+            new Instruction(UOpCode.Intrinsic, ["boolean_and"])
+        );
+
+        var andTrueOptimized = module.ProcessIr(andTrueIr, compiler);
+        var andFalseOptimized = module.ProcessIr(andFalseIr, compiler);
+
+        Assert.That(andTrueOptimized.Instructions, Has.Count.EqualTo(1));
+        Assert.That(andTrueOptimized.Instructions[0].Operands[0], Is.EqualTo("load_local"));
+
+        Assert.That(andFalseOptimized.Instructions, Has.Count.EqualTo(3));
+        Assert.That(andFalseOptimized.Instructions[2].Operands[0], Is.EqualTo("boolean_and"));
+    }
+
+    [Test]
     public void NativeCilOptimizer_ShouldKeepDecimalPush_WhenDecimalIntrinsicUnsupported()
     {
         var module = new NativeCilOptimizerModule();


### PR DESCRIPTION
### Motivation
- Уменьшить мелкие накладные расходы на простых boolean-выражениях в expression engine за счёт небольших локальных оптимизаций. 
- Сделать только безопасные, легко ревьюируемые трансформации, которые не меняют публичную семантику и не требуют рефакторинга архитектуры. 

### Description
- Добавлен лёгкий peephole-проход в `BooleanOptimizerModule` (после lowering `call C#` → boolean-интринсики) в `UniversalToolchain/ConditionsModule/Optimizers/BooleanOptimizer.cs`, реализующий только очень локальные шаблоны. 
- Реализованы безопасные literal-folding правила: `push bool; boolean_not` → `push !bool` и `push bool; push bool; boolean_and/boolean_or` → `push (folded)`. 
- Добавлены безопасные алгебраические упрощения только для identity-случаев: `x && true -> x` и `x || false -> x`, при этом намеренно не применяются рискованные правила, которые могут изменить порядок вычисления или short-circuit семантику (например `x && false` или `x || true`). 
- Тесты добавлены в `UniversalToolchain/Tests/Infrastructure/OptimizerRegressionTests.cs` для проверки: literal-folding `not/and/or`, применение безопасных identity-правил и отсутствие оптимизаций для небезопасных случаев. 

### Testing
- Restored dependencies with `dotnet restore UniversalToolchain/Wist.sln` using .NET SDK `10.0.103` (matches `global.json`). 
- Запущена полная тестовая suite: `dotnet test UniversalToolchain/Tests/Tests.csproj --no-restore`. 
- Результат: все тесты прошли успешно (`Passed: 469, Failed: 0`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac53e14c7883249484eb6bb28de715)