### PR TITLE
Fix AST boundary checks, null external handling, interpreter env and core prepared-state isolation

### DIFF
--- a/UniversalToolchain/ArithmeticModule/Core/BinaryOperationBase.cs
+++ b/UniversalToolchain/ArithmeticModule/Core/BinaryOperationBase.cs
@@ -9,11 +9,17 @@ public abstract class BinaryOperationBase(string enumStr) : IAstNodeCreator
 
     public bool TryCreateNode(AstNode scope, int childIndex)
     {
+        if (childIndex <= 0 || childIndex >= scope.Children.Count - 1)
+            return false;
+
         var child = scope.Children[childIndex];
         if (child.NodeType != AstNodeType) return false;
 
-        child.Children.Add(scope.Children[childIndex - 1]);
-        child.Children.Add(scope.Children[childIndex + 1]);
+        var leftOperand = scope.Children[childIndex - 1];
+        var rightOperand = scope.Children[childIndex + 1];
+
+        child.Children.Add(leftOperand);
+        child.Children.Add(rightOperand);
         scope.Children.RemoveAt(childIndex + 1);
         scope.Children.RemoveAt(childIndex - 1);
 

--- a/UniversalToolchain/BasicCore/Compilation/CompilationInputNormalizer.cs
+++ b/UniversalToolchain/BasicCore/Compilation/CompilationInputNormalizer.cs
@@ -12,7 +12,7 @@ public sealed class CompilationInputNormalizer
             bindings.Add(new ExternalBinding
             {
                 Name = pair.Key,
-                Type = pair.Value.GetType(),
+                Type = pair.Value?.GetType() ?? typeof(object),
                 Value = pair.Value,
                 Kind = ExternalBindingKind.Variable
             });

--- a/UniversalToolchain/BasicCore/Compilation/ExternalBindingsFactory.cs
+++ b/UniversalToolchain/BasicCore/Compilation/ExternalBindingsFactory.cs
@@ -19,7 +19,7 @@ internal static class ExternalBindingsFactory
         return parameters.Select(x => new ExternalBinding
         {
             Name = x.Key,
-            Type = x.Value.GetType(),
+            Type = x.Value?.GetType() ?? typeof(object),
             Value = x.Value,
             Kind = ExternalBindingKind.Variable
         }).ToList();

--- a/UniversalToolchain/BasicCore/Core/BasicCoreImpl.cs
+++ b/UniversalToolchain/BasicCore/Core/BasicCoreImpl.cs
@@ -6,6 +6,8 @@ using BasicCore.ParserWrapper;
 using BasicCore.TranslatorWrapper;
 using ExceptionsManager;
 
+using System.Threading;
+
 namespace BasicCore.Core;
 
 public class BasicCoreImpl<TCompilationOutput>(
@@ -34,7 +36,7 @@ public class BasicCoreImpl<TCompilationOutput>(
             optimizers,
             middleEndModules);
 
-    private PreparedExecution<TCompilationOutput>? _prepared;
+    private readonly AsyncLocal<PreparedExecution<TCompilationOutput>?> _prepared = new();
 
     public void PrepareToRun(string code, OrderedDictionary<string, Type>? parameters = null)
     {
@@ -43,8 +45,9 @@ public class BasicCoreImpl<TCompilationOutput>(
 
     public object? RunPrepared()
     {
-        Thrower.AssertAlways(_prepared != null);
-        return _prepared.Executor.Execute(_prepared.CompilationOutput, _prepared.ExecutionEnvironment);
+        var prepared = _prepared.Value;
+        Thrower.AssertAlways(prepared != null);
+        return prepared.Executor.Execute(prepared.CompilationOutput, prepared.ExecutionEnvironment);
     }
 
     public object? Run(string code, Dictionary<string, object>? parameters = null)
@@ -57,11 +60,11 @@ public class BasicCoreImpl<TCompilationOutput>(
     public TCompilationOutput GetExecutable(string code, OrderedDictionary<string, Type>? parameters = null)
     {
         PrepareToRun(code, parameters);
-        return _prepared!.CompilationOutput;
+        return _prepared.Value!.CompilationOutput;
     }
 
     public void PrepareToRun(CompilationInput input)
     {
-        _prepared = _preparedExecutionBuilder.Build(input);
+        _prepared.Value = _preparedExecutionBuilder.Build(input);
     }
 }

--- a/UniversalToolchain/BasicInterpreter/InterpreterImpl.cs
+++ b/UniversalToolchain/BasicInterpreter/InterpreterImpl.cs
@@ -12,7 +12,7 @@ public class InterpreterImpl : IExecutor<IAbstractIR>
 {
     public object? Execute(IAbstractIR air, IExecutionEnvironment environment)
     {
-        var state = new InterpreterState();
+        var state = new InterpreterState { ExecutionEnvironment = environment };
         state.BuildLabelPositions(air.Instructions);
         return ExecuteInstructions(air.Instructions, state);
     }
@@ -97,6 +97,46 @@ public class InterpreterImpl : IExecutor<IAbstractIR>
             Thrower.InvalidOpEx($"Unsupported intrinsic call: {intrinsicName}.");
     }
 
+
+    private static bool IsVariablesContainerGet(MethodInfo method)
+    {
+        var declaringType = method.DeclaringType;
+        return declaringType != null
+               && declaringType.IsGenericType
+               && declaringType.GetGenericTypeDefinition().FullName == "SettableGettableModule.Core.VariablesContainer`1"
+               && method.Name == "Get"
+               && method.GetParameters().Length == 1
+               && method.GetParameters()[0].ParameterType == typeof(string);
+    }
+
+    private static object? ResolveVariableValue(string key, InterpreterState state)
+    {
+        if (state.ExternalSlotsByName.TryGetValue(key, out var existingSlot))
+            return state.ExecutionEnvironment?.GetExternalValue(existingSlot);
+
+        if (state.LocalVariables.Contains(key))
+            return null;
+
+        if (state.ExecutionEnvironment == null)
+            return null;
+
+        var slot = state.ExternalSlotsByName.Count;
+        try
+        {
+            var value = state.ExecutionEnvironment.GetExternalValue(slot);
+            state.ExternalSlotsByName[key] = slot;
+            return value;
+        }
+        catch (IndexOutOfRangeException)
+        {
+            return null;
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+            return null;
+        }
+    }
+
     private void ExecuteCSharpCall(Instruction instruction, InterpreterState state)
     {
         var method = instruction.Operands[1].Get<MethodInfo>();
@@ -114,11 +154,24 @@ public class InterpreterImpl : IExecutor<IAbstractIR>
 
             var value = state.ValueStack.Pop();
             args[i] = value;
-            argsTypes[i] = value.GetType();
+            argsTypes[i] = value?.GetType() ?? typeof(object);
         }
 
-        // Используем ту же логику, что и в компиляторе
-        var stackTypes = argsTypes.AsReadOnly().ToList(); // Восстанавливаем порядок как в стеках компилятора
+        if (IsVariablesContainerGet(method) && args[0] is string key)
+        {
+            var value = ResolveVariableValue(key, state);
+            if (value != null || state.ExternalSlotsByName.ContainsKey(key))
+            {
+                state.ValueStack.Push(value!);
+                return;
+            }
+        }
+
+        if (method.Name == "Set" && method.GetParameters().Length == 2 && args[0] is string localVariable)
+            state.LocalVariables.Add(localVariable);
+
+        // Use the same logic as in compiler
+        var stackTypes = argsTypes.AsReadOnly().ToList();
         var targetTypes = GenericTypeResolver.GetParameterTypes(method, stackTypes).ToList();
 
         // Приводим аргументы к нужным типам, если необходимо

--- a/UniversalToolchain/BasicInterpreter/InterpreterState.cs
+++ b/UniversalToolchain/BasicInterpreter/InterpreterState.cs
@@ -1,3 +1,4 @@
+using BasicCore.Execution;
 using ExceptionsManager;
 using IntermediateRepresentationAbstractions;
 using ObjectExtensions;
@@ -9,8 +10,11 @@ public class InterpreterState
     private readonly Dictionary<Guid, int> _labelPositions = new();
     private bool _labelsBuilt;
     public Stack<object> ValueStack { get; } = new();
+    public Dictionary<string, int> ExternalSlotsByName { get; } = new();
+    public HashSet<string> LocalVariables { get; } = [];
 
     public int InstructionPointer { get; set; }
+    public IExecutionEnvironment? ExecutionEnvironment { get; set; }
 
     public void BuildLabelPositions(IReadOnlyList<Instruction> instructions)
     {

--- a/UniversalToolchain/CSharpInteropModule/Creators/CSharpFunctionCallsNodeCreator.cs
+++ b/UniversalToolchain/CSharpInteropModule/Creators/CSharpFunctionCallsNodeCreator.cs
@@ -10,11 +10,17 @@ public class CSharpFunctionCallsNodeCreator : IAstNodeCreator
 
     public bool TryCreateNode(AstNode scope, int childIndex)
     {
+        if (childIndex < 0 || childIndex >= scope.Children.Count)
+            return false;
+
         var child = scope.Children[childIndex];
         if (child.NodeType != ExtensibleEnum<AstNodeTag>.CreateOrGet("Identifier"))
             return false;
 
         if (!MethodsFinder.ContainsAnyMethod(child.Text)) return false;
+
+        if (childIndex + 1 >= scope.Children.Count)
+            return false;
 
         child.NodeType = AstNodeType;
 

--- a/UniversalToolchain/ConditionsModule/Creators/BooleanNodeCreator.cs
+++ b/UniversalToolchain/ConditionsModule/Creators/BooleanNodeCreator.cs
@@ -24,27 +24,30 @@ public class BooleanNodeCreator(string nodeType, BooleanNodeCreator.BooleanState
 
         var node = scope[childIndex];
 
-        if (type == BooleanStatementType.UnaryOperation && scope.SafeGet(childIndex + 1) != null)
+        if (type == BooleanStatementType.UnaryOperation)
         {
-            // Unary NOT operation
-            node.Children.Add(scope[childIndex + 1]);
-            scope.Children.RemoveAt(childIndex + 1);
-        }
-        else if (type == BooleanStatementType.BinaryOperation)
-        {
-            // Binary operations
-            if (scope.SafeGet(childIndex - 1) != null)
-            {
-                node.Children.Add(scope[childIndex - 1]);
-                scope.Children.RemoveAt(childIndex - 1);
-                childIndex--;
-            }
+            var operand = scope.SafeGet(childIndex + 1);
+            if (operand == null)
+                return false;
 
-            if (scope.SafeGet(childIndex + 1) != null)
-            {
-                node.Children.Add(scope[childIndex + 1]);
-                scope.Children.RemoveAt(childIndex + 1);
-            }
+            // Unary NOT operation
+            node.Children.Add(operand);
+            scope.Children.RemoveAt(childIndex + 1);
+            return true;
+        }
+
+        if (type == BooleanStatementType.BinaryOperation)
+        {
+            var leftOperand = scope.SafeGet(childIndex - 1);
+            var rightOperand = scope.SafeGet(childIndex + 1);
+            if (leftOperand == null || rightOperand == null)
+                return false;
+
+            node.Children.Add(leftOperand);
+            node.Children.Add(rightOperand);
+            scope.Children.RemoveAt(childIndex + 1);
+            scope.Children.RemoveAt(childIndex - 1);
+            return true;
         }
 
         return true;

--- a/UniversalToolchain/ConditionsModule/Creators/ComparisonNodeCreator.cs
+++ b/UniversalToolchain/ConditionsModule/Creators/ComparisonNodeCreator.cs
@@ -12,22 +12,19 @@ public class ComparisonNodeCreator(string nodeType) : IAstNodeCreator
         if (scope.SafeGet(childIndex)?.NodeType != AstNodeType)
             return false;
 
+        if (childIndex <= 0 || childIndex >= scope.Children.Count - 1)
+            return false;
+
         var opNode = scope[childIndex];
+        var leftOperand = scope.SafeGet(childIndex - 1);
+        var rightOperand = scope.SafeGet(childIndex + 1);
+        if (leftOperand == null || rightOperand == null)
+            return false;
 
-        // Left operand
-        if (scope.SafeGet(childIndex - 1) != null)
-        {
-            opNode.Children.Add(scope[childIndex - 1]);
-            scope.Children.RemoveAt(childIndex - 1);
-            childIndex--; // Index changed after removal
-        }
-
-        // Right operand
-        if (scope.SafeGet(childIndex + 1) != null)
-        {
-            opNode.Children.Add(scope[childIndex + 1]);
-            scope.Children.RemoveAt(childIndex + 1);
-        }
+        opNode.Children.Add(leftOperand);
+        opNode.Children.Add(rightOperand);
+        scope.Children.RemoveAt(childIndex + 1);
+        scope.Children.RemoveAt(childIndex - 1);
 
         opNode.NodeType = AstNodeType;
         return true;

--- a/UniversalToolchain/Tests/Infrastructure/ParameterHandlingDeepTests.cs
+++ b/UniversalToolchain/Tests/Infrastructure/ParameterHandlingDeepTests.cs
@@ -209,15 +209,17 @@ public class RuntimeParameterHandlingTests
     }
 
     [Test]
-    public void Run_WithNullRuntimeValue_ThrowsNullReferenceException()
+    public void Run_WithNullRuntimeValue_DoesNotThrowAndReturnsNull()
     {
         using var provider = ParameterTestHost.CreateProvider() as ServiceProvider;
         var core = ParameterTestHost.CreateDynamicCore(provider!);
 
-        Assert.Throws<NullReferenceException>(() => core.Run(ParameterTestHost.ProgramFor("a"), new Dictionary<string, object>
+        var result = core.Run(ParameterTestHost.ProgramFor("a"), new Dictionary<string, object>
         {
             ["a"] = null!
-        }));
+        });
+
+        Assert.That(result, Is.Null);
     }
 }
 


### PR DESCRIPTION
### Motivation
- Prevent IndexOutOfRange/ArgumentOutOfRange exceptions and partial AST mutations when creators are given malformed scopes by making creators validate boundaries before mutating the scope. 
- Ensure runtime external parameters that are `null` do not throw `NullReferenceException` during normalization/creation of external bindings and preserve a sensible type fallback. 
- Make interpreted execution honor the provided `IExecutionEnvironment` so runtime externals resolve the same way for interpreter and compiled paths. 
- Avoid prepared-state mixing between concurrent callers of `BasicCoreImpl` by separating per-execution prepared state.

### Description
- Added boundary guards and safe operand access in binary/comparison/boolean AST creators to return `false` for malformed nodes without performing partial mutations (`ArithmeticModule/Core/BinaryOperationBase.cs`, `ConditionsModule/Creators/BooleanNodeCreator.cs`, `ConditionsModule/Creators/ComparisonNodeCreator.cs`).
- Hardened `CSharpFunctionCallsNodeCreator` to validate `childIndex` and require a right-side argument node before mutating (`CSharpInteropModule/Creators/CSharpFunctionCallsNodeCreator.cs`).
- Made runtime normalization tolerate `null` values by using `pair.Value?.GetType() ?? typeof(object)` and applied the same fallback in the runtime-to-binding factory (`BasicCore/Compilation/CompilationInputNormalizer.cs`, `BasicCore/Compilation/ExternalBindingsFactory.cs`).
- Isolated `_prepared` state in `BasicCoreImpl` by storing the prepared execution in an `AsyncLocal<PreparedExecution<T>>` so concurrent `PrepareToRun`/`RunPrepared` flows do not overwrite each other (`BasicCore/Core/BasicCoreImpl.cs`).
- Updated the interpreter to carry the provided `IExecutionEnvironment` in `InterpreterState` and resolve external values for `VariablesContainer<T>.Get(string)` calls during interpreted C# invocations, plus safer null/type handling for stack values (`BasicInterpreter/InterpreterState.cs`, `BasicInterpreter/InterpreterImpl.cs`).
- Adjusted one infrastructure test to reflect the corrected contract for null runtime externals (test now expects `null` result instead of a `NullReferenceException`) (`Tests/Infrastructure/ParameterHandlingDeepTests.cs`).

### Testing
- Installed .NET SDK `10.0.103` per `global.json` and ran the focused test set with `dotnet test UniversalToolchain/Tests/Tests.csproj --filter "FullyQualifiedName~Tests.Core.AstNodeCreatorBoundaryTests|FullyQualifiedName~Tests.Core.BasicCoreConcurrencyTests|FullyQualifiedName~Tests.Core.CompilationInputNullRuntimeBugTests|FullyQualifiedName~Tests.Core.InterpreterEnvironmentBugTests"` which passed (9/9).
- Ran the full solution tests with `dotnet test UniversalToolchain/Wist.sln --nologo` and observed all tests pass (`Passed: 582, Failed: 0`).
- The modified tests reflect the corrected system contract for `null` runtime externals rather than preserving legacy buggy behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af222c4100832497378f00e680cbe3)