### PR TITLE
Add regression tests for TypesFinder error contracts

### DIFF
--- a/UniversalToolchain/Tests/Infrastructure/MethodsFinderAndTypesFinderTests.cs
+++ b/UniversalToolchain/Tests/Infrastructure/MethodsFinderAndTypesFinderTests.cs
@@ -62,6 +62,24 @@ public class MethodsFinderAndTypesFinderTests
     }
 
     [Test]
+    public void Should_IncludeRequestedTypeName_When_TypeDoesNotExist()
+    {
+        var missingTypeName = "Unknown.Type.Name.For.Contract";
+
+        var ex = Assert.Throws<InvalidOperationException>(() => TypesFinder.GetType(missingTypeName));
+
+        Assert.That(ex!.Message, Does.Contain($"Type '{missingTypeName}' was not found among loaded assemblies."));
+    }
+
+    [Test]
+    public void RegisterAssembly_ShouldThrowArgumentNullException_When_AssemblyIsNull()
+    {
+        var ex = Assert.Throws<ArgumentNullException>(() => TypesFinder.RegisterAssembly(null!));
+
+        Assert.That(ex!.ParamName, Is.EqualTo("assembly"));
+    }
+
+    [Test]
     public void Should_ReportMethodPresence_When_ContainsAnyMethodIsCalled()
     {
         var contains = MethodsFinder.ContainsAnyMethod($"{typeof(OverloadTarget).FullName}.Echo");


### PR DESCRIPTION
### Motivation

- Cover stable, public error contracts in `TypesFinder` that are explicit and unlikely to change: the missing-type `InvalidOperationException` message and the `ArgumentNull` guard on `RegisterAssembly`.

### Description

- Added `Should_IncludeRequestedTypeName_When_TypeDoesNotExist` to `UniversalToolchain/Tests/Infrastructure/MethodsFinderAndTypesFinderTests.cs` that asserts `TypesFinder.GetType` throws `InvalidOperationException` and the message contains the requested type name fragment.
- Added `RegisterAssembly_ShouldThrowArgumentNullException_When_AssemblyIsNull` to the same test file that asserts `TypesFinder.RegisterAssembly(null)` throws `ArgumentNullException` with `ParamName == "assembly"`.
- No production code changes were made; tests rely on existing deterministic `Thrower`-based guards and message templates.

### Testing

- Ran the targeted test filter with `dotnet test UniversalToolchain/Tests/Tests.csproj --configuration Release --filter "FullyQualifiedName~MethodsFinderAndTypesFinderTests"` and the filtered suite passed.
- The new tests are `Should_IncludeRequestedTypeName_When_TypeDoesNotExist` and `RegisterAssembly_ShouldThrowArgumentNullException_When_AssemblyIsNull`, and they passed in the run described above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b72c0b16a883249513dd8eb1176701)