### PR TITLE
Refactor exception throwing to use Thrower across modules and tests

### DIFF
--- a/UniversalToolchain/ExceptionsManager/Thrower.cs
+++ b/UniversalToolchain/ExceptionsManager/Thrower.cs
@@ -72,6 +72,9 @@ public static class Thrower
     }
 
     [DoesNotReturn]
+    public static T ArgumentOutOfRange<T>(string paramName = "", string message = "") => throw new ArgumentOutOfRangeException(paramName, FormatMessage(message, "Argument value is out of range."));
+
+    [DoesNotReturn]
     public static T NotSupported<T>(string message = "") => throw new NotSupportedException(FormatMessage(message, "Operation is not supported."));
 
     [DoesNotReturn]

--- a/UniversalToolchain/NCalcWist.Benchmarks/Benchmarks.cs
+++ b/UniversalToolchain/NCalcWist.Benchmarks/Benchmarks.cs
@@ -8,6 +8,7 @@ using DynamicMethodCalling.Core;
 using Microsoft.Extensions.DependencyInjection;
 using NCalc;
 using NCalc.LambdaCompilation;
+using ExceptionsManager;
 
 namespace NCalcWist.Benchmarks;
 
@@ -239,11 +240,11 @@ public class ExecuteOnlyBenchmarks
             var diff = Math.Abs(w - n);
             var scale = Math.Max(1.0, Math.Max(Math.Abs(w), Math.Abs(n)));
             if (diff > 1e-9 * scale)
-                throw new InvalidOperationException($"Mismatch for {scenario}: Wist={w}, NCalc={n}");
+                Thrower.InvalidOpEx($"Mismatch for {scenario}: Wist={w}, NCalc={n}");
         }
         else if (w != n)
         {
-            throw new InvalidOperationException($"Mismatch for {scenario}: Wist={w}, NCalc={n}");
+            Thrower.InvalidOpEx($"Mismatch for {scenario}: Wist={w}, NCalc={n}");
         }
     }
 }
@@ -281,7 +282,7 @@ public class ColdStartBenchmarks
             ScenarioId.Conditional => new DynamicMethodInvoker<int, int, int>(method).Invoke(7, 3),
             ScenarioId.ParameterHeavy20 => new DynamicMethodInvoker<double>(method).Invoke(),
             ScenarioId.PathologicalParseStress => new DynamicMethodInvoker<int>(method).Invoke(),
-            _ => throw new ArgumentOutOfRangeException()
+            _ => Thrower.ArgumentOutOfRange<ScenarioSpec>(nameof(id), $"Unknown scenario id: {id}")
         };
     }
 }
@@ -307,7 +308,7 @@ public class MultiThreadExecuteDefaultBenchmarks
         var w = _wInvoker.Invoke(_wData[0].A, _wData[0].B);
         var n = _nInvoker(_nData[0]);
         if (Math.Abs(w - n) > 1e-9)
-            throw new InvalidOperationException("MT validation failed");
+            Thrower.InvalidOpEx("MT validation failed");
     }
 
     [Benchmark(Baseline = true)]

--- a/UniversalToolchain/NativeMathModule/EGraphOptimizerModule.cs
+++ b/UniversalToolchain/NativeMathModule/EGraphOptimizerModule.cs
@@ -4,6 +4,7 @@ using DotnetAirHelper;
 using IntermediateRepresentationAbstractions;
 using ListExtensions;
 using UniversalIntermediateRepresentation;
+using ExceptionsManager;
 
 namespace NativeMathModule;
 
@@ -489,7 +490,7 @@ public class EGraphOptimizerModule : IIRProcessingModule
             ExprOp.Sub => "sub",
             ExprOp.Mul => "mul",
             ExprOp.Div => "div",
-            _ => throw new InvalidOperationException("Unsupported expression operation")
+            _ => Thrower.InvalidOpEx<string>("Unsupported expression operation")
         };
 
         var suffix = type == typeof(int)
@@ -500,7 +501,7 @@ public class EGraphOptimizerModule : IIRProcessingModule
                     ? "f32"
                     : type == typeof(double)
                         ? "f64"
-                        : throw new InvalidOperationException("Unsupported expression type");
+                        : Thrower.InvalidOpEx<string>("Unsupported expression type");
 
         return $"{prefix}_{suffix}";
     }

--- a/UniversalToolchain/Tests/Arithmetic/NegativeNumbersGeneratedTests.cs
+++ b/UniversalToolchain/Tests/Arithmetic/NegativeNumbersGeneratedTests.cs
@@ -1,4 +1,5 @@
 using NumbersModule.Core;
+using ExceptionsManager;
 
 namespace Tests.Arithmetic;
 
@@ -68,7 +69,7 @@ public class NegativeNumbersGeneratedTests : TestBase
                         "-" => left - right,
                         "*" => left * right,
                         "/" => left / right,
-                        _ => throw new InvalidOperationException("Unsupported operation")
+                        _ => Thrower.InvalidOpEx<object>("Unsupported operation")
                     };
 
                     yield return new TestCaseData(expression, expected)

--- a/UniversalToolchain/Tests/Infrastructure/ArithmeticOptimizerModuleTests.cs
+++ b/UniversalToolchain/Tests/Infrastructure/ArithmeticOptimizerModuleTests.cs
@@ -3,6 +3,7 @@ using BasicCore.Compilation;
 using BasicCore.Contracts;
 using BasicCore.Execution;
 using BytecodeDynamicMethodsCompiler.Compilers;
+using ExceptionsManager;
 
 namespace Tests.Infrastructure;
 
@@ -183,6 +184,6 @@ public class ArithmeticOptimizerModuleTests
     {
         public IReadOnlyList<string> SupportedIntrinsics => intrinsics;
 
-        public object Compile(IAbstractIR air, CompilationInput input) => throw new NotSupportedException();
+        public object Compile(IAbstractIR air, CompilationInput input) => Thrower.NotSupported<object>();
     }
 }

--- a/UniversalToolchain/Tests/Infrastructure/BasicCoreImplOrchestrationTests.cs
+++ b/UniversalToolchain/Tests/Infrastructure/BasicCoreImplOrchestrationTests.cs
@@ -4,6 +4,7 @@ using BasicCore.Core;
 using BasicCore.Execution;
 using BasicCore.ExecutorWrapper;
 using BasicCore.TranslatorWrapper;
+using ExceptionsManager;
 
 namespace Tests.Infrastructure;
 
@@ -186,7 +187,7 @@ public class BasicCoreImplOrchestrationTests
         {
             calls.Add("parser.Parse");
             if (shouldThrow)
-                throw new InvalidOperationException("parse failed");
+                Thrower.InvalidOpEx("parse failed");
             return new AstNode(ExtensibleEnum<AstNodeTag>.CreateOrGet("Root"), null, []);
         }
 

--- a/UniversalToolchain/Tests/Infrastructure/EGraphOptimizerModuleTests.cs
+++ b/UniversalToolchain/Tests/Infrastructure/EGraphOptimizerModuleTests.cs
@@ -3,6 +3,7 @@ using BasicCore.Compilation;
 using BasicCore.Contracts;
 using BasicCore.Execution;
 using BytecodeDynamicMethodsCompiler.Compilers;
+using ExceptionsManager;
 
 namespace Tests.Infrastructure;
 
@@ -216,6 +217,6 @@ public class EGraphOptimizerModuleTests
     {
         public IReadOnlyList<string> SupportedIntrinsics => intrinsics;
 
-        public object Compile(IAbstractIR air, CompilationInput input) => throw new NotSupportedException();
+        public object Compile(IAbstractIR air, CompilationInput input) => Thrower.NotSupported<object>();
     }
 }


### PR DESCRIPTION
### Motivation
- Centralize and standardize exception creation by routing all throws through the `Thrower` helper to make diagnostics and formatting consistent.
- Add a typed `ArgumentOutOfRange<T>` helper to support throw-expressions used in switch arms.

### Description
- Added `ArgumentOutOfRange<T>(...)` to `UniversalToolchain/ExceptionsManager/Thrower.cs` to support typed throw-expressions.
- Replaced direct `throw new ...` usages with `Thrower` calls in `UniversalToolchain/NativeMathModule/EGraphOptimizerModule.cs` for unsupported expression operation/type cases.
- Replaced direct throws in `UniversalToolchain/NCalcWist.Benchmarks/Benchmarks.cs` (scenario validation, switch default, MT validation) to use `Thrower`.
- Updated test helpers and fakes to use `Thrower` instead of direct `throw` in these files: `UniversalToolchain/Tests/Arithmetic/NegativeNumbersGeneratedTests.cs`, `UniversalToolchain/Tests/Infrastructure/EGraphOptimizerModuleTests.cs`, `UniversalToolchain/Tests/Infrastructure/ArithmeticOptimizerModuleTests.cs`, and `UniversalToolchain/Tests/Infrastructure/BasicCoreImplOrchestrationTests.cs`.

### Testing
- Installed .NET SDK 10 and ran repository restore with `dotnet restore UniversalToolchain/Wist.sln` which completed successfully.
- Ran the full test suite with `DOTNET_ROLL_FORWARD=Major dotnet test UniversalToolchain/Tests/Tests.csproj --configuration Release` and all tests passed: `Passed!  - Failed: 0, Passed: 573, Skipped: 0, Total: 573`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af080973008324819fc7ed6dd2389a)