### PR TITLE
Add default DI composition and standalone frontend; make compiler use shared composition; expand tests

### DIFF
--- a/UniversalToolchain/UniversalToolchain.Dialects.Frontend/Composition/DialectDslServiceCollectionExtensions.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Frontend/Composition/DialectDslServiceCollectionExtensions.cs
@@ -7,6 +7,18 @@ namespace UniversalToolchain.Dialects.Frontend;
 
 public static class DialectDslServiceCollectionExtensions
 {
+    public static IServiceCollection AddDialectDslDefaultComposition(this IServiceCollection services)
+    {
+        if (services == null)
+        {
+            Thrower.ArgumentNull(nameof(services));
+        }
+
+        return services
+            .AddDialectDsl()
+            .AddDialectDslBuiltIns();
+    }
+
     public static IServiceCollection AddDialectDsl(this IServiceCollection services)
     {
         if (services == null)

--- a/UniversalToolchain/UniversalToolchain.Dialects.Frontend/Composition/DialectDslStandaloneComposition.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Frontend/Composition/DialectDslStandaloneComposition.cs
@@ -1,0 +1,15 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace UniversalToolchain.Dialects.Frontend;
+
+internal static class DialectDslStandaloneComposition
+{
+    public static DialectDslFrontendModule CreateFrontendModule()
+    {
+        var services = new ServiceCollection();
+        services.AddDialectDslDefaultComposition();
+
+        using var provider = services.BuildServiceProvider();
+        return provider.GetRequiredService<DialectDslFrontendModule>();
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Frontend/DialectDslCompiler.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Frontend/DialectDslCompiler.cs
@@ -47,25 +47,6 @@ public sealed class DialectDslCompiler
 
     private static DialectDslFrontendModule CreateDefaultFrontendModule()
     {
-        var registry = new DialectDslRegistry(
-            [
-                new UseModulesDialectDirectiveFeature(),
-                new ExcludeModulesDialectDirectiveFeature(),
-                new RequiresModulesDialectDirectiveFeature(),
-                new BeforeModulesDialectDirectiveFeature(),
-                new AfterModulesDialectDirectiveFeature(),
-                new BackendDialectDirectiveFeature(),
-                new AllowIntrinsicDialectDirectiveFeature(),
-                new ForbidIntrinsicDialectDirectiveFeature(),
-                new EnableOptimizerDialectDirectiveFeature(),
-                new DisableOptimizerDialectDirectiveFeature(),
-                new SecurityDialectDirectiveFeature(),
-                new CapabilityDialectDirectiveFeature()
-            ],
-            [
-                new UseExcludeConflictDocumentValidationRule()
-            ]);
-
-        return new DialectDslFrontendModule(registry);
+        return DialectDslStandaloneComposition.CreateFrontendModule();
     }
 }

--- a/UniversalToolchain/UniversalToolchain.Dialects.Frontend/UniversalToolchain.Dialects.Frontend.csproj
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Frontend/UniversalToolchain.Dialects.Frontend.csproj
@@ -8,6 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.1" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.1" />
     </ItemGroup>
 

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/DialectDslArchitectureRefactorTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/DialectDslArchitectureRefactorTests.cs
@@ -1,7 +1,11 @@
+using AbstractIrConverters;
+using BasicCodeTranslator;
 using BasicCore.LexerWrapper;
 using BasicCore.ParserWrapper;
 using BasicCore.Registration;
+using BasicCore.TranslatorWrapper;
 using BasicLexer.Core;
+using BasicParser.Core;
 using CommonExceptions;
 using Microsoft.Extensions.DependencyInjection;
 using UniversalToolchain.Dialects.Frontend;
@@ -30,6 +34,23 @@ public class DialectDslArchitectureRefactorTests
     }
 
     [Test]
+    public void AddDialectDslDefaultComposition_RegistersSharedBuiltInComposition()
+    {
+        var services = new ServiceCollection();
+        services.AddDialectDslDefaultComposition();
+
+        using var provider = services.BuildServiceProvider();
+        var registry = provider.GetRequiredService<DialectDslRegistry>();
+        var compiler = provider.GetRequiredService<DialectDslCompiler>();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(registry.DirectiveFeatures.Select(x => x.Keyword), Does.Contain("capability"));
+            Assert.That(compiler.Compile("dialect Demo\nuse Arithmetic\n").UseModules, Is.EqualTo(new[] { "Arithmetic" }));
+        });
+    }
+
+    [Test]
     public void Compiler_DefaultConstructor_PreservesBuiltInStandaloneUsage()
     {
         var compiler = new DialectDslCompiler();
@@ -37,6 +58,63 @@ public class DialectDslArchitectureRefactorTests
         var slice = compiler.Compile("dialect Demo\nuse Arithmetic\n");
 
         Assert.That(slice.UseModules, Is.EqualTo(new[] { "Arithmetic" }));
+    }
+
+    [Test]
+    public void Compiler_DefaultConstructor_UsesSameBuiltInCompositionAsDiCompiler()
+    {
+        const string source =
+            """
+            dialect Demo
+            use Arithmetic,Variables
+            exclude Experimental
+            requires Core
+            before Parsing
+            after Lowering
+            backend cil
+            allow add_i32
+            forbid sub_i32
+            enable Ssa
+            disable Inlining
+            security trusted
+            capability sandbox
+            """;
+
+        var standaloneSlice = new DialectDslCompiler().Compile(source);
+        var diSlice = DialectDslTestComposition.CreateCompiler().Compile(source);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(standaloneSlice.Name, Is.EqualTo(diSlice.Name));
+            Assert.That(standaloneSlice.UseModules, Is.EqualTo(diSlice.UseModules));
+            Assert.That(standaloneSlice.ExcludeModules, Is.EqualTo(diSlice.ExcludeModules));
+            Assert.That(
+                standaloneSlice.OrderDirectives.Select(x => (x.Kind, x.SourceModule, x.TargetModule)),
+                Is.EqualTo(diSlice.OrderDirectives.Select(x => (x.Kind, x.SourceModule, x.TargetModule))));
+            Assert.That(
+                standaloneSlice.BackendDirectives.Select(x => (x.Backend, x.Enabled)),
+                Is.EqualTo(diSlice.BackendDirectives.Select(x => (x.Backend, x.Enabled))));
+            Assert.That(
+                standaloneSlice.IntrinsicDirectives.Select(x => (x.Name, x.Allowed)),
+                Is.EqualTo(diSlice.IntrinsicDirectives.Select(x => (x.Name, x.Allowed))));
+            Assert.That(
+                standaloneSlice.OptimizerDirectives.Select(x => (x.Name, x.Enabled)),
+                Is.EqualTo(diSlice.OptimizerDirectives.Select(x => (x.Name, x.Enabled))));
+            Assert.That(standaloneSlice.SecurityProfile, Is.EqualTo(diSlice.SecurityProfile));
+            Assert.That(
+                standaloneSlice.CapabilityDirectives.Select(x => x.Name),
+                Is.EqualTo(diSlice.CapabilityDirectives.Select(x => x.Name)));
+        });
+    }
+
+    [Test]
+    public void Compiler_DefaultConstructor_PreservesBuiltInDocumentValidationRules()
+    {
+        var compiler = new DialectDslCompiler();
+
+        var ex = Assert.Throws<ParserException>(() => compiler.Compile("dialect Demo\nuse Arithmetic\nexclude Arithmetic\n"));
+
+        Assert.That(ex!.Message, Does.Contain("use").And.Contain("exclude"));
     }
 
     [Test]
@@ -161,6 +239,45 @@ public class DialectDslArchitectureRefactorTests
             Assert.That(slice.OptimizerDirectives.Select(x => (x.Name, x.Enabled)), Is.EqualTo(new[] { ("Ssa", true) }));
             Assert.That(slice.SecurityProfile, Is.Null);
         });
+    }
+
+    [Test]
+    public void DefaultCompilerAndDefaultFrontendModule_RemainCompositionallyEquivalent()
+    {
+        const string source =
+            """
+            dialect Demo
+            use Arithmetic
+            capability sandbox
+            """;
+
+        var standaloneSlice = new DialectDslCompiler().Compile(source);
+        var frontendModuleSlice = ParseWithFrontendModule(DialectDslTestComposition.CreateFrontendModule(), source);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(standaloneSlice.Name, Is.EqualTo(frontendModuleSlice.Name));
+            Assert.That(standaloneSlice.UseModules, Is.EqualTo(frontendModuleSlice.UseModules));
+            Assert.That(
+                standaloneSlice.CapabilityDirectives.Select(x => x.Name),
+                Is.EqualTo(frontendModuleSlice.CapabilityDirectives.Select(x => x.Name)));
+        });
+    }
+
+    private static DialectDefinitionSlice ParseWithFrontendModule(DialectDslFrontendModule module, string source)
+    {
+        var parser = new BasicParserImpl(new ParserConfiguration([]));
+        var lexer = new BasicLexerImpl(new LexerConfiguration([]));
+        var translator = new BasicAstToBytecodeTranslatorImpl(new BytecodeTranslatorConfiguration([]));
+
+        module.InitLexer(lexer);
+        module.InitParser(parser);
+        module.InitAstTranslator(translator);
+
+        var ast = parser.Parse(lexer.Lexemize(source));
+        var bytecode = translator.Translate(module.ProcessAst(ast));
+        var ir = new BytecodeToAbstractIrConverterImpl().Translate(bytecode);
+        return DialectDefinitionSliceAirReader.Read(ir);
     }
 
     private sealed class ProviderExecutionRecorder

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/DialectDslTestComposition.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/DialectDslTestComposition.cs
@@ -8,8 +8,7 @@ internal static class DialectDslTestComposition
     public static ServiceProvider CreateProvider(Action<IServiceCollection>? configure = null)
     {
         var services = new ServiceCollection();
-        services.AddDialectDsl();
-        services.AddDialectDslBuiltIns();
+        services.AddDialectDslDefaultComposition();
         configure?.Invoke(services);
         return services.BuildServiceProvider();
     }


### PR DESCRIPTION
### Motivation
- Provide a single reusable default composition that wires both the DSL core and built-ins for DI and standalone usages.
- Reduce duplication between the compiler's default constructor and the DI-based composition by centralizing frontend creation.
- Ensure tests validate that the standalone compiler and DI-constructed compiler/module are compositionally equivalent.

### Description
- Added `AddDialectDslDefaultComposition` extension that composes `AddDialectDsl()` with `AddDialectDslBuiltIns()` for a single-call default registration.  
- Introduced `DialectDslStandaloneComposition.CreateFrontendModule()` to build a `ServiceCollection`, call the default composition, and return a `DialectDslFrontendModule` for standalone usage.  
- Updated `DialectDslCompiler` default initialization to use `DialectDslStandaloneComposition.CreateFrontendModule()` instead of manually constructing the registry and module.  
- Updated project file to add `Microsoft.Extensions.DependencyInjection` package reference and refactored test helper `DialectDslTestComposition` to use the new default composition.  
- Expanded `DialectDslArchitectureRefactorTests` with multiple tests that assert parity between the standalone compiler and DI-provided compiler/frontend and added helper parsing utilities to validate equivalence.

### Testing
- Ran unit tests in `UniversalToolchain.Dialects.Tests` (including `DialectDslArchitectureRefactorTests`) via `dotnet test`; all tests passed.  
- Exercised the new composition path by instantiating a `ServiceCollection`, calling `AddDialectDslDefaultComposition()`, building a provider, and resolving `DialectDslRegistry`, `DialectDslFrontendModule`, and `DialectDslCompiler` during tests which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bafcb6928c83249fba5066b89e8021)