### PR TITLE
Add comprehensive dialect DSL architecture test suite

### DIFF
--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/DialectDslBuiltInDirectiveTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/DialectDslBuiltInDirectiveTests.cs
@@ -1,0 +1,157 @@
+using UniversalToolchain.Dialects.Abstractions;
+using CommonExceptions;
+using UniversalToolchain.Dialects.Frontend;
+
+namespace UniversalToolchain.Dialects.Tests;
+
+public class DialectDslBuiltInDirectiveTests
+{
+    [Test]
+    public void UseDirective_ShouldParseValidateAndLowerIntoUseModuleList()
+    {
+        var slice = DialectDslTestComposition.CreateCompiler().Compile("dialect Demo\nuse Arithmetic,Variables\n");
+
+        Assert.That(slice.UseModules, Is.EqualTo(new[] { "Arithmetic", "Variables" }));
+    }
+
+    [Test]
+    public void UseDirective_ShouldRejectDuplicateIdentifiersWithinSingleDirective()
+    {
+        var ex = Assert.Throws<ParserException>(() => DialectDslTestComposition.CreateCompiler().Compile("dialect Demo\nuse Arithmetic,Arithmetic\n"));
+
+        DialectDslTestSupport.AssertParserExceptionContains(ex!, "duplicate identifiers");
+    }
+
+    [Test]
+    public void ExcludeDirective_ShouldRejectUseExcludeConflictsAcrossDocument()
+    {
+        var ex = Assert.Throws<ParserException>(() => DialectDslTestComposition.CreateCompiler().Compile("dialect Demo\nuse Arithmetic\nexclude Arithmetic\n"));
+
+        DialectDslTestSupport.AssertParserExceptionContains(ex!, "Arithmetic", "use", "exclude");
+    }
+
+    [Test]
+    public void RequiresBeforeAfterDirectives_ShouldLowerIntoOrderedRelations()
+    {
+        var slice = DialectDslTestComposition.CreateCompiler().Compile("dialect Demo\nrequires Core,Runtime\nbefore Parsing,Lowering\nafter Loading,Binding\n");
+
+        Assert.That(slice.OrderDirectives.Select(x => (x.Kind, x.SourceModule, x.TargetModule)).ToArray(), Is.EqualTo(new[]
+        {
+            (DialectOrderDirectiveKind.Requires, "Core", "Runtime"),
+            (DialectOrderDirectiveKind.Before, "Parsing", "Lowering"),
+            (DialectOrderDirectiveKind.After, "Loading", "Binding")
+        }));
+    }
+
+    [Test]
+    public void BeforeDirective_ShouldRejectDuplicateTargetsAcrossMultipleDeclarations()
+    {
+        var ex = Assert.Throws<ParserException>(() => DialectDslTestComposition.CreateCompiler().Compile("dialect Demo\nbefore Parsing\nbefore Parsing\n"));
+
+        DialectDslTestSupport.AssertParserExceptionContains(ex!, "Duplicate before module is not allowed");
+    }
+
+    [Test]
+    public void BackendDirective_ShouldParseMultipleBackends_AndRejectDuplicatesAcrossDocument()
+    {
+        var success = DialectDslTestComposition.CreateCompiler().Compile("dialect Demo\nbackend cil,interpreter\n");
+        var duplicate = Assert.Throws<ParserException>(() => DialectDslTestComposition.CreateCompiler().Compile("dialect Demo\nbackend cil\nbackend cil\n"));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(success.BackendDirectives.Select(x => (x.Backend, x.Enabled)), Is.EqualTo(new[]
+            {
+                (DialectBackendTarget.Cil, true),
+                (DialectBackendTarget.Interpreter, true)
+            }));
+            DialectDslTestSupport.AssertParserExceptionContains(duplicate!, "Duplicate backend identifier is not allowed");
+        });
+    }
+
+    [Test]
+    public void AllowAndForbidDirectives_ShouldTrackIntrinsicPolicy_AndRejectContradictions()
+    {
+        var success = DialectDslTestComposition.CreateCompiler().Compile("dialect Demo\nallow add_i32\nforbid sub_i32\n");
+        var contradiction = Assert.Throws<ParserException>(() => DialectDslTestComposition.CreateCompiler().Compile("dialect Demo\nallow add_i32\nforbid add_i32\n"));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(success.IntrinsicDirectives.Select(x => (x.Name, x.Allowed)), Is.EqualTo(new[]
+            {
+                ("add_i32", true),
+                ("sub_i32", false)
+            }));
+            DialectDslTestSupport.AssertParserExceptionContains(contradiction!, "cannot be both allowed and forbidden", "add_i32");
+        });
+    }
+
+    [Test]
+    public void EnableAndDisableDirectives_ShouldTrackOptimizerPolicy_AndRejectDuplicates()
+    {
+        var success = DialectDslTestComposition.CreateCompiler().Compile("dialect Demo\nenable Ssa\ndisable Inlining\n");
+        var duplicate = Assert.Throws<ParserException>(() => DialectDslTestComposition.CreateCompiler().Compile("dialect Demo\nenable Ssa\nenable Ssa\n"));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(success.OptimizerDirectives.Select(x => (x.Name, x.Enabled)), Is.EqualTo(new[]
+            {
+                ("Ssa", true),
+                ("Inlining", false)
+            }));
+            DialectDslTestSupport.AssertParserExceptionContains(duplicate!, "Duplicate enable optimizer directive is not allowed");
+        });
+    }
+
+    [Test]
+    public void SecurityDirective_ShouldBehaveAsSingleton_AndRejectUnsupportedProfiles()
+    {
+        var trusted = DialectDslTestComposition.CreateCompiler().Compile("dialect Demo\nsecurity trusted\n");
+        var duplicate = Assert.Throws<ParserException>(() => DialectDslTestComposition.CreateCompiler().Compile("dialect Demo\nsecurity trusted\nsecurity restricted\n"));
+        var invalid = Assert.Throws<ArgumentException>(() => DialectDslTestComposition.CreateCompiler().Compile("dialect Demo\nsecurity unknown\n"));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(trusted.SecurityProfile, Is.EqualTo(DialectSecurityProfile.Trusted));
+            DialectDslTestSupport.AssertParserExceptionContains(duplicate!, "Security directive can only be declared once");
+            Assert.That(invalid!.Message, Does.Contain("Security profile 'unknown' is not supported"));
+        });
+    }
+
+    [Test]
+    public void CapabilityDirective_ShouldLowerIntoCapabilities_AndRejectDuplicatesAcrossDocument()
+    {
+        var success = DialectDslTestComposition.CreateCompiler().Compile("dialect Demo\ncapability sandbox\ncapability unsafe-interop\n");
+        var duplicate = Assert.Throws<ParserException>(() => DialectDslTestComposition.CreateCompiler().Compile("dialect Demo\ncapability sandbox\ncapability sandbox\n"));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(success.CapabilityDirectives.Select(x => x.Name), Is.EqualTo(new[] { "sandbox", "unsafe-interop" }));
+            DialectDslTestSupport.AssertParserExceptionContains(duplicate!, "Duplicate capability identifier is not allowed");
+        });
+    }
+
+    [Test]
+    public void BuiltInDocument_WithEveryDirective_ShouldProduceExpectedSemanticSlice()
+    {
+        var slice = DialectDslTestComposition.CreateCompiler().Compile(
+            "dialect Demo\nuse Arithmetic,Variables\nexclude Legacy\nrequires Core,Runtime\nbefore Parsing,Lowering\nafter Loading,Binding\nbackend cil\nallow add_i32\nforbid sub_i32\nenable Ssa\ndisable Inlining\nsecurity restricted\ncapability sandbox\n");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(slice.Name, Is.EqualTo("Demo"));
+            Assert.That(slice.UseModules, Is.EqualTo(new[] { "Arithmetic", "Variables" }));
+            Assert.That(slice.ExcludeModules, Is.EqualTo(new[] { "Legacy" }));
+            Assert.That(slice.OrderDirectives.Select(x => (x.Kind, x.TargetModule)).ToArray(), Is.EqualTo(new[]
+            {
+                (DialectOrderDirectiveKind.Requires, "Runtime"),
+                (DialectOrderDirectiveKind.Before, "Lowering"),
+                (DialectOrderDirectiveKind.After, "Binding")
+            }));
+            Assert.That(slice.BackendDirectives.Select(x => x.Backend), Is.EqualTo(new[] { DialectBackendTarget.Cil }));
+            Assert.That(slice.IntrinsicDirectives.Select(x => (x.Name, x.Allowed)), Is.EqualTo(new[] { ("add_i32", true), ("sub_i32", false) }));
+            Assert.That(slice.OptimizerDirectives.Select(x => (x.Name, x.Enabled)), Is.EqualTo(new[] { ("Ssa", true), ("Inlining", false) }));
+            Assert.That(slice.SecurityProfile, Is.EqualTo(DialectSecurityProfile.Restricted));
+            Assert.That(slice.CapabilityDirectives.Select(x => x.Name), Is.EqualTo(new[] { "sandbox" }));
+        });
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/DialectDslCompositionParityTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/DialectDslCompositionParityTests.cs
@@ -1,0 +1,137 @@
+using CommonExceptions;
+using Microsoft.Extensions.DependencyInjection;
+using UniversalToolchain.Dialects.Frontend;
+
+namespace UniversalToolchain.Dialects.Tests;
+
+public class DialectDslCompositionParityTests
+{
+    [Test]
+    public void AddDialectDsl_ShouldRegisterCoreServices_WithoutBuiltIns()
+    {
+        var services = new ServiceCollection();
+        services.AddDialectDsl();
+
+        using var provider = services.BuildServiceProvider();
+        var registry = provider.GetRequiredService<DialectDslRegistry>();
+        var frontendModule = provider.GetRequiredService<DialectDslFrontendModule>();
+        var compiler = provider.GetRequiredService<DialectDslCompiler>();
+        var factory = provider.GetRequiredService<IDialectDslRegistryFactory>();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(registry.DirectiveFeatures, Is.Empty);
+            Assert.That(registry.DocumentRules, Is.Empty);
+            Assert.That(frontendModule.Registry, Is.SameAs(registry));
+            Assert.That(factory.CreateRegistry().DirectiveFeatures, Is.Empty);
+            Assert.That(() => compiler.Compile("dialect Demo\n"), Throws.Nothing);
+        });
+    }
+
+    [Test]
+    public void AddDialectDslBuiltIns_ShouldRegisterExpectedBuiltInFeaturesAndRules()
+    {
+        var services = new ServiceCollection();
+        services.AddDialectDsl();
+        services.AddDialectDslBuiltIns();
+
+        using var provider = services.BuildServiceProvider();
+        var features = provider.GetServices<IDialectDirectiveFeature>().ToList();
+        var rules = provider.GetServices<IDialectDocumentValidationRule>().ToList();
+        var registry = provider.GetRequiredService<DialectDslRegistry>();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(features.Select(x => x.Keyword), Is.EquivalentTo(DialectDslTestSupport.ExpectedBuiltInKeywords));
+            Assert.That(rules.Select(x => x.GetType().Name), Is.EqualTo(new[] { "UseExcludeConflictDocumentValidationRule" }));
+            Assert.That(registry.DirectiveFeatures.Select(x => x.Keyword), Is.EqualTo(DialectDslTestSupport.ExpectedBuiltInKeywords));
+        });
+    }
+
+    [Test]
+    public void AddDialectDslDefaultComposition_ShouldResolveCompilerRegistryAndFrontendModule_WithSharedRegistryInstance()
+    {
+        using var provider = DialectDslTestComposition.CreateProvider();
+
+        var registry = provider.GetRequiredService<DialectDslRegistry>();
+        var frontendModule = provider.GetRequiredService<DialectDslFrontendModule>();
+        var compiler = provider.GetRequiredService<DialectDslCompiler>();
+        var frontendCoreModules = provider.GetServices<BasicCore.Contracts.IFrontendCoreModule>().ToArray();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(registry.DirectiveFeatures.Select(x => x.Keyword), Is.EqualTo(DialectDslTestSupport.ExpectedBuiltInKeywords));
+            Assert.That(registry.DocumentRules, Has.Count.EqualTo(1));
+            Assert.That(frontendModule.Registry, Is.SameAs(registry));
+            Assert.That(frontendCoreModules, Has.Member(frontendModule));
+            Assert.That(compiler.Compile("dialect Demo\ncapability sandbox\n").CapabilityDirectives.Select(x => x.Name), Is.EqualTo(new[] { "sandbox" }));
+        });
+    }
+
+    [TestCaseSource(typeof(DialectDslTestSupport), nameof(DialectDslTestSupport.RepresentativeSources))]
+    public void StandaloneCompiler_ShouldMatchDiComposedCompiler_ForRepresentativeBuiltInInputs(string source)
+    {
+        var standalone = new DialectDslCompiler().Compile(source);
+        var di = DialectDslTestComposition.CreateCompiler().Compile(source);
+
+        DialectDslTestSupport.AssertSlicesEquivalent(standalone, di);
+    }
+
+    [TestCaseSource(typeof(DialectDslTestSupport), nameof(DialectDslTestSupport.RepresentativeSources))]
+    public void StandaloneCompiler_ShouldMatchExplicitFrontendPipeline_ForRepresentativeBuiltInInputs(string source)
+    {
+        var standalone = new DialectDslCompiler().Compile(source);
+        var viaFrontendModule = DialectDslTestSupport.CompileWithFrontendModule(DialectDslTestComposition.CreateFrontendModule(), source);
+
+        DialectDslTestSupport.AssertSlicesEquivalent(standalone, viaFrontendModule);
+    }
+
+    [Test]
+    public void StandaloneAndDiComposition_ShouldRejectUseExcludeConflicts_WithEquivalentErrorMessages()
+    {
+        const string source = "dialect Demo\nuse Arithmetic\nexclude Arithmetic\n";
+
+        var standalone = Assert.Throws<ParserException>(() => new DialectDslCompiler().Compile(source));
+        var di = Assert.Throws<ParserException>(() => DialectDslTestComposition.CreateCompiler().Compile(source));
+
+        Assert.Multiple(() =>
+        {
+            DialectDslTestSupport.AssertParserExceptionContains(standalone!, "use", "exclude", "Arithmetic");
+            DialectDslTestSupport.AssertParserExceptionContains(di!, "use", "exclude", "Arithmetic");
+            Assert.That(di!.Message, Is.EqualTo(standalone!.Message));
+        });
+    }
+
+    [Test]
+    public void StandaloneAndDiComposition_ShouldRejectDuplicateSingletonSecurityDirective_WithEquivalentErrorMessages()
+    {
+        const string source = "dialect Demo\nsecurity trusted\nsecurity restricted\n";
+
+        var standalone = Assert.Throws<ParserException>(() => new DialectDslCompiler().Compile(source));
+        var di = Assert.Throws<ParserException>(() => DialectDslTestComposition.CreateCompiler().Compile(source));
+
+        Assert.Multiple(() =>
+        {
+            DialectDslTestSupport.AssertParserExceptionContains(standalone!, "Security directive can only be declared once");
+            DialectDslTestSupport.AssertParserExceptionContains(di!, "Security directive can only be declared once");
+            Assert.That(di!.Message, Is.EqualTo(standalone!.Message));
+        });
+    }
+
+    [Test]
+    public void DefaultComposition_ShouldExposeSameBuiltInDescriptors_InDiRegistryAndFrontendModuleRegistry()
+    {
+        using var provider = DialectDslTestComposition.CreateProvider();
+        var registry = provider.GetRequiredService<DialectDslRegistry>();
+        var module = provider.GetRequiredService<DialectDslFrontendModule>();
+
+        var fromRegistry = DialectDirectiveDescriptors.CreateOrdered(registry)
+            .Select(x => (x.Id, x.Keyword, x.ParserOrder.Slot, x.ParserOrder.Sequence, x.IsSingleton))
+            .ToArray();
+        var fromModule = DialectDirectiveDescriptors.CreateOrdered(module.Registry)
+            .Select(x => (x.Id, x.Keyword, x.ParserOrder.Slot, x.ParserOrder.Sequence, x.IsSingleton))
+            .ToArray();
+
+        Assert.That(fromModule, Is.EqualTo(fromRegistry));
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/DialectDslExtensibilityTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/DialectDslExtensibilityTests.cs
@@ -1,0 +1,111 @@
+using CommonExceptions;
+using Microsoft.Extensions.DependencyInjection;
+using UniversalToolchain.Dialects.Frontend;
+
+namespace UniversalToolchain.Dialects.Tests;
+
+public class DialectDslExtensibilityTests
+{
+    [Test]
+    public void CustomProvider_ShouldRegisterDirectiveWithoutEditingDefaultPlumbing()
+    {
+        var compiler = DialectDslTestComposition.CreateCompiler(services => services.AddDialectDirectiveFeatureProvider<AliasDirectiveFeatureProvider>());
+
+        var slice = compiler.Compile("dialect Demo\nalias math arithmetic\nuse arithmetic\n");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(slice.UseModules, Is.EqualTo(new[] { "arithmetic" }));
+            Assert.That(slice.CapabilityDirectives.Select(x => x.Name), Is.EqualTo(new[] { "alias:math->arithmetic" }));
+        });
+    }
+
+    [Test]
+    public void CustomProviders_ShouldComposeTogetherAndCoexistWithBuiltIns()
+    {
+        var compiler = DialectDslTestComposition.CreateCompiler(services =>
+        {
+            services.AddDialectDirectiveFeatureProvider<AliasDirectiveFeatureProvider>();
+            services.AddDialectDirectiveFeatureProvider<AliasDirectiveFeatureProvider2>();
+        });
+
+        var slice = compiler.Compile("dialect Demo\nalias math arithmetic\nalias-2 io input\ncapability sandbox\n");
+
+        Assert.That(slice.CapabilityDirectives.Select(x => x.Name), Is.EqualTo(new[]
+        {
+            "alias:math->arithmetic",
+            "alias-2:io->input",
+            "sandbox"
+        }));
+    }
+
+    [Test]
+    public void DirectFeatureRegistration_ShouldSupportCustomDirectiveOutsideProviderPath()
+    {
+        var compiler = DialectDslTestComposition.CreateCompiler(services => services.AddDialectDirectiveFeature<DirectAliasDirectiveFeature>());
+
+        var slice = compiler.Compile("dialect Demo\ndirect-alias src dst\n");
+
+        Assert.That(slice.CapabilityDirectives.Select(x => x.Name), Is.EqualTo(new[] { "direct-alias:src->dst" }));
+    }
+
+    [Test]
+    public void ProviderRegistrationOrder_ShouldNotAffectFeatureAvailabilityOrFinalOrdering()
+    {
+        using var firstProvider = DialectDslTestComposition.CreateProvider(services =>
+        {
+            services.AddDialectDirectiveFeatureProvider<AliasDirectiveFeatureProvider2>();
+            services.AddDialectDirectiveFeatureProvider<AliasDirectiveFeatureProvider>();
+        });
+        using var secondProvider = DialectDslTestComposition.CreateProvider(services =>
+        {
+            services.AddDialectDirectiveFeatureProvider<AliasDirectiveFeatureProvider>();
+            services.AddDialectDirectiveFeatureProvider<AliasDirectiveFeatureProvider2>();
+        });
+
+        var firstRegistry = firstProvider.GetRequiredService<DialectDslRegistry>();
+        var secondRegistry = secondProvider.GetRequiredService<DialectDslRegistry>();
+
+        Assert.That(firstRegistry.DirectiveFeatures.Select(x => (x.Keyword, x.Id, x.ParserOrder.Sequence)),
+            Is.EqualTo(secondRegistry.DirectiveFeatures.Select(x => (x.Keyword, x.Id, x.ParserOrder.Sequence))));
+    }
+
+    [Test]
+    public void CustomDirective_ShouldParticipateInSemanticValidation_AndRejectInvalidPayloads()
+    {
+        var compiler = DialectDslTestComposition.CreateCompiler(services => services.AddDialectDirectiveFeatureProvider<AliasDirectiveFeatureProvider>());
+
+        var ex = Assert.Throws<ParserException>(() => compiler.Compile("dialect Demo\nalias same same\n"));
+
+        DialectDslTestSupport.AssertParserExceptionContains(ex!, "Alias source and target must differ");
+    }
+
+    [Test]
+    public void CustomDirective_ShouldParticipateInRegistryComposition_ThroughDiFactory()
+    {
+        using var provider = DialectDslTestComposition.CreateProvider(services => services.AddDialectDirectiveFeatureProvider<AliasDirectiveFeatureProvider>());
+
+        var registry = provider.GetRequiredService<DialectDslRegistry>();
+        var factory = provider.GetRequiredService<IDialectDslRegistryFactory>();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(registry.DirectiveFeatures.Select(x => x.Keyword), Does.Contain("alias"));
+            Assert.That(factory.CreateRegistry().DirectiveFeatures.Select(x => x.Keyword), Does.Contain("alias"));
+        });
+    }
+
+    [Test]
+    public void DuplicateCustomKeywords_ShouldFailFast_DuringRegistryConstruction()
+    {
+        var services = new ServiceCollection();
+        services.AddDialectDsl();
+        services.AddDialectDirectiveFeatureProvider<AliasDirectiveFeatureProvider>();
+        services.AddDialectDirectiveFeature<DuplicateAliasDirectiveFeature>();
+
+        using var provider = services.BuildServiceProvider();
+        var ex = Assert.Throws<InvalidOperationException>(() => provider.GetRequiredService<DialectDslRegistry>());
+
+        Assert.That(ex!.Message, Does.Contain("keyword").And.Contain("alias"));
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/DialectDslKeywordEscapingTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/DialectDslKeywordEscapingTests.cs
@@ -1,0 +1,55 @@
+using UniversalToolchain.Dialects.Frontend;
+
+namespace UniversalToolchain.Dialects.Tests;
+
+public class DialectDslKeywordEscapingTests
+{
+    [TestCase("meta+", "meta+ value", "meta value")]
+    [TestCase("meta?", "meta? value", "meta value")]
+    [TestCase("meta.", "meta. value", "meta.a value")]
+    [TestCase("meta[", "meta[ value", "meta value")]
+    [TestCase("meta|pipe", "meta|pipe value", "meta value")]
+    public void KeywordLexemeRegistration_ShouldEscapeRegexMetacharacters(string keyword, string matchingDirectiveLine, string similarNonMatchLine)
+    {
+        var registry = new DialectDslRegistry([new RegexKeywordDirectiveFeature(keyword, 100)], []);
+
+        var matchingLexemes = DialectDslTestSupport.Lex(registry, $"dialect Demo\n{matchingDirectiveLine}\n");
+        var nonMatchingLexemes = DialectDslTestSupport.Lex(registry, $"dialect Demo\n{similarNonMatchLine}\n");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(matchingLexemes.Any(x => x.Text == keyword && x.LexemePattern!.LexemeType.GetName() == $"DialectDirectiveKeyword.{keyword}"), Is.True);
+            Assert.That(nonMatchingLexemes.Any(x => x.LexemePattern!.LexemeType.GetName() == $"DialectDirectiveKeyword.{keyword}"), Is.False);
+        });
+    }
+
+    [TestCase("meta+", 201)]
+    [TestCase("meta?", 202)]
+    [TestCase("meta.", 203)]
+    [TestCase("meta[", 204)]
+    [TestCase("meta|pipe", 205)]
+    public void EscapedRegexKeywords_ShouldParseAndLower_AsLiteralDirectiveKeywords(string keyword, int sequence)
+    {
+        var compiler = CreateCompiler(keyword, sequence);
+
+        var slice = compiler.Compile($"dialect Demo\n{keyword} token\n");
+
+        Assert.That(slice.CapabilityDirectives.Select(x => x.Name), Is.EqualTo(new[] { $"{keyword}:token" }));
+    }
+
+    [Test]
+    public void KeywordPattern_ShouldRequireLiteralBoundary_AroundEscapedKeyword()
+    {
+        var registry = new DialectDslRegistry([new RegexKeywordDirectiveFeature("meta.", 300)], []);
+
+        var lexemes = DialectDslTestSupport.Lex(registry, "dialect Demo\nmeta.a value\n");
+
+        Assert.That(lexemes.Any(x => x.Text == "meta."), Is.False);
+    }
+
+    private static DialectDslCompiler CreateCompiler(string keyword, int sequence)
+    {
+        var registry = new DialectDslRegistry([new RegexKeywordDirectiveFeature(keyword, sequence)], []);
+        return new DialectDslCompiler(new DialectDslFrontendModule(registry));
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/DialectDslOrderingTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/DialectDslOrderingTests.cs
@@ -1,0 +1,141 @@
+using Microsoft.Extensions.DependencyInjection;
+using UniversalToolchain.Dialects.Frontend;
+
+namespace UniversalToolchain.Dialects.Tests;
+
+public class DialectDslOrderingTests
+{
+    [Test]
+    public void DirectiveParserOrder_ShouldCompareBySlotThenSequence()
+    {
+        var moduleSelection = new DialectDirectiveParserOrder(DialectDirectiveSlot.ModuleSelection, 1);
+        var moduleOrdering = new DialectDirectiveParserOrder(DialectDirectiveSlot.ModuleOrdering, 0);
+        var earlierWithinSlot = new DialectDirectiveParserOrder(DialectDirectiveSlot.Extension, 1);
+        var laterWithinSlot = new DialectDirectiveParserOrder(DialectDirectiveSlot.Extension, 2);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(moduleSelection.CompareTo(moduleOrdering), Is.LessThan(0));
+            Assert.That(moduleOrdering.CompareTo(moduleSelection), Is.GreaterThan(0));
+            Assert.That(earlierWithinSlot.CompareTo(laterWithinSlot), Is.LessThan(0));
+            Assert.That(laterWithinSlot.CompareTo(earlierWithinSlot), Is.GreaterThan(0));
+            Assert.That(earlierWithinSlot.CompareTo(new DialectDirectiveParserOrder(DialectDirectiveSlot.Extension, 1)), Is.Zero);
+        });
+    }
+
+    [Test]
+    public void ParserOrder_ShouldCompareByStageThenSlotThenSequence()
+    {
+        var lineSplit = new DialectParserOrder(DialectParserStage.LineSplitting, 0, 0);
+        var declaration = new DialectParserOrder(DialectParserStage.Declaration, 0, 0);
+        var directiveEarly = new DialectParserOrder(DialectParserStage.Directives, 3, 0);
+        var directiveLate = new DialectParserOrder(DialectParserStage.Directives, 3, 1);
+        var document = new DialectParserOrder(DialectParserStage.Document, 0, 0);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(lineSplit.CompareTo(declaration), Is.LessThan(0));
+            Assert.That(declaration.CompareTo(directiveEarly), Is.LessThan(0));
+            Assert.That(directiveEarly.CompareTo(directiveLate), Is.LessThan(0));
+            Assert.That(directiveLate.CompareTo(document), Is.LessThan(0));
+            Assert.That(DialectParserOrder.Directive(new DialectDirectiveParserOrder(DialectDirectiveSlot.Security, 4)),
+                Is.EqualTo(new DialectParserOrder(DialectParserStage.Directives, (int)DialectDirectiveSlot.Security, 4)));
+        });
+    }
+
+    [Test]
+    public void Registry_ShouldSortFeaturesDeterministically_ByParserOrderKeywordAndId()
+    {
+        var registry = new DialectDslRegistry(
+        [
+            new OrderedFeature("tests.zzz", "zzz", new DialectDirectiveParserOrder(DialectDirectiveSlot.Extension, 5)),
+            new OrderedFeature("tests.gamma", "gamma", new DialectDirectiveParserOrder(DialectDirectiveSlot.Extension, 1)),
+            new OrderedFeature("tests.alpha", "alpha", new DialectDirectiveParserOrder(DialectDirectiveSlot.Extension, 0)),
+            new OrderedFeature("tests.beta", "beta", new DialectDirectiveParserOrder(DialectDirectiveSlot.Extension, 2))
+        ],
+        []);
+
+        Assert.That(registry.DirectiveFeatures.Select(x => (x.Keyword, x.Id, x.ParserOrder.Sequence)), Is.EqualTo(new[]
+        {
+            ("alpha", "tests.alpha", 0),
+            ("gamma", "tests.gamma", 1),
+            ("beta", "tests.beta", 2),
+            ("zzz", "tests.zzz", 5)
+        }));
+    }
+
+    [Test]
+    public void RegistryFactory_ShouldOrderProviderExecutionDeterministically_ByOrderThenTypeName()
+    {
+        var executionLog = new List<string>();
+        var services = new ServiceCollection();
+        services.AddDialectDsl();
+        services.AddSingleton(executionLog);
+        services.AddSingleton<IDialectDslFeatureProvider>(provider => new RecordingProviderOmega(builder => builder.RegisterFeature(new OrderedFeature("tests.provider.omega", "omega", new(DialectDirectiveSlot.Extension, 2))), executionLog));
+        services.AddSingleton<IDialectDslFeatureProvider>(provider => new RecordingProviderAlpha(builder => builder.RegisterFeature(new OrderedFeature("tests.provider.alpha", "alpha", new(DialectDirectiveSlot.Extension, 1))), executionLog));
+
+        using var provider = services.BuildServiceProvider();
+        var registry = provider.GetRequiredService<DialectDslRegistry>();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(executionLog, Is.EqualTo(new[] { nameof(RecordingProviderAlpha), nameof(RecordingProviderOmega) }));
+            Assert.That(registry.DirectiveFeatures.Select(x => x.Keyword), Is.EqualTo(new[] { "alpha", "omega" }));
+        });
+    }
+
+    [Test]
+    public void ParserNodeRegistry_ShouldEmitContiguousPriorities_InOrderedStageSequence()
+    {
+        var registry = DialectDslTestComposition.CreateRegistry(services =>
+        {
+            services.AddDialectDirectiveFeature<DirectAliasDirectiveFeature>();
+            services.AddDialectDirectiveFeature<SingletonNoteDirectiveFeature>();
+        });
+
+        var registrations = DialectDslParserNodeRegistry.CreateRegistrations(registry);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(registrations.Select(x => x.Priority), Is.EqualTo(Enumerable.Range(0, registrations.Count).Select(static x => (float)x)));
+            Assert.That(registrations.First().Creator, Is.TypeOf<DialectLineNodeCreator>());
+            Assert.That(registrations[1].Creator, Is.TypeOf<DialectDeclarationNodeCreator>());
+            Assert.That(registrations[^1].Creator, Is.TypeOf<DialectDocumentNodeCreator>());
+            Assert.That(registrations.Skip(2).Take(registrations.Count - 3).Select(x => x.Creator.GetType().Name).Distinct(), Does.Contain(nameof(FeatureDialectDirectiveNodeCreator)));
+        });
+    }
+
+    [Test]
+    public void Registry_ShouldRejectDirectiveOrderCollisions_WithMeaningfulMessage()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(() => new DialectDslRegistry(
+        [new CollisionFeatureA(), new CollisionFeatureB()],
+        []));
+
+        Assert.That(ex!.Message, Does.Contain("collision").And.Contain("tests.collision.a").And.Contain("tests.collision.b"));
+    }
+
+    [Test]
+    public void Registry_ShouldRejectDuplicateKeywordAndDuplicateIdRegistrations()
+    {
+        var duplicateKeyword = Assert.Throws<InvalidOperationException>(() => new DialectDslRegistry(
+        [new OrderedFeature("tests.alpha", "dup", new(DialectDirectiveSlot.Extension, 1)), new OrderedFeature("tests.beta", "dup", new(DialectDirectiveSlot.Extension, 2))],
+        []));
+        var duplicateId = Assert.Throws<InvalidOperationException>(() => new DialectDslRegistry(
+        [new OrderedFeature("tests.same", "alpha", new(DialectDirectiveSlot.Extension, 1)), new OrderedFeature("tests.same", "beta", new(DialectDirectiveSlot.Extension, 2))],
+        []));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(duplicateKeyword!.Message, Does.Contain("keyword").And.Contain("dup"));
+            Assert.That(duplicateId!.Message, Does.Contain("identifier").And.Contain("tests.same"));
+        });
+    }
+
+    private sealed class OrderedFeature(string id, string keyword, DialectDirectiveParserOrder parserOrder) : SimpleIdentifierDirectiveFeatureBase
+    {
+        public override string Id => id;
+        public override string Keyword => keyword;
+        public override DialectDirectiveParserOrder ParserOrder => parserOrder;
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/DialectDslRegressionTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/DialectDslRegressionTests.cs
@@ -1,0 +1,147 @@
+using CommonExceptions;
+using IntermediateRepresentationAbstractions;
+using UniversalToolchain.Dialects.Abstractions;
+using UniversalToolchain.Dialects.Core;
+using UniversalToolchain.Dialects.Frontend;
+
+namespace UniversalToolchain.Dialects.Tests;
+
+public class DialectDslRegressionTests
+{
+    [Test]
+    public void SingletonDirectiveEnforcement_ShouldBeCentralized_ForCustomFeaturesInDiAndStandalonePipelines()
+    {
+        var customCompiler = DialectDslTestComposition.CreateCompiler(services => services.AddDialectDirectiveFeature<SingletonNoteDirectiveFeature>());
+        var baseRegistry = DialectDslTestComposition.CreateRegistry();
+        var standaloneLikeCompiler = new DialectDslCompiler(new DialectDslFrontendModule(new DialectDslRegistry(
+            baseRegistry.DirectiveFeatures.Concat([new SingletonNoteDirectiveFeature()]),
+            baseRegistry.DocumentRules)));
+
+        var diException = Assert.Throws<ParserException>(() => customCompiler.Compile("dialect Demo\nnote first\nnote second\n"));
+        var standaloneException = Assert.Throws<ParserException>(() => standaloneLikeCompiler.Compile("dialect Demo\nnote first\nnote second\n"));
+
+        Assert.Multiple(() =>
+        {
+            DialectDslTestSupport.AssertParserExceptionContains(diException!, "note directive can only be declared once");
+            DialectDslTestSupport.AssertParserExceptionContains(standaloneException!, "note directive can only be declared once");
+        });
+    }
+
+    [Test]
+    public void IntrinsicAndOptimizerPolicies_ShouldRemainSeparated_WhenDirectiveNamesOverlap()
+    {
+        var slice = DialectDslTestComposition.CreateCompiler().Compile("dialect Demo\nallow shared\nenable shared\nforbid shared-intrinsic\ndisable shared-optimizer\n");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(slice.IntrinsicDirectives.Select(x => (x.Name, x.Allowed)), Is.EqualTo(new[]
+            {
+                ("shared", true),
+                ("shared-intrinsic", false)
+            }));
+            Assert.That(slice.OptimizerDirectives.Select(x => (x.Name, x.Enabled)), Is.EqualTo(new[]
+            {
+                ("shared", true),
+                ("shared-optimizer", false)
+            }));
+        });
+    }
+
+    [Test]
+    public void AirReader_ShouldIgnoreUnrelatedMetadata_WhilePreservingDialectAnnotationsAcrossInstructions()
+    {
+        var air = new UniversalIntermediateRepresentation.AbstractIR();
+        air.AppendInstructions([
+            new Instruction(UOpCode.Annotate, metadata: [new object(), new DialectNameAirAnnotation("Demo")]),
+            new Instruction(UOpCode.Annotate, metadata: [new SecurityAirAnnotation(DialectSecurityProfile.Restricted), new object()]),
+            new Instruction(UOpCode.Annotate, metadata: [new CapabilityAirAnnotation(["sandbox"]), new UseModulesAirAnnotation(["Arithmetic"])])
+        ]);
+
+        var slice = DialectDefinitionSliceAirReader.Read(air);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(slice.Name, Is.EqualTo("Demo"));
+            Assert.That(slice.SecurityProfile, Is.EqualTo(DialectSecurityProfile.Restricted));
+            Assert.That(slice.CapabilityDirectives.Select(x => x.Name), Is.EqualTo(new[] { "sandbox" }));
+            Assert.That(slice.UseModules, Is.EqualTo(new[] { "Arithmetic" }));
+        });
+    }
+
+    [Test]
+    public void AirReader_ShouldRejectNullMetadataEntries_WithMeaningfulError()
+    {
+        var air = new UniversalIntermediateRepresentation.AbstractIR();
+        air.AppendInstructions([
+            new Instruction(UOpCode.Annotate, metadata: [new DialectNameAirAnnotation("Demo"), null!])
+        ]);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => DialectDefinitionSliceAirReader.Read(air));
+
+        Assert.That(ex!.Message, Does.Contain("null annotation entry"));
+    }
+
+    [Test]
+    public void AirReader_ShouldRejectDuplicateSingletonSecurityAnnotations()
+    {
+        var air = new UniversalIntermediateRepresentation.AbstractIR();
+        air.AppendInstructions([
+            new Instruction(UOpCode.Annotate, metadata: [new DialectNameAirAnnotation("Demo"), new SecurityAirAnnotation(DialectSecurityProfile.Trusted)]),
+            new Instruction(UOpCode.Annotate, metadata: [new SecurityAirAnnotation(DialectSecurityProfile.Restricted)])
+        ]);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => DialectDefinitionSliceAirReader.Read(air));
+
+        Assert.That(ex!.Message, Does.Contain("duplicate singleton annotation").And.Contain(nameof(SecurityAirAnnotation)));
+    }
+
+    [Test]
+    public void RestrictedSecurityProfile_WithUnsafeInteropCapability_ShouldProduceSecurityDiagnostic()
+    {
+        var slice = DialectDslTestComposition.CreateCompiler().Compile("dialect Demo\nsecurity restricted\ncapability unsafe-interop\n");
+
+        var plan = new DialectCompiledDialectBuildPlanBuilder().Build(slice);
+
+        Assert.That(plan.ValidationResult.Diagnostics.Select(x => (x.Code, x.Message, x.Severity)).ToArray(), Is.EqualTo(new[]
+        {
+            ("S006", "Capability 'unsafe-interop' cannot be enabled under restricted security profile.", DialectDiagnosticSeverity.Error)
+        }));
+    }
+
+    [Test]
+    public void TrustedSecurityProfile_WithUnsafeInteropCapability_ShouldNotProduceSecurityDiagnostic()
+    {
+        var slice = DialectDslTestComposition.CreateCompiler().Compile("dialect Demo\nsecurity trusted\ncapability unsafe-interop\n");
+
+        var plan = new DialectCompiledDialectBuildPlanBuilder().Build(slice);
+
+        Assert.That(plan.ValidationResult.Diagnostics, Is.Empty);
+    }
+
+    [Test]
+    public void RegistryFactory_ShouldRejectNullProviderEntries_RatherThanSilentlyIgnoringThem()
+    {
+        var nullProviders = new List<IDialectDslFeatureProvider> { null! };
+        var factory = new DialectDslRegistryFactory([], [], nullProviders);
+
+        var ex = Assert.Throws<ArgumentException>(() => factory.CreateRegistry());
+
+        Assert.That(ex!.Message, Does.Contain("Collection must not contain null values"));
+    }
+
+    [Test]
+    public void ValidationContext_ShouldRejectNullOrWhitespaceStateKeys()
+    {
+        var accumulation = new DialectDirectiveAccumulation();
+        var validationContext = new DialectDirectiveValidationContext();
+
+        var accumulationEx = Assert.Throws<ArgumentException>(() => accumulation.GetOrCreateList(new DialectListStateKey<string>(" ")));
+        var validationEx = Assert.Throws<ArgumentException>(() => validationContext.GetOrAddState(new DialectValueStateKey<List<string>>(""), static () => []));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(accumulationEx!.Message, Does.Contain("must not be empty"));
+            Assert.That(validationEx!.Message, Does.Contain("must not be empty"));
+        });
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/DialectDslTestSupport.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/DialectDslTestSupport.cs
@@ -1,0 +1,315 @@
+using AbstractIrConverters;
+using BasicCodeTranslator;
+using BasicCore.LexerWrapper;
+using BasicCore.ParserWrapper;
+using BasicCore.Registration;
+using BasicCore.TranslatorWrapper;
+using BasicLexer.Core;
+using BasicParser.Core;
+using CommonExceptions;
+using Microsoft.Extensions.DependencyInjection;
+using UniversalToolchain.Dialects.Abstractions;
+using UniversalToolchain.Dialects.Core;
+using UniversalToolchain.Dialects.Frontend;
+using AstNodeType = BasicTypesExtensions.ExtensibleEnum<BasicCore.ParserWrapper.AstNodeTag>;
+
+namespace UniversalToolchain.Dialects.Tests;
+
+internal static class DialectDslTestSupport
+{
+    public static readonly string[] ExpectedBuiltInKeywords =
+    [
+        "use", "exclude", "requires", "before", "after", "backend", "allow", "forbid", "enable", "disable", "security", "capability"
+    ];
+
+    public static readonly string[] RepresentativeSources =
+    [
+        "dialect Demo\n",
+        "dialect Demo\nuse Arithmetic,Variables\nexclude Legacy\nrequires Core\nbefore Parsing\nafter Lowering\n",
+        "dialect Demo\nbackend cil,interpreter\nallow add_i32\nforbid sub_i32\nenable Ssa\ndisable Inlining\nsecurity trusted\ncapability sandbox\n",
+        "dialect Demo\nuse Arithmetic\nbackend cil\nallow add_i32\nenable Ssa\ncapability sandbox\n"
+    ];
+
+    public static DialectDefinitionSlice CompileWithFrontendModule(DialectDslFrontendModule module, string source)
+    {
+        var parser = new BasicParserImpl(new ParserConfiguration([]));
+        var lexer = new BasicLexerImpl(new LexerConfiguration([]));
+        var translator = new BasicAstToBytecodeTranslatorImpl(new BytecodeTranslatorConfiguration([]));
+
+        module.InitLexer(lexer);
+        module.InitParser(parser);
+        module.InitAstTranslator(translator);
+
+        var ast = parser.Parse(lexer.Lexemize(source));
+        var bytecode = translator.Translate(module.ProcessAst(ast));
+        var ir = new BytecodeToAbstractIrConverterImpl().Translate(bytecode);
+        return DialectDefinitionSliceAirReader.Read(ir);
+    }
+
+    public static AstNode ParseAstWithFrontendModule(DialectDslFrontendModule module, string source)
+    {
+        var parser = new BasicParserImpl(new ParserConfiguration([]));
+        var lexer = new BasicLexerImpl(new LexerConfiguration([]));
+        module.InitLexer(lexer);
+        module.InitParser(parser);
+        return parser.Parse(lexer.Lexemize(source));
+    }
+
+    public static List<LexemeValue> Lex(DialectDslRegistry registry, string source)
+    {
+        var lexer = new BasicLexerImpl(new LexerConfiguration([]));
+        lexer.AddLexemes(DialectDslLexemeRegistry.CreateRegistrations(registry));
+        return lexer.Lexemize(source);
+    }
+
+    public static void AssertSlicesEquivalent(DialectDefinitionSlice expected, DialectDefinitionSlice actual)
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(actual.Name, Is.EqualTo(expected.Name));
+            Assert.That(actual.UseModules, Is.EqualTo(expected.UseModules));
+            Assert.That(actual.ExcludeModules, Is.EqualTo(expected.ExcludeModules));
+            Assert.That(actual.OrderDirectives.Select(x => (x.Kind, x.SourceModule, x.TargetModule)),
+                Is.EqualTo(expected.OrderDirectives.Select(x => (x.Kind, x.SourceModule, x.TargetModule))));
+            Assert.That(actual.BackendDirectives.Select(x => (x.Backend, x.Enabled)),
+                Is.EqualTo(expected.BackendDirectives.Select(x => (x.Backend, x.Enabled))));
+            Assert.That(actual.IntrinsicDirectives.Select(x => (x.Name, x.Allowed, x.Target)),
+                Is.EqualTo(expected.IntrinsicDirectives.Select(x => (x.Name, x.Allowed, x.Target))));
+            Assert.That(actual.OptimizerDirectives.Select(x => (x.Name, x.Enabled, x.Target)),
+                Is.EqualTo(expected.OptimizerDirectives.Select(x => (x.Name, x.Enabled, x.Target))));
+            Assert.That(actual.SecurityProfile, Is.EqualTo(expected.SecurityProfile));
+            Assert.That(actual.CapabilityDirectives.Select(x => (x.Name, x.Value)),
+                Is.EqualTo(expected.CapabilityDirectives.Select(x => (x.Name, x.Value))));
+        });
+    }
+
+    public static void AssertParserExceptionContains(ParserException exception, params string[] fragments)
+    {
+        Assert.That(exception, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            foreach (var fragment in fragments)
+            {
+                Assert.That(exception!.Message, Does.Contain(fragment), $"Expected parser exception to contain '{fragment}'.");
+            }
+        });
+    }
+
+    public static DialectDefinition BuildDefinition(DialectDefinitionSlice slice, out List<DialectDiagnostic> diagnostics)
+    {
+        diagnostics = [];
+        return DialectDefinitionSemanticBinder.Bind(slice, diagnostics);
+    }
+}
+
+internal class RecordingProvider(int order, string providerName, Action<DialectDslRegistryBuilder> registration, List<string> executionLog) : IDialectDslFeatureProvider
+{
+    public int Order => order;
+
+    public void Register(DialectDslRegistryBuilder builder)
+    {
+        executionLog.Add(providerName);
+        registration(builder);
+    }
+}
+
+internal class RecordingProviderAlpha(Action<DialectDslRegistryBuilder> registration, List<string> executionLog) : RecordingProvider(25, nameof(RecordingProviderAlpha), registration, executionLog);
+
+internal class RecordingProviderOmega(Action<DialectDslRegistryBuilder> registration, List<string> executionLog) : RecordingProvider(25, nameof(RecordingProviderOmega), registration, executionLog);
+
+internal sealed class AliasDirectiveFeatureProvider : IDialectDslFeatureProvider
+{
+    public int Order => 100;
+
+    public void Register(DialectDslRegistryBuilder builder)
+    {
+        builder.RegisterFeature(new AliasDirectiveFeature("alias", "tests.alias", "alias:", 10));
+    }
+}
+
+internal sealed class AliasDirectiveFeatureProvider2 : IDialectDslFeatureProvider
+{
+    public int Order => 100;
+
+    public void Register(DialectDslRegistryBuilder builder)
+    {
+        builder.RegisterFeature(new AliasDirectiveFeature("alias-2", "tests.alias-2", "alias-2:", 11));
+    }
+}
+
+internal sealed class DirectAliasDirectiveFeature : AliasDirectiveFeature
+{
+    public DirectAliasDirectiveFeature() : base("direct-alias", "tests.direct-alias", "direct-alias:", 12)
+    {
+    }
+}
+
+internal class AliasDirectiveFeature(string keyword, string id, string capabilityPrefix, int sequence) : IDialectDirectiveFeature
+{
+    private static readonly DialectListStateKey<string> AccumulationKey = new("AliasMappings");
+    private static readonly DialectSetStateKey<string> ValidationKey = new("AliasMappings", StringComparer.Ordinal);
+
+    public string Id => id;
+
+    public string Keyword => keyword;
+
+    public string LexemeTag => $"DialectDirectiveKeyword.{keyword}";
+
+    public DialectDirectiveParserOrder ParserOrder => new(DialectDirectiveSlot.Extension, sequence);
+
+    public bool IsSingleton => false;
+
+    public string SingletonViolationMessage => $"Directive '{keyword}' can only be declared once.";
+
+    public DialectDirectiveAstNode ParseDirective(AstNode lineNode)
+    {
+        if (lineNode.Children.Count != 3)
+        {
+            DialectDefinitionSliceParseErrors.Fail($"Directive '{keyword}' expects exactly two identifiers.", lineNode.Children[0].LexemeValue);
+        }
+
+        var source = lineNode.Children[1];
+        var target = lineNode.Children[2];
+        if (!DialectLexemeTags.IsTag(source.LexemeValue, DialectLexemeTags.Identifier) || !DialectLexemeTags.IsTag(target.LexemeValue, DialectLexemeTags.Identifier))
+        {
+            DialectDefinitionSliceParseErrors.Fail($"Directive '{keyword}' expects identifier arguments.", source.LexemeValue ?? target.LexemeValue);
+        }
+
+        return new DialectDirectiveAstNode(this, lineNode.Children[0].LexemeValue,
+        [
+            new AliasDirectivePayloadAstNode(new IdentifierValueAstNode(source.LexemeValue!), new IdentifierValueAstNode(target.LexemeValue!))
+        ]);
+    }
+
+    public void Accumulate(IReadOnlyList<LexemeValue> line, DialectDirectiveAccumulation accumulation)
+    {
+        if (line.Count != 3)
+        {
+            DialectDefinitionSliceParseErrors.Fail($"Directive '{keyword}' expects exactly two identifiers.", line[0]);
+        }
+
+        accumulation.GetOrCreateList(AccumulationKey).Add($"{line[1].Text}->{line[2].Text}");
+    }
+
+    public void ValidateSemantic(DialectDirectiveAstNode directive, DialectDirectiveValidationContext context)
+    {
+        var payload = GetPayload(directive);
+        if (string.Equals(payload.Source.Identifier, payload.Target.Identifier, StringComparison.Ordinal))
+        {
+            DialectDefinitionSliceParseErrors.Fail("Alias source and target must differ.", directive.LexemeValue);
+        }
+
+        context.AddValue(ValidationKey, $"{payload.Source.Identifier}->{payload.Target.Identifier}", "Duplicate alias directive is not allowed.", directive.LexemeValue);
+    }
+
+    public IReadOnlyList<IDialectDefinitionSliceAnnotation> Lower(DialectDirectiveAstNode directive)
+    {
+        var payload = GetPayload(directive);
+        return [new CapabilityAirAnnotation([$"{capabilityPrefix}{payload.Source.Identifier}->{payload.Target.Identifier}"])];
+    }
+
+    private static AliasDirectivePayloadAstNode GetPayload(DialectDirectiveAstNode directive)
+    {
+        return directive.Payload as AliasDirectivePayloadAstNode
+            ?? throw new ArgumentException("Alias directive payload is invalid.", nameof(directive));
+    }
+}
+
+internal sealed class DuplicateAliasDirectiveFeature : AliasDirectiveFeature
+{
+    public DuplicateAliasDirectiveFeature() : base("alias", "tests.alias.duplicate", "dup-alias:", 13)
+    {
+    }
+}
+
+internal sealed class SingletonNoteDirectiveFeature : SimpleIdentifierDirectiveFeatureBase
+{
+    public override string Id => "tests.singleton.note";
+    public override string Keyword => "note";
+    public override DialectDirectiveParserOrder ParserOrder => new(DialectDirectiveSlot.Extension, 50);
+    public override bool IsSingleton => true;
+    public override string SingletonViolationMessage => "note directive can only be declared once";
+}
+
+internal sealed class CollisionFeatureA : SimpleIdentifierDirectiveFeatureBase
+{
+    public override string Id => "tests.collision.a";
+    public override string Keyword => "collision-a";
+    public override DialectDirectiveParserOrder ParserOrder => new(DialectDirectiveSlot.Extension, 12);
+}
+
+internal sealed class CollisionFeatureB : SimpleIdentifierDirectiveFeatureBase
+{
+    public override string Id => "tests.collision.b";
+    public override string Keyword => "collision-b";
+    public override DialectDirectiveParserOrder ParserOrder => new(DialectDirectiveSlot.Extension, 12);
+}
+
+internal sealed class RegexKeywordDirectiveFeature(string keyword, int sequence) : SimpleIdentifierDirectiveFeatureBase
+{
+    public override string Id => $"tests.regex.{keyword}";
+    public override string Keyword => keyword;
+    public override string LexemeTag => $"DialectDirectiveKeyword.{keyword}";
+    public override DialectDirectiveParserOrder ParserOrder => new(DialectDirectiveSlot.Extension, sequence);
+}
+
+internal abstract class SimpleIdentifierDirectiveFeatureBase : IDialectDirectiveFeature
+{
+    public virtual string LexemeTag => $"DialectDirectiveKeyword.{Keyword}";
+    public virtual bool IsSingleton => false;
+    public virtual string SingletonViolationMessage => $"Directive '{Keyword}' can only be declared once.";
+    public abstract string Id { get; }
+    public abstract string Keyword { get; }
+    public abstract DialectDirectiveParserOrder ParserOrder { get; }
+
+    public DialectDirectiveAstNode ParseDirective(AstNode lineNode)
+    {
+        if (lineNode.Children.Count != 2 || !DialectLexemeTags.IsTag(lineNode.Children[1].LexemeValue, DialectLexemeTags.Identifier))
+        {
+            DialectDefinitionSliceParseErrors.Fail($"Directive '{Keyword}' expects a single identifier.", lineNode.Children.ElementAtOrDefault(1)?.LexemeValue ?? lineNode.Children[0].LexemeValue);
+        }
+
+        return new DialectDirectiveAstNode(this, lineNode.Children[0].LexemeValue, [new IdentifierValueAstNode(lineNode.Children[1].LexemeValue!)]);
+    }
+
+    public void Accumulate(IReadOnlyList<LexemeValue> line, DialectDirectiveAccumulation accumulation)
+    {
+        if (line.Count != 2)
+        {
+            DialectDefinitionSliceParseErrors.Fail($"Directive '{Keyword}' expects a single identifier.", line[0]);
+        }
+
+        accumulation.GetOrCreateList(new DialectListStateKey<string>($"accumulation.{Keyword}")).Add(line[1].Text);
+    }
+
+    public virtual void ValidateSemantic(DialectDirectiveAstNode directive, DialectDirectiveValidationContext context)
+    {
+        var payload = directive.Payload as IdentifierValueAstNode
+            ?? throw new ArgumentException("Directive payload is invalid.", nameof(directive));
+
+        if (string.IsNullOrWhiteSpace(payload.Identifier))
+        {
+            DialectDefinitionSliceParseErrors.Fail($"Directive '{Keyword}' identifier must not be empty.", directive.LexemeValue);
+        }
+    }
+
+    public virtual IReadOnlyList<IDialectDefinitionSliceAnnotation> Lower(DialectDirectiveAstNode directive)
+    {
+        var payload = directive.Payload as IdentifierValueAstNode
+            ?? throw new ArgumentException("Directive payload is invalid.", nameof(directive));
+        return [new CapabilityAirAnnotation([$"{Keyword}:{payload.Identifier}"])];
+    }
+}
+
+internal sealed class AliasDirectivePayloadAstNode : DialectAstNode
+{
+    private static readonly AstNodeType PayloadNodeType = AstNodeType.CreateOrGet("AliasDirectivePayload");
+
+    public AliasDirectivePayloadAstNode(IdentifierValueAstNode source, IdentifierValueAstNode target) : base(PayloadNodeType, null, [source, target])
+    {
+    }
+
+    public IdentifierValueAstNode Source => (IdentifierValueAstNode)Children[0];
+
+    public IdentifierValueAstNode Target => (IdentifierValueAstNode)Children[1];
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/DialectDslTypedStateTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/DialectDslTypedStateTests.cs
@@ -1,0 +1,133 @@
+using CommonExceptions;
+using UniversalToolchain.Dialects.Frontend;
+
+namespace UniversalToolchain.Dialects.Tests;
+
+public class DialectDslTypedStateTests
+{
+    [Test]
+    public void Accumulation_ShouldReuseLogicalListKey_ForSameNameAndType()
+    {
+        var accumulation = new DialectDirectiveAccumulation();
+        var firstKey = new DialectListStateKey<string>("tests.list");
+        var secondKey = new DialectListStateKey<string>("tests.list");
+
+        accumulation.GetOrCreateList(firstKey).Add("alpha");
+
+        Assert.That(accumulation.GetOrCreateList(secondKey), Is.EqualTo(new[] { "alpha" }));
+    }
+
+    [Test]
+    public void Accumulation_ShouldIsolateListsAcrossDifferentTypes_EvenWhenNamesMatch()
+    {
+        var accumulation = new DialectDirectiveAccumulation();
+        var stringKey = new DialectListStateKey<string>("tests.shared");
+        var intKey = new DialectListStateKey<int>("tests.shared");
+
+        accumulation.GetOrCreateList(stringKey).Add("alpha");
+        accumulation.GetOrCreateList(intKey).Add(42);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(accumulation.GetOrCreateList(stringKey), Is.EqualTo(new[] { "alpha" }));
+            Assert.That(accumulation.GetOrCreateList(intKey), Is.EqualTo(new[] { 42 }));
+        });
+    }
+
+    [Test]
+    public void Accumulation_ShouldStoreAndRetrieveValues_ByTypedKey()
+    {
+        var accumulation = new DialectDirectiveAccumulation();
+        var boolKey = new DialectValueStateKey<bool?>("tests.flag");
+        var stringKey = new DialectValueStateKey<string>("tests.name");
+
+        accumulation.SetValue(boolKey, true);
+        accumulation.SetValue(stringKey, "dialect");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(accumulation.GetValue(boolKey), Is.True);
+            Assert.That(accumulation.GetValue(stringKey), Is.EqualTo("dialect"));
+            Assert.That(accumulation.GetValue(new DialectValueStateKey<int?>("tests.missing")), Is.Null);
+        });
+    }
+
+    [Test]
+    public void Accumulation_ShouldRejectDuplicateSingletonValue_ForSameLogicalKey()
+    {
+        var accumulation = new DialectDirectiveAccumulation();
+        var key = new DialectValueStateKey<int?>("tests.singleton");
+
+        accumulation.SetSingletonValue(key, 1, "duplicate singleton");
+        var ex = Assert.Throws<ParserException>(() => accumulation.SetSingletonValue(new DialectValueStateKey<int?>("tests.singleton"), 2, "duplicate singleton"));
+
+        DialectDslTestSupport.AssertParserExceptionContains(ex!, "duplicate singleton");
+    }
+
+    [Test]
+    public void ValidationContext_ShouldReuseStateObject_ForSameLogicalValueKey()
+    {
+        var context = new DialectDirectiveValidationContext();
+        var firstKey = new DialectValueStateKey<List<string>>("tests.state");
+        var secondKey = new DialectValueStateKey<List<string>>("tests.state");
+
+        var state = context.GetOrAddState(firstKey, static () => []);
+        state.Add("alpha");
+
+        Assert.That(context.GetOrAddState(secondKey, static () => throw new InvalidOperationException()), Is.SameAs(state));
+    }
+
+    [Test]
+    public void ValidationContext_ShouldIsolateStatesAcrossDifferentTypes_EvenWhenNamesMatch()
+    {
+        var context = new DialectDirectiveValidationContext();
+        var listKey = new DialectValueStateKey<List<string>>("tests.state");
+        var setKey = new DialectSetStateKey<string>("tests.state", StringComparer.OrdinalIgnoreCase);
+
+        context.GetOrAddState(listKey, static () => []).Add("alpha");
+        context.AddValue(setKey, "VALUE", "duplicate", null);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(context.GetOrAddState(listKey, static () => throw new InvalidOperationException()), Is.EqualTo(new[] { "alpha" }));
+            Assert.That(context.GetValues(setKey), Is.EquivalentTo(new[] { "VALUE" }));
+        });
+    }
+
+    [Test]
+    public void ValidationContext_ShouldHonorSetComparer_WhenSameLogicalKeyIsReused()
+    {
+        var context = new DialectDirectiveValidationContext();
+        var firstKey = new DialectSetStateKey<string>("tests.case-insensitive", StringComparer.OrdinalIgnoreCase);
+        var secondKey = new DialectSetStateKey<string>("tests.case-insensitive", StringComparer.OrdinalIgnoreCase);
+
+        context.AddValue(firstKey, "VALUE", "duplicate", null);
+        var ex = Assert.Throws<ParserException>(() => context.AddValue(secondKey, "value", "duplicate", null));
+
+        DialectDslTestSupport.AssertParserExceptionContains(ex!, "duplicate");
+    }
+
+    [Test]
+    public void ValidationContext_ShouldRejectNullFactoryResults_ForTypedState()
+    {
+        var context = new DialectDirectiveValidationContext();
+        var key = new DialectValueStateKey<List<string>>("tests.null-state");
+
+        var ex = Assert.Throws<InvalidOperationException>(() => context.GetOrAddState(key, static () => null!));
+
+        Assert.That(ex!.Message, Does.Contain("returned null"));
+    }
+
+    [Test]
+    public void BuiltInValidationState_ShouldNotLeakAcrossIntrinsicAndOptimizerNamespaces_WhenNamesMatch()
+    {
+        var slice = DialectDslTestComposition.CreateCompiler().Compile(
+            "dialect Demo\nallow shared\nenable shared\nforbid blocked\ndisable blocked\n");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(slice.IntrinsicDirectives.Select(x => (x.Name, x.Allowed)), Is.EqualTo(new[] { ("shared", true), ("blocked", false) }));
+            Assert.That(slice.OptimizerDirectives.Select(x => (x.Name, x.Enabled)), Is.EqualTo(new[] { ("shared", true), ("blocked", false) }));
+        });
+    }
+}


### PR DESCRIPTION
### Motivation
- Harden the Dialect DSL architecture by adding a layered, production-grade test suite that protects composition, ordering, typed-state, built-ins, extensibility, lexer/keyword handling, AIR readback, singleton enforcement and security/nullability invariants.  
- Prevent subtle regressions introduced by future refactors by exercising both standalone and DI composition paths and asserting architectural invariants rather than only end-to-end outputs.  
- Keep tests realistic by using real components and DI composition rather than broad mocking, and by grouping focused unit tests into logical files.

### Description
- Added a large set of focused and grouped tests under `UniversalToolchain/UniversalToolchain.Dialects.Tests/` that exercise the Dialect DSL architecture in layers: composition/parity, ordering, typed-state, extensibility, built-in directives, keyword escaping, and regressions (AIR, security, nullability).  Files added: `DialectDslCompositionParityTests.cs`, `DialectDslOrderingTests.cs`, `DialectDslTypedStateTests.cs`, `DialectDslExtensibilityTests.cs`, `DialectDslBuiltInDirectiveTests.cs`, `DialectDslKeywordEscapingTests.cs`, `DialectDslRegressionTests.cs`, and `DialectDslTestSupport.cs`.  
- Key technical checks include: parity between `new DialectDslCompiler()` (standalone) and DI-composed `DialectDslCompiler`, `AddDialectDsl`/`AddDialectDslBuiltIns`/`AddDialectDslDefaultComposition` registrations and resolutions, deterministic provider ordering and parser node priority emission, `DialectDslRegistry` collision and duplicate-key detection, strict typed-state isolation (`DialectValueStateKey<T>`, `DialectListStateKey<T>`, `DialectSetStateKey<T>`), singleton enforcement tests, intrinsic vs optimizer namespace separation, keyword regex escaping verification, tolerant AIR readback, and explicit negative/error cases that assert meaningful messages.  
- Created reusable test fixtures and small custom provider/feature implementations (in the test project) to validate real extensibility and provider ordering without touching production code, and corrected a few test assumptions (multi-item ordering relations and build-plan vs binding diagnostics) to match actual architecture contracts.

### Testing
- Ran `export PATH="$HOME/.dotnet:$PATH" && dotnet test UniversalToolchain/UniversalToolchain.Dialects.Tests/UniversalToolchain.Dialects.Tests.csproj -v minimal` and all tests in the dialects test project passed (180 passed, 0 failed).  
- Ran `export PATH="$HOME/.dotnet:$PATH" && dotnet test UniversalToolchain/Wist.sln -v minimal` and the full solution test run passed (solution-wide tests passed).  
- During development a few new tests initially failed due to incorrect test assumptions (single-item ordering relations and location of security diagnostics), and those tests were corrected to assert the intended architectural contract rather than being weakened; no production code changes or test-only plumbing were introduced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb0498f7848324b1c6b63e07612649)