### PR TITLE
Isolate translator state, add PreparedExecution and comprehensive parameter tests

### DIFF
--- a/UniversalToolchain/BasicCodeTranslator/BasicAstToBytecodeTranslatorImpl.cs
+++ b/UniversalToolchain/BasicCodeTranslator/BasicAstToBytecodeTranslatorImpl.cs
@@ -6,6 +6,7 @@ namespace BasicCodeTranslator;
 public class BasicAstToBytecodeTranslatorImpl(BytecodeTranslatorConfiguration configuration) : IAstToBytecodeTranslator
 {
     private readonly Bytecode _code = new([]);
+    private int _translationDepth;
 
     public BasicAstToBytecodeTranslatorImpl() : this(new BytecodeTranslatorConfiguration([]))
     {
@@ -15,9 +16,21 @@ public class BasicAstToBytecodeTranslatorImpl(BytecodeTranslatorConfiguration co
 
     public Bytecode Translate(AstNode root)
     {
-        var data = new BytecodeVisitorData(this, _code, root);
-        foreach (var visitor in Configuration.Visitors)
-            visitor.TryVisit(data);
-        return _code;
+        if (_translationDepth == 0)
+            _code.Instructions.Clear();
+
+        _translationDepth++;
+        try
+        {
+            var data = new BytecodeVisitorData(this, _code, root);
+            foreach (var visitor in Configuration.Visitors)
+                visitor.TryVisit(data);
+
+            return _code;
+        }
+        finally
+        {
+            _translationDepth--;
+        }
     }
 }

--- a/UniversalToolchain/BasicCore/Compilation/ExternalBindingsFactory.cs
+++ b/UniversalToolchain/BasicCore/Compilation/ExternalBindingsFactory.cs
@@ -1,0 +1,27 @@
+namespace BasicCore.Compilation;
+
+internal static class ExternalBindingsFactory
+{
+    public static IReadOnlyList<ExternalBinding> FromDeclaredTypes(OrderedDictionary<string, Type>? parameters)
+    {
+        parameters ??= [];
+        return parameters.Select(x => new ExternalBinding
+        {
+            Name = x.Key,
+            Type = x.Value,
+            Kind = ExternalBindingKind.Variable
+        }).ToList();
+    }
+
+    public static IReadOnlyList<ExternalBinding> FromRuntimeValues(Dictionary<string, object>? parameters)
+    {
+        parameters ??= [];
+        return parameters.Select(x => new ExternalBinding
+        {
+            Name = x.Key,
+            Type = x.Value.GetType(),
+            Value = x.Value,
+            Kind = ExternalBindingKind.Variable
+        }).ToList();
+    }
+}

--- a/UniversalToolchain/BasicCore/Core/BasicCoreImpl.cs
+++ b/UniversalToolchain/BasicCore/Core/BasicCoreImpl.cs
@@ -1,4 +1,3 @@
-using System.Numerics;
 using BasicCore.Binding;
 using BasicCore.Compilation;
 using BasicCore.Contracts;
@@ -24,29 +23,48 @@ public class BasicCoreImpl<TCompilationOutput>(
     IReadOnlyList<IMiddleEndCoreModule<TCompilationOutput>> middleEndModules
 ) : ICoreRunnable, ICoreOptimizedRunnable, IExecutableGiver<TCompilationOutput>
 {
-    private string _code = null!;
-    private TCompilationOutput _compilationOutput = default!;
-    private IExecutor<TCompilationOutput> _executor = null!;
-    private IExecutionEnvironment _executionEnvironment = null!;
+    private PreparedExecution<TCompilationOutput>? _prepared;
 
     public void PrepareToRun(string code, OrderedDictionary<string, Type>? parameters = null)
     {
-        parameters ??= [];
-        var input = new CompilationInput
+        PrepareToRun(new CompilationInput
         {
             SourceText = code,
-            ExternalBindings = parameters.Select(x => new ExternalBinding
-            {
-                Name = x.Key,
-                Type = x.Value,
-                Kind = ExternalBindingKind.Variable
-            }).ToList(),
+            ExternalBindings = ExternalBindingsFactory.FromDeclaredTypes(parameters),
             Options = new CompilationOptions()
-        };
-        PrepareToRun(input);
+        });
     }
 
     public void PrepareToRun(CompilationInput input)
+    {
+        _prepared = BuildPreparedExecution(input);
+    }
+
+    public object? RunPrepared()
+    {
+        Thrower.AssertAlways(_prepared != null);
+        return _prepared.Executor.Execute(_prepared.CompilationOutput, _prepared.ExecutionEnvironment);
+    }
+
+    public object? Run(string code, Dictionary<string, object>? parameters = null)
+    {
+        PrepareToRun(new CompilationInput
+        {
+            SourceText = code,
+            ExternalBindings = ExternalBindingsFactory.FromRuntimeValues(parameters),
+            Options = new CompilationOptions()
+        });
+
+        return RunPrepared();
+    }
+
+    public TCompilationOutput GetExecutable(string code, OrderedDictionary<string, Type>? parameters = null)
+    {
+        PrepareToRun(code, parameters);
+        return _prepared!.CompilationOutput;
+    }
+
+    private PreparedExecution<TCompilationOutput> BuildPreparedExecution(CompilationInput input)
     {
         var lexer = lexerFactory();
         var parser = parserFactory();
@@ -80,40 +98,10 @@ public class BasicCoreImpl<TCompilationOutput>(
         var compilationOutput = middleEndModules.Aggregate(compiled, (current, module) => module.ProcessCompilation(current));
         middleEndModules.ForEach(module => module.InitExecutor(executor));
 
-        _executor = executor;
-        _compilationOutput = compilationOutput;
-        _executionEnvironment = new ExecutionEnvironment(input.ExternalBindings);
-        _code = input.SourceText;
-    }
-
-    public object? RunPrepared()
-    {
-        Thrower.AssertAlways(_code != null);
-        return _executor.Execute(_compilationOutput, _executionEnvironment);
-    }
-
-    public object? Run(string code, Dictionary<string, object>? parameters = null)
-    {
-        parameters ??= [];
-        var input = new CompilationInput
-        {
-            SourceText = code,
-            ExternalBindings = parameters.Select(x => new ExternalBinding
-            {
-                Name = x.Key,
-                Type = x.Value.GetType(),
-                Value = x.Value,
-                Kind = ExternalBindingKind.Variable
-            }).ToList(),
-            Options = new CompilationOptions()
-        };
-        PrepareToRun(input);
-        return RunPrepared();
-    }
-
-    public TCompilationOutput GetExecutable(string code, OrderedDictionary<string, Type>? parameters = null)
-    {
-        PrepareToRun(code, parameters);
-        return _compilationOutput;
+        return new PreparedExecution<TCompilationOutput>(
+            input.SourceText,
+            compilationOutput,
+            executor,
+            new ExecutionEnvironment(input.ExternalBindings));
     }
 }

--- a/UniversalToolchain/BasicCore/Core/PreparedExecution.cs
+++ b/UniversalToolchain/BasicCore/Core/PreparedExecution.cs
@@ -1,0 +1,19 @@
+using BasicCore.Execution;
+using BasicCore.ExecutorWrapper;
+
+namespace BasicCore.Core;
+
+internal sealed class PreparedExecution<TCompilationOutput>(
+    string sourceText,
+    TCompilationOutput compilationOutput,
+    IExecutor<TCompilationOutput> executor,
+    IExecutionEnvironment executionEnvironment)
+{
+    public string SourceText { get; } = sourceText;
+
+    public TCompilationOutput CompilationOutput { get; } = compilationOutput;
+
+    public IExecutor<TCompilationOutput> Executor { get; } = executor;
+
+    public IExecutionEnvironment ExecutionEnvironment { get; } = executionEnvironment;
+}

--- a/UniversalToolchain/Tests/Infrastructure/BytecodeAndStateIsolationTests.cs
+++ b/UniversalToolchain/Tests/Infrastructure/BytecodeAndStateIsolationTests.cs
@@ -96,6 +96,21 @@ public class BytecodeAndStateIsolationTests : TestBase
         Assert.That(second, Is.EqualTo(first));
     }
 
+
+    [Test]
+    public void Should_NotAccumulateBytecodeAcrossTranslateCalls_When_TranslatorIsReused()
+    {
+        var translator = new BasicCodeTranslator.BasicAstToBytecodeTranslatorImpl(
+            new BytecodeTranslatorConfiguration([new AppendingVisitor()]));
+        var ast = new AstNode(ExtensibleEnum<AstNodeTag>.CreateOrGet("Root"), null, []);
+
+        var first = translator.Translate(ast);
+        var second = translator.Translate(ast);
+
+        Assert.That(first.Instructions.Count, Is.EqualTo(1));
+        Assert.That(second.Instructions.Count, Is.EqualTo(1));
+    }
+
     [Test]
     public void Should_RegisterAirIntrinsicPredictably_When_RegisteringSameNameTwice()
     {
@@ -106,6 +121,14 @@ public class BytecodeAndStateIsolationTests : TestBase
 
         Assert.That(first, Is.True);
         Assert.That(second, Is.False);
+    }
+
+    private sealed class AppendingVisitor : IAstVisitor
+    {
+        public void TryVisit(BytecodeVisitorData data)
+        {
+            data.Bytecode.Instructions.Add(new BytecodeInstruction(new StubConvertable("append", _ => CreateIr(new Instruction(UOpCode.Nop)))));
+        }
     }
 
     private static IAbstractIR CreateIr(params Instruction[] instructions)

--- a/UniversalToolchain/Tests/Infrastructure/CoreExecutionParameterFlowTests.cs
+++ b/UniversalToolchain/Tests/Infrastructure/CoreExecutionParameterFlowTests.cs
@@ -1,0 +1,178 @@
+using System.Reflection.Emit;
+using BasicCilCompiler.Execution;
+using BasicCore.Contracts;
+using BasicCore.Core;
+using BasicCore.ExecutorWrapper;
+using BasicCore.TranslatorWrapper;
+using BytecodeDynamicMethodsCompiler.Compilers;
+using DynamicMethodCalling.Core;
+
+namespace Tests.Infrastructure;
+
+[TestFixture]
+public class CoreExecutionParameterFlowTests
+{
+    [Test]
+    public void Should_KeepOrderedDictionaryParameterOrder_When_GeneratingDynamicMethod()
+    {
+        var method = GetExecutable(
+            "a - b",
+            new OrderedDictionary<string, Type>
+            {
+                ["a"] = typeof(int),
+                ["b"] = typeof(int)
+            });
+
+        Assert.That(method.GetParameters().Select(x => x.ParameterType), Is.EqualTo(new[] { typeof(int), typeof(int) }));
+    }
+
+    [Test]
+    public void Should_MapInvocationArgumentsByDeclaredOrder_When_UsingTypedInvoker()
+    {
+        var method = GetExecutable(
+            "a - b",
+            new OrderedDictionary<string, Type>
+            {
+                ["a"] = typeof(int),
+                ["b"] = typeof(int)
+            });
+
+        var invoker = new DynamicMethodInvoker<int, int, int>(method);
+
+        Assert.That(invoker.Invoke(7, 2), Is.EqualTo(5));
+    }
+
+    [Test]
+    public void Should_RunWithoutParameters_When_CodeHasNoExternals()
+    {
+        var core = CreateDynamicMethodCore();
+
+        var result = core.Run("40 + 2");
+
+        Assert.That(result, Is.EqualTo(42));
+    }
+
+    [Test]
+    public void Should_RunWithOneParameter_When_RuntimeDictionaryProvided()
+    {
+        var core = CreateDynamicMethodCore();
+
+        var result = core.Run("a + 2", new Dictionary<string, object>
+        {
+            ["a"] = 40
+        });
+
+        Assert.That(result, Is.EqualTo(42));
+    }
+
+    [Test]
+    public void Should_RunWithTwoParameters_When_RuntimeDictionaryProvided()
+    {
+        var core = CreateDynamicMethodCore();
+
+        var result = core.Run("a + b", new Dictionary<string, object>
+        {
+            ["a"] = 5,
+            ["b"] = 7
+        });
+
+        Assert.That(result, Is.EqualTo(12));
+    }
+
+    [Test]
+    public void Should_BeIsolatedAcrossRepeatedRunCalls_When_ReusingSameCore()
+    {
+        var core = CreateDynamicMethodCore();
+
+        var first = core.Run("a + b", new Dictionary<string, object>
+        {
+            ["a"] = 5,
+            ["b"] = 7
+        });
+        var second = core.Run("a + b", new Dictionary<string, object>
+        {
+            ["a"] = 10,
+            ["b"] = 1
+        });
+
+        Assert.That(first, Is.EqualTo(12));
+        Assert.That(second, Is.EqualTo(11));
+    }
+
+    [Test]
+    public void Should_BeDeterministicAcrossRepeatedGetExecutableCalls_When_CodeAndBindingsAreSame()
+    {
+        var parameters = new OrderedDictionary<string, Type>
+        {
+            ["a"] = typeof(int),
+            ["b"] = typeof(int)
+        };
+
+        var first = GetExecutable("a + b", parameters);
+        var second = GetExecutable("a + b", parameters);
+
+        var firstInvoker = new DynamicMethodInvoker<int, int, int>(first);
+        var secondInvoker = new DynamicMethodInvoker<int, int, int>(second);
+
+        Assert.That(firstInvoker.Invoke(7, 15), Is.EqualTo(22));
+        Assert.That(secondInvoker.Invoke(7, 15), Is.EqualTo(22));
+    }
+
+    [Test]
+    public void Should_MatchRunAndCompiledExecutionSemantics_When_UsingEquivalentInputs()
+    {
+        const string code = "a + b";
+
+        var runCore = CreateDynamicMethodCore();
+        var runResult = runCore.Run(code, new Dictionary<string, object>
+        {
+            ["a"] = 7,
+            ["b"] = 15
+        });
+
+        var method = GetExecutable(code, new OrderedDictionary<string, Type>
+        {
+            ["a"] = typeof(int),
+            ["b"] = typeof(int)
+        });
+        var invoker = new DynamicMethodInvoker<int, int, int>(method);
+
+        Assert.That(runResult, Is.EqualTo(22));
+        Assert.That(invoker.Invoke(7, 15), Is.EqualTo(22));
+    }
+
+    private static DynamicMethod GetExecutable(string code, OrderedDictionary<string, Type> parameters)
+    {
+        var services = new ServiceCollection();
+        services.AddWistServices(options => options.ArithmeticMode = WistOptions.ArithmeticModeEnum.Native);
+        var provider = services.BuildServiceProvider();
+
+        var giver = provider.GetRequiredService<IExecutableGiver<DynamicMethod>>();
+        return giver.GetExecutable(code, parameters);
+    }
+
+    private static ICoreRunnable CreateDynamicMethodCore()
+    {
+        var services = new ServiceCollection();
+        services.AddWistServices(options => options.ArithmeticMode = WistOptions.ArithmeticModeEnum.Native);
+        var provider = services.BuildServiceProvider();
+
+        var modules = provider.GetServices<IFrontendCoreModule>()
+            .OrderBy(module => module.GetType().FullName, StringComparer.Ordinal)
+            .ToList();
+        var optimizers = provider.GetServices<IIRProcessingModule>()
+            .OrderBy(module => module.GetType().FullName, StringComparer.Ordinal)
+            .ToList();
+
+        return new BasicCoreImpl<DynamicMethod>(
+            provider.GetRequiredService<Func<ILexer>>(),
+            provider.GetRequiredService<Func<IParser>>(),
+            provider.GetRequiredService<Func<IAstToBytecodeTranslator>>(),
+            provider.GetRequiredService<Func<IAbstractMethodsTranslator>>(),
+            () => provider.GetRequiredService<AbstractMethodsCompilerImpl>(),
+            () => new DynamicMethodExecutor(),
+            modules,
+            optimizers,
+            []);
+    }
+}

--- a/UniversalToolchain/Tests/Infrastructure/ParameterHandlingDeepTests.cs
+++ b/UniversalToolchain/Tests/Infrastructure/ParameterHandlingDeepTests.cs
@@ -1,0 +1,669 @@
+using AbstractIrConverters;
+using System.Reflection;
+using BasicCilCompiler.Execution;
+using BasicCore.Compilation;
+using BasicCore.Contracts;
+using BasicCore.Core;
+using BasicCore.ExecutorWrapper;
+using BasicCore.LexerWrapper;
+using BasicCore.ParserWrapper;
+using BasicCore.TranslatorWrapper;
+using BasicInterpreter;
+using BytecodeDynamicMethodsCompiler.Compilers;
+using DynamicMethodCalling.Core;
+
+namespace Tests.Infrastructure;
+
+internal static class ParameterTestHost
+{
+    public static IServiceProvider CreateProvider()
+    {
+        var services = new ServiceCollection();
+        services.AddWistServices(options => options.ArithmeticMode = WistOptions.ArithmeticModeEnum.Native);
+        return services.BuildServiceProvider();
+    }
+
+    public static BasicCoreImpl<DynamicMethod> CreateDynamicCore(IServiceProvider provider)
+    {
+        var modules = provider.GetServices<IFrontendCoreModule>().ToList();
+        var optimizers = provider.GetServices<IIRProcessingModule>().ToList();
+
+        return new BasicCoreImpl<DynamicMethod>(
+            provider.GetRequiredService<Func<ILexer>>(),
+            provider.GetRequiredService<Func<IParser>>(),
+            provider.GetRequiredService<Func<IAstToBytecodeTranslator>>(),
+            provider.GetRequiredService<Func<IAbstractMethodsTranslator>>(),
+            () => provider.GetRequiredService<AbstractMethodsCompilerImpl>(),
+            () => new DynamicMethodExecutor(),
+            modules,
+            optimizers,
+            []);
+    }
+
+    public static BasicCoreImpl<IAbstractIR> CreateInterpreterCore(IServiceProvider provider)
+    {
+        var modules = provider.GetServices<IFrontendCoreModule>().ToList();
+        var optimizers = provider.GetServices<IIRProcessingModule>().ToList();
+
+        return new BasicCoreImpl<IAbstractIR>(
+            provider.GetRequiredService<Func<ILexer>>(),
+            provider.GetRequiredService<Func<IParser>>(),
+            provider.GetRequiredService<Func<IAstToBytecodeTranslator>>(),
+            provider.GetRequiredService<Func<IAbstractMethodsTranslator>>(),
+            () => provider.GetRequiredService<AbstractIrToAbstractIrStub>(),
+            () => new InterpreterImpl(),
+            modules,
+            optimizers,
+            []);
+    }
+
+    public static string ProgramFor(string expression) => $"""
+        let result = {expression}
+        result
+        """;
+}
+
+[TestFixture]
+public class RuntimeParameterHandlingTests
+{
+    [Test]
+    public void Run_WithNoParameters_WorksForConstantExpression()
+    {
+        using var provider = ParameterTestHost.CreateProvider() as ServiceProvider;
+        var core = ParameterTestHost.CreateDynamicCore(provider!);
+
+        var result = core.Run(ParameterTestHost.ProgramFor("40 + 2"));
+
+        Assert.That(result, Is.EqualTo(42));
+    }
+
+    [Test]
+    public void Run_WithNullDictionary_BehavesSameAsNoArguments()
+    {
+        using var provider = ParameterTestHost.CreateProvider() as ServiceProvider;
+        var core = ParameterTestHost.CreateDynamicCore(provider!);
+
+        var result = core.Run(ParameterTestHost.ProgramFor("40 + 2"), null);
+
+        Assert.That(result, Is.EqualTo(42));
+    }
+
+    [Test]
+    public void Run_WithEmptyDictionary_BehavesSameAsNoArguments()
+    {
+        using var provider = ParameterTestHost.CreateProvider() as ServiceProvider;
+        var core = ParameterTestHost.CreateDynamicCore(provider!);
+
+        var result = core.Run(ParameterTestHost.ProgramFor("40 + 2"), new Dictionary<string, object>());
+
+        Assert.That(result, Is.EqualTo(42));
+    }
+
+    [Test]
+    public void Run_WithOneParameter_BindsByName()
+    {
+        using var provider = ParameterTestHost.CreateProvider() as ServiceProvider;
+        var core = ParameterTestHost.CreateDynamicCore(provider!);
+
+        var result = core.Run(ParameterTestHost.ProgramFor("a + 3"), new Dictionary<string, object> { ["a"] = 5 });
+
+        Assert.That(result, Is.EqualTo(8));
+    }
+
+    [Test]
+    public void Run_WithTwoParameters_BindsBothValues()
+    {
+        using var provider = ParameterTestHost.CreateProvider() as ServiceProvider;
+        var core = ParameterTestHost.CreateDynamicCore(provider!);
+
+        var result = core.Run(ParameterTestHost.ProgramFor("a + b"), new Dictionary<string, object> { ["a"] = 5, ["b"] = 7 });
+
+        Assert.That(result, Is.EqualTo(12));
+    }
+
+    [Test]
+    public void Run_WithThreeParameters_BindsAllValues()
+    {
+        using var provider = ParameterTestHost.CreateProvider() as ServiceProvider;
+        var core = ParameterTestHost.CreateDynamicCore(provider!);
+
+        var result = core.Run(ParameterTestHost.ProgramFor("a * 100 + b * 10 + c"), new Dictionary<string, object>
+        {
+            ["a"] = 1,
+            ["b"] = 2,
+            ["c"] = 3
+        });
+
+        Assert.That(result, Is.EqualTo(123));
+    }
+
+    [Test]
+    public void Run_WithRepeatedParameterReferences_UsesSameBoundValueEachTime()
+    {
+        using var provider = ParameterTestHost.CreateProvider() as ServiceProvider;
+        var core = ParameterTestHost.CreateDynamicCore(provider!);
+
+        var result = core.Run(ParameterTestHost.ProgramFor("a + a + b + a"), new Dictionary<string, object>
+        {
+            ["a"] = 4,
+            ["b"] = 1
+        });
+
+        Assert.That(result, Is.EqualTo(13));
+    }
+
+    [Test]
+    public void Run_WithDictionaryInsertionOrderDifferentFromUsage_BindsByNameNotPosition()
+    {
+        using var provider = ParameterTestHost.CreateProvider() as ServiceProvider;
+        var core = ParameterTestHost.CreateDynamicCore(provider!);
+
+        var result = core.Run(ParameterTestHost.ProgramFor("a * 10 + b"), new Dictionary<string, object>
+        {
+            ["b"] = 3,
+            ["a"] = 4
+        });
+
+        Assert.That(result, Is.EqualTo(43));
+    }
+
+    [Test]
+    public void Run_WithUnusedExtraRuntimeParameter_DoesNotAffectResult()
+    {
+        using var provider = ParameterTestHost.CreateProvider() as ServiceProvider;
+        var core = ParameterTestHost.CreateDynamicCore(provider!);
+
+        var result = core.Run(ParameterTestHost.ProgramFor("a + b"), new Dictionary<string, object>
+        {
+            ["a"] = 9,
+            ["b"] = 1,
+            ["unused"] = 123
+        });
+
+        Assert.That(result, Is.EqualTo(10));
+    }
+
+    [Test]
+    public void Run_WithSimilarParameterNames_DoesNotCollide()
+    {
+        using var provider = ParameterTestHost.CreateProvider() as ServiceProvider;
+        var core = ParameterTestHost.CreateDynamicCore(provider!);
+
+        var result = core.Run(ParameterTestHost.ProgramFor("a + aa + a1 + arg + arg1"), new Dictionary<string, object>
+        {
+            ["a"] = 1,
+            ["aa"] = 2,
+            ["a1"] = 3,
+            ["arg"] = 4,
+            ["arg1"] = 5
+        });
+
+        Assert.That(result, Is.EqualTo(15));
+    }
+
+    [Test]
+    public void Run_WithMissingRuntimeArgument_Throws()
+    {
+        using var provider = ParameterTestHost.CreateProvider() as ServiceProvider;
+        var core = ParameterTestHost.CreateDynamicCore(provider!);
+
+        Assert.Throws<InvalidOperationException>(() => core.Run(ParameterTestHost.ProgramFor("a + b"), new Dictionary<string, object>
+        {
+            ["a"] = 10
+        }));
+    }
+
+    [Test]
+    public void Run_WithNullRuntimeValue_ThrowsNullReferenceException()
+    {
+        using var provider = ParameterTestHost.CreateProvider() as ServiceProvider;
+        var core = ParameterTestHost.CreateDynamicCore(provider!);
+
+        Assert.Throws<NullReferenceException>(() => core.Run(ParameterTestHost.ProgramFor("a"), new Dictionary<string, object>
+        {
+            ["a"] = null!
+        }));
+    }
+}
+
+[TestFixture]
+public class CompiledParameterHandlingTests
+{
+    [Test]
+    public void GetExecutable_WithNoParameters_BuildsZeroArgMethod()
+    {
+        using var provider = ParameterTestHost.CreateProvider() as ServiceProvider;
+        var core = ParameterTestHost.CreateDynamicCore(provider!);
+
+        var method = core.GetExecutable(ParameterTestHost.ProgramFor("10 + 5"), new OrderedDictionary<string, Type>());
+        var invoker = new DynamicMethodInvoker<int>(method);
+
+        Assert.That(method.GetParameters(), Has.Length.EqualTo(0));
+        Assert.That(invoker.Invoke(), Is.EqualTo(15));
+    }
+
+    [Test]
+    public void GetExecutable_WithOneParameter_BuildsSingleArgMethod()
+    {
+        using var provider = ParameterTestHost.CreateProvider() as ServiceProvider;
+        var core = ParameterTestHost.CreateDynamicCore(provider!);
+
+        var method = core.GetExecutable(ParameterTestHost.ProgramFor("a + 1"), new OrderedDictionary<string, Type> { ["a"] = typeof(int) });
+        var invoker = new DynamicMethodInvoker<int, int>(method);
+
+        Assert.That(method.GetParameters().Select(x => x.ParameterType), Is.EqualTo(new[] { typeof(int) }));
+        Assert.That(invoker.Invoke(41), Is.EqualTo(42));
+    }
+
+    [Test]
+    public void GetExecutable_WithTwoParameters_BuildsTwoArgMethod()
+    {
+        using var provider = ParameterTestHost.CreateProvider() as ServiceProvider;
+        var core = ParameterTestHost.CreateDynamicCore(provider!);
+
+        var method = core.GetExecutable(ParameterTestHost.ProgramFor("a + b"), new OrderedDictionary<string, Type>
+        {
+            ["a"] = typeof(int),
+            ["b"] = typeof(int)
+        });
+        var invoker = new DynamicMethodInvoker<int, int, int>(method);
+
+        Assert.That(method.GetParameters().Select(x => x.ParameterType), Is.EqualTo(new[] { typeof(int), typeof(int) }));
+        Assert.That(invoker.Invoke(7, 15), Is.EqualTo(22));
+    }
+
+    [Test]
+    public void GetExecutable_WithThreeParameters_BuildsThreeArgMethod()
+    {
+        using var provider = ParameterTestHost.CreateProvider() as ServiceProvider;
+        var core = ParameterTestHost.CreateDynamicCore(provider!);
+
+        var method = core.GetExecutable(ParameterTestHost.ProgramFor("a * 100 + b * 10 + c"), new OrderedDictionary<string, Type>
+        {
+            ["a"] = typeof(int),
+            ["b"] = typeof(int),
+            ["c"] = typeof(int)
+        });
+        var invoker = new DynamicMethodInvoker<int, int, int, int>(method);
+
+        Assert.That(invoker.Invoke(1, 2, 3), Is.EqualTo(123));
+    }
+
+    [Test]
+    public void GetExecutable_WithUnusedDeclaredParameter_AddsParameterButDoesNotChangeSemantics()
+    {
+        using var provider = ParameterTestHost.CreateProvider() as ServiceProvider;
+        var core = ParameterTestHost.CreateDynamicCore(provider!);
+
+        var method = core.GetExecutable(ParameterTestHost.ProgramFor("a + b"), new OrderedDictionary<string, Type>
+        {
+            ["a"] = typeof(int),
+            ["b"] = typeof(int),
+            ["c"] = typeof(int)
+        });
+        var invoker = new DynamicMethodInvoker<int, int, int, int>(method);
+
+        Assert.That(method.GetParameters(), Has.Length.EqualTo(3));
+        Assert.That(invoker.Invoke(5, 7, 999), Is.EqualTo(12));
+    }
+
+    [Test]
+    public void GetExecutable_WithMissingDeclaredParameter_Throws()
+    {
+        using var provider = ParameterTestHost.CreateProvider() as ServiceProvider;
+        var core = ParameterTestHost.CreateDynamicCore(provider!);
+
+        Assert.Throws<InvalidOperationException>(() => core.GetExecutable(ParameterTestHost.ProgramFor("a + b"), new OrderedDictionary<string, Type>
+        {
+            ["a"] = typeof(int)
+        }));
+    }
+
+    [Test]
+    public void DynamicMethodInvoke_WithWrongArgumentCount_ThrowsTargetParameterCountException()
+    {
+        using var provider = ParameterTestHost.CreateProvider() as ServiceProvider;
+        var core = ParameterTestHost.CreateDynamicCore(provider!);
+
+        var method = core.GetExecutable(ParameterTestHost.ProgramFor("a + b"), new OrderedDictionary<string, Type>
+        {
+            ["a"] = typeof(int),
+            ["b"] = typeof(int)
+        });
+
+        Assert.Throws<TargetParameterCountException>(() => method.Invoke(null, [1]));
+    }
+
+    [Test]
+    public void DynamicMethodInvoke_WithWrongArgumentType_ThrowsArgumentException()
+    {
+        using var provider = ParameterTestHost.CreateProvider() as ServiceProvider;
+        var core = ParameterTestHost.CreateDynamicCore(provider!);
+
+        var method = core.GetExecutable(ParameterTestHost.ProgramFor("a + b"), new OrderedDictionary<string, Type>
+        {
+            ["a"] = typeof(int),
+            ["b"] = typeof(int)
+        });
+
+        Assert.Throws<ArgumentException>(() => method.Invoke(null, ["bad", 2]));
+    }
+
+    [Test]
+    public void GetExecutable_SameInputRepeatedly_ProducesDeterministicResults()
+    {
+        using var provider = ParameterTestHost.CreateProvider() as ServiceProvider;
+        var core = ParameterTestHost.CreateDynamicCore(provider!);
+
+        var parameters = new OrderedDictionary<string, Type>
+        {
+            ["a"] = typeof(int),
+            ["b"] = typeof(int)
+        };
+
+        var first = core.GetExecutable(ParameterTestHost.ProgramFor("a * 10 + b"), parameters);
+        var second = core.GetExecutable(ParameterTestHost.ProgramFor("a * 10 + b"), parameters);
+
+        var firstInvoker = new DynamicMethodInvoker<int, int, int>(first);
+        var secondInvoker = new DynamicMethodInvoker<int, int, int>(second);
+
+        Assert.That(firstInvoker.Invoke(4, 3), Is.EqualTo(43));
+        Assert.That(secondInvoker.Invoke(4, 3), Is.EqualTo(43));
+    }
+}
+
+[TestFixture]
+public class ParameterOrderingAndConsistencyTests
+{
+    [Test]
+    public void OrderedDictionaryOrder_ChangesCallableSignatureOrder()
+    {
+        using var provider = ParameterTestHost.CreateProvider() as ServiceProvider;
+        var core = ParameterTestHost.CreateDynamicCore(provider!);
+
+        var abc = core.GetExecutable(ParameterTestHost.ProgramFor("a * 100 + b * 10 + c"), new OrderedDictionary<string, Type>
+        {
+            ["a"] = typeof(int),
+            ["b"] = typeof(int),
+            ["c"] = typeof(int)
+        });
+        var cab = core.GetExecutable(ParameterTestHost.ProgramFor("a * 100 + b * 10 + c"), new OrderedDictionary<string, Type>
+        {
+            ["c"] = typeof(int),
+            ["a"] = typeof(int),
+            ["b"] = typeof(int)
+        });
+
+        var abcInvoker = new DynamicMethodInvoker<int, int, int, int>(abc);
+        var cabInvoker = new DynamicMethodInvoker<int, int, int, int>(cab);
+
+        Assert.That(abcInvoker.Invoke(1, 2, 3), Is.EqualTo(123));
+        Assert.That(cabInvoker.Invoke(1, 2, 3), Is.EqualTo(231));
+    }
+
+    [Test]
+    public void OrderedDictionaryOrder_PreservesParameterTypePositions()
+    {
+        using var provider = ParameterTestHost.CreateProvider() as ServiceProvider;
+        var core = ParameterTestHost.CreateDynamicCore(provider!);
+
+        var method = core.GetExecutable(ParameterTestHost.ProgramFor("a + b + c"), new OrderedDictionary<string, Type>
+        {
+            ["c"] = typeof(int),
+            ["a"] = typeof(int),
+            ["b"] = typeof(int)
+        });
+
+        Assert.That(method.GetParameters().Select(x => x.ParameterType), Is.EqualTo(new[] { typeof(int), typeof(int), typeof(int) }));
+        Assert.That(method.GetParameters(), Has.Length.EqualTo(3));
+    }
+
+    [Test]
+    public void RuntimeBinding_WithDifferentDictionaryOrders_ProducesSameResult()
+    {
+        using var provider = ParameterTestHost.CreateProvider() as ServiceProvider;
+        var core = ParameterTestHost.CreateDynamicCore(provider!);
+
+        var code = ParameterTestHost.ProgramFor("a * 10 + b");
+
+        var first = core.Run(code, new Dictionary<string, object> { ["a"] = 4, ["b"] = 3 });
+        var second = core.Run(code, new Dictionary<string, object> { ["b"] = 3, ["a"] = 4 });
+
+        Assert.That(first, Is.EqualTo(43));
+        Assert.That(second, Is.EqualTo(43));
+    }
+
+    [Test]
+    public void RuntimeVsCompiled_ForSimpleArithmetic_AreConsistent()
+    {
+        using var provider = ParameterTestHost.CreateProvider() as ServiceProvider;
+        var runtimeCore = ParameterTestHost.CreateDynamicCore(provider!);
+        var compiledCore = ParameterTestHost.CreateDynamicCore(provider!);
+
+        var code = ParameterTestHost.ProgramFor("a + b * 2");
+
+        var runtime = runtimeCore.Run(code, new Dictionary<string, object> { ["a"] = 5, ["b"] = 7 });
+        var method = compiledCore.GetExecutable(code, new OrderedDictionary<string, Type>
+        {
+            ["a"] = typeof(int),
+            ["b"] = typeof(int)
+        });
+        var compiled = new DynamicMethodInvoker<int, int, int>(method).Invoke(5, 7);
+
+        Assert.That(runtime, Is.EqualTo(compiled));
+    }
+
+    [Test]
+    public void RuntimeVsCompiled_ForRepeatedParameters_AreConsistent()
+    {
+        using var provider = ParameterTestHost.CreateProvider() as ServiceProvider;
+        var runtimeCore = ParameterTestHost.CreateDynamicCore(provider!);
+        var compiledCore = ParameterTestHost.CreateDynamicCore(provider!);
+
+        var code = ParameterTestHost.ProgramFor("a + a + b + a");
+
+        var runtime = runtimeCore.Run(code, new Dictionary<string, object> { ["a"] = 4, ["b"] = 1 });
+        var method = compiledCore.GetExecutable(code, new OrderedDictionary<string, Type>
+        {
+            ["a"] = typeof(int),
+            ["b"] = typeof(int)
+        });
+        var compiled = new DynamicMethodInvoker<int, int, int>(method).Invoke(4, 1);
+
+        Assert.That(runtime, Is.EqualTo(compiled));
+    }
+
+    [Test]
+    public void RuntimeVsCompiled_ForConditionExpression_AreConsistent()
+    {
+        using var provider = ParameterTestHost.CreateProvider() as ServiceProvider;
+        var runtimeCore = ParameterTestHost.CreateDynamicCore(provider!);
+        var compiledCore = ParameterTestHost.CreateDynamicCore(provider!);
+
+        var code = """
+            if a > b (
+                a - b
+            )
+            else (
+                b - a
+            )
+            """;
+
+        var runtime = runtimeCore.Run(code, new Dictionary<string, object> { ["a"] = 3, ["b"] = 10 });
+        var method = compiledCore.GetExecutable(code, new OrderedDictionary<string, Type>
+        {
+            ["a"] = typeof(int),
+            ["b"] = typeof(int)
+        });
+        var compiled = new DynamicMethodInvoker<int, int, int>(method).Invoke(3, 10);
+
+        Assert.That(runtime, Is.EqualTo(7));
+        Assert.That(compiled, Is.EqualTo(7));
+    }
+
+    [Test]
+    public void RuntimeVsCompiled_WithDeclarationOrderChanged_RemainsSemanticallyCorrect()
+    {
+        using var provider = ParameterTestHost.CreateProvider() as ServiceProvider;
+        var runtimeCore = ParameterTestHost.CreateDynamicCore(provider!);
+        var compiledCore = ParameterTestHost.CreateDynamicCore(provider!);
+
+        var code = ParameterTestHost.ProgramFor("a * 100 + b * 10 + c");
+
+        var runtime = runtimeCore.Run(code, new Dictionary<string, object>
+        {
+            ["a"] = 2,
+            ["b"] = 3,
+            ["c"] = 4
+        });
+
+        var method = compiledCore.GetExecutable(code, new OrderedDictionary<string, Type>
+        {
+            ["c"] = typeof(int),
+            ["a"] = typeof(int),
+            ["b"] = typeof(int)
+        });
+        var compiled = new DynamicMethodInvoker<int, int, int, int>(method).Invoke(4, 2, 3);
+
+        Assert.That(runtime, Is.EqualTo(234));
+        Assert.That(compiled, Is.EqualTo(234));
+    }
+
+}
+
+[TestFixture]
+public class PreparedExecutionParameterTests
+{
+    [Test]
+    public void PrepareToRun_ThenRunPrepared_ExecutesWithoutParameters()
+    {
+        using var provider = ParameterTestHost.CreateProvider() as ServiceProvider;
+        ICoreOptimizedRunnable core = ParameterTestHost.CreateDynamicCore(provider!);
+
+        core.PrepareToRun(ParameterTestHost.ProgramFor("40 + 2"));
+        var result = core.RunPrepared();
+
+        Assert.That(result, Is.EqualTo(42));
+    }
+
+    [Test]
+    public void PrepareToRun_CalledTwice_UsesLatestPreparedProgram()
+    {
+        using var provider = ParameterTestHost.CreateProvider() as ServiceProvider;
+        ICoreOptimizedRunnable core = ParameterTestHost.CreateDynamicCore(provider!);
+
+        core.PrepareToRun(ParameterTestHost.ProgramFor("1 + 2"));
+        var first = core.RunPrepared();
+
+        core.PrepareToRun(ParameterTestHost.ProgramFor("10 + 20"));
+        var second = core.RunPrepared();
+
+        Assert.That(first, Is.EqualTo(3));
+        Assert.That(second, Is.EqualTo(30));
+    }
+
+    [Test]
+    public void PrepareToRun_SameProgramRepeated_RunPreparedIsDeterministic()
+    {
+        using var provider = ParameterTestHost.CreateProvider() as ServiceProvider;
+        ICoreOptimizedRunnable core = ParameterTestHost.CreateDynamicCore(provider!);
+
+        core.PrepareToRun(ParameterTestHost.ProgramFor("5 + 6"));
+        var first = core.RunPrepared();
+        var second = core.RunPrepared();
+        var third = core.RunPrepared();
+
+        Assert.That(first, Is.EqualTo(11));
+        Assert.That(second, Is.EqualTo(11));
+        Assert.That(third, Is.EqualTo(11));
+    }
+
+    [Test]
+    public void PrepareToRun_WithDeclaredParameters_AndNoValues_UsesDefaultValuesOnExecution()
+    {
+        using var provider = ParameterTestHost.CreateProvider() as ServiceProvider;
+        ICoreOptimizedRunnable core = ParameterTestHost.CreateDynamicCore(provider!);
+
+        core.PrepareToRun(ParameterTestHost.ProgramFor("a + b"), new OrderedDictionary<string, Type>
+        {
+            ["a"] = typeof(int),
+            ["b"] = typeof(int)
+        });
+
+        Assert.That(core.RunPrepared(), Is.EqualTo(0));
+    }
+
+    [Test]
+    public void PrepareToRunCompilationInput_WithValues_AllowsRunPreparedWithParameters()
+    {
+        using var provider = ParameterTestHost.CreateProvider() as ServiceProvider;
+        var core = ParameterTestHost.CreateDynamicCore(provider!);
+
+        core.PrepareToRun(new CompilationInput
+        {
+            SourceText = ParameterTestHost.ProgramFor("a + b"),
+            ExternalBindings =
+            [
+                new ExternalBinding { Name = "a", Type = typeof(int), Value = 7, Kind = ExternalBindingKind.Variable },
+                new ExternalBinding { Name = "b", Type = typeof(int), Value = 15, Kind = ExternalBindingKind.Variable }
+            ]
+        });
+
+        Assert.That(core.RunPrepared(), Is.EqualTo(22));
+    }
+
+    [Test]
+    public void PrepareToRunCompilationInput_ReprepareWithDifferentBindings_DoesNotLeakState()
+    {
+        using var provider = ParameterTestHost.CreateProvider() as ServiceProvider;
+        var core = ParameterTestHost.CreateDynamicCore(provider!);
+
+        core.PrepareToRun(new CompilationInput
+        {
+            SourceText = ParameterTestHost.ProgramFor("a + b"),
+            ExternalBindings =
+            [
+                new ExternalBinding { Name = "a", Type = typeof(int), Value = 5, Kind = ExternalBindingKind.Variable },
+                new ExternalBinding { Name = "b", Type = typeof(int), Value = 7, Kind = ExternalBindingKind.Variable }
+            ]
+        });
+        var first = core.RunPrepared();
+
+        core.PrepareToRun(new CompilationInput
+        {
+            SourceText = ParameterTestHost.ProgramFor("x * 10 + y"),
+            ExternalBindings =
+            [
+                new ExternalBinding { Name = "x", Type = typeof(int), Value = 4, Kind = ExternalBindingKind.Variable },
+                new ExternalBinding { Name = "y", Type = typeof(int), Value = 3, Kind = ExternalBindingKind.Variable }
+            ]
+        });
+        var second = core.RunPrepared();
+
+        Assert.That(first, Is.EqualTo(12));
+        Assert.That(second, Is.EqualTo(43));
+    }
+
+    [Test]
+    public void PrepareToRunCompilationInput_RepeatedRunPrepared_DoesNotMutateBoundExternalValues()
+    {
+        using var provider = ParameterTestHost.CreateProvider() as ServiceProvider;
+        var core = ParameterTestHost.CreateDynamicCore(provider!);
+
+        core.PrepareToRun(new CompilationInput
+        {
+            SourceText = ParameterTestHost.ProgramFor("a + b"),
+            ExternalBindings =
+            [
+                new ExternalBinding { Name = "a", Type = typeof(int), Value = 2, Kind = ExternalBindingKind.Variable },
+                new ExternalBinding { Name = "b", Type = typeof(int), Value = 9, Kind = ExternalBindingKind.Variable }
+            ]
+        });
+
+        var first = core.RunPrepared();
+        var second = core.RunPrepared();
+
+        Assert.That(first, Is.EqualTo(11));
+        Assert.That(second, Is.EqualTo(11));
+    }
+}


### PR DESCRIPTION
### Motivation

- Prevent bytecode accumulation when reusing an AST-to-bytecode translator and centralize handling of external bindings and prepared execution state.
- Provide a clearer Prepare/Run lifecycle for the core to allow precompilation and repeated execution without leaking state.
- Add coverage to ensure runtime/compiled parameter binding is correct and stable across repeated runs and varying input forms.

### Description

- Added a translation depth counter to `BasicAstToBytecodeTranslatorImpl` and clear top-level `_code.Instructions` before a fresh translate to avoid accumulating instructions across reused translator instances.  
- Introduced `ExternalBindingsFactory` with `FromDeclaredTypes` and `FromRuntimeValues` to centralize conversion of parameter dictionaries and ordered declarations into `ExternalBinding` lists.  
- Refactored `BasicCoreImpl` to use a `PreparedExecution<T>` abstraction, moved run/prepare logic into `PrepareToRun`, `RunPrepared`, `Run`, `GetExecutable`, and `BuildPreparedExecution`, and removed previous mutable fields in favor of a single `_prepared` instance.  
- Added `PreparedExecution<TCompilationOutput>` record-like class to hold `SourceText`, `CompilationOutput`, `Executor`, and `ExecutionEnvironment`.  
- Added and expanded tests: updated `BytecodeAndStateIsolationTests` with a translator reuse test and added new test files `CoreExecutionParameterFlowTests` and `ParameterHandlingDeepTests` that validate parameter ordering, runtime vs compiled semantics, Prepare/Run lifecycle, and edge cases for declared/runtime bindings.  
- Removed an unused `using` and performed small cleanups accompanying the refactor.

### Testing

- Ran the unit tests covering translator isolation and parameter handling, including `BytecodeAndStateIsolationTests`, `CoreExecutionParameterFlowTests`, and `ParameterHandlingDeepTests`.  
- Executed the full affected test suite locally; all added and existing tests relevant to this change passed.  
- Verified deterministic behavior for repeated `GetExecutable` and `RunPrepared` scenarios via the new tests.  
- Confirmed that translator reuse no longer accumulates bytecode by the new isolation test.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae7f6dd938832489f1fba3a41a04ca)