### PR TITLE
Refactor dialect DSL into an explicit feature registry

### DIFF
--- a/UniversalToolchain/UniversalToolchain.Dialects.Abstractions/DialectDefinition.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Abstractions/DialectDefinition.cs
@@ -29,7 +29,7 @@ public sealed class DialectDefinition
         BackendPolicy backendPolicy,
         IntrinsicPolicy intrinsicPolicy,
         OptimizerPolicy optimizerPolicy,
-        SecurityPolicy securityPolicy,
+        SecurityPolicy? securityPolicy,
         CapabilityPolicy capabilityPolicy,
         IEnumerable<OrderRule>? orderRules = null,
         string? version = null,

--- a/UniversalToolchain/UniversalToolchain.Dialects.Core/DialectDefinitionSemanticBinder.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Core/DialectDefinitionSemanticBinder.cs
@@ -60,7 +60,7 @@ internal static class DialectDefinitionSemanticBinder
             new OptimizerPolicy(
                 optimizerDirectives.Where(x => x.Enabled).Select(FormatRuleName),
                 optimizerDirectives.Where(x => !x.Enabled).Select(FormatRuleName)),
-            syntaxDocument.SecurityProfile.HasValue ? new SecurityPolicy(syntaxDocument.SecurityProfile.Value) : null!,
+            syntaxDocument.SecurityProfile.HasValue ? new SecurityPolicy(syntaxDocument.SecurityProfile.Value) : null,
             new CapabilityPolicy(syntaxDocument.Capabilities.OrderBy(x => x.Key, StringComparer.Ordinal)),
             DialectOrderConstraintMapper.ToDefinitionRules(DialectOrderConstraintMapper.FromSyntaxRules(syntaxDocument.OrderRules)),
             syntaxDocument.Version);
@@ -123,7 +123,7 @@ internal static class DialectDefinitionSemanticBinder
             new OptimizerPolicy(
                 optimizerDirectives.Where(x => x.Enabled).Select(FormatRuleName),
                 optimizerDirectives.Where(x => !x.Enabled).Select(FormatRuleName)),
-            compiledDialect.SecurityProfile.HasValue ? new SecurityPolicy(ToSecurityProfile(compiledDialect.SecurityProfile.Value)) : null!,
+            compiledDialect.SecurityProfile.HasValue ? new SecurityPolicy(ToSecurityProfile(compiledDialect.SecurityProfile.Value)) : null,
             new CapabilityPolicy(capabilities),
             DialectOrderConstraintMapper.ToDefinitionRules(DialectOrderConstraintMapper.FromCompiledDirectives(compiledDialect.OrderDirectives)));
     }

--- a/UniversalToolchain/UniversalToolchain.Dialects.Frontend/DialectAstNodes.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Frontend/DialectAstNodes.cs
@@ -13,18 +13,6 @@ public static class DialectAstNodeTypes
     public static readonly AstNodeType IdentifierValue = AstNodeType.CreateOrGet("IdentifierValue");
     public static readonly AstNodeType IdentifierList = AstNodeType.CreateOrGet("IdentifierList");
     public static readonly AstNodeType DialectDirective = AstNodeType.CreateOrGet("DialectDirective");
-    public static readonly AstNodeType UseModulesDirective = AstNodeType.CreateOrGet("UseModulesDirective");
-    public static readonly AstNodeType ExcludeModulesDirective = AstNodeType.CreateOrGet("ExcludeModulesDirective");
-    public static readonly AstNodeType RequiresModulesDirective = AstNodeType.CreateOrGet("RequiresModulesDirective");
-    public static readonly AstNodeType BeforeModulesDirective = AstNodeType.CreateOrGet("BeforeModulesDirective");
-    public static readonly AstNodeType AfterModulesDirective = AstNodeType.CreateOrGet("AfterModulesDirective");
-    public static readonly AstNodeType BackendDirective = AstNodeType.CreateOrGet("BackendDirective");
-    public static readonly AstNodeType AllowIntrinsicDirective = AstNodeType.CreateOrGet("AllowIntrinsicDirective");
-    public static readonly AstNodeType ForbidIntrinsicDirective = AstNodeType.CreateOrGet("ForbidIntrinsicDirective");
-    public static readonly AstNodeType EnableIntrinsicDirective = AstNodeType.CreateOrGet("EnableIntrinsicDirective");
-    public static readonly AstNodeType DisableIntrinsicDirective = AstNodeType.CreateOrGet("DisableIntrinsicDirective");
-    public static readonly AstNodeType SecurityDirective = AstNodeType.CreateOrGet("SecurityDirective");
-    public static readonly AstNodeType CapabilityDirective = AstNodeType.CreateOrGet("CapabilityDirective");
 }
 
 public abstract class DialectAstNode : AstNode
@@ -74,9 +62,12 @@ public sealed class DialectDeclarationAstNode : DialectAstNode
     public IdentifierValueAstNode NameNode => (IdentifierValueAstNode)Children[0];
 }
 
-public abstract class DialectDirectiveAstNode : DialectAstNode
+public sealed class DialectDirectiveAstNode : DialectAstNode
 {
-    protected DialectDirectiveAstNode(AstNodeType nodeType, IDialectDirectiveFeature feature, LexemeValue? lexemeValue, List<AstNode> children) : base(nodeType, lexemeValue, children)
+    public DialectDirectiveAstNode(IDialectDirectiveFeature feature, LexemeValue? lexemeValue, IReadOnlyList<AstNode> payloadNodes) : base(
+        DialectAstNodeTypes.DialectDirective,
+        lexemeValue,
+        CreateChildren(payloadNodes))
     {
         if (feature == null)
         {
@@ -88,70 +79,28 @@ public abstract class DialectDirectiveAstNode : DialectAstNode
 
     public IDialectDirectiveFeature Feature { get; }
 
-    public DialectDirectiveKind DirectiveKind => Feature.Kind;
-}
+    public AstNode Payload => Children[0];
 
-public abstract class IdentifierListDirectiveAstNode : DialectDirectiveAstNode
-{
-    protected IdentifierListDirectiveAstNode(AstNodeType nodeType, IDialectDirectiveFeature feature, LexemeValue? lexemeValue, IdentifierListAstNode identifiers) : base(
-        nodeType,
-        feature,
-        lexemeValue,
-        [identifiers])
+    private static List<AstNode> CreateChildren(IReadOnlyList<AstNode> payloadNodes)
     {
+        if (payloadNodes == null)
+        {
+            Thrower.ArgumentNull(nameof(payloadNodes));
+        }
+
+        if (payloadNodes.Count != 1)
+        {
+            Thrower.Argument(nameof(payloadNodes), "Dialect directives must contain exactly one payload node.");
+        }
+
+        if (payloadNodes[0] == null)
+        {
+            Thrower.Argument(nameof(payloadNodes), "Dialect directive payload must not be null.");
+        }
+
+        return payloadNodes.ToList();
     }
-
-    public IdentifierListAstNode Identifiers => (IdentifierListAstNode)Children[0];
 }
-
-public abstract class SingleIdentifierDirectiveAstNode : DialectDirectiveAstNode
-{
-    protected SingleIdentifierDirectiveAstNode(AstNodeType nodeType, IDialectDirectiveFeature feature, LexemeValue? lexemeValue, IdentifierValueAstNode identifier) : base(
-        nodeType,
-        feature,
-        lexemeValue,
-        [identifier])
-    {
-    }
-
-    public IdentifierValueAstNode Identifier => (IdentifierValueAstNode)Children[0];
-}
-
-public sealed class UseModulesDirectiveAstNode(IDialectDirectiveFeature feature, LexemeValue? lexemeValue, IdentifierListAstNode identifiers)
-    : IdentifierListDirectiveAstNode(DialectAstNodeTypes.UseModulesDirective, feature, lexemeValue, identifiers);
-
-public sealed class ExcludeModulesDirectiveAstNode(IDialectDirectiveFeature feature, LexemeValue? lexemeValue, IdentifierListAstNode identifiers)
-    : IdentifierListDirectiveAstNode(DialectAstNodeTypes.ExcludeModulesDirective, feature, lexemeValue, identifiers);
-
-public sealed class RequiresModulesDirectiveAstNode(IDialectDirectiveFeature feature, LexemeValue? lexemeValue, IdentifierListAstNode identifiers)
-    : IdentifierListDirectiveAstNode(DialectAstNodeTypes.RequiresModulesDirective, feature, lexemeValue, identifiers);
-
-public sealed class BeforeModulesDirectiveAstNode(IDialectDirectiveFeature feature, LexemeValue? lexemeValue, IdentifierListAstNode identifiers)
-    : IdentifierListDirectiveAstNode(DialectAstNodeTypes.BeforeModulesDirective, feature, lexemeValue, identifiers);
-
-public sealed class AfterModulesDirectiveAstNode(IDialectDirectiveFeature feature, LexemeValue? lexemeValue, IdentifierListAstNode identifiers)
-    : IdentifierListDirectiveAstNode(DialectAstNodeTypes.AfterModulesDirective, feature, lexemeValue, identifiers);
-
-public sealed class BackendDirectiveAstNode(IDialectDirectiveFeature feature, LexemeValue? lexemeValue, IdentifierListAstNode identifiers)
-    : IdentifierListDirectiveAstNode(DialectAstNodeTypes.BackendDirective, feature, lexemeValue, identifiers);
-
-public sealed class CapabilityDirectiveAstNode(IDialectDirectiveFeature feature, LexemeValue? lexemeValue, IdentifierListAstNode identifiers)
-    : IdentifierListDirectiveAstNode(DialectAstNodeTypes.CapabilityDirective, feature, lexemeValue, identifiers);
-
-public sealed class AllowIntrinsicDirectiveAstNode(IDialectDirectiveFeature feature, LexemeValue? lexemeValue, IdentifierValueAstNode identifier)
-    : SingleIdentifierDirectiveAstNode(DialectAstNodeTypes.AllowIntrinsicDirective, feature, lexemeValue, identifier);
-
-public sealed class ForbidIntrinsicDirectiveAstNode(IDialectDirectiveFeature feature, LexemeValue? lexemeValue, IdentifierValueAstNode identifier)
-    : SingleIdentifierDirectiveAstNode(DialectAstNodeTypes.ForbidIntrinsicDirective, feature, lexemeValue, identifier);
-
-public sealed class EnableIntrinsicDirectiveAstNode(IDialectDirectiveFeature feature, LexemeValue? lexemeValue, IdentifierValueAstNode identifier)
-    : SingleIdentifierDirectiveAstNode(DialectAstNodeTypes.EnableIntrinsicDirective, feature, lexemeValue, identifier);
-
-public sealed class DisableIntrinsicDirectiveAstNode(IDialectDirectiveFeature feature, LexemeValue? lexemeValue, IdentifierValueAstNode identifier)
-    : SingleIdentifierDirectiveAstNode(DialectAstNodeTypes.DisableIntrinsicDirective, feature, lexemeValue, identifier);
-
-public sealed class SecurityDirectiveAstNode(IDialectDirectiveFeature feature, LexemeValue? lexemeValue, IdentifierValueAstNode identifier)
-    : SingleIdentifierDirectiveAstNode(DialectAstNodeTypes.SecurityDirective, feature, lexemeValue, identifier);
 
 public sealed class IdentifierValueAstNode : DialectAstNode
 {
@@ -168,13 +117,19 @@ public sealed class IdentifierValueAstNode : DialectAstNode
 
 public sealed class IdentifierListAstNode : DialectAstNode
 {
-    public IdentifierListAstNode(IReadOnlyList<IdentifierValueAstNode> identifiers) : base(DialectAstNodeTypes.IdentifierList, null, identifiers.Cast<AstNode>().ToList())
+    public IdentifierListAstNode(IReadOnlyList<IdentifierValueAstNode> identifiers) : base(DialectAstNodeTypes.IdentifierList, null, CreateChildren(identifiers))
+    {
+    }
+
+    public IReadOnlyList<IdentifierValueAstNode> Identifiers => Children.Cast<IdentifierValueAstNode>().ToList();
+
+    private static List<AstNode> CreateChildren(IReadOnlyList<IdentifierValueAstNode> identifiers)
     {
         if (identifiers == null)
         {
             Thrower.ArgumentNull(nameof(identifiers));
         }
-    }
 
-    public IReadOnlyList<IdentifierValueAstNode> Identifiers => Children.Cast<IdentifierValueAstNode>().ToList();
+        return identifiers.Cast<AstNode>().ToList();
+    }
 }

--- a/UniversalToolchain/UniversalToolchain.Dialects.Frontend/DialectAstPipelineValidator.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Frontend/DialectAstPipelineValidator.cs
@@ -1,4 +1,3 @@
-using BasicCore.LexerWrapper;
 using BasicCore.ParserWrapper;
 using ExceptionsManager;
 
@@ -6,21 +5,21 @@ namespace UniversalToolchain.Dialects.Frontend;
 
 public static class DialectAstPipelineValidator
 {
-    public static AstNode Validate(AstNode astRoot)
+    public static AstNode Validate(AstNode astRoot, DialectDslRegistry? registry = null)
     {
         if (astRoot == null)
         {
             Thrower.ArgumentNull(nameof(astRoot));
         }
 
-        DialectDslAstValidator.Validate(astRoot);
+        DialectDslAstValidator.Validate(astRoot, registry);
         return astRoot;
     }
 }
 
 public static class DialectDslAstValidator
 {
-    public static DialectDocumentAstNode Validate(AstNode astRoot)
+    public static DialectDocumentAstNode Validate(AstNode astRoot, DialectDslRegistry? registry = null)
     {
         if (astRoot == null)
         {
@@ -33,11 +32,11 @@ public static class DialectDslAstValidator
         }
 
         var document = (DialectDocumentAstNode)astRoot.Children[0];
-        ValidateDocument(document);
+        ValidateDocument(document, registry ?? DialectDslBuiltInFeatures.CreateRegistry());
         return document;
     }
 
-    private static void ValidateDocument(DialectDocumentAstNode document)
+    private static void ValidateDocument(DialectDocumentAstNode document, DialectDslRegistry registry)
     {
         if (document.Children.Count == 0)
         {
@@ -52,24 +51,15 @@ public static class DialectDslAstValidator
         var declaration = (DialectDeclarationAstNode)document.Children[0];
         ValidateDeclaration(declaration);
 
-        var state = new DialectDirectiveValidationState();
-        foreach (var node in document.Children.Skip(1))
+        var context = new DialectDirectiveValidationContext();
+        foreach (var directive in document.Directives)
         {
-            if (node is not DialectDirectiveAstNode)
-            {
-                DialectDefinitionSliceParseErrors.Fail(
-                    $"Dialect document contains an unexpected child node of type '{node.NodeType.GetName()}'.",
-                    node.LexemeValue ?? node.Children.FirstOrDefault()?.LexemeValue);
-            }
-
-            var directive = (DialectDirectiveAstNode)node;
-            ValidateDirectiveShape(directive);
-            directive.Feature.ValidateSemantic(directive, state);
+            directive.Feature.ValidateSemantic(directive, context);
         }
 
-        foreach (var rule in DialectDslFeatureCatalog.DocumentRules)
+        foreach (var rule in registry.DocumentRules)
         {
-            rule.Validate(document, state);
+            rule.Validate(document, context);
         }
     }
 
@@ -80,68 +70,10 @@ public static class DialectDslAstValidator
             DialectDefinitionSliceParseErrors.Fail("Dialect declaration must contain exactly one identifier child.", declaration.LexemeValue);
         }
 
-        ValidateIdentifier((IdentifierValueAstNode)declaration.Children[0], "Dialect name must not be empty.");
-    }
-
-    private static void ValidateDirectiveShape(DialectDirectiveAstNode directive)
-    {
-        if (directive.Feature.ArgumentShape == DialectDirectiveArgumentShape.IdentifierList)
-        {
-            if (directive.Children.Count != 1 || directive.Children[0] is not IdentifierListAstNode)
-            {
-                DialectDefinitionSliceParseErrors.Fail(
-                    $"Directive '{directive.Feature.Keyword}' must contain exactly one identifier-list child.",
-                    directive.LexemeValue ?? directive.Children.FirstOrDefault()?.LexemeValue);
-            }
-
-            var listNode = (IdentifierListAstNode)directive.Children[0];
-            if (listNode.Identifiers.Count == 0)
-            {
-                DialectDefinitionSliceParseErrors.Fail($"Directive '{directive.Feature.Keyword}' must contain at least one identifier.", directive.LexemeValue);
-            }
-
-            foreach (var identifier in listNode.Identifiers)
-            {
-                ValidateIdentifier(identifier, $"Directive '{directive.Feature.Keyword}' contains an empty identifier.");
-            }
-
-            ValidateNoDuplicates(listNode.Identifiers.Select(x => x.Identifier), $"Directive '{directive.Feature.Keyword}' contains duplicate identifiers.", directive.LexemeValue);
-            return;
-        }
-
-        if (directive.Children.Count != 1 || directive.Children[0] is not IdentifierValueAstNode)
-        {
-            DialectDefinitionSliceParseErrors.Fail(
-                $"Directive '{directive.Feature.Keyword}' must contain exactly one identifier child.",
-                directive.LexemeValue ?? directive.Children.FirstOrDefault()?.LexemeValue);
-        }
-
-        var identifierNode = (IdentifierValueAstNode)directive.Children[0];
-        ValidateIdentifier(identifierNode, $"Directive '{directive.Feature.Keyword}' must not be empty.");
-    }
-
-    private static void ValidateIdentifier(IdentifierValueAstNode identifier, string message)
-    {
-        if (identifier == null)
-        {
-            Thrower.ArgumentNull(nameof(identifier));
-        }
-
+        var identifier = (IdentifierValueAstNode)declaration.Children[0];
         if (string.IsNullOrWhiteSpace(identifier.Identifier))
         {
-            DialectDefinitionSliceParseErrors.Fail(message, identifier.LexemeValue);
-        }
-    }
-
-    private static void ValidateNoDuplicates(IEnumerable<string> values, string message, LexemeValue? token)
-    {
-        var set = new HashSet<string>(StringComparer.Ordinal);
-        foreach (var value in values)
-        {
-            if (!set.Add(value))
-            {
-                DialectDefinitionSliceParseErrors.Fail(message, token);
-            }
+            DialectDefinitionSliceParseErrors.Fail("Dialect name must not be empty.", identifier.LexemeValue);
         }
     }
 }

--- a/UniversalToolchain/UniversalToolchain.Dialects.Frontend/DialectAstToBytecodeVisitor.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Frontend/DialectAstToBytecodeVisitor.cs
@@ -6,6 +6,13 @@ namespace UniversalToolchain.Dialects.Frontend;
 
 public sealed class DialectAstToBytecodeVisitor : IAstVisitor
 {
+    private readonly DialectDslRegistry _registry;
+
+    public DialectAstToBytecodeVisitor(DialectDslRegistry? registry = null)
+    {
+        _registry = registry ?? DialectDslBuiltInFeatures.CreateRegistry();
+    }
+
     public void TryVisit(BytecodeVisitorData data)
     {
         if (data == null)
@@ -13,7 +20,7 @@ public sealed class DialectAstToBytecodeVisitor : IAstVisitor
             Thrower.ArgumentNull(nameof(data));
         }
 
-        var document = DialectDslAstValidator.Validate(data.Node);
+        var document = DialectDslAstValidator.Validate(data.Node, _registry);
         var annotations = DialectAstLowering.Lower(document);
         data.Bytecode.Instructions.Add(new BytecodeInstruction(new DialectSliceToAirConvertable(annotations.Cast<object>().ToList())));
     }

--- a/UniversalToolchain/UniversalToolchain.Dialects.Frontend/DialectDefinitionSliceAirReader.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Frontend/DialectDefinitionSliceAirReader.cs
@@ -16,17 +16,15 @@ public static class DialectDefinitionSliceAirReader
         var aggregation = new DialectDefinitionAggregation();
         foreach (var annotation in air.Instructions.SelectMany(x => x.Metadata))
         {
-            if (annotation is not IDialectDefinitionSliceAnnotation)
+            if (annotation == null)
             {
-                if (annotation == null)
-                {
-                    Thrower.InvalidOpEx("Dialect AIR contained a null annotation entry.");
-                }
-
-                Thrower.InvalidOpEx($"Dialect AIR contained unsupported annotation type '{annotation.GetType().FullName}'.");
+                Thrower.InvalidOpEx("Dialect AIR contained a null annotation entry.");
             }
 
-            ((IDialectDefinitionSliceAnnotation)annotation).Apply(aggregation);
+            if (annotation is IDialectDefinitionSliceAnnotation dialectAnnotation)
+            {
+                dialectAnnotation.Apply(aggregation);
+            }
         }
 
         return new DialectDefinitionSliceBuilder().Build(aggregation);

--- a/UniversalToolchain/UniversalToolchain.Dialects.Frontend/DialectDirectiveAccumulation.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Frontend/DialectDirectiveAccumulation.cs
@@ -1,28 +1,74 @@
+using ExceptionsManager;
+
 namespace UniversalToolchain.Dialects.Frontend;
 
 public sealed class DialectDirectiveAccumulation
 {
-    public List<string> UseModules { get; } = [];
+    private readonly Dictionary<string, List<string>> _lists = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, object?> _values = new(StringComparer.Ordinal);
 
-    public List<string> ExcludeModules { get; } = [];
+    public List<string> UseModules => GetOrCreateList(nameof(UseModules));
 
-    public List<string> RequiresModules { get; } = [];
+    public List<string> ExcludeModules => GetOrCreateList(nameof(ExcludeModules));
 
-    public List<string> BeforeModules { get; } = [];
+    public List<string> RequiresModules => GetOrCreateList(nameof(RequiresModules));
 
-    public List<string> AfterModules { get; } = [];
+    public List<string> BeforeModules => GetOrCreateList(nameof(BeforeModules));
 
-    public List<string> Backends { get; } = [];
+    public List<string> AfterModules => GetOrCreateList(nameof(AfterModules));
 
-    public List<string> AllowedIntrinsics { get; } = [];
+    public List<string> Backends => GetOrCreateList(nameof(Backends));
 
-    public List<string> ForbiddenIntrinsics { get; } = [];
+    public List<string> AllowedIntrinsics => GetOrCreateList(nameof(AllowedIntrinsics));
 
-    public List<string> EnabledIntrinsics { get; } = [];
+    public List<string> ForbiddenIntrinsics => GetOrCreateList(nameof(ForbiddenIntrinsics));
 
-    public List<string> DisabledIntrinsics { get; } = [];
+    public List<string> EnabledOptimizers => GetOrCreateList(nameof(EnabledOptimizers));
 
-    public List<string> Capabilities { get; } = [];
+    public List<string> DisabledOptimizers => GetOrCreateList(nameof(DisabledOptimizers));
 
-    public DialectSecurityProfile? SecurityProfile { get; set; }
+    public List<string> Capabilities => GetOrCreateList(nameof(Capabilities));
+
+    public DialectSecurityProfile? SecurityProfile
+    {
+        get => GetValue<DialectSecurityProfile?>(nameof(SecurityProfile));
+        set => _values[nameof(SecurityProfile)] = value;
+    }
+
+    public List<string> GetOrCreateList(string key)
+    {
+        if (string.IsNullOrWhiteSpace(key))
+        {
+            Thrower.Argument(nameof(key), "Accumulation key must not be empty.");
+        }
+
+        if (_lists.TryGetValue(key, out var existing))
+        {
+            return existing;
+        }
+
+        var created = new List<string>();
+        _lists[key] = created;
+        return created;
+    }
+
+    public T GetValue<T>(string key)
+    {
+        if (string.IsNullOrWhiteSpace(key))
+        {
+            Thrower.Argument(nameof(key), "Accumulation value key must not be empty.");
+        }
+
+        if (!_values.TryGetValue(key, out var value) || value == null)
+        {
+            return default!;
+        }
+
+        if (value is not T)
+        {
+            Thrower.InvalidOpEx<T>($"Accumulation value '{key}' has incompatible runtime type '{value.GetType().FullName}'.");
+        }
+
+        return (T)value;
+    }
 }

--- a/UniversalToolchain/UniversalToolchain.Dialects.Frontend/DialectDirectiveLineParser.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Frontend/DialectDirectiveLineParser.cs
@@ -5,6 +5,13 @@ namespace UniversalToolchain.Dialects.Frontend;
 
 public sealed class DialectDirectiveLineParser
 {
+    private readonly DialectDslRegistry _registry;
+
+    public DialectDirectiveLineParser(DialectDslRegistry? registry = null)
+    {
+        _registry = registry ?? DialectDslBuiltInFeatures.CreateRegistry();
+    }
+
     public bool TryParse(IReadOnlyList<LexemeValue> line, DialectDirectiveAccumulation accumulation)
     {
         if (line == null)
@@ -23,7 +30,7 @@ public sealed class DialectDirectiveLineParser
         }
 
         var keyword = line[0].Text;
-        if (!DialectDslFeatureCatalog.TryGetFeature(keyword, out var feature))
+        if (!_registry.TryGetFeature(keyword, out var feature))
         {
             return false;
         }

--- a/UniversalToolchain/UniversalToolchain.Dialects.Frontend/DialectDirectiveMetadata.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Frontend/DialectDirectiveMetadata.cs
@@ -1,44 +1,35 @@
+using ExceptionsManager;
+
 namespace UniversalToolchain.Dialects.Frontend;
 
 public sealed class DialectDirectiveDescriptor
 {
-    public required DialectDirectiveKind Kind { get; init; }
+    public required string Id { get; init; }
 
     public required string Keyword { get; init; }
 
-    public required DialectDirectiveArgumentShape ArgumentShape { get; init; }
+    public required DialectDirectiveParserOrder ParserOrder { get; init; }
 
     public bool IsSingleton { get; init; }
 }
 
 public static class DialectDirectiveDescriptors
 {
-    private static readonly Lazy<IReadOnlyList<DialectDirectiveDescriptor>> _ordered = new(() =>
-        DialectDslFeatureCatalog.Features
+    public static IReadOnlyList<DialectDirectiveDescriptor> CreateOrdered(DialectDslRegistry registry)
+    {
+        if (registry == null)
+        {
+            Thrower.ArgumentNull(nameof(registry));
+        }
+
+        return registry.DirectiveFeatures
             .Select(x => new DialectDirectiveDescriptor
             {
-                Kind = x.Kind,
+                Id = x.Id,
                 Keyword = x.Keyword,
-                ArgumentShape = x.ArgumentShape,
+                ParserOrder = x.ParserOrder,
                 IsSingleton = x.IsSingleton
             })
-            .ToList());
-
-    private static readonly Lazy<IReadOnlyDictionary<DialectDirectiveKind, DialectDirectiveDescriptor>> _byKind = new(() =>
-        _ordered.Value.ToDictionary(x => x.Kind));
-
-    private static readonly Lazy<IReadOnlyDictionary<string, DialectDirectiveDescriptor>> _byKeyword = new(() =>
-        _ordered.Value.ToDictionary(x => x.Keyword, StringComparer.Ordinal));
-
-    public static IReadOnlyList<DialectDirectiveDescriptor> Ordered => _ordered.Value;
-
-    public static DialectDirectiveDescriptor Get(DialectDirectiveKind kind)
-    {
-        return _byKind.Value[kind];
-    }
-
-    public static bool TryGetByKeyword(string keyword, out DialectDirectiveDescriptor descriptor)
-    {
-        return _byKeyword.Value.TryGetValue(keyword, out descriptor!);
+            .ToList();
     }
 }

--- a/UniversalToolchain/UniversalToolchain.Dialects.Frontend/DialectDslCompiler.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Frontend/DialectDslCompiler.cs
@@ -13,9 +13,9 @@ public sealed class DialectDslCompiler
 {
     private readonly BasicCoreImpl<DialectDefinitionSlice> _core;
 
-    public DialectDslCompiler()
+    public DialectDslCompiler(DialectDslRegistry? registry = null)
     {
-        var frontendModule = new DialectDslFrontendModule();
+        var frontendModule = new DialectDslFrontendModule(registry);
         var compiler = new DialectDefinitionSliceCompiler();
 
         _core = new BasicCoreImpl<DialectDefinitionSlice>(

--- a/UniversalToolchain/UniversalToolchain.Dialects.Frontend/DialectDslFeatureCatalog.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Frontend/DialectDslFeatureCatalog.cs
@@ -1,53 +1,71 @@
-using System.Reflection;
 using BasicCore.LexerWrapper;
 using BasicCore.ParserWrapper;
-using BasicCore.Registration;
 using ExceptionsManager;
 using UniversalToolchain.Dialects.Abstractions;
 
 namespace UniversalToolchain.Dialects.Frontend;
 
-public enum DialectDirectiveKind
+public enum DialectParserStage
 {
-    UseModules,
-    ExcludeModules,
-    RequiresModules,
-    BeforeModules,
-    AfterModules,
-    Backend,
-    AllowIntrinsic,
-    ForbidIntrinsic,
-    EnableIntrinsic,
-    DisableIntrinsic,
-    Security,
-    Capability
+    LineSplitting = 0,
+    Declaration = 1,
+    Directives = 2,
+    Document = 3
 }
 
-public enum DialectDirectiveArgumentShape
+public enum DialectDirectiveSlot
 {
-    Identifier,
-    IdentifierList
+    ModuleSelection = 0,
+    ModuleOrdering = 1,
+    BackendSelection = 2,
+    IntrinsicPolicy = 3,
+    OptimizerPolicy = 4,
+    Security = 5,
+    Capabilities = 6,
+    Extension = 100
+}
+
+public readonly record struct DialectDirectiveParserOrder(DialectDirectiveSlot Slot, int Sequence);
+
+public readonly record struct DialectParserOrder(DialectParserStage Stage, int Slot, int Sequence)
+{
+    internal float Encode()
+    {
+        return ((int)Stage * 100000f) + (Slot * 100f) + Sequence;
+    }
+
+    public static DialectParserOrder Directive(DialectDirectiveParserOrder order)
+    {
+        return new DialectParserOrder(DialectParserStage.Directives, (int)order.Slot, order.Sequence);
+    }
+}
+
+public static class DialectParserOrders
+{
+    public static DialectParserOrder LineSplitter { get; } = new(DialectParserStage.LineSplitting, 0, 0);
+
+    public static DialectParserOrder Declaration { get; } = new(DialectParserStage.Declaration, 0, 0);
+
+    public static DialectParserOrder Document { get; } = new(DialectParserStage.Document, 0, 0);
 }
 
 public interface IDialectDirectiveFeature
 {
-    DialectDirectiveKind Kind { get; }
+    string Id { get; }
 
     string Keyword { get; }
 
     string LexemeTag { get; }
 
-    DialectDirectiveArgumentShape ArgumentShape { get; }
-
-    float ParserPriority { get; }
+    DialectDirectiveParserOrder ParserOrder { get; }
 
     bool IsSingleton { get; }
 
-    IAstNodeCreator CreateNodeCreator();
+    DialectDirectiveAstNode ParseDirective(AstNode lineNode);
 
     void Accumulate(IReadOnlyList<LexemeValue> line, DialectDirectiveAccumulation accumulation);
 
-    void ValidateSemantic(DialectDirectiveAstNode directive, DialectDirectiveValidationState state);
+    void ValidateSemantic(DialectDirectiveAstNode directive, DialectDirectiveValidationContext context);
 
     IReadOnlyList<IDialectDefinitionSliceAnnotation> Lower(DialectDirectiveAstNode directive);
 }
@@ -56,80 +74,150 @@ public interface IDialectDocumentValidationRule
 {
     int Order { get; }
 
-    void Validate(DialectDocumentAstNode document, DialectDirectiveValidationState state);
+    void Validate(DialectDocumentAstNode document, DialectDirectiveValidationContext context);
 }
 
-public static class DialectDslFeatureCatalog
+public interface IDialectDslFeatureProvider
 {
-    private static readonly Lazy<IReadOnlyList<IDialectDirectiveFeature>> _features = new(DiscoverFeatures);
-    private static readonly Lazy<IReadOnlyDictionary<DialectDirectiveKind, IDialectDirectiveFeature>> _featuresByKind = new(() =>
-        _features.Value.ToDictionary(x => x.Kind));
-    private static readonly Lazy<IReadOnlyDictionary<string, IDialectDirectiveFeature>> _featuresByKeyword = new(() =>
-        _features.Value.ToDictionary(x => x.Keyword, StringComparer.Ordinal));
-    private static readonly Lazy<IReadOnlyList<IDialectDocumentValidationRule>> _documentRules = new(DiscoverDocumentRules);
+    int Order { get; }
 
-    public static IReadOnlyList<IDialectDirectiveFeature> Features => _features.Value;
+    void Register(DialectDslRegistryBuilder builder);
+}
 
-    public static IReadOnlyList<IDialectDocumentValidationRule> DocumentRules => _documentRules.Value;
+public sealed class DialectDslRegistryBuilder
+{
+    private readonly List<IDialectDirectiveFeature> _features = [];
+    private readonly List<IDialectDocumentValidationRule> _documentRules = [];
 
-    public static IDialectDirectiveFeature GetFeature(DialectDirectiveKind kind)
+    public DialectDslRegistryBuilder RegisterFeature(IDialectDirectiveFeature feature)
     {
-        if (!_featuresByKind.Value.TryGetValue(kind, out var feature))
+        if (feature == null)
         {
-            Thrower.Argument(nameof(kind), $"Unknown dialect directive kind '{kind}'.");
+            Thrower.ArgumentNull(nameof(feature));
         }
 
-        return feature;
+        _features.Add(feature);
+        return this;
     }
 
-    public static bool TryGetFeature(string keyword, out IDialectDirectiveFeature feature)
+    public DialectDslRegistryBuilder RegisterDocumentRule(IDialectDocumentValidationRule rule)
+    {
+        if (rule == null)
+        {
+            Thrower.ArgumentNull(nameof(rule));
+        }
+
+        _documentRules.Add(rule);
+        return this;
+    }
+
+    public DialectDslRegistry Build()
+    {
+        return new DialectDslRegistry(_features, _documentRules);
+    }
+}
+
+public sealed class DialectDslRegistry
+{
+    private readonly IReadOnlyList<IDialectDirectiveFeature> _directiveFeatures;
+    private readonly IReadOnlyList<IDialectDocumentValidationRule> _documentRules;
+    private readonly IReadOnlyDictionary<string, IDialectDirectiveFeature> _featuresByKeyword;
+    private readonly IReadOnlyDictionary<string, IDialectDirectiveFeature> _featuresById;
+
+    public DialectDslRegistry(
+        IEnumerable<IDialectDirectiveFeature> directiveFeatures,
+        IEnumerable<IDialectDocumentValidationRule> documentRules)
+    {
+        var features = Snapshot(directiveFeatures, nameof(directiveFeatures))
+            .OrderBy(x => x.ParserOrder.Slot)
+            .ThenBy(x => x.ParserOrder.Sequence)
+            .ThenBy(x => x.Keyword, StringComparer.Ordinal)
+            .ThenBy(x => x.GetType().FullName, StringComparer.Ordinal)
+            .ToList();
+
+        ValidateFeatures(features);
+
+        _directiveFeatures = features;
+        _documentRules = Snapshot(documentRules, nameof(documentRules))
+            .OrderBy(x => x.Order)
+            .ThenBy(x => x.GetType().FullName, StringComparer.Ordinal)
+            .ToList();
+        _featuresByKeyword = _directiveFeatures.ToDictionary(x => x.Keyword, StringComparer.Ordinal);
+        _featuresById = _directiveFeatures.ToDictionary(x => x.Id, StringComparer.Ordinal);
+    }
+
+    public IReadOnlyList<IDialectDirectiveFeature> DirectiveFeatures => _directiveFeatures;
+
+    public IReadOnlyList<IDialectDocumentValidationRule> DocumentRules => _documentRules;
+
+    public bool TryGetFeature(string keyword, out IDialectDirectiveFeature feature)
     {
         if (string.IsNullOrWhiteSpace(keyword))
         {
             Thrower.Argument(nameof(keyword), "Directive keyword must not be empty.");
         }
 
-        return _featuresByKeyword.Value.TryGetValue(keyword, out feature!);
+        return _featuresByKeyword.TryGetValue(keyword, out feature!);
     }
 
-    private static IReadOnlyList<IDialectDirectiveFeature> DiscoverFeatures()
+    public IDialectDirectiveFeature GetFeatureById(string id)
     {
-        var features = typeof(DialectDslFeatureCatalog).Assembly
-            .GetTypes()
-            .Where(x => x is { IsClass: true, IsAbstract: false } && typeof(IDialectDirectiveFeature).IsAssignableFrom(x))
-            .Select(Create<IDialectDirectiveFeature>)
-            .OrderBy(x => x.ParserPriority)
-            .ThenBy(x => x.Keyword, StringComparer.Ordinal)
-            .ThenBy(x => x.GetType().FullName, StringComparer.Ordinal)
-            .ToList();
+        if (string.IsNullOrWhiteSpace(id))
+        {
+            Thrower.Argument(nameof(id), "Directive identifier must not be empty.");
+        }
 
-        ValidateFeatureSet(features);
-        return features;
+        if (!_featuresById.TryGetValue(id, out var feature))
+        {
+            Thrower.Argument(nameof(id), $"Unknown dialect directive identifier '{id}'.");
+        }
+
+        return feature;
     }
 
-    private static IReadOnlyList<IDialectDocumentValidationRule> DiscoverDocumentRules()
+    public static DialectDslRegistry BuildFromProviders(IEnumerable<IDialectDslFeatureProvider> providers)
     {
-        return typeof(DialectDslFeatureCatalog).Assembly
-            .GetTypes()
-            .Where(x => x is { IsClass: true, IsAbstract: false } && typeof(IDialectDocumentValidationRule).IsAssignableFrom(x))
-            .Select(Create<IDialectDocumentValidationRule>)
+        if (providers == null)
+        {
+            Thrower.ArgumentNull(nameof(providers));
+        }
+
+        var orderedProviders = Snapshot(providers, nameof(providers))
             .OrderBy(x => x.Order)
             .ThenBy(x => x.GetType().FullName, StringComparer.Ordinal)
             .ToList();
-    }
 
-    private static T Create<T>(Type type)
-    {
-        var instance = Activator.CreateInstance(type);
-        if (instance is not T)
+        var builder = new DialectDslRegistryBuilder();
+        foreach (var provider in orderedProviders)
         {
-            Thrower.InvalidOpEx<T>($"Could not create dialect feature instance '{type.FullName}'.");
+            provider.Register(builder);
         }
 
-        return (T)instance;
+        return builder.Build();
     }
 
-    private static void ValidateFeatureSet(IReadOnlyList<IDialectDirectiveFeature> features)
+    private static List<T> Snapshot<T>(IEnumerable<T> values, string paramName)
+    {
+        if (values == null)
+        {
+            Thrower.ArgumentNull(paramName);
+        }
+
+        var result = new List<T>();
+        foreach (var value in values)
+        {
+            if (value == null)
+            {
+                Thrower.Argument(paramName, "Collection must not contain null values.");
+            }
+
+            result.Add(value);
+        }
+
+        return result;
+    }
+
+    private static void ValidateFeatures(IReadOnlyList<IDialectDirectiveFeature> features)
     {
         var duplicateKeyword = features
             .GroupBy(x => x.Keyword, StringComparer.Ordinal)
@@ -139,382 +227,583 @@ public static class DialectDslFeatureCatalog
             Thrower.InvalidOpEx($"Dialect DSL keyword '{duplicateKeyword.Key}' is implemented by multiple features.");
         }
 
-        var duplicateKind = features
-            .GroupBy(x => x.Kind)
+        var duplicateId = features
+            .GroupBy(x => x.Id, StringComparer.Ordinal)
             .FirstOrDefault(x => x.Count() > 1);
-        if (duplicateKind != null)
+        if (duplicateId != null)
         {
-            Thrower.InvalidOpEx($"Dialect directive kind '{duplicateKind.Key}' is implemented by multiple features.");
+            Thrower.InvalidOpEx($"Dialect directive identifier '{duplicateId.Key}' is implemented by multiple features.");
         }
     }
 }
 
-public sealed class DialectDirectiveValidationState
+public static class DialectDslBuiltInFeatures
 {
-    private readonly HashSet<string> _useModules = new(StringComparer.Ordinal);
-    private readonly HashSet<string> _excludeModules = new(StringComparer.Ordinal);
-    private readonly HashSet<string> _requiresModules = new(StringComparer.Ordinal);
-    private readonly HashSet<string> _beforeModules = new(StringComparer.Ordinal);
-    private readonly HashSet<string> _afterModules = new(StringComparer.Ordinal);
-    private readonly HashSet<string> _backends = new(StringComparer.Ordinal);
-    private readonly HashSet<string> _capabilities = new(StringComparer.Ordinal);
-    private readonly HashSet<string> _allowedIntrinsics = new(StringComparer.Ordinal);
-    private readonly HashSet<string> _forbiddenIntrinsics = new(StringComparer.Ordinal);
-    private readonly HashSet<string> _enabledOptimizers = new(StringComparer.Ordinal);
-    private readonly HashSet<string> _disabledOptimizers = new(StringComparer.Ordinal);
-
-    public IReadOnlySet<string> UseModules => _useModules;
-
-    public IReadOnlySet<string> ExcludeModules => _excludeModules;
-
-    public bool HasSecurityDirective { get; private set; }
-
-    public void AddUseModules(IEnumerable<string> modules, LexemeValue? token) => AddMany(_useModules, modules, "Duplicate use module is not allowed.", token);
-
-    public void AddExcludeModules(IEnumerable<string> modules, LexemeValue? token) => AddMany(_excludeModules, modules, "Duplicate exclude module is not allowed.", token);
-
-    public void AddRequiresModules(IEnumerable<string> modules, LexemeValue? token) => AddMany(_requiresModules, modules, "Duplicate requires module is not allowed.", token);
-
-    public void AddBeforeModules(IEnumerable<string> modules, LexemeValue? token) => AddMany(_beforeModules, modules, "Duplicate before module is not allowed.", token);
-
-    public void AddAfterModules(IEnumerable<string> modules, LexemeValue? token) => AddMany(_afterModules, modules, "Duplicate after module is not allowed.", token);
-
-    public void AddBackends(IEnumerable<string> backends, LexemeValue? token) => AddMany(_backends, backends, "Duplicate backend identifier is not allowed.", token);
-
-    public void AddCapabilities(IEnumerable<string> capabilities, LexemeValue? token) => AddMany(_capabilities, capabilities, "Duplicate capability identifier is not allowed.", token);
-
-    public void AddAllowedIntrinsic(string name, LexemeValue? token)
+    public static DialectDslRegistry CreateRegistry(IEnumerable<IDialectDslFeatureProvider>? additionalProviders = null)
     {
-        AddSingle(_allowedIntrinsics, name, "Duplicate allow intrinsic directive is not allowed.", token);
-        if (_forbiddenIntrinsics.Contains(name))
+        var providers = new List<IDialectDslFeatureProvider>
         {
-            DialectDefinitionSliceParseErrors.Fail($"Intrinsic '{name}' cannot be both allowed and forbidden.", token);
-        }
-    }
+            new BuiltInDialectDslFeatureProvider()
+        };
 
-    public void AddForbiddenIntrinsic(string name, LexemeValue? token)
-    {
-        AddSingle(_forbiddenIntrinsics, name, "Duplicate forbid intrinsic directive is not allowed.", token);
-        if (_allowedIntrinsics.Contains(name))
+        if (additionalProviders != null)
         {
-            DialectDefinitionSliceParseErrors.Fail($"Intrinsic '{name}' cannot be both allowed and forbidden.", token);
-        }
-    }
-
-    public void AddEnabledOptimizer(string name, LexemeValue? token)
-    {
-        AddSingle(_enabledOptimizers, name, "Duplicate enable directive is not allowed.", token);
-        if (_disabledOptimizers.Contains(name))
-        {
-            DialectDefinitionSliceParseErrors.Fail($"Optimizer '{name}' cannot be both enabled and disabled.", token);
-        }
-    }
-
-    public void AddDisabledOptimizer(string name, LexemeValue? token)
-    {
-        AddSingle(_disabledOptimizers, name, "Duplicate disable directive is not allowed.", token);
-        if (_enabledOptimizers.Contains(name))
-        {
-            DialectDefinitionSliceParseErrors.Fail($"Optimizer '{name}' cannot be both enabled and disabled.", token);
-        }
-    }
-
-    public void MarkSecurity(LexemeValue? token)
-    {
-        if (HasSecurityDirective)
-        {
-            DialectDefinitionSliceParseErrors.Fail("Security directive can only be declared once.", token);
+            providers.AddRange(additionalProviders);
         }
 
-        HasSecurityDirective = true;
+        return DialectDslRegistry.BuildFromProviders(providers);
+    }
+}
+
+public sealed class DialectDirectiveValidationContext
+{
+    private readonly Dictionary<string, HashSet<string>> _sets = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, object> _state = new(StringComparer.Ordinal);
+
+    public IReadOnlySet<string> GetValues(string key)
+    {
+        return GetOrCreateSet(key);
     }
 
-    private static void AddMany(HashSet<string> set, IEnumerable<string> values, string duplicateMessage, LexemeValue? token)
+    public void AddValues(string key, IEnumerable<string> values, string duplicateMessage, LexemeValue? token)
     {
         foreach (var value in values)
         {
-            AddSingle(set, value, duplicateMessage, token);
+            AddValue(key, value, duplicateMessage, token);
         }
     }
 
-    private static void AddSingle(HashSet<string> set, string value, string duplicateMessage, LexemeValue? token)
+    public void AddValue(string key, string value, string duplicateMessage, LexemeValue? token)
     {
-        if (!set.Add(value))
+        if (!GetOrCreateSet(key).Add(value))
         {
             DialectDefinitionSliceParseErrors.Fail(duplicateMessage, token);
         }
+    }
+
+    public void EnsureSingleton(string key, string duplicateMessage, LexemeValue? token)
+    {
+        if (_state.ContainsKey(key))
+        {
+            DialectDefinitionSliceParseErrors.Fail(duplicateMessage, token);
+        }
+
+        _state[key] = SingletonMarker.Instance;
+    }
+
+    public TState GetOrAddState<TState>(string key, Func<TState> factory) where TState : class
+    {
+        if (string.IsNullOrWhiteSpace(key))
+        {
+            Thrower.Argument(nameof(key), "Validation state key must not be empty.");
+        }
+
+        if (factory == null)
+        {
+            Thrower.ArgumentNull(nameof(factory));
+        }
+
+        if (_state.TryGetValue(key, out var existing))
+        {
+            if (existing is not TState)
+            {
+                Thrower.InvalidOpEx<TState>($"Validation state '{key}' has incompatible runtime type '{existing.GetType().FullName}'.");
+            }
+
+            return (TState)existing;
+        }
+
+        var created = factory();
+        if (created == null)
+        {
+            Thrower.InvalidOpEx<TState>($"Validation state factory for '{key}' returned null.");
+        }
+
+        _state[key] = created;
+        return created;
+    }
+
+    private HashSet<string> GetOrCreateSet(string key)
+    {
+        if (string.IsNullOrWhiteSpace(key))
+        {
+            Thrower.Argument(nameof(key), "Validation set key must not be empty.");
+        }
+
+        if (_sets.TryGetValue(key, out var existing))
+        {
+            return existing;
+        }
+
+        var created = new HashSet<string>(StringComparer.Ordinal);
+        _sets[key] = created;
+        return created;
+    }
+
+    private sealed class SingletonMarker
+    {
+        public static SingletonMarker Instance { get; } = new();
     }
 }
 
 internal abstract class DialectDirectiveFeatureBase : IDialectDirectiveFeature
 {
-    public abstract DialectDirectiveKind Kind { get; }
+    public abstract string Id { get; }
 
     public abstract string Keyword { get; }
 
     public string LexemeTag => $"DialectDirectiveKeyword.{Keyword}";
 
-    public abstract DialectDirectiveArgumentShape ArgumentShape { get; }
-
-    public abstract float ParserPriority { get; }
+    public abstract DialectDirectiveParserOrder ParserOrder { get; }
 
     public virtual bool IsSingleton => false;
 
-    public virtual IAstNodeCreator CreateNodeCreator()
-    {
-        return ArgumentShape switch
-        {
-            DialectDirectiveArgumentShape.Identifier => new SingleIdentifierDialectDirectiveNodeCreator(this),
-            _ => new IdentifierListDialectDirectiveNodeCreator(this)
-        };
-    }
+    public abstract DialectDirectiveAstNode ParseDirective(AstNode lineNode);
 
     public virtual void Accumulate(IReadOnlyList<LexemeValue> line, DialectDirectiveAccumulation accumulation)
     {
         Thrower.InvalidOpEx($"Dialect feature '{GetType().Name}' does not support line accumulation.");
-        return;
     }
 
-    public virtual void ValidateSemantic(DialectDirectiveAstNode directive, DialectDirectiveValidationState state)
+    public virtual void ValidateSemantic(DialectDirectiveAstNode directive, DialectDirectiveValidationContext context)
     {
     }
 
     public abstract IReadOnlyList<IDialectDefinitionSliceAnnotation> Lower(DialectDirectiveAstNode directive);
 
-    protected static IReadOnlyList<string> GetIdentifierList(DialectDirectiveAstNode directive)
+    protected static IReadOnlyList<string> GetIdentifierListArgument(DialectDirectiveAstNode directive)
     {
-        if (directive is not IdentifierListDirectiveAstNode)
+        if (directive.Payload is not IdentifierListAstNode)
         {
-            Thrower.Argument(nameof(directive), $"Directive '{directive.GetType().Name}' must provide an identifier list.");
+            Thrower.Argument(nameof(directive), $"Directive '{directive.Feature.Keyword}' must provide an identifier list payload.");
         }
 
-        return ((IdentifierListDirectiveAstNode)directive).Identifiers.Identifiers.Select(x => x.Identifier).ToList();
+        var identifierList = (IdentifierListAstNode)directive.Payload;
+        if (identifierList.Identifiers.Count == 0)
+        {
+            DialectDefinitionSliceParseErrors.Fail($"Directive '{directive.Feature.Keyword}' must contain at least one identifier.", directive.LexemeValue);
+        }
+
+        foreach (var identifier in identifierList.Identifiers)
+        {
+            ValidateIdentifier(identifier, $"Directive '{directive.Feature.Keyword}' contains an empty identifier.");
+        }
+
+        ValidateNoDuplicates(identifierList.Identifiers.Select(x => x.Identifier), $"Directive '{directive.Feature.Keyword}' contains duplicate identifiers.", directive.LexemeValue);
+        return identifierList.Identifiers.Select(x => x.Identifier).ToList();
     }
 
-    protected static string GetSingleIdentifier(DialectDirectiveAstNode directive)
+    protected static string GetSingleIdentifierArgument(DialectDirectiveAstNode directive)
     {
-        if (directive is not SingleIdentifierDirectiveAstNode)
+        if (directive.Payload is not IdentifierValueAstNode)
         {
-            Thrower.Argument(nameof(directive), $"Directive '{directive.GetType().Name}' must provide one identifier.");
+            Thrower.Argument(nameof(directive), $"Directive '{directive.Feature.Keyword}' must provide a single identifier payload.");
         }
 
-        return ((SingleIdentifierDirectiveAstNode)directive).Identifier.Identifier;
+        var identifier = (IdentifierValueAstNode)directive.Payload;
+        ValidateIdentifier(identifier, $"Directive '{directive.Feature.Keyword}' must not be empty.");
+        return identifier.Identifier;
+    }
+
+    protected static void ValidateIdentifier(IdentifierValueAstNode identifier, string message)
+    {
+        if (identifier == null)
+        {
+            Thrower.ArgumentNull(nameof(identifier));
+        }
+
+        if (string.IsNullOrWhiteSpace(identifier.Identifier))
+        {
+            DialectDefinitionSliceParseErrors.Fail(message, identifier.LexemeValue);
+        }
+    }
+
+    protected static void ValidateNoDuplicates(IEnumerable<string> values, string message, LexemeValue? token)
+    {
+        var set = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var value in values)
+        {
+            if (!set.Add(value))
+            {
+                DialectDefinitionSliceParseErrors.Fail(message, token);
+            }
+        }
+    }
+
+    protected static DialectDirectiveAstNode CreateDirectiveNode(IDialectDirectiveFeature feature, LexemeValue? lexemeValue, AstNode payload)
+    {
+        return new DialectDirectiveAstNode(feature, lexemeValue, [payload]);
     }
 }
 
-internal sealed class UseModulesDialectDirectiveFeature : DialectDirectiveFeatureBase
+internal abstract class IdentifierListDialectDirectiveFeatureBase : DialectDirectiveFeatureBase
 {
-    public override DialectDirectiveKind Kind => DialectDirectiveKind.UseModules;
+    public sealed override DialectDirectiveAstNode ParseDirective(AstNode lineNode)
+    {
+        var identifiers = DialectNodeCreatorSupport.ParseIdentifierList(lineNode, Keyword);
+        return CreateDirectiveNode(this, lineNode.Children[0].LexemeValue, identifiers);
+    }
+
+    public sealed override void Accumulate(IReadOnlyList<LexemeValue> line, DialectDirectiveAccumulation accumulation)
+    {
+        AccumulateIdentifiers(accumulation, DialectDirectiveParserSupport.ParseIdentifierList(line, Keyword));
+    }
+
+    protected abstract void AccumulateIdentifiers(DialectDirectiveAccumulation accumulation, IReadOnlyList<string> values);
+}
+
+internal abstract class SingleIdentifierDialectDirectiveFeatureBase : DialectDirectiveFeatureBase
+{
+    public sealed override DialectDirectiveAstNode ParseDirective(AstNode lineNode)
+    {
+        var identifier = DialectNodeCreatorSupport.ParseSingleIdentifier(lineNode, Keyword);
+        return CreateDirectiveNode(this, lineNode.Children[0].LexemeValue, identifier);
+    }
+
+    public sealed override void Accumulate(IReadOnlyList<LexemeValue> line, DialectDirectiveAccumulation accumulation)
+    {
+        AccumulateIdentifier(accumulation, DialectDirectiveParserSupport.ParseSingleIdentifier(line, Keyword));
+    }
+
+    protected abstract void AccumulateIdentifier(DialectDirectiveAccumulation accumulation, string value);
+}
+
+internal sealed class UseModulesDialectDirectiveFeature : IdentifierListDialectDirectiveFeatureBase
+{
+    public const string FeatureId = "builtin.modules.use";
+    public const string ValidationKey = FeatureId;
+
+    public override string Id => FeatureId;
+
     public override string Keyword => DialectDslKeywords.Use;
-    public override DialectDirectiveArgumentShape ArgumentShape => DialectDirectiveArgumentShape.IdentifierList;
-    public override float ParserPriority => 11f;
 
-    public override void Accumulate(IReadOnlyList<LexemeValue> line, DialectDirectiveAccumulation accumulation)
+    public override DialectDirectiveParserOrder ParserOrder => new(DialectDirectiveSlot.ModuleSelection, 0);
+
+    protected override void AccumulateIdentifiers(DialectDirectiveAccumulation accumulation, IReadOnlyList<string> values)
     {
-        accumulation.UseModules.AddRange(DialectDirectiveParserSupport.ParseIdentifierList(line, Keyword));
+        accumulation.UseModules.AddRange(values);
     }
 
-    public override void ValidateSemantic(DialectDirectiveAstNode directive, DialectDirectiveValidationState state)
+    public override void ValidateSemantic(DialectDirectiveAstNode directive, DialectDirectiveValidationContext context)
     {
-        state.AddUseModules(GetIdentifierList(directive), directive.LexemeValue);
-    }
-
-    public override IReadOnlyList<IDialectDefinitionSliceAnnotation> Lower(DialectDirectiveAstNode directive) => [new UseModulesAirAnnotation(GetIdentifierList(directive))];
-}
-
-internal sealed class ExcludeModulesDialectDirectiveFeature : DialectDirectiveFeatureBase
-{
-    public override DialectDirectiveKind Kind => DialectDirectiveKind.ExcludeModules;
-    public override string Keyword => DialectDslKeywords.Exclude;
-    public override DialectDirectiveArgumentShape ArgumentShape => DialectDirectiveArgumentShape.IdentifierList;
-    public override float ParserPriority => 12f;
-
-    public override void Accumulate(IReadOnlyList<LexemeValue> line, DialectDirectiveAccumulation accumulation)
-    {
-        accumulation.ExcludeModules.AddRange(DialectDirectiveParserSupport.ParseIdentifierList(line, Keyword));
-    }
-
-    public override void ValidateSemantic(DialectDirectiveAstNode directive, DialectDirectiveValidationState state)
-    {
-        state.AddExcludeModules(GetIdentifierList(directive), directive.LexemeValue);
-    }
-
-    public override IReadOnlyList<IDialectDefinitionSliceAnnotation> Lower(DialectDirectiveAstNode directive) => [new ExcludeModulesAirAnnotation(GetIdentifierList(directive))];
-}
-
-internal abstract class OrderDialectDirectiveFeatureBase : DialectDirectiveFeatureBase
-{
-    protected abstract DialectOrderDirectiveKind OrderKind { get; }
-
-    protected abstract Action<DialectDirectiveValidationState, IReadOnlyList<string>, LexemeValue?> ValidationAction { get; }
-
-    public override void Accumulate(IReadOnlyList<LexemeValue> line, DialectDirectiveAccumulation accumulation)
-    {
-        GetTargetList(accumulation).AddRange(DialectDirectiveParserSupport.ParseIdentifierList(line, Keyword));
-    }
-
-    public override void ValidateSemantic(DialectDirectiveAstNode directive, DialectDirectiveValidationState state)
-    {
-        ValidationAction(state, GetIdentifierList(directive), directive.LexemeValue);
+        context.AddValues(ValidationKey, GetIdentifierListArgument(directive), "Duplicate use module is not allowed.", directive.LexemeValue);
     }
 
     public override IReadOnlyList<IDialectDefinitionSliceAnnotation> Lower(DialectDirectiveAstNode directive)
     {
-        return [new OrderAirAnnotation(OrderKind, GetIdentifierList(directive))];
+        return [new UseModulesAirAnnotation(GetIdentifierListArgument(directive))];
+    }
+}
+
+internal sealed class ExcludeModulesDialectDirectiveFeature : IdentifierListDialectDirectiveFeatureBase
+{
+    public const string FeatureId = "builtin.modules.exclude";
+    public const string ValidationKey = FeatureId;
+
+    public override string Id => FeatureId;
+
+    public override string Keyword => DialectDslKeywords.Exclude;
+
+    public override DialectDirectiveParserOrder ParserOrder => new(DialectDirectiveSlot.ModuleSelection, 1);
+
+    protected override void AccumulateIdentifiers(DialectDirectiveAccumulation accumulation, IReadOnlyList<string> values)
+    {
+        accumulation.ExcludeModules.AddRange(values);
     }
 
-    protected abstract List<string> GetTargetList(DialectDirectiveAccumulation accumulation);
+    public override void ValidateSemantic(DialectDirectiveAstNode directive, DialectDirectiveValidationContext context)
+    {
+        context.AddValues(ValidationKey, GetIdentifierListArgument(directive), "Duplicate exclude module is not allowed.", directive.LexemeValue);
+    }
+
+    public override IReadOnlyList<IDialectDefinitionSliceAnnotation> Lower(DialectDirectiveAstNode directive)
+    {
+        return [new ExcludeModulesAirAnnotation(GetIdentifierListArgument(directive))];
+    }
+}
+
+internal abstract class OrderDialectDirectiveFeatureBase : IdentifierListDialectDirectiveFeatureBase
+{
+    protected abstract DialectOrderDirectiveKind OrderKind { get; }
+
+    protected abstract string ValidationKey { get; }
+
+    protected abstract string DuplicateMessage { get; }
+
+    protected abstract List<string> GetAccumulationTarget(DialectDirectiveAccumulation accumulation);
+
+    protected override void AccumulateIdentifiers(DialectDirectiveAccumulation accumulation, IReadOnlyList<string> values)
+    {
+        GetAccumulationTarget(accumulation).AddRange(values);
+    }
+
+    public override void ValidateSemantic(DialectDirectiveAstNode directive, DialectDirectiveValidationContext context)
+    {
+        context.AddValues(ValidationKey, GetIdentifierListArgument(directive), DuplicateMessage, directive.LexemeValue);
+    }
+
+    public override IReadOnlyList<IDialectDefinitionSliceAnnotation> Lower(DialectDirectiveAstNode directive)
+    {
+        return [new OrderAirAnnotation(OrderKind, GetIdentifierListArgument(directive))];
+    }
 }
 
 internal sealed class RequiresModulesDialectDirectiveFeature : OrderDialectDirectiveFeatureBase
 {
-    public override DialectDirectiveKind Kind => DialectDirectiveKind.RequiresModules;
+    public override string Id => "builtin.order.requires";
+
     public override string Keyword => DialectDslKeywords.Requires;
-    public override DialectDirectiveArgumentShape ArgumentShape => DialectDirectiveArgumentShape.IdentifierList;
-    public override float ParserPriority => 13f;
+
+    public override DialectDirectiveParserOrder ParserOrder => new(DialectDirectiveSlot.ModuleOrdering, 0);
+
     protected override DialectOrderDirectiveKind OrderKind => DialectOrderDirectiveKind.Requires;
-    protected override Action<DialectDirectiveValidationState, IReadOnlyList<string>, LexemeValue?> ValidationAction => static (state, values, token) => state.AddRequiresModules(values, token);
-    protected override List<string> GetTargetList(DialectDirectiveAccumulation accumulation) => accumulation.RequiresModules;
+
+    protected override string ValidationKey => Id;
+
+    protected override string DuplicateMessage => "Duplicate requires module is not allowed.";
+
+    protected override List<string> GetAccumulationTarget(DialectDirectiveAccumulation accumulation) => accumulation.RequiresModules;
 }
 
 internal sealed class BeforeModulesDialectDirectiveFeature : OrderDialectDirectiveFeatureBase
 {
-    public override DialectDirectiveKind Kind => DialectDirectiveKind.BeforeModules;
+    public override string Id => "builtin.order.before";
+
     public override string Keyword => DialectDslKeywords.Before;
-    public override DialectDirectiveArgumentShape ArgumentShape => DialectDirectiveArgumentShape.IdentifierList;
-    public override float ParserPriority => 14f;
+
+    public override DialectDirectiveParserOrder ParserOrder => new(DialectDirectiveSlot.ModuleOrdering, 1);
+
     protected override DialectOrderDirectiveKind OrderKind => DialectOrderDirectiveKind.Before;
-    protected override Action<DialectDirectiveValidationState, IReadOnlyList<string>, LexemeValue?> ValidationAction => static (state, values, token) => state.AddBeforeModules(values, token);
-    protected override List<string> GetTargetList(DialectDirectiveAccumulation accumulation) => accumulation.BeforeModules;
+
+    protected override string ValidationKey => Id;
+
+    protected override string DuplicateMessage => "Duplicate before module is not allowed.";
+
+    protected override List<string> GetAccumulationTarget(DialectDirectiveAccumulation accumulation) => accumulation.BeforeModules;
 }
 
 internal sealed class AfterModulesDialectDirectiveFeature : OrderDialectDirectiveFeatureBase
 {
-    public override DialectDirectiveKind Kind => DialectDirectiveKind.AfterModules;
+    public override string Id => "builtin.order.after";
+
     public override string Keyword => DialectDslKeywords.After;
-    public override DialectDirectiveArgumentShape ArgumentShape => DialectDirectiveArgumentShape.IdentifierList;
-    public override float ParserPriority => 15f;
+
+    public override DialectDirectiveParserOrder ParserOrder => new(DialectDirectiveSlot.ModuleOrdering, 2);
+
     protected override DialectOrderDirectiveKind OrderKind => DialectOrderDirectiveKind.After;
-    protected override Action<DialectDirectiveValidationState, IReadOnlyList<string>, LexemeValue?> ValidationAction => static (state, values, token) => state.AddAfterModules(values, token);
-    protected override List<string> GetTargetList(DialectDirectiveAccumulation accumulation) => accumulation.AfterModules;
+
+    protected override string ValidationKey => Id;
+
+    protected override string DuplicateMessage => "Duplicate after module is not allowed.";
+
+    protected override List<string> GetAccumulationTarget(DialectDirectiveAccumulation accumulation) => accumulation.AfterModules;
 }
 
-internal sealed class BackendDialectDirectiveFeature : DialectDirectiveFeatureBase
+internal sealed class BackendDialectDirectiveFeature : IdentifierListDialectDirectiveFeatureBase
 {
-    public override DialectDirectiveKind Kind => DialectDirectiveKind.Backend;
+    public override string Id => "builtin.backends.enable";
+
     public override string Keyword => DialectDslKeywords.Backend;
-    public override DialectDirectiveArgumentShape ArgumentShape => DialectDirectiveArgumentShape.IdentifierList;
-    public override float ParserPriority => 16f;
 
-    public override void Accumulate(IReadOnlyList<LexemeValue> line, DialectDirectiveAccumulation accumulation)
+    public override DialectDirectiveParserOrder ParserOrder => new(DialectDirectiveSlot.BackendSelection, 0);
+
+    protected override void AccumulateIdentifiers(DialectDirectiveAccumulation accumulation, IReadOnlyList<string> values)
     {
-        accumulation.Backends.AddRange(DialectDirectiveParserSupport.ParseIdentifierList(line, Keyword));
+        accumulation.Backends.AddRange(values);
     }
 
-    public override void ValidateSemantic(DialectDirectiveAstNode directive, DialectDirectiveValidationState state)
+    public override void ValidateSemantic(DialectDirectiveAstNode directive, DialectDirectiveValidationContext context)
     {
-        state.AddBackends(GetIdentifierList(directive), directive.LexemeValue);
+        context.AddValues(Id, GetIdentifierListArgument(directive), "Duplicate backend identifier is not allowed.", directive.LexemeValue);
     }
 
-    public override IReadOnlyList<IDialectDefinitionSliceAnnotation> Lower(DialectDirectiveAstNode directive) => [new BackendAirAnnotation(GetIdentifierList(directive))];
+    public override IReadOnlyList<IDialectDefinitionSliceAnnotation> Lower(DialectDirectiveAstNode directive)
+    {
+        return [new BackendAirAnnotation(GetIdentifierListArgument(directive))];
+    }
 }
 
-internal abstract class ToggleDirectiveFeatureBase : DialectDirectiveFeatureBase
+internal abstract class IntrinsicPolicyDialectDirectiveFeatureBase : SingleIdentifierDialectDirectiveFeatureBase
 {
-    public override DialectDirectiveArgumentShape ArgumentShape => DialectDirectiveArgumentShape.Identifier;
+    private const string ToggleStateKey = "builtin.intrinsics.toggle";
 
-    public override void Accumulate(IReadOnlyList<LexemeValue> line, DialectDirectiveAccumulation accumulation)
+    protected abstract bool Allowed { get; }
+
+    protected abstract string DuplicateMessage { get; }
+
+    protected abstract string ContradictionMessageTemplate { get; }
+
+    public override void ValidateSemantic(DialectDirectiveAstNode directive, DialectDirectiveValidationContext context)
     {
-        AddAccumulatedValue(accumulation, DialectDirectiveParserSupport.ParseSingleIdentifier(line, Keyword));
+        var value = GetSingleIdentifierArgument(directive);
+        var state = context.GetOrAddState(ToggleStateKey, static () => new ToggleValidationState());
+        state.Add(value, Allowed, DuplicateMessage, ContradictionMessageTemplate, directive.LexemeValue);
     }
 
-    protected abstract void AddAccumulatedValue(DialectDirectiveAccumulation accumulation, string value);
+    public override IReadOnlyList<IDialectDefinitionSliceAnnotation> Lower(DialectDirectiveAstNode directive)
+    {
+        return [new IntrinsicAirAnnotation(GetSingleIdentifierArgument(directive), Allowed)];
+    }
+
+    private sealed class ToggleValidationState
+    {
+        private readonly HashSet<string> _allowed = new(StringComparer.Ordinal);
+        private readonly HashSet<string> _forbidden = new(StringComparer.Ordinal);
+
+        public void Add(string value, bool allowed, string duplicateMessage, string contradictionMessageTemplate, LexemeValue? token)
+        {
+            var current = allowed ? _allowed : _forbidden;
+            var opposite = allowed ? _forbidden : _allowed;
+
+            if (!current.Add(value))
+            {
+                DialectDefinitionSliceParseErrors.Fail(duplicateMessage, token);
+            }
+
+            if (opposite.Contains(value))
+            {
+                DialectDefinitionSliceParseErrors.Fail(string.Format(contradictionMessageTemplate, value), token);
+            }
+        }
+    }
 }
 
-internal sealed class AllowIntrinsicDialectDirectiveFeature : ToggleDirectiveFeatureBase
+internal sealed class AllowIntrinsicDialectDirectiveFeature : IntrinsicPolicyDialectDirectiveFeatureBase
 {
-    public override DialectDirectiveKind Kind => DialectDirectiveKind.AllowIntrinsic;
+    public override string Id => "builtin.intrinsics.allow";
+
     public override string Keyword => DialectDslKeywords.Allow;
-    public override float ParserPriority => 17f;
 
-    protected override void AddAccumulatedValue(DialectDirectiveAccumulation accumulation, string value)
+    public override DialectDirectiveParserOrder ParserOrder => new(DialectDirectiveSlot.IntrinsicPolicy, 0);
+
+    protected override bool Allowed => true;
+
+    protected override string DuplicateMessage => "Duplicate allow intrinsic directive is not allowed.";
+
+    protected override string ContradictionMessageTemplate => "Intrinsic '{0}' cannot be both allowed and forbidden.";
+
+    protected override void AccumulateIdentifier(DialectDirectiveAccumulation accumulation, string value)
     {
         accumulation.AllowedIntrinsics.Add(value);
     }
-
-    public override void ValidateSemantic(DialectDirectiveAstNode directive, DialectDirectiveValidationState state)
-    {
-        state.AddAllowedIntrinsic(GetSingleIdentifier(directive), directive.LexemeValue);
-    }
-
-    public override IReadOnlyList<IDialectDefinitionSliceAnnotation> Lower(DialectDirectiveAstNode directive) => [new IntrinsicAirAnnotation(GetSingleIdentifier(directive), allowed: true)];
 }
 
-internal sealed class ForbidIntrinsicDialectDirectiveFeature : ToggleDirectiveFeatureBase
+internal sealed class ForbidIntrinsicDialectDirectiveFeature : IntrinsicPolicyDialectDirectiveFeatureBase
 {
-    public override DialectDirectiveKind Kind => DialectDirectiveKind.ForbidIntrinsic;
-    public override string Keyword => DialectDslKeywords.Forbid;
-    public override float ParserPriority => 18f;
+    public override string Id => "builtin.intrinsics.forbid";
 
-    protected override void AddAccumulatedValue(DialectDirectiveAccumulation accumulation, string value)
+    public override string Keyword => DialectDslKeywords.Forbid;
+
+    public override DialectDirectiveParserOrder ParserOrder => new(DialectDirectiveSlot.IntrinsicPolicy, 1);
+
+    protected override bool Allowed => false;
+
+    protected override string DuplicateMessage => "Duplicate forbid intrinsic directive is not allowed.";
+
+    protected override string ContradictionMessageTemplate => "Intrinsic '{0}' cannot be both allowed and forbidden.";
+
+    protected override void AccumulateIdentifier(DialectDirectiveAccumulation accumulation, string value)
     {
         accumulation.ForbiddenIntrinsics.Add(value);
     }
-
-    public override void ValidateSemantic(DialectDirectiveAstNode directive, DialectDirectiveValidationState state)
-    {
-        state.AddForbiddenIntrinsic(GetSingleIdentifier(directive), directive.LexemeValue);
-    }
-
-    public override IReadOnlyList<IDialectDefinitionSliceAnnotation> Lower(DialectDirectiveAstNode directive) => [new IntrinsicAirAnnotation(GetSingleIdentifier(directive), allowed: false)];
 }
 
-internal sealed class EnableIntrinsicDialectDirectiveFeature : ToggleDirectiveFeatureBase
+internal abstract class OptimizerPolicyDialectDirectiveFeatureBase : SingleIdentifierDialectDirectiveFeatureBase
 {
-    public override DialectDirectiveKind Kind => DialectDirectiveKind.EnableIntrinsic;
+    private const string ToggleStateKey = "builtin.optimizers.toggle";
+
+    protected abstract bool Enabled { get; }
+
+    protected abstract string DuplicateMessage { get; }
+
+    protected abstract string ContradictionMessageTemplate { get; }
+
+    public override void ValidateSemantic(DialectDirectiveAstNode directive, DialectDirectiveValidationContext context)
+    {
+        var value = GetSingleIdentifierArgument(directive);
+        var state = context.GetOrAddState(ToggleStateKey, static () => new ToggleValidationState());
+        state.Add(value, Enabled, DuplicateMessage, ContradictionMessageTemplate, directive.LexemeValue);
+    }
+
+    public override IReadOnlyList<IDialectDefinitionSliceAnnotation> Lower(DialectDirectiveAstNode directive)
+    {
+        return [new OptimizerAirAnnotation(GetSingleIdentifierArgument(directive), Enabled)];
+    }
+
+    private sealed class ToggleValidationState
+    {
+        private readonly HashSet<string> _enabled = new(StringComparer.Ordinal);
+        private readonly HashSet<string> _disabled = new(StringComparer.Ordinal);
+
+        public void Add(string value, bool enabled, string duplicateMessage, string contradictionMessageTemplate, LexemeValue? token)
+        {
+            var current = enabled ? _enabled : _disabled;
+            var opposite = enabled ? _disabled : _enabled;
+
+            if (!current.Add(value))
+            {
+                DialectDefinitionSliceParseErrors.Fail(duplicateMessage, token);
+            }
+
+            if (opposite.Contains(value))
+            {
+                DialectDefinitionSliceParseErrors.Fail(string.Format(contradictionMessageTemplate, value), token);
+            }
+        }
+    }
+}
+
+internal sealed class EnableOptimizerDialectDirectiveFeature : OptimizerPolicyDialectDirectiveFeatureBase
+{
+    public override string Id => "builtin.optimizers.enable";
+
     public override string Keyword => DialectDslKeywords.Enable;
-    public override float ParserPriority => 19f;
 
-    protected override void AddAccumulatedValue(DialectDirectiveAccumulation accumulation, string value)
+    public override DialectDirectiveParserOrder ParserOrder => new(DialectDirectiveSlot.OptimizerPolicy, 0);
+
+    protected override bool Enabled => true;
+
+    protected override string DuplicateMessage => "Duplicate enable optimizer directive is not allowed.";
+
+    protected override string ContradictionMessageTemplate => "Optimizer '{0}' cannot be both enabled and disabled.";
+
+    protected override void AccumulateIdentifier(DialectDirectiveAccumulation accumulation, string value)
     {
-        accumulation.EnabledIntrinsics.Add(value);
+        accumulation.EnabledOptimizers.Add(value);
     }
-
-    public override void ValidateSemantic(DialectDirectiveAstNode directive, DialectDirectiveValidationState state)
-    {
-        state.AddEnabledOptimizer(GetSingleIdentifier(directive), directive.LexemeValue);
-    }
-
-    public override IReadOnlyList<IDialectDefinitionSliceAnnotation> Lower(DialectDirectiveAstNode directive) => [new OptimizerAirAnnotation(GetSingleIdentifier(directive), enabled: true)];
 }
 
-internal sealed class DisableIntrinsicDialectDirectiveFeature : ToggleDirectiveFeatureBase
+internal sealed class DisableOptimizerDialectDirectiveFeature : OptimizerPolicyDialectDirectiveFeatureBase
 {
-    public override DialectDirectiveKind Kind => DialectDirectiveKind.DisableIntrinsic;
+    public override string Id => "builtin.optimizers.disable";
+
     public override string Keyword => DialectDslKeywords.Disable;
-    public override float ParserPriority => 20f;
 
-    protected override void AddAccumulatedValue(DialectDirectiveAccumulation accumulation, string value)
+    public override DialectDirectiveParserOrder ParserOrder => new(DialectDirectiveSlot.OptimizerPolicy, 1);
+
+    protected override bool Enabled => false;
+
+    protected override string DuplicateMessage => "Duplicate disable optimizer directive is not allowed.";
+
+    protected override string ContradictionMessageTemplate => "Optimizer '{0}' cannot be both enabled and disabled.";
+
+    protected override void AccumulateIdentifier(DialectDirectiveAccumulation accumulation, string value)
     {
-        accumulation.DisabledIntrinsics.Add(value);
+        accumulation.DisabledOptimizers.Add(value);
     }
-
-    public override void ValidateSemantic(DialectDirectiveAstNode directive, DialectDirectiveValidationState state)
-    {
-        state.AddDisabledOptimizer(GetSingleIdentifier(directive), directive.LexemeValue);
-    }
-
-    public override IReadOnlyList<IDialectDefinitionSliceAnnotation> Lower(DialectDirectiveAstNode directive) => [new OptimizerAirAnnotation(GetSingleIdentifier(directive), enabled: false)];
 }
 
-internal sealed class SecurityDialectDirectiveFeature : ToggleDirectiveFeatureBase
+internal sealed class SecurityDialectDirectiveFeature : SingleIdentifierDialectDirectiveFeatureBase
 {
-    public override DialectDirectiveKind Kind => DialectDirectiveKind.Security;
+    public override string Id => "builtin.security.profile";
+
     public override string Keyword => DialectDslKeywords.Security;
-    public override float ParserPriority => 21f;
+
+    public override DialectDirectiveParserOrder ParserOrder => new(DialectDirectiveSlot.Security, 0);
+
     public override bool IsSingleton => true;
 
-    protected override void AddAccumulatedValue(DialectDirectiveAccumulation accumulation, string value)
+    protected override void AccumulateIdentifier(DialectDirectiveAccumulation accumulation, string value)
     {
         if (accumulation.SecurityProfile != null)
         {
@@ -524,47 +813,75 @@ internal sealed class SecurityDialectDirectiveFeature : ToggleDirectiveFeatureBa
         accumulation.SecurityProfile = DialectAnnotationValueGuard.ParseSecurityProfile(value);
     }
 
-    public override void ValidateSemantic(DialectDirectiveAstNode directive, DialectDirectiveValidationState state)
+    public override void ValidateSemantic(DialectDirectiveAstNode directive, DialectDirectiveValidationContext context)
     {
-        state.MarkSecurity(directive.LexemeValue);
+        context.EnsureSingleton(Id, "Security directive can only be declared once.", directive.LexemeValue);
+        GetSingleIdentifierArgument(directive);
     }
 
     public override IReadOnlyList<IDialectDefinitionSliceAnnotation> Lower(DialectDirectiveAstNode directive)
     {
-        return [new SecurityAirAnnotation(DialectAnnotationValueGuard.ParseSecurityProfile(GetSingleIdentifier(directive)))];
+        return [new SecurityAirAnnotation(DialectAnnotationValueGuard.ParseSecurityProfile(GetSingleIdentifierArgument(directive)))];
     }
 }
 
-internal sealed class CapabilityDialectDirectiveFeature : DialectDirectiveFeatureBase
+internal sealed class CapabilityDialectDirectiveFeature : IdentifierListDialectDirectiveFeatureBase
 {
-    public override DialectDirectiveKind Kind => DialectDirectiveKind.Capability;
+    public override string Id => "builtin.capabilities.enable";
+
     public override string Keyword => DialectDslKeywords.Capability;
-    public override DialectDirectiveArgumentShape ArgumentShape => DialectDirectiveArgumentShape.IdentifierList;
-    public override float ParserPriority => 22f;
 
-    public override void Accumulate(IReadOnlyList<LexemeValue> line, DialectDirectiveAccumulation accumulation)
+    public override DialectDirectiveParserOrder ParserOrder => new(DialectDirectiveSlot.Capabilities, 0);
+
+    protected override void AccumulateIdentifiers(DialectDirectiveAccumulation accumulation, IReadOnlyList<string> values)
     {
-        accumulation.Capabilities.AddRange(DialectDirectiveParserSupport.ParseIdentifierList(line, Keyword));
+        accumulation.Capabilities.AddRange(values);
     }
 
-    public override void ValidateSemantic(DialectDirectiveAstNode directive, DialectDirectiveValidationState state)
+    public override void ValidateSemantic(DialectDirectiveAstNode directive, DialectDirectiveValidationContext context)
     {
-        state.AddCapabilities(GetIdentifierList(directive), directive.LexemeValue);
+        context.AddValues(Id, GetIdentifierListArgument(directive), "Duplicate capability identifier is not allowed.", directive.LexemeValue);
     }
 
-    public override IReadOnlyList<IDialectDefinitionSliceAnnotation> Lower(DialectDirectiveAstNode directive) => [new CapabilityAirAnnotation(GetIdentifierList(directive))];
+    public override IReadOnlyList<IDialectDefinitionSliceAnnotation> Lower(DialectDirectiveAstNode directive)
+    {
+        return [new CapabilityAirAnnotation(GetIdentifierListArgument(directive))];
+    }
 }
 
 internal sealed class UseExcludeConflictDocumentValidationRule : IDialectDocumentValidationRule
 {
     public int Order => 0;
 
-    public void Validate(DialectDocumentAstNode document, DialectDirectiveValidationState state)
+    public void Validate(DialectDocumentAstNode document, DialectDirectiveValidationContext context)
     {
-        foreach (var conflict in state.UseModules.Intersect(state.ExcludeModules, StringComparer.Ordinal))
+        foreach (var conflict in context.GetValues(UseModulesDialectDirectiveFeature.ValidationKey).Intersect(context.GetValues(ExcludeModulesDialectDirectiveFeature.ValidationKey), StringComparer.Ordinal))
         {
             DialectDefinitionSliceParseErrors.Fail($"Module '{conflict}' cannot appear in both use and exclude directives.", document.Declaration.NameNode.LexemeValue);
         }
+    }
+}
+
+internal sealed class BuiltInDialectDslFeatureProvider : IDialectDslFeatureProvider
+{
+    public int Order => 0;
+
+    public void Register(DialectDslRegistryBuilder builder)
+    {
+        builder
+            .RegisterFeature(new UseModulesDialectDirectiveFeature())
+            .RegisterFeature(new ExcludeModulesDialectDirectiveFeature())
+            .RegisterFeature(new RequiresModulesDialectDirectiveFeature())
+            .RegisterFeature(new BeforeModulesDialectDirectiveFeature())
+            .RegisterFeature(new AfterModulesDialectDirectiveFeature())
+            .RegisterFeature(new BackendDialectDirectiveFeature())
+            .RegisterFeature(new AllowIntrinsicDialectDirectiveFeature())
+            .RegisterFeature(new ForbidIntrinsicDialectDirectiveFeature())
+            .RegisterFeature(new EnableOptimizerDialectDirectiveFeature())
+            .RegisterFeature(new DisableOptimizerDialectDirectiveFeature())
+            .RegisterFeature(new SecurityDialectDirectiveFeature())
+            .RegisterFeature(new CapabilityDialectDirectiveFeature())
+            .RegisterDocumentRule(new UseExcludeConflictDocumentValidationRule());
     }
 }
 

--- a/UniversalToolchain/UniversalToolchain.Dialects.Frontend/DialectDslFrontendModule.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Frontend/DialectDslFrontendModule.cs
@@ -9,6 +9,15 @@ namespace UniversalToolchain.Dialects.Frontend;
 
 public sealed class DialectDslFrontendModule : IFrontendCoreModule
 {
+    private readonly DialectDslRegistry _registry;
+
+    public DialectDslFrontendModule(DialectDslRegistry? registry = null)
+    {
+        _registry = registry ?? DialectDslBuiltInFeatures.CreateRegistry();
+    }
+
+    public DialectDslRegistry Registry => _registry;
+
     public void InitLexer(ILexer lexer)
     {
         if (lexer == null)
@@ -16,7 +25,7 @@ public sealed class DialectDslFrontendModule : IFrontendCoreModule
             Thrower.ArgumentNull(nameof(lexer));
         }
 
-        lexer.AddLexemes(DialectDslLexemeRegistry.Registrations);
+        lexer.AddLexemes(DialectDslLexemeRegistry.CreateRegistrations(_registry));
     }
 
     public void InitParser(IParser parser)
@@ -26,12 +35,12 @@ public sealed class DialectDslFrontendModule : IFrontendCoreModule
             Thrower.ArgumentNull(nameof(parser));
         }
 
-        parser.AddNodeCreators(DialectDslParserNodeRegistry.Registrations);
+        parser.AddNodeCreators(DialectDslParserNodeRegistry.CreateRegistrations(_registry));
     }
 
     public AstNode ProcessAst(AstNode astRoot)
     {
-        return DialectAstPipelineValidator.Validate(astRoot);
+        return DialectAstPipelineValidator.Validate(astRoot, _registry);
     }
 
     public void InitAstTranslator(IAstToBytecodeTranslator translator)
@@ -41,6 +50,6 @@ public sealed class DialectDslFrontendModule : IFrontendCoreModule
             Thrower.ArgumentNull(nameof(translator));
         }
 
-        translator.AddVisitors(new DialectAstToBytecodeVisitor());
+        translator.AddVisitors(new DialectAstToBytecodeVisitor(_registry));
     }
 }

--- a/UniversalToolchain/UniversalToolchain.Dialects.Frontend/DialectDslLexemeRegistry.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Frontend/DialectDslLexemeRegistry.cs
@@ -1,21 +1,23 @@
 using BasicCore.Registration;
+using ExceptionsManager;
 
 namespace UniversalToolchain.Dialects.Frontend;
 
 public static class DialectDslLexemeRegistry
 {
-    private static readonly Lazy<IReadOnlyList<LexemeRegistration>> _registrations = new(BuildRegistrations);
-
-    public static IReadOnlyList<LexemeRegistration> Registrations => _registrations.Value;
-
-    private static IReadOnlyList<LexemeRegistration> BuildRegistrations()
+    public static IReadOnlyList<LexemeRegistration> CreateRegistrations(DialectDslRegistry registry)
     {
+        if (registry == null)
+        {
+            Thrower.ArgumentNull(nameof(registry));
+        }
+
         var registrations = new List<LexemeRegistration>
         {
             new($@"\b{DialectDslKeywords.Dialect}\b", DialectLexemeTags.DialectKeyword)
         };
 
-        registrations.AddRange(DialectDslFeatureCatalog.Features.Select(x => new LexemeRegistration($@"\b{x.Keyword}\b", x.LexemeTag)));
+        registrations.AddRange(registry.DirectiveFeatures.Select(x => new LexemeRegistration($@"\b{x.Keyword}\b", x.LexemeTag)));
         registrations.Add(new LexemeRegistration(@",", DialectLexemeTags.CommaToken));
         registrations.Add(new LexemeRegistration(@"\r?\n", DialectLexemeTags.NewLine));
         registrations.Add(new LexemeRegistration(@"[A-Za-z_][A-Za-z0-9_\.-]*", DialectLexemeTags.Identifier));

--- a/UniversalToolchain/UniversalToolchain.Dialects.Frontend/DialectDslParserNodeRegistry.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Frontend/DialectDslParserNodeRegistry.cs
@@ -1,23 +1,25 @@
 using BasicCore.Registration;
+using ExceptionsManager;
 
 namespace UniversalToolchain.Dialects.Frontend;
 
 public static class DialectDslParserNodeRegistry
 {
-    private static readonly Lazy<IReadOnlyList<NodeCreatorRegistration>> _registrations = new(BuildRegistrations);
-
-    public static IReadOnlyList<NodeCreatorRegistration> Registrations => _registrations.Value;
-
-    private static IReadOnlyList<NodeCreatorRegistration> BuildRegistrations()
+    public static IReadOnlyList<NodeCreatorRegistration> CreateRegistrations(DialectDslRegistry registry)
     {
+        if (registry == null)
+        {
+            Thrower.ArgumentNull(nameof(registry));
+        }
+
         var registrations = new List<NodeCreatorRegistration>
         {
-            new(0f, new DialectLineNodeCreator()),
-            new(10f, new DialectDeclarationNodeCreator())
+            new(DialectParserOrders.LineSplitter.Encode(), new DialectLineNodeCreator()),
+            new(DialectParserOrders.Declaration.Encode(), new DialectDeclarationNodeCreator())
         };
 
-        registrations.AddRange(DialectDslFeatureCatalog.Features.Select(x => new NodeCreatorRegistration(x.ParserPriority, x.CreateNodeCreator())));
-        registrations.Add(new NodeCreatorRegistration(100f, new DialectDocumentNodeCreator()));
+        registrations.AddRange(registry.DirectiveFeatures.Select(x => new NodeCreatorRegistration(DialectParserOrder.Directive(x.ParserOrder).Encode(), new FeatureDialectDirectiveNodeCreator(x))));
+        registrations.Add(new NodeCreatorRegistration(DialectParserOrders.Document.Encode(), new DialectDocumentNodeCreator()));
         return registrations;
     }
 }

--- a/UniversalToolchain/UniversalToolchain.Dialects.Frontend/DialectNodeCreators.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Frontend/DialectNodeCreators.cs
@@ -34,21 +34,6 @@ internal static class DialectNodeCreatorSupport
         return DialectLexemeTags.IsTag(node.LexemeValue, DialectLexemeTags.Identifier);
     }
 
-    public static AstNode GetChild(AstNode scope, int childIndex)
-    {
-        if (scope == null)
-        {
-            Thrower.ArgumentNull(nameof(scope));
-        }
-
-        if (childIndex < 0 || childIndex >= scope.Children.Count)
-        {
-            Thrower.ArgumentOutOfRange<object>(nameof(childIndex), "Child index is out of range for the current parser scope.");
-        }
-
-        return scope.Children[childIndex];
-    }
-
     public static string GetKeywordText(AstNode lineNode)
     {
         if (lineNode.Children.Count == 0 || lineNode.Children[0].LexemeValue == null)
@@ -249,156 +234,29 @@ public sealed class DialectDeclarationNodeCreator : DialectLineConstructNodeCrea
     }
 }
 
-public abstract class IdentifierListDirectiveNodeCreator<TNode> : DialectLineConstructNodeCreator where TNode : AstNode
-{
-    protected override AstNode CreateNode(AstNode lineNode)
-    {
-        return CreateTypedNode(lineNode, DialectNodeCreatorSupport.ParseIdentifierList(lineNode, Keyword));
-    }
-
-    protected abstract TNode CreateTypedNode(AstNode lineNode, IdentifierListAstNode identifiers);
-}
-
-public abstract class SingleIdentifierDirectiveNodeCreator<TNode> : DialectLineConstructNodeCreator where TNode : AstNode
-{
-    protected override AstNode CreateNode(AstNode lineNode)
-    {
-        return CreateTypedNode(lineNode, DialectNodeCreatorSupport.ParseSingleIdentifier(lineNode, Keyword));
-    }
-
-    protected abstract TNode CreateTypedNode(AstNode lineNode, IdentifierValueAstNode identifier);
-}
-
-public class IdentifierListDialectDirectiveNodeCreator : IdentifierListDirectiveNodeCreator<DialectDirectiveAstNode>
+public sealed class FeatureDialectDirectiveNodeCreator : DialectLineConstructNodeCreator
 {
     private readonly IDialectDirectiveFeature _feature;
-    private readonly Func<LexemeValue?, IdentifierListAstNode, DialectDirectiveAstNode> _factory;
 
-    public IdentifierListDialectDirectiveNodeCreator(IDialectDirectiveFeature feature)
+    public FeatureDialectDirectiveNodeCreator(IDialectDirectiveFeature feature)
     {
         if (feature == null)
         {
             Thrower.ArgumentNull(nameof(feature));
         }
 
-        if (feature.ArgumentShape != DialectDirectiveArgumentShape.IdentifierList)
-        {
-            Thrower.Argument(nameof(feature), $"Feature '{feature.Keyword}' must use identifier-list syntax.");
-        }
-
         _feature = feature;
-        _factory = DialectDirectiveNodeFactory.CreateIdentifierListFactory(feature);
     }
 
-    public override AstNodeType AstNodeType => DialectDirectiveNodeFactory.GetNodeType(_feature.Kind);
+    public override AstNodeType AstNodeType => DialectAstNodeTypes.DialectDirective;
 
     protected override string Keyword => _feature.Keyword;
 
-    protected override DialectDirectiveAstNode CreateTypedNode(AstNode lineNode, IdentifierListAstNode identifiers) => _factory(lineNode.Children[0].LexemeValue, identifiers);
-}
-
-public class SingleIdentifierDialectDirectiveNodeCreator : SingleIdentifierDirectiveNodeCreator<DialectDirectiveAstNode>
-{
-    private readonly IDialectDirectiveFeature _feature;
-    private readonly Func<LexemeValue?, IdentifierValueAstNode, DialectDirectiveAstNode> _factory;
-
-    public SingleIdentifierDialectDirectiveNodeCreator(IDialectDirectiveFeature feature)
+    protected override AstNode CreateNode(AstNode lineNode)
     {
-        if (feature == null)
-        {
-            Thrower.ArgumentNull(nameof(feature));
-        }
-
-        if (feature.ArgumentShape != DialectDirectiveArgumentShape.Identifier)
-        {
-            Thrower.Argument(nameof(feature), $"Feature '{feature.Keyword}' must use single-identifier syntax.");
-        }
-
-        _feature = feature;
-        _factory = DialectDirectiveNodeFactory.CreateSingleIdentifierFactory(feature);
-    }
-
-    public override AstNodeType AstNodeType => DialectDirectiveNodeFactory.GetNodeType(_feature.Kind);
-
-    protected override string Keyword => _feature.Keyword;
-
-    protected override DialectDirectiveAstNode CreateTypedNode(AstNode lineNode, IdentifierValueAstNode identifier) => _factory(lineNode.Children[0].LexemeValue, identifier);
-}
-
-internal static class DialectDirectiveNodeFactory
-{
-    public static AstNodeType GetNodeType(DialectDirectiveKind kind)
-    {
-        return kind switch
-        {
-            DialectDirectiveKind.UseModules => DialectAstNodeTypes.UseModulesDirective,
-            DialectDirectiveKind.ExcludeModules => DialectAstNodeTypes.ExcludeModulesDirective,
-            DialectDirectiveKind.RequiresModules => DialectAstNodeTypes.RequiresModulesDirective,
-            DialectDirectiveKind.BeforeModules => DialectAstNodeTypes.BeforeModulesDirective,
-            DialectDirectiveKind.AfterModules => DialectAstNodeTypes.AfterModulesDirective,
-            DialectDirectiveKind.Backend => DialectAstNodeTypes.BackendDirective,
-            DialectDirectiveKind.AllowIntrinsic => DialectAstNodeTypes.AllowIntrinsicDirective,
-            DialectDirectiveKind.ForbidIntrinsic => DialectAstNodeTypes.ForbidIntrinsicDirective,
-            DialectDirectiveKind.EnableIntrinsic => DialectAstNodeTypes.EnableIntrinsicDirective,
-            DialectDirectiveKind.DisableIntrinsic => DialectAstNodeTypes.DisableIntrinsicDirective,
-            DialectDirectiveKind.Security => DialectAstNodeTypes.SecurityDirective,
-            DialectDirectiveKind.Capability => DialectAstNodeTypes.CapabilityDirective,
-            _ => Thrower.InvalidOpEx<AstNodeType>($"Unknown dialect directive kind '{kind}'.")
-        };
-    }
-
-    public static Func<LexemeValue?, IdentifierListAstNode, DialectDirectiveAstNode> CreateIdentifierListFactory(IDialectDirectiveFeature feature)
-    {
-        return feature.Kind switch
-        {
-            DialectDirectiveKind.UseModules => (lexeme, identifiers) => new UseModulesDirectiveAstNode(feature, lexeme, identifiers),
-            DialectDirectiveKind.ExcludeModules => (lexeme, identifiers) => new ExcludeModulesDirectiveAstNode(feature, lexeme, identifiers),
-            DialectDirectiveKind.RequiresModules => (lexeme, identifiers) => new RequiresModulesDirectiveAstNode(feature, lexeme, identifiers),
-            DialectDirectiveKind.BeforeModules => (lexeme, identifiers) => new BeforeModulesDirectiveAstNode(feature, lexeme, identifiers),
-            DialectDirectiveKind.AfterModules => (lexeme, identifiers) => new AfterModulesDirectiveAstNode(feature, lexeme, identifiers),
-            DialectDirectiveKind.Backend => (lexeme, identifiers) => new BackendDirectiveAstNode(feature, lexeme, identifiers),
-            DialectDirectiveKind.Capability => (lexeme, identifiers) => new CapabilityDirectiveAstNode(feature, lexeme, identifiers),
-            _ => Thrower.InvalidOpEx<Func<LexemeValue?, IdentifierListAstNode, DialectDirectiveAstNode>>($"Feature '{feature.Keyword}' does not support identifier-list directives.")
-        };
-    }
-
-    public static Func<LexemeValue?, IdentifierValueAstNode, DialectDirectiveAstNode> CreateSingleIdentifierFactory(IDialectDirectiveFeature feature)
-    {
-        return feature.Kind switch
-        {
-            DialectDirectiveKind.AllowIntrinsic => (lexeme, identifier) => new AllowIntrinsicDirectiveAstNode(feature, lexeme, identifier),
-            DialectDirectiveKind.ForbidIntrinsic => (lexeme, identifier) => new ForbidIntrinsicDirectiveAstNode(feature, lexeme, identifier),
-            DialectDirectiveKind.EnableIntrinsic => (lexeme, identifier) => new EnableIntrinsicDirectiveAstNode(feature, lexeme, identifier),
-            DialectDirectiveKind.DisableIntrinsic => (lexeme, identifier) => new DisableIntrinsicDirectiveAstNode(feature, lexeme, identifier),
-            DialectDirectiveKind.Security => (lexeme, identifier) => new SecurityDirectiveAstNode(feature, lexeme, identifier),
-            _ => Thrower.InvalidOpEx<Func<LexemeValue?, IdentifierValueAstNode, DialectDirectiveAstNode>>($"Feature '{feature.Keyword}' does not support single-identifier directives.")
-        };
+        return _feature.ParseDirective(lineNode);
     }
 }
-
-public sealed class UseModulesDirectiveNodeCreator() : IdentifierListDialectDirectiveNodeCreator(DialectDslFeatureCatalog.GetFeature(DialectDirectiveKind.UseModules));
-
-public sealed class ExcludeModulesDirectiveNodeCreator() : IdentifierListDialectDirectiveNodeCreator(DialectDslFeatureCatalog.GetFeature(DialectDirectiveKind.ExcludeModules));
-
-public sealed class RequiresModulesDirectiveNodeCreator() : IdentifierListDialectDirectiveNodeCreator(DialectDslFeatureCatalog.GetFeature(DialectDirectiveKind.RequiresModules));
-
-public sealed class BeforeModulesDirectiveNodeCreator() : IdentifierListDialectDirectiveNodeCreator(DialectDslFeatureCatalog.GetFeature(DialectDirectiveKind.BeforeModules));
-
-public sealed class AfterModulesDirectiveNodeCreator() : IdentifierListDialectDirectiveNodeCreator(DialectDslFeatureCatalog.GetFeature(DialectDirectiveKind.AfterModules));
-
-public sealed class BackendDirectiveNodeCreator() : IdentifierListDialectDirectiveNodeCreator(DialectDslFeatureCatalog.GetFeature(DialectDirectiveKind.Backend));
-
-public sealed class AllowIntrinsicDirectiveNodeCreator() : SingleIdentifierDialectDirectiveNodeCreator(DialectDslFeatureCatalog.GetFeature(DialectDirectiveKind.AllowIntrinsic));
-
-public sealed class ForbidIntrinsicDirectiveNodeCreator() : SingleIdentifierDialectDirectiveNodeCreator(DialectDslFeatureCatalog.GetFeature(DialectDirectiveKind.ForbidIntrinsic));
-
-public sealed class EnableIntrinsicDirectiveNodeCreator() : SingleIdentifierDialectDirectiveNodeCreator(DialectDslFeatureCatalog.GetFeature(DialectDirectiveKind.EnableIntrinsic));
-
-public sealed class DisableIntrinsicDirectiveNodeCreator() : SingleIdentifierDialectDirectiveNodeCreator(DialectDslFeatureCatalog.GetFeature(DialectDirectiveKind.DisableIntrinsic));
-
-public sealed class SecurityDirectiveNodeCreator() : SingleIdentifierDialectDirectiveNodeCreator(DialectDslFeatureCatalog.GetFeature(DialectDirectiveKind.Security));
-
-public sealed class CapabilityDirectiveNodeCreator() : IdentifierListDialectDirectiveNodeCreator(DialectDslFeatureCatalog.GetFeature(DialectDirectiveKind.Capability));
 
 public sealed class DialectDocumentNodeCreator : IAstNodeCreator
 {
@@ -421,9 +279,9 @@ public sealed class DialectDocumentNodeCreator : IAstNodeCreator
             return false;
         }
 
-        if (scope.Children.Any(x => DialectNodeCreatorSupport.IsDialectLine(x)))
+        if (scope.Children.Any(DialectNodeCreatorSupport.IsDialectLine))
         {
-            var lineNode = scope.Children.First(x => DialectNodeCreatorSupport.IsDialectLine(x));
+            var lineNode = scope.Children.First(DialectNodeCreatorSupport.IsDialectLine);
             var keyword = DialectNodeCreatorSupport.GetKeywordText(lineNode);
             var message = string.IsNullOrWhiteSpace(keyword)
                 ? "Encountered an empty directive line."

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/DialectDefinitionTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/DialectDefinitionTests.cs
@@ -34,6 +34,22 @@ public class DialectDefinitionTests
         Assert.That(definition.OrderRules.Count, Is.EqualTo(1));
     }
 
+
+    [Test]
+    public void Constructor_AllowsMissingSecurityPolicy()
+    {
+        var definition = new DialectDefinition(
+            "dialect",
+            new ModulePolicy(),
+            new BackendPolicy(),
+            new IntrinsicPolicy(),
+            new OptimizerPolicy(),
+            null,
+            new CapabilityPolicy());
+
+        Assert.That(definition.SecurityPolicy, Is.Null);
+    }
+
     [Test]
     public void Constructor_ExposesCapabilityLookup()
     {

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/FrameworkNativeExtensionSeamsTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/FrameworkNativeExtensionSeamsTests.cs
@@ -1,30 +1,75 @@
 using System.Reflection;
+using BasicCore.LexerWrapper;
+using BasicCore.ParserWrapper;
+using BasicTypesExtensions;
+using IntermediateRepresentationAbstractions;
 using UniversalToolchain.Dialects.Abstractions;
 using UniversalToolchain.Dialects.Core;
 using UniversalToolchain.Dialects.Frontend;
 using UniversalToolchain.Dialects.Integration;
 using UniversalToolchain.Dialects.Parsing;
+using AstNodeType = BasicTypesExtensions.ExtensibleEnum<BasicCore.ParserWrapper.AstNodeTag>;
 
 namespace UniversalToolchain.Dialects.Tests;
 
 public class FrameworkNativeExtensionSeamsTests
 {
     [Test]
-    public void DirectiveFeatures_AreDiscoveredDeterministically_AndDriveParserRegistrations()
+    public void ExplicitRegistryComposition_IsDeterministic_AndUsesStagedOrdering()
     {
-        var first = DialectDslFeatureCatalog.Features.Select(x => (x.Kind, x.Keyword, x.ParserPriority, x.GetType().Name)).ToArray();
-        var second = DialectDslFeatureCatalog.Features.Select(x => (x.Kind, x.Keyword, x.ParserPriority, x.GetType().Name)).ToArray();
-        var parserCreatorTypes = DialectDslParserNodeRegistry.Registrations.Select(x => x.Creator.GetType().Name).ToArray();
+        var first = DialectDslBuiltInFeatures.CreateRegistry();
+        var second = DialectDslBuiltInFeatures.CreateRegistry();
+        var parserCreators = DialectDslParserNodeRegistry.CreateRegistrations(first).Select(x => x.Creator.GetType().Name).ToArray();
 
         Assert.Multiple(() =>
         {
-            Assert.That(first, Is.EqualTo(second));
-            Assert.That(first.Select(x => x.Keyword), Is.EqualTo(new[]
+            Assert.That(first.DirectiveFeatures.Select(x => (x.Id, x.Keyword, x.ParserOrder.Slot, x.ParserOrder.Sequence)),
+                Is.EqualTo(second.DirectiveFeatures.Select(x => (x.Id, x.Keyword, x.ParserOrder.Slot, x.ParserOrder.Sequence))));
+            Assert.That(first.DirectiveFeatures.Select(x => x.Keyword), Is.EqualTo(new[]
             {
                 "use", "exclude", "requires", "before", "after", "backend", "allow", "forbid", "enable", "disable", "security", "capability"
             }));
-            Assert.That(parserCreatorTypes, Does.Contain(nameof(IdentifierListDialectDirectiveNodeCreator)));
-            Assert.That(parserCreatorTypes, Does.Contain(nameof(SingleIdentifierDialectDirectiveNodeCreator)));
+            Assert.That(first.DirectiveFeatures.Select(x => x.ParserOrder.Slot), Is.EqualTo(new[]
+            {
+                DialectDirectiveSlot.ModuleSelection,
+                DialectDirectiveSlot.ModuleSelection,
+                DialectDirectiveSlot.ModuleOrdering,
+                DialectDirectiveSlot.ModuleOrdering,
+                DialectDirectiveSlot.ModuleOrdering,
+                DialectDirectiveSlot.BackendSelection,
+                DialectDirectiveSlot.IntrinsicPolicy,
+                DialectDirectiveSlot.IntrinsicPolicy,
+                DialectDirectiveSlot.OptimizerPolicy,
+                DialectDirectiveSlot.OptimizerPolicy,
+                DialectDirectiveSlot.Security,
+                DialectDirectiveSlot.Capabilities
+            }));
+            Assert.That(parserCreators, Does.Contain(nameof(FeatureDialectDirectiveNodeCreator)));
+        });
+    }
+
+    [Test]
+    public void CustomDirectiveFeature_CanBeAddedWithoutEditingCentralDirectivePlumbing()
+    {
+        var registry = DialectDslBuiltInFeatures.CreateRegistry([new AliasDirectiveFeatureProvider()]);
+        var compiler = new DialectDslCompiler(registry);
+
+        var slice = compiler.Compile(
+            """
+            dialect Tiny
+            alias math arithmetic
+            use arithmetic
+            """);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(slice.Name, Is.EqualTo("Tiny"));
+            Assert.That(slice.UseModules, Is.EqualTo(new[] { "arithmetic" }));
+            Assert.That(slice.CapabilityDirectives.Select(x => (x.Name, x.Value)), Is.EqualTo(new[]
+            {
+                ("alias:math->arithmetic", true)
+            }));
+            Assert.That(registry.DirectiveFeatures.Select(x => x.Keyword), Does.Contain("alias"));
         });
     }
 
@@ -59,6 +104,7 @@ public class FrameworkNativeExtensionSeamsTests
             Assert.That(definition.IntrinsicPolicy.ForbiddenIntrinsics, Is.EqualTo(new[] { "sub_i32" }));
             Assert.That(definition.OptimizerPolicy.EnabledOptimizers, Is.EqualTo(new[] { "Ssa" }));
             Assert.That(definition.OptimizerPolicy.DisabledOptimizers, Is.EqualTo(new[] { "Fold" }));
+            Assert.That(definition.SecurityPolicy, Is.Null);
             Assert.That(definition.OrderRules.Select(x => (x.Kind, x.ModuleName, x.RelatedModuleName)), Is.EqualTo(new[]
             {
                 (OrderRuleKind.Before, "A", "B")
@@ -130,6 +176,95 @@ public class FrameworkNativeExtensionSeamsTests
         }
     }
 
+    private sealed class AliasDirectiveFeatureProvider : IDialectDslFeatureProvider
+    {
+        public int Order => 100;
+
+        public void Register(DialectDslRegistryBuilder builder)
+        {
+            builder.RegisterFeature(new AliasDirectiveFeature());
+        }
+    }
+
+    private sealed class AliasDirectiveFeature : IDialectDirectiveFeature
+    {
+        public string Id => "tests.alias";
+
+        public string Keyword => "alias";
+
+        public string LexemeTag => "DialectDirectiveKeyword.alias";
+
+        public DialectDirectiveParserOrder ParserOrder => new(DialectDirectiveSlot.Extension, 0);
+
+        public bool IsSingleton => false;
+
+        public DialectDirectiveAstNode ParseDirective(AstNode lineNode)
+        {
+            if (lineNode.Children.Count != 3)
+            {
+                DialectDefinitionSliceParseErrors.Fail("Directive 'alias' expects exactly two identifiers.", lineNode.Children[0].LexemeValue);
+            }
+
+            var source = lineNode.Children[1];
+            var target = lineNode.Children[2];
+            if (!DialectLexemeTags.IsTag(source.LexemeValue, DialectLexemeTags.Identifier) || !DialectLexemeTags.IsTag(target.LexemeValue, DialectLexemeTags.Identifier))
+            {
+                DialectDefinitionSliceParseErrors.Fail("Directive 'alias' expects identifier arguments.", source.LexemeValue ?? target.LexemeValue);
+            }
+
+            return new DialectDirectiveAstNode(this, lineNode.Children[0].LexemeValue,
+            [
+                new AliasDirectivePayloadAstNode(new IdentifierValueAstNode(source.LexemeValue!), new IdentifierValueAstNode(target.LexemeValue!))
+            ]);
+        }
+
+        public void Accumulate(IReadOnlyList<LexemeValue> line, DialectDirectiveAccumulation accumulation)
+        {
+            if (line.Count != 3)
+            {
+                DialectDefinitionSliceParseErrors.Fail("Directive 'alias' expects exactly two identifiers.", line[0]);
+            }
+
+            accumulation.GetOrCreateList("AliasMappings").Add($"{line[1].Text}->{line[2].Text}");
+        }
+
+        public void ValidateSemantic(DialectDirectiveAstNode directive, DialectDirectiveValidationContext context)
+        {
+            var payload = GetPayload(directive);
+            if (string.Equals(payload.Source.Identifier, payload.Target.Identifier, StringComparison.Ordinal))
+            {
+                DialectDefinitionSliceParseErrors.Fail("Alias source and target must differ.", directive.LexemeValue);
+            }
+
+            context.AddValue(Id, $"{payload.Source.Identifier}->{payload.Target.Identifier}", "Duplicate alias directive is not allowed.", directive.LexemeValue);
+        }
+
+        public IReadOnlyList<IDialectDefinitionSliceAnnotation> Lower(DialectDirectiveAstNode directive)
+        {
+            var payload = GetPayload(directive);
+            return [new CapabilityAirAnnotation([ $"alias:{payload.Source.Identifier}->{payload.Target.Identifier}" ])];
+        }
+
+        private static AliasDirectivePayloadAstNode GetPayload(DialectDirectiveAstNode directive)
+        {
+            return directive.Payload as AliasDirectivePayloadAstNode
+                ?? throw new ArgumentException("Alias directive payload is invalid.", nameof(directive));
+        }
+    }
+
+    private sealed class AliasDirectivePayloadAstNode : DialectAstNode
+    {
+        private static readonly AstNodeType PayloadNodeType = ExtensibleEnum<AstNodeTag>.CreateOrGet("AliasDirectivePayload");
+
+        public AliasDirectivePayloadAstNode(IdentifierValueAstNode source, IdentifierValueAstNode target) : base(PayloadNodeType, null, [source, target])
+        {
+        }
+
+        public IdentifierValueAstNode Source => (IdentifierValueAstNode)Children[0];
+
+        public IdentifierValueAstNode Target => (IdentifierValueAstNode)Children[1];
+    }
+
     private sealed class FakeFrontendModule : BasicCore.Contracts.IFrontendCoreModule
     {
         public void InitLexer(BasicCore.LexerWrapper.ILexer lexer)
@@ -152,7 +287,7 @@ public class FrameworkNativeExtensionSeamsTests
 
     private sealed class FakeOptimizerModule : BasicCore.Contracts.IIRProcessingModule
     {
-        public IntermediateRepresentationAbstractions.IAbstractIR Process(IntermediateRepresentationAbstractions.IAbstractIR air)
+        public IAbstractIR Process(IAbstractIR air)
         {
             return air;
         }

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/FrameworkNativeSemanticBuildPlanTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/FrameworkNativeSemanticBuildPlanTests.cs
@@ -23,7 +23,7 @@ public class FrameworkNativeSemanticBuildPlanTests
     [Test]
     public void BuildPlan_ListBasedOrdering_IsNormalizedDeterministically()
     {
-        var source =
+        const string source =
             """
             dialect D
             use C,B,A
@@ -66,31 +66,46 @@ public class FrameworkNativeSemanticBuildPlanTests
     }
 
     [Test]
-    public void ParserRegistry_ContainsMultipleSpecializedCreators()
+    public void ParserRegistry_UsesFeatureOwnedCreators_AndStagedDirectiveSlots()
     {
-        var creatorTypes = DialectDslParserNodeRegistry.Registrations.Select(x => x.Creator.GetType().Name).ToArray();
-        var featureKinds = DialectDslFeatureCatalog.Features.Select(x => x.Kind).ToArray();
+        var registry = DialectDslBuiltInFeatures.CreateRegistry();
+        var creatorTypes = DialectDslParserNodeRegistry.CreateRegistrations(registry).Select(x => x.Creator.GetType().Name).ToArray();
+        var descriptors = DialectDirectiveDescriptors.CreateOrdered(registry);
 
         Assert.Multiple(() =>
         {
             Assert.That(creatorTypes, Does.Contain(nameof(DialectDeclarationNodeCreator)));
-            Assert.That(creatorTypes, Does.Contain(nameof(IdentifierListDialectDirectiveNodeCreator)));
-            Assert.That(creatorTypes, Does.Contain(nameof(SingleIdentifierDialectDirectiveNodeCreator)));
+            Assert.That(creatorTypes, Does.Contain(nameof(FeatureDialectDirectiveNodeCreator)));
             Assert.That(creatorTypes, Does.Contain(nameof(DialectDocumentNodeCreator)));
-            Assert.That(featureKinds, Is.EqualTo(new[]
+            Assert.That(descriptors.Select(x => x.Id), Is.EqualTo(new[]
             {
-                DialectDirectiveKind.UseModules,
-                DialectDirectiveKind.ExcludeModules,
-                DialectDirectiveKind.RequiresModules,
-                DialectDirectiveKind.BeforeModules,
-                DialectDirectiveKind.AfterModules,
-                DialectDirectiveKind.Backend,
-                DialectDirectiveKind.AllowIntrinsic,
-                DialectDirectiveKind.ForbidIntrinsic,
-                DialectDirectiveKind.EnableIntrinsic,
-                DialectDirectiveKind.DisableIntrinsic,
-                DialectDirectiveKind.Security,
-                DialectDirectiveKind.Capability
+                "builtin.modules.use",
+                "builtin.modules.exclude",
+                "builtin.order.requires",
+                "builtin.order.before",
+                "builtin.order.after",
+                "builtin.backends.enable",
+                "builtin.intrinsics.allow",
+                "builtin.intrinsics.forbid",
+                "builtin.optimizers.enable",
+                "builtin.optimizers.disable",
+                "builtin.security.profile",
+                "builtin.capabilities.enable"
+            }));
+            Assert.That(descriptors.Select(x => x.ParserOrder.Slot), Is.EqualTo(new[]
+            {
+                DialectDirectiveSlot.ModuleSelection,
+                DialectDirectiveSlot.ModuleSelection,
+                DialectDirectiveSlot.ModuleOrdering,
+                DialectDirectiveSlot.ModuleOrdering,
+                DialectDirectiveSlot.ModuleOrdering,
+                DialectDirectiveSlot.BackendSelection,
+                DialectDirectiveSlot.IntrinsicPolicy,
+                DialectDirectiveSlot.IntrinsicPolicy,
+                DialectDirectiveSlot.OptimizerPolicy,
+                DialectDirectiveSlot.OptimizerPolicy,
+                DialectDirectiveSlot.Security,
+                DialectDirectiveSlot.Capabilities
             }));
         });
     }

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/FrontendLayerServiceTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/FrontendLayerServiceTests.cs
@@ -44,10 +44,11 @@ public class FrontendLayerServiceTests
     }
 
     [Test]
-    public void FrontendModule_InitParser_CreatesExplicitDocumentTree()
+    public void FrontendModule_InitParser_CreatesFeatureOwnedDocumentTree()
     {
-        var ast = ParseWithFrontendModule("\n dialect Tiny\n\nuse Arithmetic,Variables\nallow add_i32\n");
-        var document = DialectDslAstValidator.Validate(ast);
+        var module = new DialectDslFrontendModule();
+        var ast = ParseWithFrontendModule(module, "\n dialect Tiny\n\nuse Arithmetic,Variables\nallow add_i32\n");
+        var document = DialectDslAstValidator.Validate(ast, module.Registry);
 
         Assert.Multiple(() =>
         {
@@ -55,12 +56,14 @@ public class FrontendLayerServiceTests
             Assert.That(document.Children.Select(x => x.GetType()).ToArray(), Is.EqualTo(new[]
             {
                 typeof(DialectDeclarationAstNode),
-                typeof(UseModulesDirectiveAstNode),
-                typeof(AllowIntrinsicDirectiveAstNode)
+                typeof(DialectDirectiveAstNode),
+                typeof(DialectDirectiveAstNode)
             }));
             Assert.That(document.Declaration.NameNode.Identifier, Is.EqualTo("Tiny"));
-            Assert.That(((UseModulesDirectiveAstNode)document.Directives[0]).Identifiers.Identifiers.Select(x => x.Identifier),
+            Assert.That(document.Directives.Select(x => x.Feature.Keyword), Is.EqualTo(new[] { "use", "allow" }));
+            Assert.That(((IdentifierListAstNode)document.Directives[0].Payload).Identifiers.Select(x => x.Identifier),
                 Is.EqualTo(new[] { "Arithmetic", "Variables" }));
+            Assert.That(((IdentifierValueAstNode)document.Directives[1].Payload).Identifier, Is.EqualTo("add_i32"));
         });
     }
 
@@ -93,25 +96,30 @@ public class FrontendLayerServiceTests
     [Test]
     public void DefinitionSliceParser_InvalidHeader_ThrowsParserException()
     {
-        var ex = Assert.Throws<ParserException>(() => ParseWithFrontendModule("use Arithmetic\n"));
+        var ex = Assert.Throws<ParserException>(() => ParseWithFrontendModule(new DialectDslFrontendModule(), "use Arithmetic\n"));
 
         Assert.That(ex!.Message, Does.Contain("dialect <name>").IgnoreCase);
     }
 
     [Test]
-    public void AirReader_RejectsUnknownAnnotationType_Explicitly()
+    public void AirReader_IgnoresUnrelatedAnnotationTypes()
     {
         var ir = new UniversalIntermediateRepresentation.AbstractIR();
-        ir.AppendInstructions([new Instruction(UOpCode.Annotate, metadata: [new object()])]);
+        ir.AppendInstructions([
+            new Instruction(UOpCode.Annotate, metadata: [new object(), new DialectNameAirAnnotation("Tiny"), new UseModulesAirAnnotation(new[] { "Arithmetic" })])
+        ]);
 
-        var ex = Assert.Throws<InvalidOperationException>(() => DialectDefinitionSliceAirReader.Read(ir));
+        var result = DialectDefinitionSliceAirReader.Read(ir);
 
-        Assert.That(ex!.Message, Does.Contain("unsupported annotation type"));
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Name, Is.EqualTo("Tiny"));
+            Assert.That(result.UseModules, Is.EqualTo(new[] { "Arithmetic" }));
+        });
     }
 
-    private static AstNode ParseWithFrontendModule(string source)
+    private static AstNode ParseWithFrontendModule(DialectDslFrontendModule module, string source)
     {
-        var module = new DialectDslFrontendModule();
         var parser = new BasicParserImpl(new ParserConfiguration([]));
         var lexer = new BasicLexerImpl(new LexerConfiguration([]));
         module.InitLexer(lexer);
@@ -122,7 +130,7 @@ public class FrontendLayerServiceTests
     private static List<LexemeValue> Lex(string source)
     {
         var lexer = new BasicLexerImpl(new LexerConfiguration([]));
-        lexer.AddLexemes(DialectDslLexemeRegistry.Registrations);
+        lexer.AddLexemes(DialectDslLexemeRegistry.CreateRegistrations(DialectDslBuiltInFeatures.CreateRegistry()));
         return lexer.Lexemize(source);
     }
 }


### PR DESCRIPTION
### Motivation
- Remove reflection-heavy, enum/switch-driven directive plumbing and make directive features self-owning end-to-end so new directives can be added without editing central factories or switches.
- Replace hidden static composition and float‑priority ordering with an explicit, deterministic, framework‑native registration and staged ordering model.
- Correct domain bugs: separate intrinsic vs optimizer modeling, fix SecurityPolicy nullability, and make AIR readback tolerant of unrelated metadata.

### Description
- Introduced an explicit registry/provider seam (`DialectDslRegistry`, `DialectDslRegistryBuilder`, `IDialectDslFeatureProvider`, `DialectDslBuiltInFeatures.CreateRegistry(...)`) so features are composed deterministically rather than discovered via reflection/`Lazy`/`Activator`.  The frontend accepts a registry instance to wire lexer/parser/translator registrations. 
- Replaced enum/switch node factories with feature-owned behavior: `IDialectDirectiveFeature` now owns `Id`, `Keyword`, `ParserOrder`, `ParseDirective`, `Accumulate`, `ValidateSemantic`, and `Lower`; parser node creation delegates to `FeatureDialectDirectiveNodeCreator` and `DialectDirectiveAstNode`, eliminating any central directive-kind switch. 
- Replaced ad‑hoc float priorities with a staged ordering abstraction (`DialectParserStage`, `DialectDirectiveSlot`, `DialectDirectiveParserOrder`, `DialectParserOrder`) which encodes deterministic ordering and is used when building parser registrations. 
- Moved argument-shape responsibility into features and feature base classes (`IdentifierListDialectDirectiveFeatureBase`, `SingleIdentifierDialectDirectiveFeatureBase`), removing the central validator’s assumptions about argument shapes and enabling future argument shapes per-feature. 
- Separated intrinsic vs optimizer domain modeling into distinct feature bases and validation state keys so intrinsics and optimizers no longer conflate concepts or lower through each other. 
- Fixed nullability: `DialectDefinition.SecurityPolicy` is now nullable and `DialectDefinitionSemanticBinder` passes `null` when no profile exists (removed `null!` suppression). 
- Made AIR readback composable and robust: `DialectDefinitionSliceAirReader` now ignores unrelated metadata annotations (but still rejects null entries) and drives aggregation deterministically. 
- Reworked accumulation/validation state into `DialectDirectiveAccumulation` and `DialectDirectiveValidationContext` (map/set backed) to support per-feature validation keys and singleton guards. 
- Tests updated/added to assert the new architectural guarantees: explicit registry composition and staged ordering, adding a custom directive via a provider without touching central plumbing, AIR readback ignoring unrelated annotations, and security nullability behavior.

### Testing
- Ran `dotnet restore UniversalToolchain/Wist.sln` and rebuilt; solution builds succeeded.
- Ran `dotnet build UniversalToolchain/UniversalToolchain.Dialects.Tests/UniversalToolchain.Dialects.Tests.csproj -c Release` and `dotnet test UniversalToolchain/UniversalToolchain.Dialects.Tests/UniversalToolchain.Dialects.Tests.csproj -c Release`; Dialects tests passed (97/97).
- Built full solution with `dotnet build UniversalToolchain/Wist.sln -c Release` and ran solution tests with `dotnet test UniversalToolchain/Wist.sln -c Release --no-build`; all tests passed (total across test assemblies: 716 passed, 0 failed).
- Key behavioral tests added/updated: custom directive provider extension seam, deterministic registry ordering and parser registrations, intrinsic/optimizer separation semantics, AIR readback ignoring unrelated annotations, and SecurityPolicy nullability checks (all succeeded in CI runs above).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bab86825808324afaf7244e827cb18)