### PR TITLE
Rework dialect DSL to use framework-native feature seams

### DIFF
--- a/UniversalToolchain/UniversalToolchain.Dialects.Abstractions/BackendPolicy.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Abstractions/BackendPolicy.cs
@@ -17,9 +17,13 @@ public sealed class BackendPolicy
         var disabled = NormalizeNames(disabledBackends, nameof(disabledBackends));
 
         var enabledSet = new HashSet<DialectBackendTarget>(enabled);
-        var overlap = disabled.FirstOrDefault(enabledSet.Contains);
-        if (enabledSet.Contains(overlap))
-            Thrower.Argument(nameof(disabledBackends), $"Backend '{DialectBackendTargetText.ToText(overlap)}' cannot be both enabled and disabled.");
+        foreach (var disabledBackend in disabled)
+        {
+            if (enabledSet.Contains(disabledBackend))
+            {
+                Thrower.Argument(nameof(disabledBackends), $"Backend '{DialectBackendTargetText.ToText(disabledBackend)}' cannot be both enabled and disabled.");
+            }
+        }
 
         _enabledBackends = new ReadOnlyCollection<DialectBackendTarget>(enabled);
         _disabledBackends = new ReadOnlyCollection<DialectBackendTarget>(disabled);

--- a/UniversalToolchain/UniversalToolchain.Dialects.Abstractions/DialectDefinition.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Abstractions/DialectDefinition.cs
@@ -50,9 +50,6 @@ public sealed class DialectDefinition
         if (optimizerPolicy == null)
             Thrower.ArgumentNull(nameof(optimizerPolicy));
 
-        if (securityPolicy == null)
-            Thrower.ArgumentNull(nameof(securityPolicy));
-
         if (capabilityPolicy == null)
             Thrower.ArgumentNull(nameof(capabilityPolicy));
 
@@ -92,7 +89,7 @@ public sealed class DialectDefinition
 
     public OptimizerPolicy OptimizerPolicy { get; }
 
-    public SecurityPolicy SecurityPolicy { get; }
+    public SecurityPolicy? SecurityPolicy { get; }
 
     public CapabilityPolicy CapabilityPolicy { get; }
 

--- a/UniversalToolchain/UniversalToolchain.Dialects.Core/DialectBuildPlanBuilder.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Core/DialectBuildPlanBuilder.cs
@@ -12,37 +12,18 @@ public sealed class DialectBuildPlanBuilder : IDialectBuildPlanBuilder
     public DialectBuildPlan Build(DialectSyntaxDocument syntaxDocument)
     {
         if (syntaxDocument == null)
+        {
             Thrower.ArgumentNull(nameof(syntaxDocument));
+        }
 
         var diagnostics = new List<DialectDiagnostic>();
-        var normalized = DialectSyntaxSemanticNormalizer.Normalize(syntaxDocument, diagnostics);
-
-        DialectSecurityCapabilityPolicyValidator.Validate(
-            syntaxDocument.SecurityProfile,
-            syntaxDocument.Capabilities,
-            diagnostics);
-
-        var orderedModules = DialectSemanticNormalization.ResolveOrder(
-            normalized.ActiveModules,
-            normalized.OrderConstraints,
+        var definition = DialectDefinitionSemanticBinder.Bind(syntaxDocument, diagnostics);
+        return DialectDefinitionBuildPlanProjector.Project(
+            definition,
             diagnostics,
             cycleCode: "S007",
             cycleMessagePrefix: "Order rules contain a cycle involving modules",
             missingReferenceCode: "S002",
             missingReferenceMessagePrefix: "Order rule references module(s) not present in active module set");
-
-        var validationResult = new DialectValidationResult(diagnostics);
-
-        return new DialectBuildPlan(
-            syntaxDocument.Name,
-            syntaxDocument.Version,
-            orderedModules,
-            normalized.BackendMap.Where(x => x.Value).Select(x => x.Key).OrderBy(x => x).ToList(),
-            normalized.BackendMap.Where(x => !x.Value).Select(x => x.Key).OrderBy(x => x).ToList(),
-            normalized.IntrinsicDirectives,
-            normalized.OptimizerDirectives,
-            syntaxDocument.SecurityProfile,
-            syntaxDocument.Capabilities.OrderBy(x => x.Key, StringComparer.Ordinal).ToList(),
-            validationResult);
     }
 }

--- a/UniversalToolchain/UniversalToolchain.Dialects.Core/DialectCompiledDialectBuildPlanBuilder.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Core/DialectCompiledDialectBuildPlanBuilder.cs
@@ -17,70 +17,11 @@ public sealed class DialectCompiledDialectBuildPlanBuilder : IDialectCompiledDia
         }
 
         var diagnostics = new List<DialectDiagnostic>();
-
-        var activeModules = DialectSemanticNormalization.NormalizeActiveModules(
-            compiledDialect.UseModules,
-            compiledDialect.ExcludeModules,
-            diagnostics,
-            conflictCode: "S101");
-
-        var backendMap = DialectSemanticNormalization.NormalizeBackendRules(
-            compiledDialect.BackendDirectives,
-            x => x.Backend,
-            x => x.Enabled,
-            diagnostics,
-            contradictionCode: "S102");
-
-        var intrinsicDirectives = DialectSemanticNormalization.NormalizeIntrinsicRules(
-            compiledDialect.IntrinsicDirectives,
-            x => x.Name,
-            x => x.Target,
-            x => x.Allowed,
-            diagnostics,
-            contradictionCode: "S103");
-
-        var optimizerDirectives = DialectSemanticNormalization.NormalizeOptimizerRules(
-            compiledDialect.OptimizerDirectives,
-            x => x.Name,
-            x => x.Target,
-            x => x.Enabled,
-            diagnostics,
-            contradictionCode: "S104");
-
-        var orderedModules = DialectSemanticNormalization.ResolveOrder(
-            activeModules,
-            DialectOrderConstraintMapper.FromCompiledDirectives(compiledDialect.OrderDirectives),
+        var definition = DialectDefinitionSemanticBinder.Bind(compiledDialect, diagnostics);
+        return DialectDefinitionBuildPlanProjector.Project(
+            definition,
             diagnostics,
             cycleCode: "S105",
             cycleMessagePrefix: "Order directives contain a cycle involving modules");
-
-        var capabilities = compiledDialect.CapabilityDirectives
-            .OrderBy(x => x.Name, StringComparer.Ordinal)
-            .Select(x => new KeyValuePair<string, bool>(x.Name, x.Value))
-            .ToList();
-
-        var validationResult = new DialectValidationResult(diagnostics);
-
-        return new DialectBuildPlan(
-            compiledDialect.Name,
-            version: null,
-            orderedModules,
-            enabledBackends: backendMap.Where(x => x.Value).Select(x => x.Key).OrderBy(x => x).ToList(),
-            disabledBackends: backendMap.Where(x => !x.Value).Select(x => x.Key).OrderBy(x => x).ToList(),
-            intrinsicDirectives,
-            optimizerDirectives,
-            securityProfile: ToSecurityProfile(compiledDialect.SecurityProfile),
-            capabilities,
-            validationResult);
-    }
-
-    private static SecurityProfile? ToSecurityProfile(DialectSecurityProfile? profile)
-    {
-        return profile switch
-        {
-            null => null,
-            DialectSecurityProfile.Trusted => SecurityProfile.Trusted,
-            _ => SecurityProfile.Restricted
-        };
     }
 }

--- a/UniversalToolchain/UniversalToolchain.Dialects.Core/DialectDefinitionBuildPlanProjector.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Core/DialectDefinitionBuildPlanProjector.cs
@@ -1,0 +1,105 @@
+using ExceptionsManager;
+using UniversalToolchain.Dialects.Abstractions;
+
+namespace UniversalToolchain.Dialects.Core;
+
+internal static class DialectDefinitionBuildPlanProjector
+{
+    public static DialectBuildPlan Project(DialectDefinition definition, List<DialectDiagnostic> diagnostics, string cycleCode, string cycleMessagePrefix, string? missingReferenceCode = null, string? missingReferenceMessagePrefix = null)
+    {
+        if (definition == null)
+        {
+            Thrower.ArgumentNull(nameof(definition));
+        }
+
+        if (diagnostics == null)
+        {
+            Thrower.ArgumentNull(nameof(diagnostics));
+        }
+
+        var securityProfile = definition.SecurityPolicy?.Profile;
+        var capabilities = definition.CapabilityPolicy.Capabilities
+            .OrderBy(x => x.Key, StringComparer.Ordinal)
+            .ToList();
+        var capabilityMap = capabilities.ToDictionary(x => x.Key, x => x.Value, StringComparer.Ordinal);
+
+        DialectSecurityCapabilityPolicyValidator.Validate(
+            securityProfile,
+            capabilityMap,
+            diagnostics);
+
+        var orderedModules = DialectSemanticNormalization.ResolveOrder(
+            definition.ModulePolicy.IncludedModules,
+            DialectOrderConstraintMapper.FromDefinitionRules(definition.OrderRules),
+            diagnostics,
+            cycleCode,
+            cycleMessagePrefix,
+            missingReferenceCode,
+            missingReferenceMessagePrefix);
+
+        var validationResult = new DialectValidationResult(diagnostics);
+
+        return new DialectBuildPlan(
+            definition.Name,
+            definition.Version,
+            orderedModules,
+            ExpandBackendPolicy(definition.BackendPolicy.EnabledBackends),
+            ExpandBackendPolicy(definition.BackendPolicy.DisabledBackends),
+            ExpandIntrinsicPolicy(definition.IntrinsicPolicy.AllowedIntrinsics, allowed: true)
+                .Concat(ExpandIntrinsicPolicy(definition.IntrinsicPolicy.ForbiddenIntrinsics, allowed: false))
+                .OrderBy(x => x.Name, StringComparer.Ordinal)
+                .ThenBy(x => x.Target)
+                .ToList(),
+            ExpandOptimizerPolicy(definition.OptimizerPolicy.EnabledOptimizers, enabled: true)
+                .Concat(ExpandOptimizerPolicy(definition.OptimizerPolicy.DisabledOptimizers, enabled: false))
+                .OrderBy(x => x.Name, StringComparer.Ordinal)
+                .ThenBy(x => x.Target)
+                .ToList(),
+            securityProfile,
+            capabilities,
+            validationResult);
+    }
+
+    private static IReadOnlyList<DialectBackendTarget> ExpandBackendPolicy(IReadOnlyList<DialectBackendTarget> backends)
+    {
+        return backends.OrderBy(x => x).ToList();
+    }
+
+    private static IReadOnlyList<IntrinsicBuildDirective> ExpandIntrinsicPolicy(IEnumerable<string> directives, bool allowed)
+    {
+        return directives.Select(x => ParseScopedName(x, allowed)).ToList();
+    }
+
+    private static IReadOnlyList<OptimizerBuildDirective> ExpandOptimizerPolicy(IEnumerable<string> directives, bool enabled)
+    {
+        return directives.Select(x => ParseScopedOptimizer(x, enabled)).ToList();
+    }
+
+    private static IntrinsicBuildDirective ParseScopedName(string value, bool allowed)
+    {
+        var (name, target) = ParseScopedTarget(value);
+        return new IntrinsicBuildDirective(name, allowed, target);
+    }
+
+    private static OptimizerBuildDirective ParseScopedOptimizer(string value, bool enabled)
+    {
+        var (name, target) = ParseScopedTarget(value);
+        return new OptimizerBuildDirective(name, enabled, target);
+    }
+
+    private static (string Name, DialectBackendTarget Target) ParseScopedTarget(string value)
+    {
+        var parts = value.Split('@', 2, StringSplitOptions.TrimEntries);
+        if (parts.Length == 1)
+        {
+            return (value, DialectBackendTarget.Any);
+        }
+
+        if (!DialectBackendTargetText.TryParse(parts[1], allowAny: false, out var target))
+        {
+            Thrower.Argument(nameof(value), $"Scoped backend target '{parts[1]}' is not supported.");
+        }
+
+        return (parts[0], target);
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Core/DialectDefinitionSemanticBinder.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Core/DialectDefinitionSemanticBinder.cs
@@ -1,0 +1,154 @@
+using ExceptionsManager;
+using UniversalToolchain.Dialects.Abstractions;
+using UniversalToolchain.Dialects.Frontend;
+using UniversalToolchain.Dialects.Parsing;
+
+namespace UniversalToolchain.Dialects.Core;
+
+internal static class DialectDefinitionSemanticBinder
+{
+    public static DialectDefinition Bind(DialectSyntaxDocument syntaxDocument, List<DialectDiagnostic> diagnostics)
+    {
+        if (syntaxDocument == null)
+        {
+            Thrower.ArgumentNull(nameof(syntaxDocument));
+        }
+
+        if (diagnostics == null)
+        {
+            Thrower.ArgumentNull(nameof(diagnostics));
+        }
+
+        var activeModules = DialectSemanticNormalization.NormalizeActiveModules(
+            syntaxDocument.UseModules,
+            syntaxDocument.ExcludeModules,
+            diagnostics,
+            conflictCode: "S001");
+
+        var backendMap = DialectSemanticNormalization.NormalizeBackendRules(
+            syntaxDocument.BackendDirectives,
+            x => x.Backend,
+            x => x.Enabled,
+            diagnostics,
+            contradictionCode: "S003");
+
+        var intrinsicDirectives = DialectSemanticNormalization.NormalizeIntrinsicRules(
+            syntaxDocument.IntrinsicDirectives,
+            x => x.Name,
+            x => x.Target,
+            x => x.Allowed,
+            diagnostics,
+            contradictionCode: "S004");
+
+        var optimizerDirectives = DialectSemanticNormalization.NormalizeOptimizerRules(
+            syntaxDocument.OptimizerDirectives,
+            x => x.Name,
+            x => x.Target,
+            x => x.Enabled,
+            diagnostics,
+            contradictionCode: "S005");
+
+        return new DialectDefinition(
+            syntaxDocument.Name,
+            new ModulePolicy(activeModules, syntaxDocument.ExcludeModules.Distinct(StringComparer.Ordinal).OrderBy(x => x, StringComparer.Ordinal)),
+            new BackendPolicy(
+                backendMap.Where(x => x.Value).Select(x => x.Key).OrderBy(x => x),
+                backendMap.Where(x => !x.Value).Select(x => x.Key).OrderBy(x => x)),
+            new IntrinsicPolicy(
+                intrinsicDirectives.Where(x => x.Allowed).Select(FormatRuleName),
+                intrinsicDirectives.Where(x => !x.Allowed).Select(FormatRuleName)),
+            new OptimizerPolicy(
+                optimizerDirectives.Where(x => x.Enabled).Select(FormatRuleName),
+                optimizerDirectives.Where(x => !x.Enabled).Select(FormatRuleName)),
+            syntaxDocument.SecurityProfile.HasValue ? new SecurityPolicy(syntaxDocument.SecurityProfile.Value) : null!,
+            new CapabilityPolicy(syntaxDocument.Capabilities.OrderBy(x => x.Key, StringComparer.Ordinal)),
+            DialectOrderConstraintMapper.ToDefinitionRules(DialectOrderConstraintMapper.FromSyntaxRules(syntaxDocument.OrderRules)),
+            syntaxDocument.Version);
+    }
+
+    public static DialectDefinition Bind(DialectDefinitionSlice compiledDialect, List<DialectDiagnostic> diagnostics)
+    {
+        if (compiledDialect == null)
+        {
+            Thrower.ArgumentNull(nameof(compiledDialect));
+        }
+
+        if (diagnostics == null)
+        {
+            Thrower.ArgumentNull(nameof(diagnostics));
+        }
+
+        var activeModules = DialectSemanticNormalization.NormalizeActiveModules(
+            compiledDialect.UseModules,
+            compiledDialect.ExcludeModules,
+            diagnostics,
+            conflictCode: "S101");
+
+        var backendMap = DialectSemanticNormalization.NormalizeBackendRules(
+            compiledDialect.BackendDirectives,
+            x => x.Backend,
+            x => x.Enabled,
+            diagnostics,
+            contradictionCode: "S102");
+
+        var intrinsicDirectives = DialectSemanticNormalization.NormalizeIntrinsicRules(
+            compiledDialect.IntrinsicDirectives,
+            x => x.Name,
+            x => x.Target,
+            x => x.Allowed,
+            diagnostics,
+            contradictionCode: "S103");
+
+        var optimizerDirectives = DialectSemanticNormalization.NormalizeOptimizerRules(
+            compiledDialect.OptimizerDirectives,
+            x => x.Name,
+            x => x.Target,
+            x => x.Enabled,
+            diagnostics,
+            contradictionCode: "S104");
+
+        var capabilities = compiledDialect.CapabilityDirectives
+            .OrderBy(x => x.Name, StringComparer.Ordinal)
+            .Select(x => new KeyValuePair<string, bool>(x.Name, x.Value));
+
+        return new DialectDefinition(
+            compiledDialect.Name,
+            new ModulePolicy(activeModules, compiledDialect.ExcludeModules.Distinct(StringComparer.Ordinal).OrderBy(x => x, StringComparer.Ordinal)),
+            new BackendPolicy(
+                backendMap.Where(x => x.Value).Select(x => x.Key).OrderBy(x => x),
+                backendMap.Where(x => !x.Value).Select(x => x.Key).OrderBy(x => x)),
+            new IntrinsicPolicy(
+                intrinsicDirectives.Where(x => x.Allowed).Select(FormatRuleName),
+                intrinsicDirectives.Where(x => !x.Allowed).Select(FormatRuleName)),
+            new OptimizerPolicy(
+                optimizerDirectives.Where(x => x.Enabled).Select(FormatRuleName),
+                optimizerDirectives.Where(x => !x.Enabled).Select(FormatRuleName)),
+            compiledDialect.SecurityProfile.HasValue ? new SecurityPolicy(ToSecurityProfile(compiledDialect.SecurityProfile.Value)) : null!,
+            new CapabilityPolicy(capabilities),
+            DialectOrderConstraintMapper.ToDefinitionRules(DialectOrderConstraintMapper.FromCompiledDirectives(compiledDialect.OrderDirectives)));
+    }
+
+    private static string FormatRuleName(IntrinsicBuildDirective directive)
+    {
+        return FormatRuleName(directive.Name, directive.Target);
+    }
+
+    private static string FormatRuleName(OptimizerBuildDirective directive)
+    {
+        return FormatRuleName(directive.Name, directive.Target);
+    }
+
+    private static string FormatRuleName(string name, DialectBackendTarget target)
+    {
+        return target == DialectBackendTarget.Any ? name : $"{name}@{DialectBackendTargetText.ToText(target)}";
+    }
+
+    private static SecurityProfile ToSecurityProfile(DialectSecurityProfile profile)
+    {
+        return profile switch
+        {
+            DialectSecurityProfile.Trusted => SecurityProfile.Trusted,
+            _ => SecurityProfile.Restricted
+        };
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Core/DialectOrderConstraintMapper.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Core/DialectOrderConstraintMapper.cs
@@ -16,6 +16,16 @@ internal static class DialectOrderConstraintMapper
         return directives.Select(ToOrderConstraint).ToList();
     }
 
+    public static List<DialectOrderConstraint> FromDefinitionRules(IReadOnlyList<OrderRule> rules)
+    {
+        return rules.Select(ToOrderConstraint).ToList();
+    }
+
+    public static List<OrderRule> ToDefinitionRules(IReadOnlyList<DialectOrderConstraint> constraints)
+    {
+        return constraints.Select(ToDefinitionRule).ToList();
+    }
+
     private static DialectOrderConstraint ToOrderConstraint(OrderRule rule)
     {
         return new DialectOrderConstraint(
@@ -30,6 +40,11 @@ internal static class DialectOrderConstraintMapper
             ToConstraintKind(directive.Kind),
             directive.SourceModule,
             directive.TargetModule);
+    }
+
+    private static OrderRule ToDefinitionRule(DialectOrderConstraint constraint)
+    {
+        return new OrderRule(ToDefinitionKind(constraint.Kind), constraint.SourceModule, constraint.TargetModule);
     }
 
     private static DialectOrderConstraintKind ToConstraintKind(OrderRuleKind kind)
@@ -49,6 +64,16 @@ internal static class DialectOrderConstraintMapper
             DialectOrderDirectiveKind.Before => DialectOrderConstraintKind.Before,
             DialectOrderDirectiveKind.After => DialectOrderConstraintKind.After,
             _ => DialectOrderConstraintKind.Requires,
+        };
+    }
+
+    private static OrderRuleKind ToDefinitionKind(DialectOrderConstraintKind kind)
+    {
+        return kind switch
+        {
+            DialectOrderConstraintKind.Before => OrderRuleKind.Before,
+            DialectOrderConstraintKind.After => OrderRuleKind.After,
+            _ => OrderRuleKind.Requires,
         };
     }
 }

--- a/UniversalToolchain/UniversalToolchain.Dialects.Frontend/DialectAirAnnotations.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Frontend/DialectAirAnnotations.cs
@@ -3,9 +3,24 @@ using UniversalToolchain.Dialects.Abstractions;
 
 namespace UniversalToolchain.Dialects.Frontend;
 
-public sealed class DialectNameAirAnnotation(string name)
+public interface IDialectDefinitionSliceAnnotation
+{
+    void Apply(DialectDefinitionAggregation aggregation);
+}
+
+public sealed class DialectNameAirAnnotation(string name) : IDialectDefinitionSliceAnnotation
 {
     public string Name { get; } = RequireValue(name, nameof(name), "Dialect name annotation must not be empty.");
+
+    public void Apply(DialectDefinitionAggregation aggregation)
+    {
+        if (aggregation == null)
+        {
+            Thrower.ArgumentNull(nameof(aggregation));
+        }
+
+        aggregation.SetDialectName(Name);
+    }
 
     private static string RequireValue(string value, string paramName, string message)
     {
@@ -18,64 +33,134 @@ public sealed class DialectNameAirAnnotation(string name)
     }
 }
 
-public sealed class UseModulesAirAnnotation(IReadOnlyList<string> modules)
+public sealed class UseModulesAirAnnotation(IReadOnlyList<string> modules) : IDialectDefinitionSliceAnnotation
 {
     public IReadOnlyList<string> Modules { get; } = DialectAnnotationValueGuard.RequireList(modules, nameof(modules), "Use modules annotation must not contain empty values.");
+
+    public void Apply(DialectDefinitionAggregation aggregation)
+    {
+        aggregation.AddUseModules(Modules);
+    }
 }
 
-public sealed class ExcludeModulesAirAnnotation(IReadOnlyList<string> modules)
+public sealed class ExcludeModulesAirAnnotation(IReadOnlyList<string> modules) : IDialectDefinitionSliceAnnotation
 {
     public IReadOnlyList<string> Modules { get; } = DialectAnnotationValueGuard.RequireList(modules, nameof(modules), "Exclude modules annotation must not contain empty values.");
+
+    public void Apply(DialectDefinitionAggregation aggregation)
+    {
+        aggregation.AddExcludeModules(Modules);
+    }
 }
 
-public sealed class RequiresModulesAirAnnotation(IReadOnlyList<string> modules)
+public sealed class OrderAirAnnotation : IDialectDefinitionSliceAnnotation
 {
-    public IReadOnlyList<string> Modules { get; } = DialectAnnotationValueGuard.RequireList(modules, nameof(modules), "Requires modules annotation must not contain empty values.");
+    private readonly IReadOnlyList<string> _modules;
+
+    public OrderAirAnnotation(DialectOrderDirectiveKind kind, IReadOnlyList<string> modules)
+    {
+        Kind = kind;
+        _modules = DialectAnnotationValueGuard.RequireList(modules, nameof(modules), "Order annotation must not contain empty values.");
+    }
+
+    public DialectOrderDirectiveKind Kind { get; }
+
+    public IReadOnlyList<string> Modules => _modules;
+
+    public void Apply(DialectDefinitionAggregation aggregation)
+    {
+        aggregation.AddOrderDirectives(BuildOrderDirectives(Kind, Modules));
+    }
+
+    private static IReadOnlyList<DialectOrderDirective> BuildOrderDirectives(DialectOrderDirectiveKind kind, IReadOnlyList<string> modules)
+    {
+        var result = new List<DialectOrderDirective>();
+        for (var i = 0; i + 1 < modules.Count; i++)
+        {
+            result.Add(new DialectOrderDirective(kind, modules[i], modules[i + 1]));
+        }
+
+        return result;
+    }
 }
 
-public sealed class BeforeModulesAirAnnotation(IReadOnlyList<string> modules)
+public sealed class BackendAirAnnotation : IDialectDefinitionSliceAnnotation
 {
-    public IReadOnlyList<string> Modules { get; } = DialectAnnotationValueGuard.RequireList(modules, nameof(modules), "Before modules annotation must not contain empty values.");
+    private readonly IReadOnlyList<string> _backends;
+
+    public BackendAirAnnotation(IReadOnlyList<string> backends)
+    {
+        _backends = DialectAnnotationValueGuard.RequireList(backends, nameof(backends), "Backend annotation must not contain empty values.");
+    }
+
+    public IReadOnlyList<string> Backends => _backends;
+
+    public void Apply(DialectDefinitionAggregation aggregation)
+    {
+        aggregation.AddBackends(_backends.Select(x => new DialectBackendDirective(DialectAnnotationValueGuard.ParseBackend(x), true)).ToList());
+    }
 }
 
-public sealed class AfterModulesAirAnnotation(IReadOnlyList<string> modules)
+public sealed class IntrinsicAirAnnotation : IDialectDefinitionSliceAnnotation
 {
-    public IReadOnlyList<string> Modules { get; } = DialectAnnotationValueGuard.RequireList(modules, nameof(modules), "After modules annotation must not contain empty values.");
+    public IntrinsicAirAnnotation(string intrinsicName, bool allowed, DialectBackendTarget target = DialectBackendTarget.Any)
+    {
+        IntrinsicName = DialectAnnotationValueGuard.RequireValue(intrinsicName, nameof(intrinsicName), "Intrinsic annotation must not be empty.");
+        Allowed = allowed;
+        Target = target;
+    }
+
+    public string IntrinsicName { get; }
+
+    public bool Allowed { get; }
+
+    public DialectBackendTarget Target { get; }
+
+    public void Apply(DialectDefinitionAggregation aggregation)
+    {
+        aggregation.AddIntrinsicDirectives([new DialectIntrinsicDirective(IntrinsicName, Allowed, Target)]);
+    }
 }
 
-public sealed class BackendAirAnnotation(IReadOnlyList<string> backends)
+public sealed class OptimizerAirAnnotation : IDialectDefinitionSliceAnnotation
 {
-    public IReadOnlyList<string> Backends { get; } = DialectAnnotationValueGuard.RequireList(backends, nameof(backends), "Backend annotation must not contain empty values.");
+    public OptimizerAirAnnotation(string optimizerName, bool enabled, DialectBackendTarget target = DialectBackendTarget.Any)
+    {
+        OptimizerName = DialectAnnotationValueGuard.RequireValue(optimizerName, nameof(optimizerName), "Optimizer annotation must not be empty.");
+        Enabled = enabled;
+        Target = target;
+    }
+
+    public string OptimizerName { get; }
+
+    public bool Enabled { get; }
+
+    public DialectBackendTarget Target { get; }
+
+    public void Apply(DialectDefinitionAggregation aggregation)
+    {
+        aggregation.AddOptimizerDirectives([new DialectOptimizerDirective(OptimizerName, Enabled, Target)]);
+    }
 }
 
-public sealed class AllowIntrinsicAirAnnotation(string intrinsicName)
-{
-    public string IntrinsicName { get; } = DialectAnnotationValueGuard.RequireValue(intrinsicName, nameof(intrinsicName), "Allow intrinsic annotation must not be empty.");
-}
-
-public sealed class ForbidIntrinsicAirAnnotation(string intrinsicName)
-{
-    public string IntrinsicName { get; } = DialectAnnotationValueGuard.RequireValue(intrinsicName, nameof(intrinsicName), "Forbid intrinsic annotation must not be empty.");
-}
-
-public sealed class EnableIntrinsicAirAnnotation(string intrinsicName)
-{
-    public string IntrinsicName { get; } = DialectAnnotationValueGuard.RequireValue(intrinsicName, nameof(intrinsicName), "Enable intrinsic annotation must not be empty.");
-}
-
-public sealed class DisableIntrinsicAirAnnotation(string intrinsicName)
-{
-    public string IntrinsicName { get; } = DialectAnnotationValueGuard.RequireValue(intrinsicName, nameof(intrinsicName), "Disable intrinsic annotation must not be empty.");
-}
-
-public sealed class SecurityAirAnnotation(DialectSecurityProfile profile)
+public sealed class SecurityAirAnnotation(DialectSecurityProfile profile) : IDialectDefinitionSliceAnnotation
 {
     public DialectSecurityProfile Profile { get; } = profile;
+
+    public void Apply(DialectDefinitionAggregation aggregation)
+    {
+        aggregation.SetSecurityProfile(Profile);
+    }
 }
 
-public sealed class CapabilityAirAnnotation(IReadOnlyList<string> capabilities)
+public sealed class CapabilityAirAnnotation(IReadOnlyList<string> capabilities) : IDialectDefinitionSliceAnnotation
 {
     public IReadOnlyList<string> Capabilities { get; } = DialectAnnotationValueGuard.RequireList(capabilities, nameof(capabilities), "Capability annotation must not contain empty values.");
+
+    public void Apply(DialectDefinitionAggregation aggregation)
+    {
+        aggregation.AddCapabilities(Capabilities.Select(x => new DialectCapabilityDirective(x, true)).ToList());
+    }
 }
 
 internal static class DialectAnnotationValueGuard

--- a/UniversalToolchain/UniversalToolchain.Dialects.Frontend/DialectAstNodes.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Frontend/DialectAstNodes.cs
@@ -76,19 +76,26 @@ public sealed class DialectDeclarationAstNode : DialectAstNode
 
 public abstract class DialectDirectiveAstNode : DialectAstNode
 {
-    protected DialectDirectiveAstNode(AstNodeType nodeType, DialectDirectiveKind directiveKind, LexemeValue? lexemeValue, List<AstNode> children) : base(nodeType, lexemeValue, children)
+    protected DialectDirectiveAstNode(AstNodeType nodeType, IDialectDirectiveFeature feature, LexemeValue? lexemeValue, List<AstNode> children) : base(nodeType, lexemeValue, children)
     {
-        DirectiveKind = directiveKind;
+        if (feature == null)
+        {
+            Thrower.ArgumentNull(nameof(feature));
+        }
+
+        Feature = feature;
     }
 
-    public DialectDirectiveKind DirectiveKind { get; }
+    public IDialectDirectiveFeature Feature { get; }
+
+    public DialectDirectiveKind DirectiveKind => Feature.Kind;
 }
 
 public abstract class IdentifierListDirectiveAstNode : DialectDirectiveAstNode
 {
-    protected IdentifierListDirectiveAstNode(AstNodeType nodeType, DialectDirectiveKind directiveKind, LexemeValue? lexemeValue, IdentifierListAstNode identifiers) : base(
+    protected IdentifierListDirectiveAstNode(AstNodeType nodeType, IDialectDirectiveFeature feature, LexemeValue? lexemeValue, IdentifierListAstNode identifiers) : base(
         nodeType,
-        directiveKind,
+        feature,
         lexemeValue,
         [identifiers])
     {
@@ -99,9 +106,9 @@ public abstract class IdentifierListDirectiveAstNode : DialectDirectiveAstNode
 
 public abstract class SingleIdentifierDirectiveAstNode : DialectDirectiveAstNode
 {
-    protected SingleIdentifierDirectiveAstNode(AstNodeType nodeType, DialectDirectiveKind directiveKind, LexemeValue? lexemeValue, IdentifierValueAstNode identifier) : base(
+    protected SingleIdentifierDirectiveAstNode(AstNodeType nodeType, IDialectDirectiveFeature feature, LexemeValue? lexemeValue, IdentifierValueAstNode identifier) : base(
         nodeType,
-        directiveKind,
+        feature,
         lexemeValue,
         [identifier])
     {
@@ -110,41 +117,41 @@ public abstract class SingleIdentifierDirectiveAstNode : DialectDirectiveAstNode
     public IdentifierValueAstNode Identifier => (IdentifierValueAstNode)Children[0];
 }
 
-public sealed class UseModulesDirectiveAstNode(LexemeValue? lexemeValue, IdentifierListAstNode identifiers)
-    : IdentifierListDirectiveAstNode(DialectAstNodeTypes.UseModulesDirective, DialectDirectiveKind.UseModules, lexemeValue, identifiers);
+public sealed class UseModulesDirectiveAstNode(IDialectDirectiveFeature feature, LexemeValue? lexemeValue, IdentifierListAstNode identifiers)
+    : IdentifierListDirectiveAstNode(DialectAstNodeTypes.UseModulesDirective, feature, lexemeValue, identifiers);
 
-public sealed class ExcludeModulesDirectiveAstNode(LexemeValue? lexemeValue, IdentifierListAstNode identifiers)
-    : IdentifierListDirectiveAstNode(DialectAstNodeTypes.ExcludeModulesDirective, DialectDirectiveKind.ExcludeModules, lexemeValue, identifiers);
+public sealed class ExcludeModulesDirectiveAstNode(IDialectDirectiveFeature feature, LexemeValue? lexemeValue, IdentifierListAstNode identifiers)
+    : IdentifierListDirectiveAstNode(DialectAstNodeTypes.ExcludeModulesDirective, feature, lexemeValue, identifiers);
 
-public sealed class RequiresModulesDirectiveAstNode(LexemeValue? lexemeValue, IdentifierListAstNode identifiers)
-    : IdentifierListDirectiveAstNode(DialectAstNodeTypes.RequiresModulesDirective, DialectDirectiveKind.RequiresModules, lexemeValue, identifiers);
+public sealed class RequiresModulesDirectiveAstNode(IDialectDirectiveFeature feature, LexemeValue? lexemeValue, IdentifierListAstNode identifiers)
+    : IdentifierListDirectiveAstNode(DialectAstNodeTypes.RequiresModulesDirective, feature, lexemeValue, identifiers);
 
-public sealed class BeforeModulesDirectiveAstNode(LexemeValue? lexemeValue, IdentifierListAstNode identifiers)
-    : IdentifierListDirectiveAstNode(DialectAstNodeTypes.BeforeModulesDirective, DialectDirectiveKind.BeforeModules, lexemeValue, identifiers);
+public sealed class BeforeModulesDirectiveAstNode(IDialectDirectiveFeature feature, LexemeValue? lexemeValue, IdentifierListAstNode identifiers)
+    : IdentifierListDirectiveAstNode(DialectAstNodeTypes.BeforeModulesDirective, feature, lexemeValue, identifiers);
 
-public sealed class AfterModulesDirectiveAstNode(LexemeValue? lexemeValue, IdentifierListAstNode identifiers)
-    : IdentifierListDirectiveAstNode(DialectAstNodeTypes.AfterModulesDirective, DialectDirectiveKind.AfterModules, lexemeValue, identifiers);
+public sealed class AfterModulesDirectiveAstNode(IDialectDirectiveFeature feature, LexemeValue? lexemeValue, IdentifierListAstNode identifiers)
+    : IdentifierListDirectiveAstNode(DialectAstNodeTypes.AfterModulesDirective, feature, lexemeValue, identifiers);
 
-public sealed class BackendDirectiveAstNode(LexemeValue? lexemeValue, IdentifierListAstNode identifiers)
-    : IdentifierListDirectiveAstNode(DialectAstNodeTypes.BackendDirective, DialectDirectiveKind.Backend, lexemeValue, identifiers);
+public sealed class BackendDirectiveAstNode(IDialectDirectiveFeature feature, LexemeValue? lexemeValue, IdentifierListAstNode identifiers)
+    : IdentifierListDirectiveAstNode(DialectAstNodeTypes.BackendDirective, feature, lexemeValue, identifiers);
 
-public sealed class CapabilityDirectiveAstNode(LexemeValue? lexemeValue, IdentifierListAstNode identifiers)
-    : IdentifierListDirectiveAstNode(DialectAstNodeTypes.CapabilityDirective, DialectDirectiveKind.Capability, lexemeValue, identifiers);
+public sealed class CapabilityDirectiveAstNode(IDialectDirectiveFeature feature, LexemeValue? lexemeValue, IdentifierListAstNode identifiers)
+    : IdentifierListDirectiveAstNode(DialectAstNodeTypes.CapabilityDirective, feature, lexemeValue, identifiers);
 
-public sealed class AllowIntrinsicDirectiveAstNode(LexemeValue? lexemeValue, IdentifierValueAstNode identifier)
-    : SingleIdentifierDirectiveAstNode(DialectAstNodeTypes.AllowIntrinsicDirective, DialectDirectiveKind.AllowIntrinsic, lexemeValue, identifier);
+public sealed class AllowIntrinsicDirectiveAstNode(IDialectDirectiveFeature feature, LexemeValue? lexemeValue, IdentifierValueAstNode identifier)
+    : SingleIdentifierDirectiveAstNode(DialectAstNodeTypes.AllowIntrinsicDirective, feature, lexemeValue, identifier);
 
-public sealed class ForbidIntrinsicDirectiveAstNode(LexemeValue? lexemeValue, IdentifierValueAstNode identifier)
-    : SingleIdentifierDirectiveAstNode(DialectAstNodeTypes.ForbidIntrinsicDirective, DialectDirectiveKind.ForbidIntrinsic, lexemeValue, identifier);
+public sealed class ForbidIntrinsicDirectiveAstNode(IDialectDirectiveFeature feature, LexemeValue? lexemeValue, IdentifierValueAstNode identifier)
+    : SingleIdentifierDirectiveAstNode(DialectAstNodeTypes.ForbidIntrinsicDirective, feature, lexemeValue, identifier);
 
-public sealed class EnableIntrinsicDirectiveAstNode(LexemeValue? lexemeValue, IdentifierValueAstNode identifier)
-    : SingleIdentifierDirectiveAstNode(DialectAstNodeTypes.EnableIntrinsicDirective, DialectDirectiveKind.EnableIntrinsic, lexemeValue, identifier);
+public sealed class EnableIntrinsicDirectiveAstNode(IDialectDirectiveFeature feature, LexemeValue? lexemeValue, IdentifierValueAstNode identifier)
+    : SingleIdentifierDirectiveAstNode(DialectAstNodeTypes.EnableIntrinsicDirective, feature, lexemeValue, identifier);
 
-public sealed class DisableIntrinsicDirectiveAstNode(LexemeValue? lexemeValue, IdentifierValueAstNode identifier)
-    : SingleIdentifierDirectiveAstNode(DialectAstNodeTypes.DisableIntrinsicDirective, DialectDirectiveKind.DisableIntrinsic, lexemeValue, identifier);
+public sealed class DisableIntrinsicDirectiveAstNode(IDialectDirectiveFeature feature, LexemeValue? lexemeValue, IdentifierValueAstNode identifier)
+    : SingleIdentifierDirectiveAstNode(DialectAstNodeTypes.DisableIntrinsicDirective, feature, lexemeValue, identifier);
 
-public sealed class SecurityDirectiveAstNode(LexemeValue? lexemeValue, IdentifierValueAstNode identifier)
-    : SingleIdentifierDirectiveAstNode(DialectAstNodeTypes.SecurityDirective, DialectDirectiveKind.Security, lexemeValue, identifier);
+public sealed class SecurityDirectiveAstNode(IDialectDirectiveFeature feature, LexemeValue? lexemeValue, IdentifierValueAstNode identifier)
+    : SingleIdentifierDirectiveAstNode(DialectAstNodeTypes.SecurityDirective, feature, lexemeValue, identifier);
 
 public sealed class IdentifierValueAstNode : DialectAstNode
 {

--- a/UniversalToolchain/UniversalToolchain.Dialects.Frontend/DialectAstPipelineValidator.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Frontend/DialectAstPipelineValidator.cs
@@ -52,6 +52,7 @@ public static class DialectDslAstValidator
         var declaration = (DialectDeclarationAstNode)document.Children[0];
         ValidateDeclaration(declaration);
 
+        var state = new DialectDirectiveValidationState();
         foreach (var node in document.Children.Skip(1))
         {
             if (node is not DialectDirectiveAstNode)
@@ -61,10 +62,15 @@ public static class DialectDslAstValidator
                     node.LexemeValue ?? node.Children.FirstOrDefault()?.LexemeValue);
             }
 
-            ValidateDirectiveShape((DialectDirectiveAstNode)node);
+            var directive = (DialectDirectiveAstNode)node;
+            ValidateDirectiveShape(directive);
+            directive.Feature.ValidateSemantic(directive, state);
         }
 
-        ValidateSemanticPolicies(document.Directives);
+        foreach (var rule in DialectDslFeatureCatalog.DocumentRules)
+        {
+            rule.Validate(document, state);
+        }
     }
 
     private static void ValidateDeclaration(DialectDeclarationAstNode declaration)
@@ -79,154 +85,39 @@ public static class DialectDslAstValidator
 
     private static void ValidateDirectiveShape(DialectDirectiveAstNode directive)
     {
-        var descriptor = DialectDirectiveDescriptors.Get(directive.DirectiveKind);
-        switch (descriptor.ArgumentShape)
+        if (directive.Feature.ArgumentShape == DialectDirectiveArgumentShape.IdentifierList)
         {
-            case DialectDirectiveArgumentShape.IdentifierList:
-                if (directive.Children.Count != 1 || directive.Children[0] is not IdentifierListAstNode)
-                {
-                    DialectDefinitionSliceParseErrors.Fail(
-                        $"Directive '{descriptor.Keyword}' must contain exactly one identifier-list child.",
-                        directive.LexemeValue ?? directive.Children.FirstOrDefault()?.LexemeValue);
-                }
-
-                var listNode = (IdentifierListAstNode)directive.Children[0];
-                if (listNode.Identifiers.Count == 0)
-                {
-                    DialectDefinitionSliceParseErrors.Fail($"Directive '{descriptor.Keyword}' must contain at least one identifier.", directive.LexemeValue);
-                }
-
-                foreach (var identifier in listNode.Identifiers)
-                {
-                    ValidateIdentifier(identifier, $"Directive '{descriptor.Keyword}' contains an empty identifier.");
-                }
-
-                ValidateNoDuplicates(listNode.Identifiers.Select(x => x.Identifier), $"Directive '{descriptor.Keyword}' contains duplicate identifiers.", directive.LexemeValue);
-                break;
-
-            case DialectDirectiveArgumentShape.Identifier:
-                if (directive.Children.Count != 1 || directive.Children[0] is not IdentifierValueAstNode)
-                {
-                    DialectDefinitionSliceParseErrors.Fail(
-                        $"Directive '{descriptor.Keyword}' must contain exactly one identifier child.",
-                        directive.LexemeValue ?? directive.Children.FirstOrDefault()?.LexemeValue);
-                }
-
-                ValidateIdentifier((IdentifierValueAstNode)directive.Children[0], $"Directive '{descriptor.Keyword}' must not be empty.");
-                break;
-
-            default:
-                Thrower.InvalidOpEx($"Unsupported directive argument shape '{descriptor.ArgumentShape}'.");
-                break;
-        }
-    }
-
-    private static void ValidateSemanticPolicies(IReadOnlyList<DialectDirectiveAstNode> directives)
-    {
-        var seenSecurity = false;
-        var useModules = new HashSet<string>(StringComparer.Ordinal);
-        var excludeModules = new HashSet<string>(StringComparer.Ordinal);
-        var requiresModules = new HashSet<string>(StringComparer.Ordinal);
-        var beforeModules = new HashSet<string>(StringComparer.Ordinal);
-        var afterModules = new HashSet<string>(StringComparer.Ordinal);
-        var backends = new HashSet<string>(StringComparer.Ordinal);
-        var capabilities = new HashSet<string>(StringComparer.Ordinal);
-        var allowed = new HashSet<string>(StringComparer.Ordinal);
-        var forbidden = new HashSet<string>(StringComparer.Ordinal);
-        var enabled = new HashSet<string>(StringComparer.Ordinal);
-        var disabled = new HashSet<string>(StringComparer.Ordinal);
-
-        foreach (var directive in directives)
-        {
-            switch (directive)
+            if (directive.Children.Count != 1 || directive.Children[0] is not IdentifierListAstNode)
             {
-                case UseModulesDirectiveAstNode useDirective:
-                    AddMany(useModules, useDirective.Identifiers.Identifiers.Select(x => x.Identifier), "Duplicate use module is not allowed.", useDirective.LexemeValue);
-                    break;
-
-                case ExcludeModulesDirectiveAstNode excludeDirective:
-                    AddMany(excludeModules, excludeDirective.Identifiers.Identifiers.Select(x => x.Identifier), "Duplicate exclude module is not allowed.", excludeDirective.LexemeValue);
-                    break;
-
-                case RequiresModulesDirectiveAstNode requiresDirective:
-                    AddMany(requiresModules, requiresDirective.Identifiers.Identifiers.Select(x => x.Identifier), "Duplicate requires module is not allowed.", requiresDirective.LexemeValue);
-                    break;
-
-                case BeforeModulesDirectiveAstNode beforeDirective:
-                    AddMany(beforeModules, beforeDirective.Identifiers.Identifiers.Select(x => x.Identifier), "Duplicate before module is not allowed.", beforeDirective.LexemeValue);
-                    break;
-
-                case AfterModulesDirectiveAstNode afterDirective:
-                    AddMany(afterModules, afterDirective.Identifiers.Identifiers.Select(x => x.Identifier), "Duplicate after module is not allowed.", afterDirective.LexemeValue);
-                    break;
-
-                case BackendDirectiveAstNode backendDirective:
-                    AddMany(backends, backendDirective.Identifiers.Identifiers.Select(x => x.Identifier), "Duplicate backend identifier is not allowed.", backendDirective.LexemeValue);
-                    break;
-
-                case CapabilityDirectiveAstNode capabilityDirective:
-                    AddMany(capabilities, capabilityDirective.Identifiers.Identifiers.Select(x => x.Identifier), "Duplicate capability identifier is not allowed.", capabilityDirective.LexemeValue);
-                    break;
-
-                case AllowIntrinsicDirectiveAstNode allowDirective:
-                    AddSingle(allowed, allowDirective.Identifier.Identifier, "Duplicate allow intrinsic directive is not allowed.", allowDirective.LexemeValue);
-                    if (forbidden.Contains(allowDirective.Identifier.Identifier))
-                    {
-                        DialectDefinitionSliceParseErrors.Fail(
-                            $"Intrinsic '{allowDirective.Identifier.Identifier}' cannot be both allowed and forbidden.",
-                            allowDirective.LexemeValue);
-                    }
-
-                    break;
-
-                case ForbidIntrinsicDirectiveAstNode forbidDirective:
-                    AddSingle(forbidden, forbidDirective.Identifier.Identifier, "Duplicate forbid intrinsic directive is not allowed.", forbidDirective.LexemeValue);
-                    if (allowed.Contains(forbidDirective.Identifier.Identifier))
-                    {
-                        DialectDefinitionSliceParseErrors.Fail(
-                            $"Intrinsic '{forbidDirective.Identifier.Identifier}' cannot be both allowed and forbidden.",
-                            forbidDirective.LexemeValue);
-                    }
-
-                    break;
-
-                case EnableIntrinsicDirectiveAstNode enableDirective:
-                    AddSingle(enabled, enableDirective.Identifier.Identifier, "Duplicate enable directive is not allowed.", enableDirective.LexemeValue);
-                    if (disabled.Contains(enableDirective.Identifier.Identifier))
-                    {
-                        DialectDefinitionSliceParseErrors.Fail(
-                            $"Intrinsic '{enableDirective.Identifier.Identifier}' cannot be both enabled and disabled.",
-                            enableDirective.LexemeValue);
-                    }
-
-                    break;
-
-                case DisableIntrinsicDirectiveAstNode disableDirective:
-                    AddSingle(disabled, disableDirective.Identifier.Identifier, "Duplicate disable directive is not allowed.", disableDirective.LexemeValue);
-                    if (enabled.Contains(disableDirective.Identifier.Identifier))
-                    {
-                        DialectDefinitionSliceParseErrors.Fail(
-                            $"Intrinsic '{disableDirective.Identifier.Identifier}' cannot be both enabled and disabled.",
-                            disableDirective.LexemeValue);
-                    }
-
-                    break;
-
-                case SecurityDirectiveAstNode securityDirective:
-                    if (seenSecurity)
-                    {
-                        DialectDefinitionSliceParseErrors.Fail("Security directive can only be declared once.", securityDirective.LexemeValue);
-                    }
-
-                    seenSecurity = true;
-                    break;
+                DialectDefinitionSliceParseErrors.Fail(
+                    $"Directive '{directive.Feature.Keyword}' must contain exactly one identifier-list child.",
+                    directive.LexemeValue ?? directive.Children.FirstOrDefault()?.LexemeValue);
             }
+
+            var listNode = (IdentifierListAstNode)directive.Children[0];
+            if (listNode.Identifiers.Count == 0)
+            {
+                DialectDefinitionSliceParseErrors.Fail($"Directive '{directive.Feature.Keyword}' must contain at least one identifier.", directive.LexemeValue);
+            }
+
+            foreach (var identifier in listNode.Identifiers)
+            {
+                ValidateIdentifier(identifier, $"Directive '{directive.Feature.Keyword}' contains an empty identifier.");
+            }
+
+            ValidateNoDuplicates(listNode.Identifiers.Select(x => x.Identifier), $"Directive '{directive.Feature.Keyword}' contains duplicate identifiers.", directive.LexemeValue);
+            return;
         }
 
-        foreach (var conflict in useModules.Intersect(excludeModules, StringComparer.Ordinal))
+        if (directive.Children.Count != 1 || directive.Children[0] is not IdentifierValueAstNode)
         {
-            DialectDefinitionSliceParseErrors.Fail($"Module '{conflict}' cannot appear in both use and exclude directives.", null);
+            DialectDefinitionSliceParseErrors.Fail(
+                $"Directive '{directive.Feature.Keyword}' must contain exactly one identifier child.",
+                directive.LexemeValue ?? directive.Children.FirstOrDefault()?.LexemeValue);
         }
+
+        var identifierNode = (IdentifierValueAstNode)directive.Children[0];
+        ValidateIdentifier(identifierNode, $"Directive '{directive.Feature.Keyword}' must not be empty.");
     }
 
     private static void ValidateIdentifier(IdentifierValueAstNode identifier, string message)
@@ -251,22 +142,6 @@ public static class DialectDslAstValidator
             {
                 DialectDefinitionSliceParseErrors.Fail(message, token);
             }
-        }
-    }
-
-    private static void AddMany(HashSet<string> set, IEnumerable<string> values, string duplicateMessage, LexemeValue? token)
-    {
-        foreach (var value in values)
-        {
-            AddSingle(set, value, duplicateMessage, token);
-        }
-    }
-
-    private static void AddSingle(HashSet<string> set, string value, string duplicateMessage, LexemeValue? token)
-    {
-        if (!set.Add(value))
-        {
-            DialectDefinitionSliceParseErrors.Fail(duplicateMessage, token);
         }
     }
 }

--- a/UniversalToolchain/UniversalToolchain.Dialects.Frontend/DialectAstToBytecodeVisitor.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Frontend/DialectAstToBytecodeVisitor.cs
@@ -15,54 +15,29 @@ public sealed class DialectAstToBytecodeVisitor : IAstVisitor
 
         var document = DialectDslAstValidator.Validate(data.Node);
         var annotations = DialectAstLowering.Lower(document);
-        data.Bytecode.Instructions.Add(new BytecodeInstruction(new DialectSliceToAirConvertable(annotations)));
+        data.Bytecode.Instructions.Add(new BytecodeInstruction(new DialectSliceToAirConvertable(annotations.Cast<object>().ToList())));
     }
 }
 
 internal static class DialectAstLowering
 {
-    public static IReadOnlyList<object> Lower(DialectDocumentAstNode document)
+    public static IReadOnlyList<IDialectDefinitionSliceAnnotation> Lower(DialectDocumentAstNode document)
     {
         if (document == null)
         {
             Thrower.ArgumentNull(nameof(document));
         }
 
-        var annotations = new List<object>
+        var annotations = new List<IDialectDefinitionSliceAnnotation>
         {
             new DialectNameAirAnnotation(document.Declaration.NameNode.Identifier)
         };
 
         foreach (var directive in document.Directives)
         {
-            annotations.Add(LowerDirective(directive));
+            annotations.AddRange(directive.Feature.Lower(directive));
         }
 
         return annotations;
-    }
-
-    private static object LowerDirective(DialectDirectiveAstNode directive)
-    {
-        return directive switch
-        {
-            UseModulesDirectiveAstNode useDirective => new UseModulesAirAnnotation(GetIdentifiers(useDirective.Identifiers)),
-            ExcludeModulesDirectiveAstNode excludeDirective => new ExcludeModulesAirAnnotation(GetIdentifiers(excludeDirective.Identifiers)),
-            RequiresModulesDirectiveAstNode requiresDirective => new RequiresModulesAirAnnotation(GetIdentifiers(requiresDirective.Identifiers)),
-            BeforeModulesDirectiveAstNode beforeDirective => new BeforeModulesAirAnnotation(GetIdentifiers(beforeDirective.Identifiers)),
-            AfterModulesDirectiveAstNode afterDirective => new AfterModulesAirAnnotation(GetIdentifiers(afterDirective.Identifiers)),
-            BackendDirectiveAstNode backendDirective => new BackendAirAnnotation(GetIdentifiers(backendDirective.Identifiers)),
-            AllowIntrinsicDirectiveAstNode allowDirective => new AllowIntrinsicAirAnnotation(allowDirective.Identifier.Identifier),
-            ForbidIntrinsicDirectiveAstNode forbidDirective => new ForbidIntrinsicAirAnnotation(forbidDirective.Identifier.Identifier),
-            EnableIntrinsicDirectiveAstNode enableDirective => new EnableIntrinsicAirAnnotation(enableDirective.Identifier.Identifier),
-            DisableIntrinsicDirectiveAstNode disableDirective => new DisableIntrinsicAirAnnotation(disableDirective.Identifier.Identifier),
-            SecurityDirectiveAstNode securityDirective => new SecurityAirAnnotation(DialectAnnotationValueGuard.ParseSecurityProfile(securityDirective.Identifier.Identifier)),
-            CapabilityDirectiveAstNode capabilityDirective => new CapabilityAirAnnotation(GetIdentifiers(capabilityDirective.Identifiers)),
-            _ => Thrower.InvalidOpEx<object>($"Dialect lowering does not support AST node type '{directive.GetType().Name}'.")
-        };
-    }
-
-    private static IReadOnlyList<string> GetIdentifiers(IdentifierListAstNode identifiers)
-    {
-        return identifiers.Identifiers.Select(x => x.Identifier).ToList();
     }
 }

--- a/UniversalToolchain/UniversalToolchain.Dialects.Frontend/DialectDefinitionSliceAirReader.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Frontend/DialectDefinitionSliceAirReader.cs
@@ -16,62 +16,20 @@ public static class DialectDefinitionSliceAirReader
         var aggregation = new DialectDefinitionAggregation();
         foreach (var annotation in air.Instructions.SelectMany(x => x.Metadata))
         {
-            ReadAnnotation(aggregation, annotation);
+            if (annotation is not IDialectDefinitionSliceAnnotation)
+            {
+                if (annotation == null)
+                {
+                    Thrower.InvalidOpEx("Dialect AIR contained a null annotation entry.");
+                }
+
+                Thrower.InvalidOpEx($"Dialect AIR contained unsupported annotation type '{annotation.GetType().FullName}'.");
+            }
+
+            ((IDialectDefinitionSliceAnnotation)annotation).Apply(aggregation);
         }
 
         return new DialectDefinitionSliceBuilder().Build(aggregation);
-    }
-
-    private static void ReadAnnotation(DialectDefinitionAggregation aggregation, object annotation)
-    {
-        switch (annotation)
-        {
-            case DialectNameAirAnnotation dialectName:
-                aggregation.SetDialectName(dialectName.Name);
-                break;
-            case UseModulesAirAnnotation useModules:
-                aggregation.AddUseModules(useModules.Modules);
-                break;
-            case ExcludeModulesAirAnnotation excludeModules:
-                aggregation.AddExcludeModules(excludeModules.Modules);
-                break;
-            case RequiresModulesAirAnnotation requiresModules:
-                aggregation.AddRequiresModules(requiresModules.Modules);
-                break;
-            case BeforeModulesAirAnnotation beforeModules:
-                aggregation.AddBeforeModules(beforeModules.Modules);
-                break;
-            case AfterModulesAirAnnotation afterModules:
-                aggregation.AddAfterModules(afterModules.Modules);
-                break;
-            case BackendAirAnnotation backend:
-                aggregation.AddBackends(backend.Backends);
-                break;
-            case AllowIntrinsicAirAnnotation allowIntrinsic:
-                aggregation.AddAllowedIntrinsic(allowIntrinsic.IntrinsicName);
-                break;
-            case ForbidIntrinsicAirAnnotation forbidIntrinsic:
-                aggregation.AddForbiddenIntrinsic(forbidIntrinsic.IntrinsicName);
-                break;
-            case EnableIntrinsicAirAnnotation enableIntrinsic:
-                aggregation.AddEnabledIntrinsic(enableIntrinsic.IntrinsicName);
-                break;
-            case DisableIntrinsicAirAnnotation disableIntrinsic:
-                aggregation.AddDisabledIntrinsic(disableIntrinsic.IntrinsicName);
-                break;
-            case SecurityAirAnnotation security:
-                aggregation.SetSecurityProfile(security.Profile);
-                break;
-            case CapabilityAirAnnotation capability:
-                aggregation.AddCapabilities(capability.Capabilities);
-                break;
-            case null:
-                Thrower.InvalidOpEx("Dialect AIR contained a null annotation entry.");
-                break;
-            default:
-                Thrower.InvalidOpEx($"Dialect AIR contained unsupported annotation type '{annotation.GetType().FullName}'.");
-                break;
-        }
     }
 }
 
@@ -93,58 +51,12 @@ public sealed class DialectDefinitionSliceBuilder
             aggregation.DialectName,
             aggregation.UseModules,
             aggregation.ExcludeModules,
-            BuildOrderDirectives(aggregation),
-            BuildBackendDirectives(aggregation.Backends),
-            BuildIntrinsicDirectives(aggregation.AllowedIntrinsics, aggregation.ForbiddenIntrinsics),
-            BuildOptimizerDirectives(aggregation.EnabledIntrinsics, aggregation.DisabledIntrinsics),
+            aggregation.OrderDirectives,
+            aggregation.Backends,
+            aggregation.IntrinsicDirectives,
+            aggregation.OptimizerDirectives,
             aggregation.SecurityProfile,
-            BuildCapabilities(aggregation.Capabilities));
-    }
-
-    private static IReadOnlyList<DialectOrderDirective> BuildOrderDirectives(DialectOrderDirectiveKind kind, IReadOnlyList<string> modules)
-    {
-        var result = new List<DialectOrderDirective>();
-        for (var i = 0; i + 1 < modules.Count; i++)
-        {
-            result.Add(new DialectOrderDirective(kind, modules[i], modules[i + 1]));
-        }
-
-        return result;
-    }
-
-    private static IReadOnlyList<DialectOrderDirective> BuildOrderDirectives(DialectDefinitionAggregation aggregation)
-    {
-        var result = new List<DialectOrderDirective>();
-        result.AddRange(BuildOrderDirectives(DialectOrderDirectiveKind.Requires, aggregation.RequiresModules));
-        result.AddRange(BuildOrderDirectives(DialectOrderDirectiveKind.Before, aggregation.BeforeModules));
-        result.AddRange(BuildOrderDirectives(DialectOrderDirectiveKind.After, aggregation.AfterModules));
-        return result;
-    }
-
-    private static IReadOnlyList<DialectBackendDirective> BuildBackendDirectives(IReadOnlyList<string> backends)
-    {
-        return backends.Select(x => new DialectBackendDirective(DialectAnnotationValueGuard.ParseBackend(x), true)).ToList();
-    }
-
-    private static IReadOnlyList<DialectIntrinsicDirective> BuildIntrinsicDirectives(IReadOnlyList<string> allowed, IReadOnlyList<string> forbidden)
-    {
-        var result = new List<DialectIntrinsicDirective>();
-        result.AddRange(allowed.Select(x => new DialectIntrinsicDirective(x, true, DialectBackendTarget.Any)));
-        result.AddRange(forbidden.Select(x => new DialectIntrinsicDirective(x, false, DialectBackendTarget.Any)));
-        return result;
-    }
-
-    private static IReadOnlyList<DialectOptimizerDirective> BuildOptimizerDirectives(IReadOnlyList<string> enabled, IReadOnlyList<string> disabled)
-    {
-        var result = new List<DialectOptimizerDirective>();
-        result.AddRange(enabled.Select(x => new DialectOptimizerDirective(x, true, DialectBackendTarget.Any)));
-        result.AddRange(disabled.Select(x => new DialectOptimizerDirective(x, false, DialectBackendTarget.Any)));
-        return result;
-    }
-
-    private static IReadOnlyList<DialectCapabilityDirective> BuildCapabilities(IReadOnlyList<string> capabilities)
-    {
-        return capabilities.Select(x => new DialectCapabilityDirective(x, true)).ToList();
+            aggregation.Capabilities);
     }
 }
 
@@ -152,26 +64,18 @@ public sealed class DialectDefinitionAggregation
 {
     private readonly List<string> _useModules = [];
     private readonly List<string> _excludeModules = [];
-    private readonly List<string> _requiresModules = [];
-    private readonly List<string> _beforeModules = [];
-    private readonly List<string> _afterModules = [];
-    private readonly List<string> _backends = [];
-    private readonly List<string> _allowedIntrinsics = [];
-    private readonly List<string> _forbiddenIntrinsics = [];
-    private readonly List<string> _enabledIntrinsics = [];
-    private readonly List<string> _disabledIntrinsics = [];
-    private readonly List<string> _capabilities = [];
+    private readonly List<DialectOrderDirective> _orderDirectives = [];
+    private readonly List<DialectBackendDirective> _backends = [];
+    private readonly List<DialectIntrinsicDirective> _intrinsicDirectives = [];
+    private readonly List<DialectOptimizerDirective> _optimizerDirectives = [];
+    private readonly List<DialectCapabilityDirective> _capabilities = [];
     private readonly HashSet<string> _seenUseModules = new(StringComparer.Ordinal);
     private readonly HashSet<string> _seenExcludeModules = new(StringComparer.Ordinal);
-    private readonly HashSet<string> _seenRequiresModules = new(StringComparer.Ordinal);
-    private readonly HashSet<string> _seenBeforeModules = new(StringComparer.Ordinal);
-    private readonly HashSet<string> _seenAfterModules = new(StringComparer.Ordinal);
-    private readonly HashSet<string> _seenBackends = new(StringComparer.Ordinal);
+    private readonly HashSet<(DialectOrderDirectiveKind Kind, string Source, string Target)> _seenOrderDirectives = [];
+    private readonly HashSet<DialectBackendTarget> _seenBackends = [];
+    private readonly HashSet<(string Name, DialectBackendTarget Target)> _seenIntrinsics = [];
+    private readonly HashSet<(string Name, DialectBackendTarget Target)> _seenOptimizers = [];
     private readonly HashSet<string> _seenCapabilities = new(StringComparer.Ordinal);
-    private readonly HashSet<string> _allowedIntrinsicSet = new(StringComparer.Ordinal);
-    private readonly HashSet<string> _forbiddenIntrinsicSet = new(StringComparer.Ordinal);
-    private readonly HashSet<string> _enabledIntrinsicSet = new(StringComparer.Ordinal);
-    private readonly HashSet<string> _disabledIntrinsicSet = new(StringComparer.Ordinal);
 
     public string? DialectName { get; private set; }
 
@@ -181,23 +85,15 @@ public sealed class DialectDefinitionAggregation
 
     public IReadOnlyList<string> ExcludeModules => _excludeModules;
 
-    public IReadOnlyList<string> RequiresModules => _requiresModules;
+    public IReadOnlyList<DialectOrderDirective> OrderDirectives => _orderDirectives;
 
-    public IReadOnlyList<string> BeforeModules => _beforeModules;
+    public IReadOnlyList<DialectBackendDirective> Backends => _backends;
 
-    public IReadOnlyList<string> AfterModules => _afterModules;
+    public IReadOnlyList<DialectIntrinsicDirective> IntrinsicDirectives => _intrinsicDirectives;
 
-    public IReadOnlyList<string> Backends => _backends;
+    public IReadOnlyList<DialectOptimizerDirective> OptimizerDirectives => _optimizerDirectives;
 
-    public IReadOnlyList<string> AllowedIntrinsics => _allowedIntrinsics;
-
-    public IReadOnlyList<string> ForbiddenIntrinsics => _forbiddenIntrinsics;
-
-    public IReadOnlyList<string> EnabledIntrinsics => _enabledIntrinsics;
-
-    public IReadOnlyList<string> DisabledIntrinsics => _disabledIntrinsics;
-
-    public IReadOnlyList<string> Capabilities => _capabilities;
+    public IReadOnlyList<DialectCapabilityDirective> Capabilities => _capabilities;
 
     public void SetDialectName(string name)
     {
@@ -223,49 +119,71 @@ public sealed class DialectDefinitionAggregation
 
     public void AddExcludeModules(IReadOnlyList<string> values) => AddMany(values, _excludeModules, _seenExcludeModules, "Duplicate exclude module annotation value '{0}'.");
 
-    public void AddRequiresModules(IReadOnlyList<string> values) => AddMany(values, _requiresModules, _seenRequiresModules, "Duplicate requires module annotation value '{0}'.");
-
-    public void AddBeforeModules(IReadOnlyList<string> values) => AddMany(values, _beforeModules, _seenBeforeModules, "Duplicate before module annotation value '{0}'.");
-
-    public void AddAfterModules(IReadOnlyList<string> values) => AddMany(values, _afterModules, _seenAfterModules, "Duplicate after module annotation value '{0}'.");
-
-    public void AddBackends(IReadOnlyList<string> values) => AddMany(values, _backends, _seenBackends, "Duplicate backend annotation value '{0}'.");
-
-    public void AddCapabilities(IReadOnlyList<string> values) => AddMany(values, _capabilities, _seenCapabilities, "Duplicate capability annotation value '{0}'.");
-
-    public void AddAllowedIntrinsic(string value)
+    public void AddOrderDirectives(IReadOnlyList<DialectOrderDirective> directives)
     {
-        AddOne(value, _allowedIntrinsics, _allowedIntrinsicSet, "Duplicate allow intrinsic annotation value '{0}'.");
-        if (_forbiddenIntrinsicSet.Contains(value))
+        foreach (var directive in directives)
         {
-            Thrower.InvalidOpEx($"Intrinsic '{value}' cannot be both allowed and forbidden in AIR annotations.");
+            var key = (directive.Kind, directive.SourceModule, directive.TargetModule);
+            if (!_seenOrderDirectives.Add(key))
+            {
+                Thrower.InvalidOpEx($"Duplicate order annotation value '{directive.Directive}:{directive.SourceModule}->{directive.TargetModule}'.");
+            }
+
+            _orderDirectives.Add(directive);
         }
     }
 
-    public void AddForbiddenIntrinsic(string value)
+    public void AddBackends(IReadOnlyList<DialectBackendDirective> values)
     {
-        AddOne(value, _forbiddenIntrinsics, _forbiddenIntrinsicSet, "Duplicate forbid intrinsic annotation value '{0}'.");
-        if (_allowedIntrinsicSet.Contains(value))
+        foreach (var value in values)
         {
-            Thrower.InvalidOpEx($"Intrinsic '{value}' cannot be both allowed and forbidden in AIR annotations.");
+            if (!_seenBackends.Add(value.Backend))
+            {
+                Thrower.InvalidOpEx($"Duplicate backend annotation value '{DialectBackendTargetText.ToText(value.Backend)}'.");
+            }
+
+            _backends.Add(value);
         }
     }
 
-    public void AddEnabledIntrinsic(string value)
+    public void AddIntrinsicDirectives(IReadOnlyList<DialectIntrinsicDirective> values)
     {
-        AddOne(value, _enabledIntrinsics, _enabledIntrinsicSet, "Duplicate enable intrinsic annotation value '{0}'.");
-        if (_disabledIntrinsicSet.Contains(value))
+        foreach (var value in values)
         {
-            Thrower.InvalidOpEx($"Intrinsic '{value}' cannot be both enabled and disabled in AIR annotations.");
+            var key = (value.Name, value.Target);
+            if (!_seenIntrinsics.Add(key))
+            {
+                Thrower.InvalidOpEx($"Duplicate intrinsic annotation value '{value.Name}' for '{DialectBackendTargetText.ToText(value.Target)}'.");
+            }
+
+            _intrinsicDirectives.Add(value);
         }
     }
 
-    public void AddDisabledIntrinsic(string value)
+    public void AddOptimizerDirectives(IReadOnlyList<DialectOptimizerDirective> values)
     {
-        AddOne(value, _disabledIntrinsics, _disabledIntrinsicSet, "Duplicate disable intrinsic annotation value '{0}'.");
-        if (_enabledIntrinsicSet.Contains(value))
+        foreach (var value in values)
         {
-            Thrower.InvalidOpEx($"Intrinsic '{value}' cannot be both enabled and disabled in AIR annotations.");
+            var key = (value.Name, value.Target);
+            if (!_seenOptimizers.Add(key))
+            {
+                Thrower.InvalidOpEx($"Duplicate optimizer annotation value '{value.Name}' for '{DialectBackendTargetText.ToText(value.Target)}'.");
+            }
+
+            _optimizerDirectives.Add(value);
+        }
+    }
+
+    public void AddCapabilities(IReadOnlyList<DialectCapabilityDirective> values)
+    {
+        foreach (var value in values)
+        {
+            if (!_seenCapabilities.Add(value.Name))
+            {
+                Thrower.InvalidOpEx($"Duplicate capability annotation value '{value.Name}'.");
+            }
+
+            _capabilities.Add(value);
         }
     }
 
@@ -273,18 +191,13 @@ public sealed class DialectDefinitionAggregation
     {
         foreach (var value in values)
         {
-            AddOne(value, target, seen, duplicateMessage);
-        }
-    }
+            var normalized = DialectAnnotationValueGuard.RequireValue(value, nameof(values), "Dialect annotation value must not be empty.");
+            if (!seen.Add(normalized))
+            {
+                Thrower.InvalidOpEx(string.Format(duplicateMessage, normalized));
+            }
 
-    private static void AddOne(string value, List<string> target, HashSet<string> seen, string duplicateMessage)
-    {
-        var normalized = DialectAnnotationValueGuard.RequireValue(value, nameof(value), "Dialect annotation value must not be empty.");
-        if (!seen.Add(normalized))
-        {
-            Thrower.InvalidOpEx(string.Format(duplicateMessage, normalized));
+            target.Add(normalized);
         }
-
-        target.Add(normalized);
     }
 }

--- a/UniversalToolchain/UniversalToolchain.Dialects.Frontend/DialectDefinitionSliceParser.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Frontend/DialectDefinitionSliceParser.cs
@@ -17,51 +17,7 @@ public sealed class DialectDefinitionSliceParser
         var aggregation = new DialectDefinitionAggregation();
         foreach (var annotation in annotations)
         {
-            switch (annotation)
-            {
-                case DialectNameAirAnnotation dialectName:
-                    aggregation.SetDialectName(dialectName.Name);
-                    break;
-                case UseModulesAirAnnotation useModules:
-                    aggregation.AddUseModules(useModules.Modules);
-                    break;
-                case ExcludeModulesAirAnnotation excludeModules:
-                    aggregation.AddExcludeModules(excludeModules.Modules);
-                    break;
-                case RequiresModulesAirAnnotation requiresModules:
-                    aggregation.AddRequiresModules(requiresModules.Modules);
-                    break;
-                case BeforeModulesAirAnnotation beforeModules:
-                    aggregation.AddBeforeModules(beforeModules.Modules);
-                    break;
-                case AfterModulesAirAnnotation afterModules:
-                    aggregation.AddAfterModules(afterModules.Modules);
-                    break;
-                case BackendAirAnnotation backend:
-                    aggregation.AddBackends(backend.Backends);
-                    break;
-                case AllowIntrinsicAirAnnotation allowIntrinsic:
-                    aggregation.AddAllowedIntrinsic(allowIntrinsic.IntrinsicName);
-                    break;
-                case ForbidIntrinsicAirAnnotation forbidIntrinsic:
-                    aggregation.AddForbiddenIntrinsic(forbidIntrinsic.IntrinsicName);
-                    break;
-                case EnableIntrinsicAirAnnotation enableIntrinsic:
-                    aggregation.AddEnabledIntrinsic(enableIntrinsic.IntrinsicName);
-                    break;
-                case DisableIntrinsicAirAnnotation disableIntrinsic:
-                    aggregation.AddDisabledIntrinsic(disableIntrinsic.IntrinsicName);
-                    break;
-                case SecurityAirAnnotation security:
-                    aggregation.SetSecurityProfile(security.Profile);
-                    break;
-                case CapabilityAirAnnotation capability:
-                    aggregation.AddCapabilities(capability.Capabilities);
-                    break;
-                default:
-                    Thrower.InvalidOpEx($"Dialect lowering produced unsupported annotation type '{annotation.GetType().FullName}'.");
-                    break;
-            }
+            annotation.Apply(aggregation);
         }
 
         return new DialectDefinitionSliceBuilder().Build(aggregation);

--- a/UniversalToolchain/UniversalToolchain.Dialects.Frontend/DialectDirectiveLineParser.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Frontend/DialectDirectiveLineParser.cs
@@ -23,107 +23,12 @@ public sealed class DialectDirectiveLineParser
         }
 
         var keyword = line[0].Text;
-        if (!DialectDirectiveDescriptors.TryGetByKeyword(keyword, out var descriptor))
+        if (!DialectDslFeatureCatalog.TryGetFeature(keyword, out var feature))
         {
             return false;
         }
 
-        switch (descriptor.Kind)
-        {
-            case DialectDirectiveKind.UseModules:
-                accumulation.UseModules.AddRange(ParseIdentifierList(line, descriptor.Keyword));
-                return true;
-            case DialectDirectiveKind.ExcludeModules:
-                accumulation.ExcludeModules.AddRange(ParseIdentifierList(line, descriptor.Keyword));
-                return true;
-            case DialectDirectiveKind.RequiresModules:
-                accumulation.RequiresModules.AddRange(ParseIdentifierList(line, descriptor.Keyword));
-                return true;
-            case DialectDirectiveKind.BeforeModules:
-                accumulation.BeforeModules.AddRange(ParseIdentifierList(line, descriptor.Keyword));
-                return true;
-            case DialectDirectiveKind.AfterModules:
-                accumulation.AfterModules.AddRange(ParseIdentifierList(line, descriptor.Keyword));
-                return true;
-            case DialectDirectiveKind.Backend:
-                accumulation.Backends.AddRange(ParseIdentifierList(line, descriptor.Keyword));
-                return true;
-            case DialectDirectiveKind.AllowIntrinsic:
-                accumulation.AllowedIntrinsics.Add(ParseSingleIdentifier(line, descriptor.Keyword));
-                return true;
-            case DialectDirectiveKind.ForbidIntrinsic:
-                accumulation.ForbiddenIntrinsics.Add(ParseSingleIdentifier(line, descriptor.Keyword));
-                return true;
-            case DialectDirectiveKind.EnableIntrinsic:
-                accumulation.EnabledIntrinsics.Add(ParseSingleIdentifier(line, descriptor.Keyword));
-                return true;
-            case DialectDirectiveKind.DisableIntrinsic:
-                accumulation.DisabledIntrinsics.Add(ParseSingleIdentifier(line, descriptor.Keyword));
-                return true;
-            case DialectDirectiveKind.Security:
-                if (accumulation.SecurityProfile != null)
-                {
-                    DialectDefinitionSliceParseErrors.Fail("Security directive can only be declared once.", line[0]);
-                }
-
-                accumulation.SecurityProfile = DialectAnnotationValueGuard.ParseSecurityProfile(ParseSingleIdentifier(line, descriptor.Keyword));
-                return true;
-            case DialectDirectiveKind.Capability:
-                accumulation.Capabilities.AddRange(ParseIdentifierList(line, descriptor.Keyword));
-                return true;
-            default:
-                Thrower.InvalidOpEx($"Directive parser does not support directive kind '{descriptor.Kind}'.");
-                return false;
-        }
-    }
-
-    private static string ParseSingleIdentifier(IReadOnlyList<LexemeValue> line, string directiveName)
-    {
-        if (line.Count != 2 || !DialectLexemeTags.IsTag(line[1], DialectLexemeTags.Identifier))
-        {
-            DialectDefinitionSliceParseErrors.Fail($"Directive '{directiveName}' expects exactly one identifier argument.", line.ElementAtOrDefault(1) ?? line[0]);
-        }
-
-        return line[1].Text;
-    }
-
-    private static IReadOnlyList<string> ParseIdentifierList(IReadOnlyList<LexemeValue> line, string directiveName)
-    {
-        if (line.Count < 2)
-        {
-            DialectDefinitionSliceParseErrors.Fail($"Directive '{directiveName}' expects at least one identifier.", line[0]);
-        }
-
-        var values = new List<string>();
-        var expectIdentifier = true;
-        for (var i = 1; i < line.Count; i++)
-        {
-            var token = line[i];
-            if (expectIdentifier)
-            {
-                if (!DialectLexemeTags.IsTag(token, DialectLexemeTags.Identifier))
-                {
-                    DialectDefinitionSliceParseErrors.Fail($"Directive '{directiveName}' contains an invalid identifier list item.", token);
-                }
-
-                values.Add(token.Text);
-                expectIdentifier = false;
-                continue;
-            }
-
-            if (!DialectLexemeTags.IsTag(token, DialectLexemeTags.CommaToken))
-            {
-                DialectDefinitionSliceParseErrors.Fail($"Directive '{directiveName}' expects comma-separated identifiers.", token);
-            }
-
-            expectIdentifier = true;
-        }
-
-        if (expectIdentifier)
-        {
-            DialectDefinitionSliceParseErrors.Fail($"Directive '{directiveName}' must not end with a trailing comma.", line[^1]);
-        }
-
-        return values;
+        feature.Accumulate(line, accumulation);
+        return true;
     }
 }

--- a/UniversalToolchain/UniversalToolchain.Dialects.Frontend/DialectDirectiveMetadata.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Frontend/DialectDirectiveMetadata.cs
@@ -1,28 +1,4 @@
-using ExceptionsManager;
-
 namespace UniversalToolchain.Dialects.Frontend;
-
-public enum DialectDirectiveKind
-{
-    UseModules,
-    ExcludeModules,
-    RequiresModules,
-    BeforeModules,
-    AfterModules,
-    Backend,
-    AllowIntrinsic,
-    ForbidIntrinsic,
-    EnableIntrinsic,
-    DisableIntrinsic,
-    Security,
-    Capability
-}
-
-public enum DialectDirectiveArgumentShape
-{
-    Identifier,
-    IdentifierList
-}
 
 public sealed class DialectDirectiveDescriptor
 {
@@ -37,47 +13,32 @@ public sealed class DialectDirectiveDescriptor
 
 public static class DialectDirectiveDescriptors
 {
-    private static readonly IReadOnlyList<DialectDirectiveDescriptor> _orderedDescriptors =
-    [
-        new() { Kind = DialectDirectiveKind.UseModules, Keyword = "use", ArgumentShape = DialectDirectiveArgumentShape.IdentifierList },
-        new() { Kind = DialectDirectiveKind.ExcludeModules, Keyword = "exclude", ArgumentShape = DialectDirectiveArgumentShape.IdentifierList },
-        new() { Kind = DialectDirectiveKind.RequiresModules, Keyword = "requires", ArgumentShape = DialectDirectiveArgumentShape.IdentifierList },
-        new() { Kind = DialectDirectiveKind.BeforeModules, Keyword = "before", ArgumentShape = DialectDirectiveArgumentShape.IdentifierList },
-        new() { Kind = DialectDirectiveKind.AfterModules, Keyword = "after", ArgumentShape = DialectDirectiveArgumentShape.IdentifierList },
-        new() { Kind = DialectDirectiveKind.Backend, Keyword = "backend", ArgumentShape = DialectDirectiveArgumentShape.IdentifierList },
-        new() { Kind = DialectDirectiveKind.AllowIntrinsic, Keyword = "allow", ArgumentShape = DialectDirectiveArgumentShape.Identifier },
-        new() { Kind = DialectDirectiveKind.ForbidIntrinsic, Keyword = "forbid", ArgumentShape = DialectDirectiveArgumentShape.Identifier },
-        new() { Kind = DialectDirectiveKind.EnableIntrinsic, Keyword = "enable", ArgumentShape = DialectDirectiveArgumentShape.Identifier },
-        new() { Kind = DialectDirectiveKind.DisableIntrinsic, Keyword = "disable", ArgumentShape = DialectDirectiveArgumentShape.Identifier },
-        new() { Kind = DialectDirectiveKind.Security, Keyword = "security", ArgumentShape = DialectDirectiveArgumentShape.Identifier, IsSingleton = true },
-        new() { Kind = DialectDirectiveKind.Capability, Keyword = "capability", ArgumentShape = DialectDirectiveArgumentShape.IdentifierList }
-    ];
+    private static readonly Lazy<IReadOnlyList<DialectDirectiveDescriptor>> _ordered = new(() =>
+        DialectDslFeatureCatalog.Features
+            .Select(x => new DialectDirectiveDescriptor
+            {
+                Kind = x.Kind,
+                Keyword = x.Keyword,
+                ArgumentShape = x.ArgumentShape,
+                IsSingleton = x.IsSingleton
+            })
+            .ToList());
 
-    private static readonly IReadOnlyDictionary<DialectDirectiveKind, DialectDirectiveDescriptor> _byKind =
-        _orderedDescriptors.ToDictionary(x => x.Kind);
+    private static readonly Lazy<IReadOnlyDictionary<DialectDirectiveKind, DialectDirectiveDescriptor>> _byKind = new(() =>
+        _ordered.Value.ToDictionary(x => x.Kind));
 
-    private static readonly IReadOnlyDictionary<string, DialectDirectiveDescriptor> _byKeyword =
-        _orderedDescriptors.ToDictionary(x => x.Keyword, StringComparer.Ordinal);
+    private static readonly Lazy<IReadOnlyDictionary<string, DialectDirectiveDescriptor>> _byKeyword = new(() =>
+        _ordered.Value.ToDictionary(x => x.Keyword, StringComparer.Ordinal));
 
-    public static IReadOnlyList<DialectDirectiveDescriptor> Ordered => _orderedDescriptors;
+    public static IReadOnlyList<DialectDirectiveDescriptor> Ordered => _ordered.Value;
 
     public static DialectDirectiveDescriptor Get(DialectDirectiveKind kind)
     {
-        if (!_byKind.TryGetValue(kind, out var descriptor))
-        {
-            Thrower.Argument(nameof(kind), $"Unknown dialect directive kind '{kind}'.");
-        }
-
-        return descriptor;
+        return _byKind.Value[kind];
     }
 
     public static bool TryGetByKeyword(string keyword, out DialectDirectiveDescriptor descriptor)
     {
-        if (string.IsNullOrWhiteSpace(keyword))
-        {
-            Thrower.Argument(nameof(keyword), "Directive keyword must not be empty.");
-        }
-
-        return _byKeyword.TryGetValue(keyword, out descriptor!);
+        return _byKeyword.Value.TryGetValue(keyword, out descriptor!);
     }
 }

--- a/UniversalToolchain/UniversalToolchain.Dialects.Frontend/DialectDslFeatureCatalog.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Frontend/DialectDslFeatureCatalog.cs
@@ -1,0 +1,622 @@
+using System.Reflection;
+using BasicCore.LexerWrapper;
+using BasicCore.ParserWrapper;
+using BasicCore.Registration;
+using ExceptionsManager;
+using UniversalToolchain.Dialects.Abstractions;
+
+namespace UniversalToolchain.Dialects.Frontend;
+
+public enum DialectDirectiveKind
+{
+    UseModules,
+    ExcludeModules,
+    RequiresModules,
+    BeforeModules,
+    AfterModules,
+    Backend,
+    AllowIntrinsic,
+    ForbidIntrinsic,
+    EnableIntrinsic,
+    DisableIntrinsic,
+    Security,
+    Capability
+}
+
+public enum DialectDirectiveArgumentShape
+{
+    Identifier,
+    IdentifierList
+}
+
+public interface IDialectDirectiveFeature
+{
+    DialectDirectiveKind Kind { get; }
+
+    string Keyword { get; }
+
+    string LexemeTag { get; }
+
+    DialectDirectiveArgumentShape ArgumentShape { get; }
+
+    float ParserPriority { get; }
+
+    bool IsSingleton { get; }
+
+    IAstNodeCreator CreateNodeCreator();
+
+    void Accumulate(IReadOnlyList<LexemeValue> line, DialectDirectiveAccumulation accumulation);
+
+    void ValidateSemantic(DialectDirectiveAstNode directive, DialectDirectiveValidationState state);
+
+    IReadOnlyList<IDialectDefinitionSliceAnnotation> Lower(DialectDirectiveAstNode directive);
+}
+
+public interface IDialectDocumentValidationRule
+{
+    int Order { get; }
+
+    void Validate(DialectDocumentAstNode document, DialectDirectiveValidationState state);
+}
+
+public static class DialectDslFeatureCatalog
+{
+    private static readonly Lazy<IReadOnlyList<IDialectDirectiveFeature>> _features = new(DiscoverFeatures);
+    private static readonly Lazy<IReadOnlyDictionary<DialectDirectiveKind, IDialectDirectiveFeature>> _featuresByKind = new(() =>
+        _features.Value.ToDictionary(x => x.Kind));
+    private static readonly Lazy<IReadOnlyDictionary<string, IDialectDirectiveFeature>> _featuresByKeyword = new(() =>
+        _features.Value.ToDictionary(x => x.Keyword, StringComparer.Ordinal));
+    private static readonly Lazy<IReadOnlyList<IDialectDocumentValidationRule>> _documentRules = new(DiscoverDocumentRules);
+
+    public static IReadOnlyList<IDialectDirectiveFeature> Features => _features.Value;
+
+    public static IReadOnlyList<IDialectDocumentValidationRule> DocumentRules => _documentRules.Value;
+
+    public static IDialectDirectiveFeature GetFeature(DialectDirectiveKind kind)
+    {
+        if (!_featuresByKind.Value.TryGetValue(kind, out var feature))
+        {
+            Thrower.Argument(nameof(kind), $"Unknown dialect directive kind '{kind}'.");
+        }
+
+        return feature;
+    }
+
+    public static bool TryGetFeature(string keyword, out IDialectDirectiveFeature feature)
+    {
+        if (string.IsNullOrWhiteSpace(keyword))
+        {
+            Thrower.Argument(nameof(keyword), "Directive keyword must not be empty.");
+        }
+
+        return _featuresByKeyword.Value.TryGetValue(keyword, out feature!);
+    }
+
+    private static IReadOnlyList<IDialectDirectiveFeature> DiscoverFeatures()
+    {
+        var features = typeof(DialectDslFeatureCatalog).Assembly
+            .GetTypes()
+            .Where(x => x is { IsClass: true, IsAbstract: false } && typeof(IDialectDirectiveFeature).IsAssignableFrom(x))
+            .Select(Create<IDialectDirectiveFeature>)
+            .OrderBy(x => x.ParserPriority)
+            .ThenBy(x => x.Keyword, StringComparer.Ordinal)
+            .ThenBy(x => x.GetType().FullName, StringComparer.Ordinal)
+            .ToList();
+
+        ValidateFeatureSet(features);
+        return features;
+    }
+
+    private static IReadOnlyList<IDialectDocumentValidationRule> DiscoverDocumentRules()
+    {
+        return typeof(DialectDslFeatureCatalog).Assembly
+            .GetTypes()
+            .Where(x => x is { IsClass: true, IsAbstract: false } && typeof(IDialectDocumentValidationRule).IsAssignableFrom(x))
+            .Select(Create<IDialectDocumentValidationRule>)
+            .OrderBy(x => x.Order)
+            .ThenBy(x => x.GetType().FullName, StringComparer.Ordinal)
+            .ToList();
+    }
+
+    private static T Create<T>(Type type)
+    {
+        var instance = Activator.CreateInstance(type);
+        if (instance is not T)
+        {
+            Thrower.InvalidOpEx<T>($"Could not create dialect feature instance '{type.FullName}'.");
+        }
+
+        return (T)instance;
+    }
+
+    private static void ValidateFeatureSet(IReadOnlyList<IDialectDirectiveFeature> features)
+    {
+        var duplicateKeyword = features
+            .GroupBy(x => x.Keyword, StringComparer.Ordinal)
+            .FirstOrDefault(x => x.Count() > 1);
+        if (duplicateKeyword != null)
+        {
+            Thrower.InvalidOpEx($"Dialect DSL keyword '{duplicateKeyword.Key}' is implemented by multiple features.");
+        }
+
+        var duplicateKind = features
+            .GroupBy(x => x.Kind)
+            .FirstOrDefault(x => x.Count() > 1);
+        if (duplicateKind != null)
+        {
+            Thrower.InvalidOpEx($"Dialect directive kind '{duplicateKind.Key}' is implemented by multiple features.");
+        }
+    }
+}
+
+public sealed class DialectDirectiveValidationState
+{
+    private readonly HashSet<string> _useModules = new(StringComparer.Ordinal);
+    private readonly HashSet<string> _excludeModules = new(StringComparer.Ordinal);
+    private readonly HashSet<string> _requiresModules = new(StringComparer.Ordinal);
+    private readonly HashSet<string> _beforeModules = new(StringComparer.Ordinal);
+    private readonly HashSet<string> _afterModules = new(StringComparer.Ordinal);
+    private readonly HashSet<string> _backends = new(StringComparer.Ordinal);
+    private readonly HashSet<string> _capabilities = new(StringComparer.Ordinal);
+    private readonly HashSet<string> _allowedIntrinsics = new(StringComparer.Ordinal);
+    private readonly HashSet<string> _forbiddenIntrinsics = new(StringComparer.Ordinal);
+    private readonly HashSet<string> _enabledOptimizers = new(StringComparer.Ordinal);
+    private readonly HashSet<string> _disabledOptimizers = new(StringComparer.Ordinal);
+
+    public IReadOnlySet<string> UseModules => _useModules;
+
+    public IReadOnlySet<string> ExcludeModules => _excludeModules;
+
+    public bool HasSecurityDirective { get; private set; }
+
+    public void AddUseModules(IEnumerable<string> modules, LexemeValue? token) => AddMany(_useModules, modules, "Duplicate use module is not allowed.", token);
+
+    public void AddExcludeModules(IEnumerable<string> modules, LexemeValue? token) => AddMany(_excludeModules, modules, "Duplicate exclude module is not allowed.", token);
+
+    public void AddRequiresModules(IEnumerable<string> modules, LexemeValue? token) => AddMany(_requiresModules, modules, "Duplicate requires module is not allowed.", token);
+
+    public void AddBeforeModules(IEnumerable<string> modules, LexemeValue? token) => AddMany(_beforeModules, modules, "Duplicate before module is not allowed.", token);
+
+    public void AddAfterModules(IEnumerable<string> modules, LexemeValue? token) => AddMany(_afterModules, modules, "Duplicate after module is not allowed.", token);
+
+    public void AddBackends(IEnumerable<string> backends, LexemeValue? token) => AddMany(_backends, backends, "Duplicate backend identifier is not allowed.", token);
+
+    public void AddCapabilities(IEnumerable<string> capabilities, LexemeValue? token) => AddMany(_capabilities, capabilities, "Duplicate capability identifier is not allowed.", token);
+
+    public void AddAllowedIntrinsic(string name, LexemeValue? token)
+    {
+        AddSingle(_allowedIntrinsics, name, "Duplicate allow intrinsic directive is not allowed.", token);
+        if (_forbiddenIntrinsics.Contains(name))
+        {
+            DialectDefinitionSliceParseErrors.Fail($"Intrinsic '{name}' cannot be both allowed and forbidden.", token);
+        }
+    }
+
+    public void AddForbiddenIntrinsic(string name, LexemeValue? token)
+    {
+        AddSingle(_forbiddenIntrinsics, name, "Duplicate forbid intrinsic directive is not allowed.", token);
+        if (_allowedIntrinsics.Contains(name))
+        {
+            DialectDefinitionSliceParseErrors.Fail($"Intrinsic '{name}' cannot be both allowed and forbidden.", token);
+        }
+    }
+
+    public void AddEnabledOptimizer(string name, LexemeValue? token)
+    {
+        AddSingle(_enabledOptimizers, name, "Duplicate enable directive is not allowed.", token);
+        if (_disabledOptimizers.Contains(name))
+        {
+            DialectDefinitionSliceParseErrors.Fail($"Optimizer '{name}' cannot be both enabled and disabled.", token);
+        }
+    }
+
+    public void AddDisabledOptimizer(string name, LexemeValue? token)
+    {
+        AddSingle(_disabledOptimizers, name, "Duplicate disable directive is not allowed.", token);
+        if (_enabledOptimizers.Contains(name))
+        {
+            DialectDefinitionSliceParseErrors.Fail($"Optimizer '{name}' cannot be both enabled and disabled.", token);
+        }
+    }
+
+    public void MarkSecurity(LexemeValue? token)
+    {
+        if (HasSecurityDirective)
+        {
+            DialectDefinitionSliceParseErrors.Fail("Security directive can only be declared once.", token);
+        }
+
+        HasSecurityDirective = true;
+    }
+
+    private static void AddMany(HashSet<string> set, IEnumerable<string> values, string duplicateMessage, LexemeValue? token)
+    {
+        foreach (var value in values)
+        {
+            AddSingle(set, value, duplicateMessage, token);
+        }
+    }
+
+    private static void AddSingle(HashSet<string> set, string value, string duplicateMessage, LexemeValue? token)
+    {
+        if (!set.Add(value))
+        {
+            DialectDefinitionSliceParseErrors.Fail(duplicateMessage, token);
+        }
+    }
+}
+
+internal abstract class DialectDirectiveFeatureBase : IDialectDirectiveFeature
+{
+    public abstract DialectDirectiveKind Kind { get; }
+
+    public abstract string Keyword { get; }
+
+    public string LexemeTag => $"DialectDirectiveKeyword.{Keyword}";
+
+    public abstract DialectDirectiveArgumentShape ArgumentShape { get; }
+
+    public abstract float ParserPriority { get; }
+
+    public virtual bool IsSingleton => false;
+
+    public virtual IAstNodeCreator CreateNodeCreator()
+    {
+        return ArgumentShape switch
+        {
+            DialectDirectiveArgumentShape.Identifier => new SingleIdentifierDialectDirectiveNodeCreator(this),
+            _ => new IdentifierListDialectDirectiveNodeCreator(this)
+        };
+    }
+
+    public virtual void Accumulate(IReadOnlyList<LexemeValue> line, DialectDirectiveAccumulation accumulation)
+    {
+        Thrower.InvalidOpEx($"Dialect feature '{GetType().Name}' does not support line accumulation.");
+        return;
+    }
+
+    public virtual void ValidateSemantic(DialectDirectiveAstNode directive, DialectDirectiveValidationState state)
+    {
+    }
+
+    public abstract IReadOnlyList<IDialectDefinitionSliceAnnotation> Lower(DialectDirectiveAstNode directive);
+
+    protected static IReadOnlyList<string> GetIdentifierList(DialectDirectiveAstNode directive)
+    {
+        if (directive is not IdentifierListDirectiveAstNode)
+        {
+            Thrower.Argument(nameof(directive), $"Directive '{directive.GetType().Name}' must provide an identifier list.");
+        }
+
+        return ((IdentifierListDirectiveAstNode)directive).Identifiers.Identifiers.Select(x => x.Identifier).ToList();
+    }
+
+    protected static string GetSingleIdentifier(DialectDirectiveAstNode directive)
+    {
+        if (directive is not SingleIdentifierDirectiveAstNode)
+        {
+            Thrower.Argument(nameof(directive), $"Directive '{directive.GetType().Name}' must provide one identifier.");
+        }
+
+        return ((SingleIdentifierDirectiveAstNode)directive).Identifier.Identifier;
+    }
+}
+
+internal sealed class UseModulesDialectDirectiveFeature : DialectDirectiveFeatureBase
+{
+    public override DialectDirectiveKind Kind => DialectDirectiveKind.UseModules;
+    public override string Keyword => DialectDslKeywords.Use;
+    public override DialectDirectiveArgumentShape ArgumentShape => DialectDirectiveArgumentShape.IdentifierList;
+    public override float ParserPriority => 11f;
+
+    public override void Accumulate(IReadOnlyList<LexemeValue> line, DialectDirectiveAccumulation accumulation)
+    {
+        accumulation.UseModules.AddRange(DialectDirectiveParserSupport.ParseIdentifierList(line, Keyword));
+    }
+
+    public override void ValidateSemantic(DialectDirectiveAstNode directive, DialectDirectiveValidationState state)
+    {
+        state.AddUseModules(GetIdentifierList(directive), directive.LexemeValue);
+    }
+
+    public override IReadOnlyList<IDialectDefinitionSliceAnnotation> Lower(DialectDirectiveAstNode directive) => [new UseModulesAirAnnotation(GetIdentifierList(directive))];
+}
+
+internal sealed class ExcludeModulesDialectDirectiveFeature : DialectDirectiveFeatureBase
+{
+    public override DialectDirectiveKind Kind => DialectDirectiveKind.ExcludeModules;
+    public override string Keyword => DialectDslKeywords.Exclude;
+    public override DialectDirectiveArgumentShape ArgumentShape => DialectDirectiveArgumentShape.IdentifierList;
+    public override float ParserPriority => 12f;
+
+    public override void Accumulate(IReadOnlyList<LexemeValue> line, DialectDirectiveAccumulation accumulation)
+    {
+        accumulation.ExcludeModules.AddRange(DialectDirectiveParserSupport.ParseIdentifierList(line, Keyword));
+    }
+
+    public override void ValidateSemantic(DialectDirectiveAstNode directive, DialectDirectiveValidationState state)
+    {
+        state.AddExcludeModules(GetIdentifierList(directive), directive.LexemeValue);
+    }
+
+    public override IReadOnlyList<IDialectDefinitionSliceAnnotation> Lower(DialectDirectiveAstNode directive) => [new ExcludeModulesAirAnnotation(GetIdentifierList(directive))];
+}
+
+internal abstract class OrderDialectDirectiveFeatureBase : DialectDirectiveFeatureBase
+{
+    protected abstract DialectOrderDirectiveKind OrderKind { get; }
+
+    protected abstract Action<DialectDirectiveValidationState, IReadOnlyList<string>, LexemeValue?> ValidationAction { get; }
+
+    public override void Accumulate(IReadOnlyList<LexemeValue> line, DialectDirectiveAccumulation accumulation)
+    {
+        GetTargetList(accumulation).AddRange(DialectDirectiveParserSupport.ParseIdentifierList(line, Keyword));
+    }
+
+    public override void ValidateSemantic(DialectDirectiveAstNode directive, DialectDirectiveValidationState state)
+    {
+        ValidationAction(state, GetIdentifierList(directive), directive.LexemeValue);
+    }
+
+    public override IReadOnlyList<IDialectDefinitionSliceAnnotation> Lower(DialectDirectiveAstNode directive)
+    {
+        return [new OrderAirAnnotation(OrderKind, GetIdentifierList(directive))];
+    }
+
+    protected abstract List<string> GetTargetList(DialectDirectiveAccumulation accumulation);
+}
+
+internal sealed class RequiresModulesDialectDirectiveFeature : OrderDialectDirectiveFeatureBase
+{
+    public override DialectDirectiveKind Kind => DialectDirectiveKind.RequiresModules;
+    public override string Keyword => DialectDslKeywords.Requires;
+    public override DialectDirectiveArgumentShape ArgumentShape => DialectDirectiveArgumentShape.IdentifierList;
+    public override float ParserPriority => 13f;
+    protected override DialectOrderDirectiveKind OrderKind => DialectOrderDirectiveKind.Requires;
+    protected override Action<DialectDirectiveValidationState, IReadOnlyList<string>, LexemeValue?> ValidationAction => static (state, values, token) => state.AddRequiresModules(values, token);
+    protected override List<string> GetTargetList(DialectDirectiveAccumulation accumulation) => accumulation.RequiresModules;
+}
+
+internal sealed class BeforeModulesDialectDirectiveFeature : OrderDialectDirectiveFeatureBase
+{
+    public override DialectDirectiveKind Kind => DialectDirectiveKind.BeforeModules;
+    public override string Keyword => DialectDslKeywords.Before;
+    public override DialectDirectiveArgumentShape ArgumentShape => DialectDirectiveArgumentShape.IdentifierList;
+    public override float ParserPriority => 14f;
+    protected override DialectOrderDirectiveKind OrderKind => DialectOrderDirectiveKind.Before;
+    protected override Action<DialectDirectiveValidationState, IReadOnlyList<string>, LexemeValue?> ValidationAction => static (state, values, token) => state.AddBeforeModules(values, token);
+    protected override List<string> GetTargetList(DialectDirectiveAccumulation accumulation) => accumulation.BeforeModules;
+}
+
+internal sealed class AfterModulesDialectDirectiveFeature : OrderDialectDirectiveFeatureBase
+{
+    public override DialectDirectiveKind Kind => DialectDirectiveKind.AfterModules;
+    public override string Keyword => DialectDslKeywords.After;
+    public override DialectDirectiveArgumentShape ArgumentShape => DialectDirectiveArgumentShape.IdentifierList;
+    public override float ParserPriority => 15f;
+    protected override DialectOrderDirectiveKind OrderKind => DialectOrderDirectiveKind.After;
+    protected override Action<DialectDirectiveValidationState, IReadOnlyList<string>, LexemeValue?> ValidationAction => static (state, values, token) => state.AddAfterModules(values, token);
+    protected override List<string> GetTargetList(DialectDirectiveAccumulation accumulation) => accumulation.AfterModules;
+}
+
+internal sealed class BackendDialectDirectiveFeature : DialectDirectiveFeatureBase
+{
+    public override DialectDirectiveKind Kind => DialectDirectiveKind.Backend;
+    public override string Keyword => DialectDslKeywords.Backend;
+    public override DialectDirectiveArgumentShape ArgumentShape => DialectDirectiveArgumentShape.IdentifierList;
+    public override float ParserPriority => 16f;
+
+    public override void Accumulate(IReadOnlyList<LexemeValue> line, DialectDirectiveAccumulation accumulation)
+    {
+        accumulation.Backends.AddRange(DialectDirectiveParserSupport.ParseIdentifierList(line, Keyword));
+    }
+
+    public override void ValidateSemantic(DialectDirectiveAstNode directive, DialectDirectiveValidationState state)
+    {
+        state.AddBackends(GetIdentifierList(directive), directive.LexemeValue);
+    }
+
+    public override IReadOnlyList<IDialectDefinitionSliceAnnotation> Lower(DialectDirectiveAstNode directive) => [new BackendAirAnnotation(GetIdentifierList(directive))];
+}
+
+internal abstract class ToggleDirectiveFeatureBase : DialectDirectiveFeatureBase
+{
+    public override DialectDirectiveArgumentShape ArgumentShape => DialectDirectiveArgumentShape.Identifier;
+
+    public override void Accumulate(IReadOnlyList<LexemeValue> line, DialectDirectiveAccumulation accumulation)
+    {
+        AddAccumulatedValue(accumulation, DialectDirectiveParserSupport.ParseSingleIdentifier(line, Keyword));
+    }
+
+    protected abstract void AddAccumulatedValue(DialectDirectiveAccumulation accumulation, string value);
+}
+
+internal sealed class AllowIntrinsicDialectDirectiveFeature : ToggleDirectiveFeatureBase
+{
+    public override DialectDirectiveKind Kind => DialectDirectiveKind.AllowIntrinsic;
+    public override string Keyword => DialectDslKeywords.Allow;
+    public override float ParserPriority => 17f;
+
+    protected override void AddAccumulatedValue(DialectDirectiveAccumulation accumulation, string value)
+    {
+        accumulation.AllowedIntrinsics.Add(value);
+    }
+
+    public override void ValidateSemantic(DialectDirectiveAstNode directive, DialectDirectiveValidationState state)
+    {
+        state.AddAllowedIntrinsic(GetSingleIdentifier(directive), directive.LexemeValue);
+    }
+
+    public override IReadOnlyList<IDialectDefinitionSliceAnnotation> Lower(DialectDirectiveAstNode directive) => [new IntrinsicAirAnnotation(GetSingleIdentifier(directive), allowed: true)];
+}
+
+internal sealed class ForbidIntrinsicDialectDirectiveFeature : ToggleDirectiveFeatureBase
+{
+    public override DialectDirectiveKind Kind => DialectDirectiveKind.ForbidIntrinsic;
+    public override string Keyword => DialectDslKeywords.Forbid;
+    public override float ParserPriority => 18f;
+
+    protected override void AddAccumulatedValue(DialectDirectiveAccumulation accumulation, string value)
+    {
+        accumulation.ForbiddenIntrinsics.Add(value);
+    }
+
+    public override void ValidateSemantic(DialectDirectiveAstNode directive, DialectDirectiveValidationState state)
+    {
+        state.AddForbiddenIntrinsic(GetSingleIdentifier(directive), directive.LexemeValue);
+    }
+
+    public override IReadOnlyList<IDialectDefinitionSliceAnnotation> Lower(DialectDirectiveAstNode directive) => [new IntrinsicAirAnnotation(GetSingleIdentifier(directive), allowed: false)];
+}
+
+internal sealed class EnableIntrinsicDialectDirectiveFeature : ToggleDirectiveFeatureBase
+{
+    public override DialectDirectiveKind Kind => DialectDirectiveKind.EnableIntrinsic;
+    public override string Keyword => DialectDslKeywords.Enable;
+    public override float ParserPriority => 19f;
+
+    protected override void AddAccumulatedValue(DialectDirectiveAccumulation accumulation, string value)
+    {
+        accumulation.EnabledIntrinsics.Add(value);
+    }
+
+    public override void ValidateSemantic(DialectDirectiveAstNode directive, DialectDirectiveValidationState state)
+    {
+        state.AddEnabledOptimizer(GetSingleIdentifier(directive), directive.LexemeValue);
+    }
+
+    public override IReadOnlyList<IDialectDefinitionSliceAnnotation> Lower(DialectDirectiveAstNode directive) => [new OptimizerAirAnnotation(GetSingleIdentifier(directive), enabled: true)];
+}
+
+internal sealed class DisableIntrinsicDialectDirectiveFeature : ToggleDirectiveFeatureBase
+{
+    public override DialectDirectiveKind Kind => DialectDirectiveKind.DisableIntrinsic;
+    public override string Keyword => DialectDslKeywords.Disable;
+    public override float ParserPriority => 20f;
+
+    protected override void AddAccumulatedValue(DialectDirectiveAccumulation accumulation, string value)
+    {
+        accumulation.DisabledIntrinsics.Add(value);
+    }
+
+    public override void ValidateSemantic(DialectDirectiveAstNode directive, DialectDirectiveValidationState state)
+    {
+        state.AddDisabledOptimizer(GetSingleIdentifier(directive), directive.LexemeValue);
+    }
+
+    public override IReadOnlyList<IDialectDefinitionSliceAnnotation> Lower(DialectDirectiveAstNode directive) => [new OptimizerAirAnnotation(GetSingleIdentifier(directive), enabled: false)];
+}
+
+internal sealed class SecurityDialectDirectiveFeature : ToggleDirectiveFeatureBase
+{
+    public override DialectDirectiveKind Kind => DialectDirectiveKind.Security;
+    public override string Keyword => DialectDslKeywords.Security;
+    public override float ParserPriority => 21f;
+    public override bool IsSingleton => true;
+
+    protected override void AddAccumulatedValue(DialectDirectiveAccumulation accumulation, string value)
+    {
+        if (accumulation.SecurityProfile != null)
+        {
+            DialectDefinitionSliceParseErrors.Fail("Security directive can only be declared once.", null);
+        }
+
+        accumulation.SecurityProfile = DialectAnnotationValueGuard.ParseSecurityProfile(value);
+    }
+
+    public override void ValidateSemantic(DialectDirectiveAstNode directive, DialectDirectiveValidationState state)
+    {
+        state.MarkSecurity(directive.LexemeValue);
+    }
+
+    public override IReadOnlyList<IDialectDefinitionSliceAnnotation> Lower(DialectDirectiveAstNode directive)
+    {
+        return [new SecurityAirAnnotation(DialectAnnotationValueGuard.ParseSecurityProfile(GetSingleIdentifier(directive)))];
+    }
+}
+
+internal sealed class CapabilityDialectDirectiveFeature : DialectDirectiveFeatureBase
+{
+    public override DialectDirectiveKind Kind => DialectDirectiveKind.Capability;
+    public override string Keyword => DialectDslKeywords.Capability;
+    public override DialectDirectiveArgumentShape ArgumentShape => DialectDirectiveArgumentShape.IdentifierList;
+    public override float ParserPriority => 22f;
+
+    public override void Accumulate(IReadOnlyList<LexemeValue> line, DialectDirectiveAccumulation accumulation)
+    {
+        accumulation.Capabilities.AddRange(DialectDirectiveParserSupport.ParseIdentifierList(line, Keyword));
+    }
+
+    public override void ValidateSemantic(DialectDirectiveAstNode directive, DialectDirectiveValidationState state)
+    {
+        state.AddCapabilities(GetIdentifierList(directive), directive.LexemeValue);
+    }
+
+    public override IReadOnlyList<IDialectDefinitionSliceAnnotation> Lower(DialectDirectiveAstNode directive) => [new CapabilityAirAnnotation(GetIdentifierList(directive))];
+}
+
+internal sealed class UseExcludeConflictDocumentValidationRule : IDialectDocumentValidationRule
+{
+    public int Order => 0;
+
+    public void Validate(DialectDocumentAstNode document, DialectDirectiveValidationState state)
+    {
+        foreach (var conflict in state.UseModules.Intersect(state.ExcludeModules, StringComparer.Ordinal))
+        {
+            DialectDefinitionSliceParseErrors.Fail($"Module '{conflict}' cannot appear in both use and exclude directives.", document.Declaration.NameNode.LexemeValue);
+        }
+    }
+}
+
+internal static class DialectDirectiveParserSupport
+{
+    public static string ParseSingleIdentifier(IReadOnlyList<LexemeValue> line, string directiveName)
+    {
+        if (line.Count != 2 || !DialectLexemeTags.IsTag(line[1], DialectLexemeTags.Identifier))
+        {
+            DialectDefinitionSliceParseErrors.Fail($"Directive '{directiveName}' expects exactly one identifier argument.", line.ElementAtOrDefault(1) ?? line[0]);
+        }
+
+        return line[1].Text;
+    }
+
+    public static IReadOnlyList<string> ParseIdentifierList(IReadOnlyList<LexemeValue> line, string directiveName)
+    {
+        if (line.Count < 2)
+        {
+            DialectDefinitionSliceParseErrors.Fail($"Directive '{directiveName}' expects at least one identifier.", line[0]);
+        }
+
+        var values = new List<string>();
+        var expectIdentifier = true;
+        for (var i = 1; i < line.Count; i++)
+        {
+            var token = line[i];
+            if (expectIdentifier)
+            {
+                if (!DialectLexemeTags.IsTag(token, DialectLexemeTags.Identifier))
+                {
+                    DialectDefinitionSliceParseErrors.Fail($"Directive '{directiveName}' contains an invalid identifier list item.", token);
+                }
+
+                values.Add(token.Text);
+                expectIdentifier = false;
+                continue;
+            }
+
+            if (!DialectLexemeTags.IsTag(token, DialectLexemeTags.CommaToken))
+            {
+                DialectDefinitionSliceParseErrors.Fail($"Directive '{directiveName}' expects comma-separated identifiers.", token);
+            }
+
+            expectIdentifier = true;
+        }
+
+        if (expectIdentifier)
+        {
+            DialectDefinitionSliceParseErrors.Fail($"Directive '{directiveName}' must not end with a trailing comma.", line[^1]);
+        }
+
+        return values;
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Frontend/DialectDslKeywords.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Frontend/DialectDslKeywords.cs
@@ -1,0 +1,18 @@
+namespace UniversalToolchain.Dialects.Frontend;
+
+public static class DialectDslKeywords
+{
+    public const string Dialect = "dialect";
+    public const string Use = "use";
+    public const string Exclude = "exclude";
+    public const string Requires = "requires";
+    public const string Before = "before";
+    public const string After = "after";
+    public const string Backend = "backend";
+    public const string Allow = "allow";
+    public const string Forbid = "forbid";
+    public const string Enable = "enable";
+    public const string Disable = "disable";
+    public const string Security = "security";
+    public const string Capability = "capability";
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Frontend/DialectDslLexemeRegistry.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Frontend/DialectDslLexemeRegistry.cs
@@ -4,24 +4,22 @@ namespace UniversalToolchain.Dialects.Frontend;
 
 public static class DialectDslLexemeRegistry
 {
-    public static IReadOnlyList<LexemeRegistration> Registrations { get; } =
-    [
-        new(@"\bdialect\b", DialectLexemeTags.DialectKeyword),
-        new(@"\buse\b", DialectLexemeTags.UseKeyword),
-        new(@"\bexclude\b", DialectLexemeTags.ExcludeKeyword),
-        new(@"\brequires\b", DialectLexemeTags.RequiresKeyword),
-        new(@"\bbefore\b", DialectLexemeTags.BeforeKeyword),
-        new(@"\bafter\b", DialectLexemeTags.AfterKeyword),
-        new(@"\bbackend\b", DialectLexemeTags.BackendKeyword),
-        new(@"\ballow\b", DialectLexemeTags.AllowKeyword),
-        new(@"\bforbid\b", DialectLexemeTags.ForbidKeyword),
-        new(@"\benable\b", DialectLexemeTags.EnableKeyword),
-        new(@"\bdisable\b", DialectLexemeTags.DisableKeyword),
-        new(@"\bsecurity\b", DialectLexemeTags.SecurityKeyword),
-        new(@"\bcapability\b", DialectLexemeTags.CapabilityKeyword),
-        new(@",", DialectLexemeTags.CommaToken),
-        new(@"\r?\n", DialectLexemeTags.NewLine),
-        new(@"[A-Za-z_][A-Za-z0-9_\.-]*", DialectLexemeTags.Identifier),
-        new(@"[ \t]+", "Whitespace", Ignore: true)
-    ];
+    private static readonly Lazy<IReadOnlyList<LexemeRegistration>> _registrations = new(BuildRegistrations);
+
+    public static IReadOnlyList<LexemeRegistration> Registrations => _registrations.Value;
+
+    private static IReadOnlyList<LexemeRegistration> BuildRegistrations()
+    {
+        var registrations = new List<LexemeRegistration>
+        {
+            new($@"\b{DialectDslKeywords.Dialect}\b", DialectLexemeTags.DialectKeyword)
+        };
+
+        registrations.AddRange(DialectDslFeatureCatalog.Features.Select(x => new LexemeRegistration($@"\b{x.Keyword}\b", x.LexemeTag)));
+        registrations.Add(new LexemeRegistration(@",", DialectLexemeTags.CommaToken));
+        registrations.Add(new LexemeRegistration(@"\r?\n", DialectLexemeTags.NewLine));
+        registrations.Add(new LexemeRegistration(@"[A-Za-z_][A-Za-z0-9_\.-]*", DialectLexemeTags.Identifier));
+        registrations.Add(new LexemeRegistration(@"[ \t]+", "Whitespace", Ignore: true));
+        return registrations;
+    }
 }

--- a/UniversalToolchain/UniversalToolchain.Dialects.Frontend/DialectDslParserNodeRegistry.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Frontend/DialectDslParserNodeRegistry.cs
@@ -4,22 +4,20 @@ namespace UniversalToolchain.Dialects.Frontend;
 
 public static class DialectDslParserNodeRegistry
 {
-    public static IReadOnlyList<NodeCreatorRegistration> Registrations { get; } =
-    [
-        new(0f, new DialectLineNodeCreator()),
-        new(10f, new DialectDeclarationNodeCreator()),
-        new(11f, new UseModulesDirectiveNodeCreator()),
-        new(12f, new ExcludeModulesDirectiveNodeCreator()),
-        new(13f, new RequiresModulesDirectiveNodeCreator()),
-        new(14f, new BeforeModulesDirectiveNodeCreator()),
-        new(15f, new AfterModulesDirectiveNodeCreator()),
-        new(16f, new BackendDirectiveNodeCreator()),
-        new(17f, new AllowIntrinsicDirectiveNodeCreator()),
-        new(18f, new ForbidIntrinsicDirectiveNodeCreator()),
-        new(19f, new EnableIntrinsicDirectiveNodeCreator()),
-        new(20f, new DisableIntrinsicDirectiveNodeCreator()),
-        new(21f, new SecurityDirectiveNodeCreator()),
-        new(22f, new CapabilityDirectiveNodeCreator()),
-        new(100f, new DialectDocumentNodeCreator())
-    ];
+    private static readonly Lazy<IReadOnlyList<NodeCreatorRegistration>> _registrations = new(BuildRegistrations);
+
+    public static IReadOnlyList<NodeCreatorRegistration> Registrations => _registrations.Value;
+
+    private static IReadOnlyList<NodeCreatorRegistration> BuildRegistrations()
+    {
+        var registrations = new List<NodeCreatorRegistration>
+        {
+            new(0f, new DialectLineNodeCreator()),
+            new(10f, new DialectDeclarationNodeCreator())
+        };
+
+        registrations.AddRange(DialectDslFeatureCatalog.Features.Select(x => new NodeCreatorRegistration(x.ParserPriority, x.CreateNodeCreator())));
+        registrations.Add(new NodeCreatorRegistration(100f, new DialectDocumentNodeCreator()));
+        return registrations;
+    }
 }

--- a/UniversalToolchain/UniversalToolchain.Dialects.Frontend/DialectNodeCreators.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Frontend/DialectNodeCreators.cs
@@ -1,3 +1,4 @@
+using BasicCore.LexerWrapper;
 using BasicCore.ParserWrapper;
 using ExceptionsManager;
 using AstNodeType = BasicTypesExtensions.ExtensibleEnum<BasicCore.ParserWrapper.AstNodeTag>;
@@ -229,7 +230,7 @@ public sealed class DialectDeclarationNodeCreator : DialectLineConstructNodeCrea
 {
     public override AstNodeType AstNodeType => DialectAstNodeTypes.DialectDeclaration;
 
-    protected override string Keyword => DialectDirectiveSyntax.DialectKeyword;
+    protected override string Keyword => DialectDslKeywords.Dialect;
 
     protected override AstNode CreateNode(AstNode lineNode)
     {
@@ -268,113 +269,136 @@ public abstract class SingleIdentifierDirectiveNodeCreator<TNode> : DialectLineC
     protected abstract TNode CreateTypedNode(AstNode lineNode, IdentifierValueAstNode identifier);
 }
 
-public sealed class UseModulesDirectiveNodeCreator : IdentifierListDirectiveNodeCreator<UseModulesDirectiveAstNode>
+public class IdentifierListDialectDirectiveNodeCreator : IdentifierListDirectiveNodeCreator<DialectDirectiveAstNode>
 {
-    public override AstNodeType AstNodeType => DialectAstNodeTypes.UseModulesDirective;
+    private readonly IDialectDirectiveFeature _feature;
+    private readonly Func<LexemeValue?, IdentifierListAstNode, DialectDirectiveAstNode> _factory;
 
-    protected override string Keyword => DialectDirectiveDescriptors.Get(DialectDirectiveKind.UseModules).Keyword;
+    public IdentifierListDialectDirectiveNodeCreator(IDialectDirectiveFeature feature)
+    {
+        if (feature == null)
+        {
+            Thrower.ArgumentNull(nameof(feature));
+        }
 
-    protected override UseModulesDirectiveAstNode CreateTypedNode(AstNode lineNode, IdentifierListAstNode identifiers) => new(lineNode.Children[0].LexemeValue, identifiers);
+        if (feature.ArgumentShape != DialectDirectiveArgumentShape.IdentifierList)
+        {
+            Thrower.Argument(nameof(feature), $"Feature '{feature.Keyword}' must use identifier-list syntax.");
+        }
+
+        _feature = feature;
+        _factory = DialectDirectiveNodeFactory.CreateIdentifierListFactory(feature);
+    }
+
+    public override AstNodeType AstNodeType => DialectDirectiveNodeFactory.GetNodeType(_feature.Kind);
+
+    protected override string Keyword => _feature.Keyword;
+
+    protected override DialectDirectiveAstNode CreateTypedNode(AstNode lineNode, IdentifierListAstNode identifiers) => _factory(lineNode.Children[0].LexemeValue, identifiers);
 }
 
-public sealed class ExcludeModulesDirectiveNodeCreator : IdentifierListDirectiveNodeCreator<ExcludeModulesDirectiveAstNode>
+public class SingleIdentifierDialectDirectiveNodeCreator : SingleIdentifierDirectiveNodeCreator<DialectDirectiveAstNode>
 {
-    public override AstNodeType AstNodeType => DialectAstNodeTypes.ExcludeModulesDirective;
+    private readonly IDialectDirectiveFeature _feature;
+    private readonly Func<LexemeValue?, IdentifierValueAstNode, DialectDirectiveAstNode> _factory;
 
-    protected override string Keyword => DialectDirectiveDescriptors.Get(DialectDirectiveKind.ExcludeModules).Keyword;
+    public SingleIdentifierDialectDirectiveNodeCreator(IDialectDirectiveFeature feature)
+    {
+        if (feature == null)
+        {
+            Thrower.ArgumentNull(nameof(feature));
+        }
 
-    protected override ExcludeModulesDirectiveAstNode CreateTypedNode(AstNode lineNode, IdentifierListAstNode identifiers) => new(lineNode.Children[0].LexemeValue, identifiers);
+        if (feature.ArgumentShape != DialectDirectiveArgumentShape.Identifier)
+        {
+            Thrower.Argument(nameof(feature), $"Feature '{feature.Keyword}' must use single-identifier syntax.");
+        }
+
+        _feature = feature;
+        _factory = DialectDirectiveNodeFactory.CreateSingleIdentifierFactory(feature);
+    }
+
+    public override AstNodeType AstNodeType => DialectDirectiveNodeFactory.GetNodeType(_feature.Kind);
+
+    protected override string Keyword => _feature.Keyword;
+
+    protected override DialectDirectiveAstNode CreateTypedNode(AstNode lineNode, IdentifierValueAstNode identifier) => _factory(lineNode.Children[0].LexemeValue, identifier);
 }
 
-public sealed class RequiresModulesDirectiveNodeCreator : IdentifierListDirectiveNodeCreator<RequiresModulesDirectiveAstNode>
+internal static class DialectDirectiveNodeFactory
 {
-    public override AstNodeType AstNodeType => DialectAstNodeTypes.RequiresModulesDirective;
+    public static AstNodeType GetNodeType(DialectDirectiveKind kind)
+    {
+        return kind switch
+        {
+            DialectDirectiveKind.UseModules => DialectAstNodeTypes.UseModulesDirective,
+            DialectDirectiveKind.ExcludeModules => DialectAstNodeTypes.ExcludeModulesDirective,
+            DialectDirectiveKind.RequiresModules => DialectAstNodeTypes.RequiresModulesDirective,
+            DialectDirectiveKind.BeforeModules => DialectAstNodeTypes.BeforeModulesDirective,
+            DialectDirectiveKind.AfterModules => DialectAstNodeTypes.AfterModulesDirective,
+            DialectDirectiveKind.Backend => DialectAstNodeTypes.BackendDirective,
+            DialectDirectiveKind.AllowIntrinsic => DialectAstNodeTypes.AllowIntrinsicDirective,
+            DialectDirectiveKind.ForbidIntrinsic => DialectAstNodeTypes.ForbidIntrinsicDirective,
+            DialectDirectiveKind.EnableIntrinsic => DialectAstNodeTypes.EnableIntrinsicDirective,
+            DialectDirectiveKind.DisableIntrinsic => DialectAstNodeTypes.DisableIntrinsicDirective,
+            DialectDirectiveKind.Security => DialectAstNodeTypes.SecurityDirective,
+            DialectDirectiveKind.Capability => DialectAstNodeTypes.CapabilityDirective,
+            _ => Thrower.InvalidOpEx<AstNodeType>($"Unknown dialect directive kind '{kind}'.")
+        };
+    }
 
-    protected override string Keyword => DialectDirectiveDescriptors.Get(DialectDirectiveKind.RequiresModules).Keyword;
+    public static Func<LexemeValue?, IdentifierListAstNode, DialectDirectiveAstNode> CreateIdentifierListFactory(IDialectDirectiveFeature feature)
+    {
+        return feature.Kind switch
+        {
+            DialectDirectiveKind.UseModules => (lexeme, identifiers) => new UseModulesDirectiveAstNode(feature, lexeme, identifiers),
+            DialectDirectiveKind.ExcludeModules => (lexeme, identifiers) => new ExcludeModulesDirectiveAstNode(feature, lexeme, identifiers),
+            DialectDirectiveKind.RequiresModules => (lexeme, identifiers) => new RequiresModulesDirectiveAstNode(feature, lexeme, identifiers),
+            DialectDirectiveKind.BeforeModules => (lexeme, identifiers) => new BeforeModulesDirectiveAstNode(feature, lexeme, identifiers),
+            DialectDirectiveKind.AfterModules => (lexeme, identifiers) => new AfterModulesDirectiveAstNode(feature, lexeme, identifiers),
+            DialectDirectiveKind.Backend => (lexeme, identifiers) => new BackendDirectiveAstNode(feature, lexeme, identifiers),
+            DialectDirectiveKind.Capability => (lexeme, identifiers) => new CapabilityDirectiveAstNode(feature, lexeme, identifiers),
+            _ => Thrower.InvalidOpEx<Func<LexemeValue?, IdentifierListAstNode, DialectDirectiveAstNode>>($"Feature '{feature.Keyword}' does not support identifier-list directives.")
+        };
+    }
 
-    protected override RequiresModulesDirectiveAstNode CreateTypedNode(AstNode lineNode, IdentifierListAstNode identifiers) => new(lineNode.Children[0].LexemeValue, identifiers);
+    public static Func<LexemeValue?, IdentifierValueAstNode, DialectDirectiveAstNode> CreateSingleIdentifierFactory(IDialectDirectiveFeature feature)
+    {
+        return feature.Kind switch
+        {
+            DialectDirectiveKind.AllowIntrinsic => (lexeme, identifier) => new AllowIntrinsicDirectiveAstNode(feature, lexeme, identifier),
+            DialectDirectiveKind.ForbidIntrinsic => (lexeme, identifier) => new ForbidIntrinsicDirectiveAstNode(feature, lexeme, identifier),
+            DialectDirectiveKind.EnableIntrinsic => (lexeme, identifier) => new EnableIntrinsicDirectiveAstNode(feature, lexeme, identifier),
+            DialectDirectiveKind.DisableIntrinsic => (lexeme, identifier) => new DisableIntrinsicDirectiveAstNode(feature, lexeme, identifier),
+            DialectDirectiveKind.Security => (lexeme, identifier) => new SecurityDirectiveAstNode(feature, lexeme, identifier),
+            _ => Thrower.InvalidOpEx<Func<LexemeValue?, IdentifierValueAstNode, DialectDirectiveAstNode>>($"Feature '{feature.Keyword}' does not support single-identifier directives.")
+        };
+    }
 }
 
-public sealed class BeforeModulesDirectiveNodeCreator : IdentifierListDirectiveNodeCreator<BeforeModulesDirectiveAstNode>
-{
-    public override AstNodeType AstNodeType => DialectAstNodeTypes.BeforeModulesDirective;
+public sealed class UseModulesDirectiveNodeCreator() : IdentifierListDialectDirectiveNodeCreator(DialectDslFeatureCatalog.GetFeature(DialectDirectiveKind.UseModules));
 
-    protected override string Keyword => DialectDirectiveDescriptors.Get(DialectDirectiveKind.BeforeModules).Keyword;
+public sealed class ExcludeModulesDirectiveNodeCreator() : IdentifierListDialectDirectiveNodeCreator(DialectDslFeatureCatalog.GetFeature(DialectDirectiveKind.ExcludeModules));
 
-    protected override BeforeModulesDirectiveAstNode CreateTypedNode(AstNode lineNode, IdentifierListAstNode identifiers) => new(lineNode.Children[0].LexemeValue, identifiers);
-}
+public sealed class RequiresModulesDirectiveNodeCreator() : IdentifierListDialectDirectiveNodeCreator(DialectDslFeatureCatalog.GetFeature(DialectDirectiveKind.RequiresModules));
 
-public sealed class AfterModulesDirectiveNodeCreator : IdentifierListDirectiveNodeCreator<AfterModulesDirectiveAstNode>
-{
-    public override AstNodeType AstNodeType => DialectAstNodeTypes.AfterModulesDirective;
+public sealed class BeforeModulesDirectiveNodeCreator() : IdentifierListDialectDirectiveNodeCreator(DialectDslFeatureCatalog.GetFeature(DialectDirectiveKind.BeforeModules));
 
-    protected override string Keyword => DialectDirectiveDescriptors.Get(DialectDirectiveKind.AfterModules).Keyword;
+public sealed class AfterModulesDirectiveNodeCreator() : IdentifierListDialectDirectiveNodeCreator(DialectDslFeatureCatalog.GetFeature(DialectDirectiveKind.AfterModules));
 
-    protected override AfterModulesDirectiveAstNode CreateTypedNode(AstNode lineNode, IdentifierListAstNode identifiers) => new(lineNode.Children[0].LexemeValue, identifiers);
-}
+public sealed class BackendDirectiveNodeCreator() : IdentifierListDialectDirectiveNodeCreator(DialectDslFeatureCatalog.GetFeature(DialectDirectiveKind.Backend));
 
-public sealed class BackendDirectiveNodeCreator : IdentifierListDirectiveNodeCreator<BackendDirectiveAstNode>
-{
-    public override AstNodeType AstNodeType => DialectAstNodeTypes.BackendDirective;
+public sealed class AllowIntrinsicDirectiveNodeCreator() : SingleIdentifierDialectDirectiveNodeCreator(DialectDslFeatureCatalog.GetFeature(DialectDirectiveKind.AllowIntrinsic));
 
-    protected override string Keyword => DialectDirectiveDescriptors.Get(DialectDirectiveKind.Backend).Keyword;
+public sealed class ForbidIntrinsicDirectiveNodeCreator() : SingleIdentifierDialectDirectiveNodeCreator(DialectDslFeatureCatalog.GetFeature(DialectDirectiveKind.ForbidIntrinsic));
 
-    protected override BackendDirectiveAstNode CreateTypedNode(AstNode lineNode, IdentifierListAstNode identifiers) => new(lineNode.Children[0].LexemeValue, identifiers);
-}
+public sealed class EnableIntrinsicDirectiveNodeCreator() : SingleIdentifierDialectDirectiveNodeCreator(DialectDslFeatureCatalog.GetFeature(DialectDirectiveKind.EnableIntrinsic));
 
-public sealed class AllowIntrinsicDirectiveNodeCreator : SingleIdentifierDirectiveNodeCreator<AllowIntrinsicDirectiveAstNode>
-{
-    public override AstNodeType AstNodeType => DialectAstNodeTypes.AllowIntrinsicDirective;
+public sealed class DisableIntrinsicDirectiveNodeCreator() : SingleIdentifierDialectDirectiveNodeCreator(DialectDslFeatureCatalog.GetFeature(DialectDirectiveKind.DisableIntrinsic));
 
-    protected override string Keyword => DialectDirectiveDescriptors.Get(DialectDirectiveKind.AllowIntrinsic).Keyword;
+public sealed class SecurityDirectiveNodeCreator() : SingleIdentifierDialectDirectiveNodeCreator(DialectDslFeatureCatalog.GetFeature(DialectDirectiveKind.Security));
 
-    protected override AllowIntrinsicDirectiveAstNode CreateTypedNode(AstNode lineNode, IdentifierValueAstNode identifier) => new(lineNode.Children[0].LexemeValue, identifier);
-}
-
-public sealed class ForbidIntrinsicDirectiveNodeCreator : SingleIdentifierDirectiveNodeCreator<ForbidIntrinsicDirectiveAstNode>
-{
-    public override AstNodeType AstNodeType => DialectAstNodeTypes.ForbidIntrinsicDirective;
-
-    protected override string Keyword => DialectDirectiveDescriptors.Get(DialectDirectiveKind.ForbidIntrinsic).Keyword;
-
-    protected override ForbidIntrinsicDirectiveAstNode CreateTypedNode(AstNode lineNode, IdentifierValueAstNode identifier) => new(lineNode.Children[0].LexemeValue, identifier);
-}
-
-public sealed class EnableIntrinsicDirectiveNodeCreator : SingleIdentifierDirectiveNodeCreator<EnableIntrinsicDirectiveAstNode>
-{
-    public override AstNodeType AstNodeType => DialectAstNodeTypes.EnableIntrinsicDirective;
-
-    protected override string Keyword => DialectDirectiveDescriptors.Get(DialectDirectiveKind.EnableIntrinsic).Keyword;
-
-    protected override EnableIntrinsicDirectiveAstNode CreateTypedNode(AstNode lineNode, IdentifierValueAstNode identifier) => new(lineNode.Children[0].LexemeValue, identifier);
-}
-
-public sealed class DisableIntrinsicDirectiveNodeCreator : SingleIdentifierDirectiveNodeCreator<DisableIntrinsicDirectiveAstNode>
-{
-    public override AstNodeType AstNodeType => DialectAstNodeTypes.DisableIntrinsicDirective;
-
-    protected override string Keyword => DialectDirectiveDescriptors.Get(DialectDirectiveKind.DisableIntrinsic).Keyword;
-
-    protected override DisableIntrinsicDirectiveAstNode CreateTypedNode(AstNode lineNode, IdentifierValueAstNode identifier) => new(lineNode.Children[0].LexemeValue, identifier);
-}
-
-public sealed class SecurityDirectiveNodeCreator : SingleIdentifierDirectiveNodeCreator<SecurityDirectiveAstNode>
-{
-    public override AstNodeType AstNodeType => DialectAstNodeTypes.SecurityDirective;
-
-    protected override string Keyword => DialectDirectiveDescriptors.Get(DialectDirectiveKind.Security).Keyword;
-
-    protected override SecurityDirectiveAstNode CreateTypedNode(AstNode lineNode, IdentifierValueAstNode identifier) => new(lineNode.Children[0].LexemeValue, identifier);
-}
-
-public sealed class CapabilityDirectiveNodeCreator : IdentifierListDirectiveNodeCreator<CapabilityDirectiveAstNode>
-{
-    public override AstNodeType AstNodeType => DialectAstNodeTypes.CapabilityDirective;
-
-    protected override string Keyword => DialectDirectiveDescriptors.Get(DialectDirectiveKind.Capability).Keyword;
-
-    protected override CapabilityDirectiveAstNode CreateTypedNode(AstNode lineNode, IdentifierListAstNode identifiers) => new(lineNode.Children[0].LexemeValue, identifiers);
-}
+public sealed class CapabilityDirectiveNodeCreator() : IdentifierListDialectDirectiveNodeCreator(DialectDslFeatureCatalog.GetFeature(DialectDirectiveKind.Capability));
 
 public sealed class DialectDocumentNodeCreator : IAstNodeCreator
 {
@@ -441,5 +465,5 @@ public sealed class DialectDocumentNodeCreator : IAstNodeCreator
 
 internal static class DialectDirectiveSyntax
 {
-    public const string DialectKeyword = "dialect";
+    public const string DialectKeyword = DialectDslKeywords.Dialect;
 }

--- a/UniversalToolchain/UniversalToolchain.Dialects.Integration/DialectRuntimeDescriptorRegistryFactory.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Integration/DialectRuntimeDescriptorRegistryFactory.cs
@@ -1,0 +1,57 @@
+using System.Reflection;
+using ExceptionsManager;
+
+namespace UniversalToolchain.Dialects.Integration;
+
+/// <summary>
+/// Discovers runtime descriptor providers deterministically and builds immutable runtime descriptor registries.
+/// </summary>
+public static class DialectRuntimeDescriptorRegistryFactory
+{
+    public static DialectRuntimeDescriptorRegistry BuildFromProviders(IEnumerable<IDialectRuntimeDescriptorProvider> providers)
+    {
+        if (providers == null)
+        {
+            Thrower.ArgumentNull(nameof(providers));
+        }
+
+        var orderedProviders = providers
+            .Select(x =>
+            {
+                if (x == null)
+                {
+                    Thrower.Argument(nameof(providers), "Provider collection must not contain null entries.");
+                }
+
+                return x;
+            })
+            .OrderBy(x => x.Order)
+            .ThenBy(x => x.GetType().FullName, StringComparer.Ordinal)
+            .ToList();
+
+        var builder = new DialectRuntimeDescriptorRegistryBuilder();
+        foreach (var provider in orderedProviders)
+        {
+            provider.Register(builder);
+        }
+
+        return builder.Build();
+    }
+
+    public static DialectRuntimeDescriptorRegistry BuildFromAssemblies(params Assembly[] assemblies)
+    {
+        if (assemblies == null)
+        {
+            Thrower.ArgumentNull(nameof(assemblies));
+        }
+
+        var providers = assemblies
+            .Where(x => x != null)
+            .SelectMany(x => x.GetTypes())
+            .Where(x => x is { IsClass: true, IsAbstract: false } && typeof(IDialectRuntimeDescriptorProvider).IsAssignableFrom(x))
+            .Select(x => Activator.CreateInstance(x) as IDialectRuntimeDescriptorProvider ?? Thrower.InvalidOpEx<IDialectRuntimeDescriptorProvider>($"Could not create runtime descriptor provider '{x.FullName}'."))
+            .ToList();
+
+        return BuildFromProviders(providers);
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Integration/IDialectRuntimeDescriptorProvider.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Integration/IDialectRuntimeDescriptorProvider.cs
@@ -1,0 +1,11 @@
+namespace UniversalToolchain.Dialects.Integration;
+
+/// <summary>
+/// Contributes runtime descriptors through a framework-native extension seam.
+/// </summary>
+public interface IDialectRuntimeDescriptorProvider
+{
+    int Order { get; }
+
+    void Register(DialectRuntimeDescriptorRegistryBuilder builder);
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/FrameworkNativeExtensionSeamsTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/FrameworkNativeExtensionSeamsTests.cs
@@ -1,0 +1,160 @@
+using System.Reflection;
+using UniversalToolchain.Dialects.Abstractions;
+using UniversalToolchain.Dialects.Core;
+using UniversalToolchain.Dialects.Frontend;
+using UniversalToolchain.Dialects.Integration;
+using UniversalToolchain.Dialects.Parsing;
+
+namespace UniversalToolchain.Dialects.Tests;
+
+public class FrameworkNativeExtensionSeamsTests
+{
+    [Test]
+    public void DirectiveFeatures_AreDiscoveredDeterministically_AndDriveParserRegistrations()
+    {
+        var first = DialectDslFeatureCatalog.Features.Select(x => (x.Kind, x.Keyword, x.ParserPriority, x.GetType().Name)).ToArray();
+        var second = DialectDslFeatureCatalog.Features.Select(x => (x.Kind, x.Keyword, x.ParserPriority, x.GetType().Name)).ToArray();
+        var parserCreatorTypes = DialectDslParserNodeRegistry.Registrations.Select(x => x.Creator.GetType().Name).ToArray();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(first, Is.EqualTo(second));
+            Assert.That(first.Select(x => x.Keyword), Is.EqualTo(new[]
+            {
+                "use", "exclude", "requires", "before", "after", "backend", "allow", "forbid", "enable", "disable", "security", "capability"
+            }));
+            Assert.That(parserCreatorTypes, Does.Contain(nameof(IdentifierListDialectDirectiveNodeCreator)));
+            Assert.That(parserCreatorTypes, Does.Contain(nameof(SingleIdentifierDialectDirectiveNodeCreator)));
+        });
+    }
+
+    [Test]
+    public void SemanticBinder_BindsCompiledSliceIntoNormalizedDialectDefinition()
+    {
+        var slice = new DialectDslCompiler().Compile(
+            """
+            dialect Tiny
+            use B,A
+            exclude Legacy
+            before A,B
+            backend interpreter,cil
+            allow add_i32
+            forbid sub_i32
+            enable Ssa
+            disable Fold
+            capability sandbox
+            """);
+
+        var diagnostics = new List<DialectDiagnostic>();
+        var definition = DialectDefinitionSemanticBinder.Bind(slice, diagnostics);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(diagnostics, Is.Empty);
+            Assert.That(definition.Name, Is.EqualTo("Tiny"));
+            Assert.That(definition.ModulePolicy.IncludedModules, Is.EqualTo(new[] { "A", "B" }));
+            Assert.That(definition.ModulePolicy.ExcludedModules, Is.EqualTo(new[] { "Legacy" }));
+            Assert.That(definition.BackendPolicy.EnabledBackends, Is.EqualTo(new[] { DialectBackendTarget.Interpreter, DialectBackendTarget.Cil }));
+            Assert.That(definition.IntrinsicPolicy.AllowedIntrinsics, Is.EqualTo(new[] { "add_i32" }));
+            Assert.That(definition.IntrinsicPolicy.ForbiddenIntrinsics, Is.EqualTo(new[] { "sub_i32" }));
+            Assert.That(definition.OptimizerPolicy.EnabledOptimizers, Is.EqualTo(new[] { "Ssa" }));
+            Assert.That(definition.OptimizerPolicy.DisabledOptimizers, Is.EqualTo(new[] { "Fold" }));
+            Assert.That(definition.OrderRules.Select(x => (x.Kind, x.ModuleName, x.RelatedModuleName)), Is.EqualTo(new[]
+            {
+                (OrderRuleKind.Before, "A", "B")
+            }));
+        });
+    }
+
+    [Test]
+    public void RuntimeDescriptorFactory_BuildsDeterministically_FromProviders()
+    {
+        var first = DialectRuntimeDescriptorRegistryFactory.BuildFromAssemblies(Assembly.GetExecutingAssembly());
+        var second = DialectRuntimeDescriptorRegistryFactory.BuildFromAssemblies(Assembly.GetExecutingAssembly());
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(first.Modules.Keys, Is.EqualTo(second.Modules.Keys));
+            Assert.That(first.Backends.Keys, Is.EqualTo(second.Backends.Keys));
+            Assert.That(first.Optimizers.Keys, Is.EqualTo(second.Optimizers.Keys));
+            Assert.That(first.Intrinsics.Keys, Is.EqualTo(second.Intrinsics.Keys));
+            Assert.That(first.Modules.Keys, Does.Contain("DemoFrontend"));
+            Assert.That(first.Optimizers.Keys, Does.Contain("DemoOptimizer"));
+            Assert.That(first.Intrinsics.Keys, Does.Contain(("add_i32", DialectBackendTarget.Any)));
+            Assert.That(first.Backends.Keys, Does.Contain(DialectBackendTarget.Interpreter));
+        });
+    }
+
+    [Test]
+    public void BuildPlanBuilder_ProjectsParserSemanticModel_WithScopedTargets()
+    {
+        var document = new DialectSyntaxDocument(
+            "Scoped",
+            null,
+            ["A"],
+            [],
+            [],
+            [new BackendDirectiveSyntax(DialectBackendTarget.Interpreter, true)],
+            [new IntrinsicDirectiveSyntax("add_i32", true, DialectBackendTarget.Interpreter)],
+            [new OptimizerDirectiveSyntax("Ssa", true, DialectBackendTarget.Any)],
+            null,
+            []);
+
+        var plan = new DialectBuildPlanBuilder().Build(document);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(plan.CanBuild, Is.True);
+            Assert.That(plan.IntrinsicDirectives.Select(x => (x.Name, x.Allowed, x.Target)), Is.EqualTo(new[]
+            {
+                ("add_i32", true, DialectBackendTarget.Interpreter)
+            }));
+            Assert.That(plan.OptimizerDirectives.Select(x => (x.Name, x.Enabled, x.Target)), Is.EqualTo(new[]
+            {
+                ("Ssa", true, DialectBackendTarget.Any)
+            }));
+        });
+    }
+
+    private sealed class DemoRuntimeDescriptorProvider : IDialectRuntimeDescriptorProvider
+    {
+        public int Order => 10;
+
+        public void Register(DialectRuntimeDescriptorRegistryBuilder builder)
+        {
+            builder
+                .RegisterModule(new RuntimeModuleDescriptor("DemoFrontend", typeof(FakeFrontendModule)))
+                .RegisterBackend(new RuntimeBackendDescriptor(DialectBackendTarget.Interpreter, "InterpreterBackend"))
+                .RegisterOptimizer(new RuntimeOptimizerDescriptor("DemoOptimizer", typeof(FakeOptimizerModule)))
+                .RegisterIntrinsic(new RuntimeIntrinsicDescriptor("add_i32", DialectBackendTarget.Any));
+        }
+    }
+
+    private sealed class FakeFrontendModule : BasicCore.Contracts.IFrontendCoreModule
+    {
+        public void InitLexer(BasicCore.LexerWrapper.ILexer lexer)
+        {
+        }
+
+        public void InitParser(BasicCore.ParserWrapper.IParser parser)
+        {
+        }
+
+        public BasicCore.ParserWrapper.AstNode ProcessAst(BasicCore.ParserWrapper.AstNode astRoot)
+        {
+            return astRoot;
+        }
+
+        public void InitAstTranslator(BasicCore.TranslatorWrapper.IAstToBytecodeTranslator translator)
+        {
+        }
+    }
+
+    private sealed class FakeOptimizerModule : BasicCore.Contracts.IIRProcessingModule
+    {
+        public IntermediateRepresentationAbstractions.IAbstractIR Process(IntermediateRepresentationAbstractions.IAbstractIR air)
+        {
+            return air;
+        }
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/FrameworkNativeSemanticBuildPlanTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/FrameworkNativeSemanticBuildPlanTests.cs
@@ -69,14 +69,29 @@ public class FrameworkNativeSemanticBuildPlanTests
     public void ParserRegistry_ContainsMultipleSpecializedCreators()
     {
         var creatorTypes = DialectDslParserNodeRegistry.Registrations.Select(x => x.Creator.GetType().Name).ToArray();
+        var featureKinds = DialectDslFeatureCatalog.Features.Select(x => x.Kind).ToArray();
 
         Assert.Multiple(() =>
         {
             Assert.That(creatorTypes, Does.Contain(nameof(DialectDeclarationNodeCreator)));
-            Assert.That(creatorTypes, Does.Contain(nameof(UseModulesDirectiveNodeCreator)));
-            Assert.That(creatorTypes, Does.Contain(nameof(SecurityDirectiveNodeCreator)));
+            Assert.That(creatorTypes, Does.Contain(nameof(IdentifierListDialectDirectiveNodeCreator)));
+            Assert.That(creatorTypes, Does.Contain(nameof(SingleIdentifierDialectDirectiveNodeCreator)));
             Assert.That(creatorTypes, Does.Contain(nameof(DialectDocumentNodeCreator)));
-            Assert.That(creatorTypes.Distinct().Count(), Is.GreaterThan(8));
+            Assert.That(featureKinds, Is.EqualTo(new[]
+            {
+                DialectDirectiveKind.UseModules,
+                DialectDirectiveKind.ExcludeModules,
+                DialectDirectiveKind.RequiresModules,
+                DialectDirectiveKind.BeforeModules,
+                DialectDirectiveKind.AfterModules,
+                DialectDirectiveKind.Backend,
+                DialectDirectiveKind.AllowIntrinsic,
+                DialectDirectiveKind.ForbidIntrinsic,
+                DialectDirectiveKind.EnableIntrinsic,
+                DialectDirectiveKind.DisableIntrinsic,
+                DialectDirectiveKind.Security,
+                DialectDirectiveKind.Capability
+            }));
         });
     }
 


### PR DESCRIPTION
### Motivation
- Move the DSL off centralized, hardcoded plumbing into framework-native extension paths so new directives/features can be added as self-contained features rather than edited into many central switches. 
- Normalize the internal contract: introduce a deterministic semantic model as the source-of-truth between parsing/slicing and build-plan projection. 
- Make AIR annotations self-applying to remove large ad-hoc annotation switch logic and enable deterministic, testable AIR readback. 

### Description
- Introduced a feature discovery catalog for directive features (`DialectDslFeatureCatalog`) and a `IDialectDirectiveFeature` abstraction that owns lexeme, parser node creation, accumulation, semantic validation, and lowering into slice annotations so each DSL capability is feature-local. 
- Replaced static directive registries/switches with feature-driven registrations: `DialectDslLexemeRegistry` and `DialectDslParserNodeRegistry` are now built from discovered features, and `DialectDirectiveLineParser` delegates accumulation to features. 
- Added a normalized semantic binding layer: `DialectDefinitionSemanticBinder` binds both `DialectSyntaxDocument` and `DialectDefinitionSlice` into the new `DialectDefinition` semantic model and `DialectDefinitionBuildPlanProjector` deterministically projects a `DialectBuildPlan`. 
- Made AIR annotations implement `IDialectDefinitionSliceAnnotation` and be self-applying; `DialectAstLowering` now emits these annotations and `DialectDefinitionSliceAirReader` applies them instead of large annotation switch statements. 
- Added a small runtime provider seam for deterministic runtime descriptor discovery via `IDialectRuntimeDescriptorProvider` and `DialectRuntimeDescriptorRegistryFactory` so runtime descriptors can be contributed through framework-native providers. 
- Reduced central validation logic and moved rules into extension-friendly spots (document validation rules discovered by `DialectDslFeatureCatalog`), and fixed `BackendPolicy` overlap validation logic to avoid false collisions. 
- Added targeted tests exercising the new extension seams and semantic binder, and updated parser-registration tests to reflect feature-driven creators. 

### Testing
- Built the solution with `dotnet build UniversalToolchain/Wist.sln -c Release` and the build succeeded. 
- Ran the dialect-focused test suite with `dotnet test UniversalToolchain/UniversalToolchain.Dialects.Tests/UniversalToolchain.Dialects.Tests.csproj -c Release` and it passed (95 tests passed). 
- Ran full solution tests with `dotnet test Wist.sln -c Release --no-build` and the test run passed (all relevant tests in the run passed, including core `Tests.dll`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69baaba480f08324b17994bb3249def1)