### PR TITLE
Introduce CommonExceptions module and switch toolchain to WistException-based error handling

### DIFF
--- a/UniversalToolchain/BasicInterpreter/BasicInterpreter.csproj
+++ b/UniversalToolchain/BasicInterpreter/BasicInterpreter.csproj
@@ -8,9 +8,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\BasicCodeTranslator\BasicCodeTranslator.csproj"/>
-        <ProjectReference Include="..\BytecodeDynamicMethodsCompiler\BytecodeDynamicMethodsCompiler.csproj"/>
-        <ProjectReference Include="..\UniversalIntermediateRepresentation\UniversalIntermediateRepresentation.csproj"/>
+        <ProjectReference Include="..\BasicCodeTranslator\BasicCodeTranslator.csproj" />
+        <ProjectReference Include="..\BytecodeDynamicMethodsCompiler\BytecodeDynamicMethodsCompiler.csproj" />
+        <ProjectReference Include="..\UniversalIntermediateRepresentation\UniversalIntermediateRepresentation.csproj" />
+        <ProjectReference Include="..\CommonExceptions\CommonExceptions.csproj" />
     </ItemGroup>
 
 </Project>

--- a/UniversalToolchain/BasicInterpreter/GlobalUsings.cs
+++ b/UniversalToolchain/BasicInterpreter/GlobalUsings.cs
@@ -1,3 +1,4 @@
+global using CommonExceptions;
 global using System.Reflection;
 global using BasicCore.Execution;
 global using BasicCore.ExecutorWrapper;

--- a/UniversalToolchain/BasicInterpreter/InterpreterImpl.cs
+++ b/UniversalToolchain/BasicInterpreter/InterpreterImpl.cs
@@ -16,8 +16,19 @@ public class InterpreterImpl : IExecutor<IAbstractIR>
         while (state.InstructionPointer < instructions.Count)
         {
             var instruction = instructions[state.InstructionPointer];
+            var programCounter = state.InstructionPointer;
             state.InstructionPointer++;
-            ExecuteInstruction(instruction, state);
+            try
+            {
+                ExecuteInstruction(instruction, state);
+            }
+            catch (Exception ex) when (ex is not RuntimeExecutionException)
+            {
+                WistThrower.Runtime(
+                    $"Error executing instruction '{instruction.UOpCode}' at pc={programCounter}, stack={state.ValueStack.Count}. {ex.Message}",
+                    ex
+                );
+            }
         }
 
         if (state.ValueStack.Count == 0) return null!;
@@ -73,7 +84,7 @@ public class InterpreterImpl : IExecutor<IAbstractIR>
                 ExecuteIntrinsic(instruction, state);
                 break;
             default:
-                Thrower.InvalidOpEx($"Unsupported opcode encountered: {instruction.UOpCode}.");
+                CompilerAssert.Unreachable($"Unknown instruction '{instruction.UOpCode}'.");
                 break;
         }
     }
@@ -86,7 +97,7 @@ public class InterpreterImpl : IExecutor<IAbstractIR>
         else if (intrinsicName == "call C# ctor")
             ExecuteCSharpConstructor(instruction, state);
         else
-            Thrower.InvalidOpEx($"Unsupported intrinsic call: {intrinsicName}.");
+            Thrower.InvalidOpEx($"Unknown intrinsic call: {intrinsicName}.");
     }
 
 

--- a/UniversalToolchain/BasicLexer/BasicLexer.csproj
+++ b/UniversalToolchain/BasicLexer/BasicLexer.csproj
@@ -8,10 +8,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\BasicCore\BasicCore.csproj"/>
-        <ProjectReference Include="..\BasicTypesExtensions\BasicTypesExtensions.csproj"/>
-        <ProjectReference Include="..\ExceptionsManager\ExceptionsManager.csproj"/>
-        <ProjectReference Include="..\ListExtensions\ListExtensions.csproj"/>
+        <ProjectReference Include="..\BasicCore\BasicCore.csproj" />
+        <ProjectReference Include="..\BasicTypesExtensions\BasicTypesExtensions.csproj" />
+        <ProjectReference Include="..\ExceptionsManager\ExceptionsManager.csproj" />
+        <ProjectReference Include="..\ListExtensions\ListExtensions.csproj" />
+        <ProjectReference Include="..\CommonExceptions\CommonExceptions.csproj" />
     </ItemGroup>
 
 </Project>

--- a/UniversalToolchain/BasicLexer/Core/BasicLexerImpl.cs
+++ b/UniversalToolchain/BasicLexer/Core/BasicLexerImpl.cs
@@ -53,6 +53,14 @@ public class BasicLexerImpl(LexerConfiguration configuration) : ILexer
                 $"Unknown substr '{Regex.Escape(code[index..(lexeme?.StartIndex ?? code.Length)])}'"
             );
 
+            if (index != lexeme?.StartIndex)
+            {
+                WistThrower.Lexer(
+                    $"Invalid token '{code[index..(lexeme?.StartIndex ?? code.Length)]}'.",
+                    new SourceLocation { Line = lexeme?.LineNumber ?? -1, Column = lexeme?.CharNumber ?? -1 }
+                );
+            }
+
             Thrower.AssertAlways(lexeme != null, "Internal lexer invariant violated: expected lexeme at current index.");
 
             // Update the current processing position to just past the matched token.

--- a/UniversalToolchain/BasicLexer/Core/BasicLexerImpl.cs
+++ b/UniversalToolchain/BasicLexer/Core/BasicLexerImpl.cs
@@ -46,18 +46,13 @@ public class BasicLexerImpl(LexerConfiguration configuration) : ILexer
             // ReSharper disable once AccessToModifiedClosure
             (var lexeme, prevFoundIndex) = allMatches.FirstStarts(x => x.StartIndex >= index, prevFoundIndex);
 
-            // Handle unrecognized text.
-            Thrower.AssertAlways(
-                index == lexeme?.StartIndex,
-                // ReSharper disable once ConditionalAccessQualifierIsNonNullableAccordingToAPIContract
-                $"Unknown substr '{Regex.Escape(code[index..(lexeme?.StartIndex ?? code.Length)])}'"
-            );
-
             if (index != lexeme?.StartIndex)
             {
+                var invalidSegment = code[index..(lexeme?.StartIndex ?? code.Length)];
+                var invalidLexeme = new LexemeValue(invalidSegment, null, index, code);
                 WistThrower.Lexer(
-                    $"Invalid token '{code[index..(lexeme?.StartIndex ?? code.Length)]}'.",
-                    new SourceLocation { Line = lexeme?.LineNumber ?? -1, Column = lexeme?.CharNumber ?? -1 }
+                    $"Invalid token '{invalidSegment}'.",
+                    new SourceLocation { Line = invalidLexeme.LineNumber, Column = invalidLexeme.CharNumber }
                 );
             }
 

--- a/UniversalToolchain/BasicLexer/GlobalUsings.cs
+++ b/UniversalToolchain/BasicLexer/GlobalUsings.cs
@@ -1,3 +1,4 @@
+global using CommonExceptions;
 global using System.Text.RegularExpressions;
 global using BasicCore.LexerWrapper;
 global using ExceptionsManager;

--- a/UniversalToolchain/BasicParser/BasicParser.csproj
+++ b/UniversalToolchain/BasicParser/BasicParser.csproj
@@ -8,7 +8,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\BasicLexer\BasicLexer.csproj"/>
+        <ProjectReference Include="..\BasicLexer\BasicLexer.csproj" />
+        <ProjectReference Include="..\CommonExceptions\CommonExceptions.csproj" />
     </ItemGroup>
 
 </Project>

--- a/UniversalToolchain/BasicParser/GlobalUsings.cs
+++ b/UniversalToolchain/BasicParser/GlobalUsings.cs
@@ -1,3 +1,4 @@
+global using CommonExceptions;
 global using AstNodeType = BasicTypesExtensions.ExtensibleEnum<BasicCore.ParserWrapper.AstNodeTag>;
 global using BasicCore.LexerWrapper;
 global using BasicCore.ParserWrapper;

--- a/UniversalToolchain/CSharpInteropModule/CSharpInteropModule.csproj
+++ b/UniversalToolchain/CSharpInteropModule/CSharpInteropModule.csproj
@@ -8,10 +8,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\AbstractIrExtensions\AbstractIrExtensions.csproj"/>
-        <ProjectReference Include="..\AssemblyFinder\AssemblyFinder.csproj"/>
-        <ProjectReference Include="..\BasicCore\BasicCore.csproj"/>
-        <ProjectReference Include="..\UniversalIntermediateRepresentation\UniversalIntermediateRepresentation.csproj"/>
+        <ProjectReference Include="..\AbstractIrExtensions\AbstractIrExtensions.csproj" />
+        <ProjectReference Include="..\AssemblyFinder\AssemblyFinder.csproj" />
+        <ProjectReference Include="..\BasicCore\BasicCore.csproj" />
+        <ProjectReference Include="..\UniversalIntermediateRepresentation\UniversalIntermediateRepresentation.csproj" />
+        <ProjectReference Include="..\CommonExceptions\CommonExceptions.csproj" />
     </ItemGroup>
 
 </Project>

--- a/UniversalToolchain/CSharpInteropModule/GlobalUsings.cs
+++ b/UniversalToolchain/CSharpInteropModule/GlobalUsings.cs
@@ -1,3 +1,4 @@
+global using CommonExceptions;
 global using AbstractIrExtensions;
 global using AssemblyFinder;
 global using BasicCore.Attributes;

--- a/UniversalToolchain/CSharpInteropModule/Visitors/CSharpFunctionCallsAstVisitor.cs
+++ b/UniversalToolchain/CSharpInteropModule/Visitors/CSharpFunctionCallsAstVisitor.cs
@@ -30,6 +30,9 @@ public class CSharpFunctionCallsAstVisitor : IAstVisitor
                                  ?? MethodsFinder.GetMethod(fullName, argCount)
                                  ?? MethodsFinder.GetMethod(fullName);
 
+                if (methodInfo == null)
+                    WistThrower.Import($"Method '{fullName}({argCount} args)' not found in imported assemblies.");
+
                 il.CallCSharp(methodInfo.NotNull());
             }
         );

--- a/UniversalToolchain/CommonExceptions/CommonExceptions.csproj
+++ b/UniversalToolchain/CommonExceptions/CommonExceptions.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>14</LangVersion>
+  </PropertyGroup>
+
+</Project>

--- a/UniversalToolchain/CommonExceptions/CompilerAssert.cs
+++ b/UniversalToolchain/CommonExceptions/CompilerAssert.cs
@@ -1,0 +1,9 @@
+namespace CommonExceptions;
+
+public static class CompilerAssert
+{
+    public static void Unreachable(string message)
+    {
+        WistThrower.InternalCompiler($"Unreachable code reached: {message}");
+    }
+}

--- a/UniversalToolchain/CommonExceptions/SourceLocation.cs
+++ b/UniversalToolchain/CommonExceptions/SourceLocation.cs
@@ -1,0 +1,8 @@
+namespace CommonExceptions;
+
+public struct SourceLocation
+{
+    public string? File;
+    public int Line;
+    public int Column;
+}

--- a/UniversalToolchain/CommonExceptions/StageExceptions.cs
+++ b/UniversalToolchain/CommonExceptions/StageExceptions.cs
@@ -1,0 +1,99 @@
+namespace CommonExceptions;
+
+public sealed class LexerException : WistException
+{
+    public LexerException(string message, SourceLocation location) : base(message)
+    {
+        Stage = "Lexer";
+        Location = location;
+    }
+
+    public LexerException(string message, Exception inner) : base(message, inner)
+    {
+        Stage = "Lexer";
+    }
+}
+
+public sealed class ParserException : WistException
+{
+    public ParserException(string message) : base(message)
+    {
+        Stage = "Parser";
+    }
+
+    public ParserException(string message, SourceLocation location) : base(message)
+    {
+        Stage = "Parser";
+        Location = location;
+    }
+
+    public ParserException(string message, Exception inner) : base(message, inner)
+    {
+        Stage = "Parser";
+    }
+}
+
+public sealed class BytecodeGenerationException : WistException
+{
+    public BytecodeGenerationException(string message) : base(message)
+    {
+        Stage = "Bytecode";
+    }
+
+    public BytecodeGenerationException(string message, Exception inner) : base(message, inner)
+    {
+        Stage = "Bytecode";
+    }
+}
+
+public sealed class RuntimeExecutionException : WistException
+{
+    public RuntimeExecutionException(string message) : base(message)
+    {
+        Stage = "Runtime";
+    }
+
+    public RuntimeExecutionException(string message, Exception inner) : base(message, inner)
+    {
+        Stage = "Runtime";
+    }
+}
+
+public sealed class TypeSystemException : WistException
+{
+    public TypeSystemException(string message) : base(message)
+    {
+        Stage = "TypeSystem";
+    }
+
+    public TypeSystemException(string message, Exception inner) : base(message, inner)
+    {
+        Stage = "TypeSystem";
+    }
+}
+
+public sealed class ImportException : WistException
+{
+    public ImportException(string message) : base(message)
+    {
+        Stage = "Import";
+    }
+
+    public ImportException(string message, Exception inner) : base(message, inner)
+    {
+        Stage = "Import";
+    }
+}
+
+public sealed class InternalCompilerException : WistException
+{
+    public InternalCompilerException(string message) : base(message)
+    {
+        Stage = "InternalCompiler";
+    }
+
+    public InternalCompilerException(string message, Exception inner) : base(message, inner)
+    {
+        Stage = "InternalCompiler";
+    }
+}

--- a/UniversalToolchain/CommonExceptions/WistException.cs
+++ b/UniversalToolchain/CommonExceptions/WistException.cs
@@ -1,0 +1,30 @@
+namespace CommonExceptions;
+
+public class WistException : Exception
+{
+    public string? Stage { get; protected set; }
+    public SourceLocation? Location { get; protected set; }
+
+    public WistException(string message) : base(message)
+    {
+    }
+
+    public WistException(string message, Exception inner) : base(message, inner)
+    {
+    }
+
+    public override string ToString()
+    {
+        var stagePart = string.IsNullOrWhiteSpace(Stage) ? string.Empty : $"[{Stage}] ";
+        var locationPart = string.Empty;
+
+        if (Location is { } location)
+        {
+            locationPart = $" at line {location.Line} column {location.Column}";
+            if (!string.IsNullOrWhiteSpace(location.File))
+                locationPart += $" in {location.File}";
+        }
+
+        return $"{stagePart}{Message}{locationPart}";
+    }
+}

--- a/UniversalToolchain/CommonExceptions/WistThrower.cs
+++ b/UniversalToolchain/CommonExceptions/WistThrower.cs
@@ -1,0 +1,34 @@
+namespace CommonExceptions;
+
+public static class WistThrower
+{
+    public static void Lexer(string message, SourceLocation location)
+    {
+        throw new LexerException(message, location);
+    }
+
+    public static void Parser(string message)
+    {
+        throw new ParserException(message);
+    }
+
+    public static void Parser(string message, SourceLocation location)
+    {
+        throw new ParserException(message, location);
+    }
+
+    public static void Import(string message)
+    {
+        throw new ImportException(message);
+    }
+
+    public static void Runtime(string message, Exception inner)
+    {
+        throw new RuntimeExecutionException(message, inner);
+    }
+
+    public static void InternalCompiler(string message)
+    {
+        throw new InternalCompilerException(message);
+    }
+}

--- a/UniversalToolchain/ScopesModule/Core/ScopesCreator.cs
+++ b/UniversalToolchain/ScopesModule/Core/ScopesCreator.cs
@@ -26,7 +26,13 @@ public class ScopesCreator : IAstNodeCreator
             else if (child.NodeType == AstNodeType.CreateOrGet("ClosePar")) opensCount--;
 
             if (opensCount < 0)
-                Thrower.InvalidOpEx("Scope parsing failed: found closing bracket without a matching opening bracket.");
+            {
+                var lexeme = child.LexemeValue;
+                WistThrower.Parser(
+                    "Unexpected token '}'. Expected: identifier or '('.",
+                    new SourceLocation { Line = lexeme?.LineNumber ?? -1, Column = lexeme?.CharNumber ?? -1 }
+                );
+            }
 
             if (opensCount == 1 && start == -1)
                 start = i;
@@ -49,7 +55,7 @@ public class ScopesCreator : IAstNodeCreator
         }
 
         if (opensCount != 0)
-            Thrower.InvalidOpEx("Scope parsing failed: at least one opening bracket was not closed.");
+            WistThrower.Parser("Unexpected end of input. Expected: ')' to close scope.");
 
         return done;
     }

--- a/UniversalToolchain/ScopesModule/GlobalUsings.cs
+++ b/UniversalToolchain/ScopesModule/GlobalUsings.cs
@@ -1,3 +1,4 @@
+global using CommonExceptions;
 global using AstNodeType = BasicTypesExtensions.ExtensibleEnum<BasicCore.ParserWrapper.AstNodeTag>;
 global using BasicCore.Attributes;
 global using BasicCore.Contracts;

--- a/UniversalToolchain/ScopesModule/ScopesModule.csproj
+++ b/UniversalToolchain/ScopesModule/ScopesModule.csproj
@@ -8,7 +8,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\BasicCore\BasicCore.csproj"/>
+        <ProjectReference Include="..\BasicCore\BasicCore.csproj" />
+        <ProjectReference Include="..\CommonExceptions\CommonExceptions.csproj" />
     </ItemGroup>
 
 </Project>

--- a/UniversalToolchain/Tests/Core/BasicLexerImplTests.cs
+++ b/UniversalToolchain/Tests/Core/BasicLexerImplTests.cs
@@ -72,4 +72,21 @@ public class BasicLexerImplTests
         Assert.That(result, Has.Count.EqualTo(4));
         Assert.That(result.All(x => x.Text != " "), Is.True);
     }
+
+
+
+    [Test]
+    public void Lexemize_WithUnknownToken_ThrowsLexerException()
+    {
+        var lexer = new BasicLexerImpl();
+        lexer.Configuration.AddPattern(
+            new LexemePattern("[a-zA-Z_][a-zA-Z0-9_]*", ExtensibleEnum<LexemeTag>.CreateOrGet("Identifier")),
+            priority: 100
+        );
+
+        var exception = Assert.Throws<LexerException>(() => lexer.Lexemize("ok @ bad"));
+
+        Assert.That(exception, Is.Not.Null);
+        Assert.That(exception!.Message, Does.Contain("Invalid token"));
+    }
 }

--- a/UniversalToolchain/Tests/GlobalUsings.cs
+++ b/UniversalToolchain/Tests/GlobalUsings.cs
@@ -1,3 +1,4 @@
+global using CommonExceptions;
 global using System.Collections.Concurrent;
 global using System.Diagnostics;
 global using System.Reflection;

--- a/UniversalToolchain/Tests/Infrastructure/CompilerAndInterpreterResilienceTests.cs
+++ b/UniversalToolchain/Tests/Infrastructure/CompilerAndInterpreterResilienceTests.cs
@@ -87,7 +87,7 @@ public class CompilerAndInterpreterResilienceTests
 
         var ir = BuildIr(new Instruction(UOpCode.Intrinsic, ["call C#", toString!]));
 
-        var exception = Assert.Throws<InvalidOperationException>(() => ExecuteInInterpreter(ir));
+        var exception = Assert.Throws<RuntimeExecutionException>(() => ExecuteInInterpreter(ir));
 
         Assert.That(exception!.Message, Does.Contain("instance is missing"));
     }
@@ -103,7 +103,7 @@ public class CompilerAndInterpreterResilienceTests
             new Instruction(UOpCode.Intrinsic, ["call C#", compareMethod!])
         );
 
-        var exception = Assert.Throws<InvalidOperationException>(() => ExecuteInInterpreter(ir));
+        var exception = Assert.Throws<RuntimeExecutionException>(() => ExecuteInInterpreter(ir));
 
         Assert.That(exception!.Message, Does.Contain("not enough arguments"));
     }
@@ -113,7 +113,7 @@ public class CompilerAndInterpreterResilienceTests
     {
         var ir = BuildIr(new Instruction(UOpCode.Intrinsic, ["unknown intrinsic"]));
 
-        var exception = Assert.Throws<InvalidOperationException>(() => ExecuteInInterpreter(ir));
+        var exception = Assert.Throws<RuntimeExecutionException>(() => ExecuteInInterpreter(ir));
 
         Assert.That(exception!.Message, Does.Contain("unknown intrinsic"));
     }

--- a/UniversalToolchain/Tests/Infrastructure/OptimizerRegressionTests.cs
+++ b/UniversalToolchain/Tests/Infrastructure/OptimizerRegressionTests.cs
@@ -177,8 +177,8 @@ public class OptimizerRegressionTests
             [new AstNode(ExtensibleEnum<AstNodeTag>.CreateOrGet("OpenPar"), null, [])]
         );
 
-        var exception = Assert.Throws<InvalidOperationException>(() => creator.TryCreateNode(root, 0));
-        Assert.That(exception!.Message, Does.Contain("opening bracket was not closed"));
+        var exception = Assert.Throws<ParserException>(() => creator.TryCreateNode(root, 0));
+        Assert.That(exception!.Message, Does.Contain("Expected: ')' to close scope"));
     }
 
     [Test]

--- a/UniversalToolchain/Tests/Infrastructure/WistProgramGenerationSharpFuzzTests.cs
+++ b/UniversalToolchain/Tests/Infrastructure/WistProgramGenerationSharpFuzzTests.cs
@@ -83,6 +83,7 @@ public class WistProgramGenerationSharpFuzzTests : TestBase
     private static bool IsExpectedFuzzException(Exception exception)
     {
         if (exception is InvalidOperationException
+            or WistException
             or ArgumentException
             or FormatException
             or OverflowException

--- a/UniversalToolchain/Wist.sln
+++ b/UniversalToolchain/Wist.sln
@@ -118,6 +118,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LoopsModule", "LoopsModule\
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NCalcWist.Benchmarks", "NCalcWist.Benchmarks\NCalcWist.Benchmarks.csproj", "{DEB43C4A-DC98-416F-9C20-D5D929966569}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CommonExceptions", "CommonExceptions\CommonExceptions.csproj", "{F2B1602E-B88C-4F25-828A-75A0AD428064}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -728,6 +730,18 @@ Global
 		{DEB43C4A-DC98-416F-9C20-D5D929966569}.Release|x64.Build.0 = Release|Any CPU
 		{DEB43C4A-DC98-416F-9C20-D5D929966569}.Release|x86.ActiveCfg = Release|Any CPU
 		{DEB43C4A-DC98-416F-9C20-D5D929966569}.Release|x86.Build.0 = Release|Any CPU
+		{F2B1602E-B88C-4F25-828A-75A0AD428064}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F2B1602E-B88C-4F25-828A-75A0AD428064}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F2B1602E-B88C-4F25-828A-75A0AD428064}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F2B1602E-B88C-4F25-828A-75A0AD428064}.Debug|x64.Build.0 = Debug|Any CPU
+		{F2B1602E-B88C-4F25-828A-75A0AD428064}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F2B1602E-B88C-4F25-828A-75A0AD428064}.Debug|x86.Build.0 = Debug|Any CPU
+		{F2B1602E-B88C-4F25-828A-75A0AD428064}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F2B1602E-B88C-4F25-828A-75A0AD428064}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F2B1602E-B88C-4F25-828A-75A0AD428064}.Release|x64.ActiveCfg = Release|Any CPU
+		{F2B1602E-B88C-4F25-828A-75A0AD428064}.Release|x64.Build.0 = Release|Any CPU
+		{F2B1602E-B88C-4F25-828A-75A0AD428064}.Release|x86.ActiveCfg = Release|Any CPU
+		{F2B1602E-B88C-4F25-828A-75A0AD428064}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/UniversalToolchain/Wistc/GlobalUsings.cs
+++ b/UniversalToolchain/Wistc/GlobalUsings.cs
@@ -1,3 +1,4 @@
+global using CommonExceptions;
 global using System.Diagnostics;
 global using System.Reflection;
 global using System.Reflection.Emit;

--- a/UniversalToolchain/Wistc/Program.cs
+++ b/UniversalToolchain/Wistc/Program.cs
@@ -32,6 +32,13 @@ int RunCommand(RunOptions options)
 
         return 0;
     }
+    catch (WistException ex)
+    {
+        Console.Error.WriteLine(ex.ToString());
+        if (Debugger.IsAttached)
+            Console.Error.WriteLine(ex.StackTrace);
+        return 1;
+    }
     catch (Exception ex)
     {
         Console.Error.WriteLine($"Error: {ex.Message}");
@@ -53,6 +60,11 @@ int ReplCommand(ReplOptions options)
 
         var repl = new Repl(core, options.HistoryFile);
         return repl.Run();
+    }
+    catch (WistException ex)
+    {
+        Console.Error.WriteLine(ex.ToString());
+        return 1;
     }
     catch (Exception ex)
     {

--- a/UniversalToolchain/Wistc/Wistc.csproj
+++ b/UniversalToolchain/Wistc/Wistc.csproj
@@ -9,36 +9,37 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\ArithmeticModule\ArithmeticModule.csproj"/>
-        <ProjectReference Include="..\BasicCodeTranslator\BasicCodeTranslator.csproj"/>
-        <ProjectReference Include="..\BasicCore\BasicCore.csproj"/>
-        <ProjectReference Include="..\BasicInterpreter\BasicInterpreter.csproj"/>
-        <ProjectReference Include="..\BasicStdLib\BasicStdLib.csproj"/>
-        <ProjectReference Include="..\BytecodeDynamicMethodsCompiler\BytecodeDynamicMethodsCompiler.csproj"/>
-        <ProjectReference Include="..\AbstractIrConverters\AbstractIrConverters.csproj"/>
-        <ProjectReference Include="..\ConditionsModule\ConditionsModule.csproj"/>
-        <ProjectReference Include="..\CSharpInteropModule\CSharpInteropModule.csproj"/>
-        <ProjectReference Include="..\DependencyInjection\DependencyInjection.csproj"/>
-        <ProjectReference Include="..\ExecutorLoggerModule\ExecutorLoggerModule.csproj"/>
-        <ProjectReference Include="..\IdentifierModule\IdentifierModule.csproj"/>
-        <ProjectReference Include="..\LabelsModule\LabelsModule.csproj"/>
-        <ProjectReference Include="..\LoopsModule\LoopsModule.csproj"/>
-        <ProjectReference Include="..\NativeMathModule\NativeMathModule.csproj"/>
-        <ProjectReference Include="..\NumbersModule\NumbersModule.csproj"/>
-        <ProjectReference Include="..\ParserConfigurationModule\ParserConfigurationModule.csproj"/>
-        <ProjectReference Include="..\ScopesModule\ScopesModule.csproj"/>
-        <ProjectReference Include="..\SemicolonAsNewLineModule\SemicolonAsNewLineModule.csproj"/>
-        <ProjectReference Include="..\VariablesModule\VariablesModule.csproj"/>
-        <ProjectReference Include="..\WhitespacesModule\WhitespacesModule.csproj"/>
+        <ProjectReference Include="..\ArithmeticModule\ArithmeticModule.csproj" />
+        <ProjectReference Include="..\BasicCodeTranslator\BasicCodeTranslator.csproj" />
+        <ProjectReference Include="..\BasicCore\BasicCore.csproj" />
+        <ProjectReference Include="..\BasicInterpreter\BasicInterpreter.csproj" />
+        <ProjectReference Include="..\BasicStdLib\BasicStdLib.csproj" />
+        <ProjectReference Include="..\BytecodeDynamicMethodsCompiler\BytecodeDynamicMethodsCompiler.csproj" />
+        <ProjectReference Include="..\AbstractIrConverters\AbstractIrConverters.csproj" />
+        <ProjectReference Include="..\ConditionsModule\ConditionsModule.csproj" />
+        <ProjectReference Include="..\CSharpInteropModule\CSharpInteropModule.csproj" />
+        <ProjectReference Include="..\DependencyInjection\DependencyInjection.csproj" />
+        <ProjectReference Include="..\ExecutorLoggerModule\ExecutorLoggerModule.csproj" />
+        <ProjectReference Include="..\IdentifierModule\IdentifierModule.csproj" />
+        <ProjectReference Include="..\LabelsModule\LabelsModule.csproj" />
+        <ProjectReference Include="..\LoopsModule\LoopsModule.csproj" />
+        <ProjectReference Include="..\NativeMathModule\NativeMathModule.csproj" />
+        <ProjectReference Include="..\NumbersModule\NumbersModule.csproj" />
+        <ProjectReference Include="..\ParserConfigurationModule\ParserConfigurationModule.csproj" />
+        <ProjectReference Include="..\ScopesModule\ScopesModule.csproj" />
+        <ProjectReference Include="..\SemicolonAsNewLineModule\SemicolonAsNewLineModule.csproj" />
+        <ProjectReference Include="..\VariablesModule\VariablesModule.csproj" />
+        <ProjectReference Include="..\WhitespacesModule\WhitespacesModule.csproj" />
+        <ProjectReference Include="..\CommonExceptions\CommonExceptions.csproj" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="CommandLineParser" Version="2.9.1"/>
+        <PackageReference Include="CommandLineParser" Version="2.9.1" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="JetBrains.Annotations" Version="2025.2.4"/>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.1"/>
+        <PackageReference Include="JetBrains.Annotations" Version="2025.2.4" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.1" />
     </ItemGroup>
 
 


### PR DESCRIPTION
### Motivation

- Unify and enrich error handling across the toolchain by introducing structured exceptions carrying stage and source location metadata, and surface clearer runtime/import/compiler errors.

### Description

- Add new `CommonExceptions` project containing `WistException`, stage-specific exceptions (`LexerException`, `ParserException`, `RuntimeExecutionException`, etc.), `SourceLocation`, `WistThrower` helpers, and `CompilerAssert.Unreachable`.
- Replace ad-hoc error signaling with `WistThrower` calls and `WistException` types in lexer (`BasicLexer`), parser scopes handling (`ScopesCreator`), interpreter (`InterpreterImpl`) and C# interop visitor (`CSharpFunctionCallsAstVisitor`), and use `CompilerAssert.Unreachable` for unreachable opcode handling.
- Wire `CommonExceptions` into many projects by adding project references and `global using CommonExceptions;` to relevant modules and the solution, and adjust messages for a few error cases.
- Update CLI (`Wistc`) to catch and pretty-print `WistException` errors and adjust unit tests and fuzz harness to expect the new exception types.

### Testing

- Updated and ran unit tests in the `UniversalToolchain.Tests` suite with assertions changed to expect `ParserException` and `RuntimeExecutionException`, and the fuzz harness updated to treat `WistException` as expected; the test suite passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b71f2a9a98832497125b7fbef346a2)