### PR TITLE
Refactor dialect runtime alias discovery to attribute-driven metadata

### DIFF
--- a/UniversalToolchain/ArithmeticModule/ArithmeticModule.csproj
+++ b/UniversalToolchain/ArithmeticModule/ArithmeticModule.csproj
@@ -8,6 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <ProjectReference Include="..\UniversalToolchain.Dialects.Abstractions\UniversalToolchain.Dialects.Abstractions.csproj"/>
         <ProjectReference Include="..\BasicCore\BasicCore.csproj"/>
         <ProjectReference Include="..\GenericMath\GenericMath.csproj"/>
     </ItemGroup>

--- a/UniversalToolchain/ArithmeticModule/Module/ArithmeticModuleImpl.cs
+++ b/UniversalToolchain/ArithmeticModule/Module/ArithmeticModuleImpl.cs
@@ -1,5 +1,6 @@
 namespace ArithmeticModule.Module;
 
+[UniversalToolchain.Dialects.Abstractions.DialectModuleAlias("Arithmetic")]
 [AutoRegisterService]
 public class ArithmeticModuleImpl : IFrontendCoreModule
 {

--- a/UniversalToolchain/CSharpInteropModule/CSharpInteropModule.csproj
+++ b/UniversalToolchain/CSharpInteropModule/CSharpInteropModule.csproj
@@ -8,6 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <ProjectReference Include="..\UniversalToolchain.Dialects.Abstractions\UniversalToolchain.Dialects.Abstractions.csproj"/>
         <ProjectReference Include="..\AbstractIrExtensions\AbstractIrExtensions.csproj"/>
         <ProjectReference Include="..\AssemblyFinder\AssemblyFinder.csproj"/>
         <ProjectReference Include="..\BasicCore\BasicCore.csproj"/>

--- a/UniversalToolchain/CSharpInteropModule/Module/CSharpInteropModuleImpl.cs
+++ b/UniversalToolchain/CSharpInteropModule/Module/CSharpInteropModuleImpl.cs
@@ -1,5 +1,6 @@
 namespace CSharpInteropModule.Module;
 
+[UniversalToolchain.Dialects.Abstractions.DialectModuleAlias("CSharpInterop")]
 [AutoRegisterService]
 public class CSharpInteropModuleImpl : IFrontendCoreModule
 {

--- a/UniversalToolchain/CommentsModule/CommentsModule.csproj
+++ b/UniversalToolchain/CommentsModule/CommentsModule.csproj
@@ -7,6 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <ProjectReference Include="..\UniversalToolchain.Dialects.Abstractions\UniversalToolchain.Dialects.Abstractions.csproj"/>
         <ProjectReference Include="..\BasicCore\BasicCore.csproj"/>
     </ItemGroup>
 

--- a/UniversalToolchain/CommentsModule/CommentsModuleImpl.cs
+++ b/UniversalToolchain/CommentsModule/CommentsModuleImpl.cs
@@ -1,5 +1,6 @@
 namespace CommentsModule;
 
+[UniversalToolchain.Dialects.Abstractions.DialectModuleAlias("Comments")]
 [AutoRegisterService]
 public class CommentsModuleImpl : IFrontendCoreModule
 {

--- a/UniversalToolchain/ConditionsModule/ConditionsModule.csproj
+++ b/UniversalToolchain/ConditionsModule/ConditionsModule.csproj
@@ -8,6 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <ProjectReference Include="..\UniversalToolchain.Dialects.Abstractions\UniversalToolchain.Dialects.Abstractions.csproj"/>
         <ProjectReference Include="..\AbstractIrExtensions\AbstractIrExtensions.csproj"/>
         <ProjectReference Include="..\BasicCore\BasicCore.csproj"/>
         <ProjectReference Include="..\BasicTypesExtensions\BasicTypesExtensions.csproj"/>

--- a/UniversalToolchain/ConditionsModule/Enums/BooleanOperations.cs
+++ b/UniversalToolchain/ConditionsModule/Enums/BooleanOperations.cs
@@ -1,5 +1,6 @@
 namespace ConditionsModule.Enums;
 
+[UniversalToolchain.Dialects.Abstractions.DialectModuleAlias("BooleanConditions")]
 [AutoRegisterService]
 public class BooleanOperations : IFrontendCoreModule
 {

--- a/UniversalToolchain/ConditionsModule/Enums/ComparisonOperations.cs
+++ b/UniversalToolchain/ConditionsModule/Enums/ComparisonOperations.cs
@@ -1,5 +1,6 @@
 namespace ConditionsModule.Enums;
 
+[UniversalToolchain.Dialects.Abstractions.DialectModuleAlias("ComparisonConditions")]
 [AutoRegisterService]
 public class ComparisonOperations : IFrontendCoreModule
 {

--- a/UniversalToolchain/ConditionsModule/Module/ConditionsModuleImpl.cs
+++ b/UniversalToolchain/ConditionsModule/Module/ConditionsModuleImpl.cs
@@ -1,5 +1,6 @@
 namespace ConditionsModule.Module;
 
+[UniversalToolchain.Dialects.Abstractions.DialectModuleAlias("Conditions")]
 [AutoRegisterService]
 public class ConditionsModuleImpl : IFrontendCoreModule
 {

--- a/UniversalToolchain/ConditionsModule/Optimizers/BooleanOptimizer.cs
+++ b/UniversalToolchain/ConditionsModule/Optimizers/BooleanOptimizer.cs
@@ -1,5 +1,6 @@
 namespace ConditionsModule.Optimizers;
 
+[UniversalToolchain.Dialects.Abstractions.DialectOptimizerAlias("BooleanOptimization")]
 [AutoRegisterService]
 [UsedImplicitly]
 public class BooleanOptimizerModule : IIRProcessingModule

--- a/UniversalToolchain/ConditionsModule/Optimizers/ComparisonIntrinsicOptimizerModule.cs
+++ b/UniversalToolchain/ConditionsModule/Optimizers/ComparisonIntrinsicOptimizerModule.cs
@@ -1,5 +1,6 @@
 namespace ConditionsModule.Optimizers;
 
+[UniversalToolchain.Dialects.Abstractions.DialectOptimizerAlias("ComparisonIntrinsicOptimization")]
 [AutoRegisterService]
 [UsedImplicitly]
 public class ComparisonIntrinsicOptimizerModule : IIRProcessingModule

--- a/UniversalToolchain/Dialects/RuntimeAliasDiscovery.md
+++ b/UniversalToolchain/Dialects/RuntimeAliasDiscovery.md
@@ -1,0 +1,24 @@
+# Runtime alias discovery
+
+Dialect runtime aliases are now declared on the runtime component itself instead of inside a provider-side alias table.
+
+## Declaration rules
+
+- Frontend/runtime modules use `DialectModuleAliasAttribute`.
+- Optimizers use `DialectOptimizerAliasAttribute`.
+- Backends use `DialectBackendAliasAttribute` on a `DialectBackendDeclaration` type.
+- Attributes may declare one or many aliases and may be applied multiple times.
+
+## Discovery rules
+
+- `DialectRuntimeDescriptorRegistryBuilder` discovers aliases only from explicitly provided assemblies or types.
+- Discovery is deterministic: candidate assemblies and types are ordered with `StringComparer.Ordinal`.
+- Duplicate aliases in the same category fail fast and report the alias plus both conflicting metadata owner types.
+
+## Adding a new component
+
+1. Implement the runtime component or backend declaration type.
+2. Add the appropriate alias attribute on that declaration site.
+3. Ensure the containing assembly or type is included in the dialect runtime composition path.
+
+No central alias dictionary should be edited for new modules, optimizers, or backends.

--- a/UniversalToolchain/EqualityModule/EqualityModule.csproj
+++ b/UniversalToolchain/EqualityModule/EqualityModule.csproj
@@ -8,6 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <ProjectReference Include="..\UniversalToolchain.Dialects.Abstractions\UniversalToolchain.Dialects.Abstractions.csproj"/>
         <ProjectReference Include="..\AbstractIrExtensions\AbstractIrExtensions.csproj"/>
         <ProjectReference Include="..\BasicCore\BasicCore.csproj"/>
         <ProjectReference Include="..\UniversalIntermediateRepresentation\UniversalIntermediateRepresentation.csproj"/>

--- a/UniversalToolchain/EqualityModule/EqualityModuleImpl.cs
+++ b/UniversalToolchain/EqualityModule/EqualityModuleImpl.cs
@@ -1,5 +1,6 @@
 namespace EqualityModule;
 
+[UniversalToolchain.Dialects.Abstractions.DialectModuleAlias("Equality")]
 [AutoRegisterService]
 public class EqualityModuleImpl : IFrontendCoreModule
 {

--- a/UniversalToolchain/IdentifierModule/IdentifierModule.csproj
+++ b/UniversalToolchain/IdentifierModule/IdentifierModule.csproj
@@ -8,6 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <ProjectReference Include="..\UniversalToolchain.Dialects.Abstractions\UniversalToolchain.Dialects.Abstractions.csproj"/>
         <ProjectReference Include="..\BasicCore\BasicCore.csproj"/>
     </ItemGroup>
 

--- a/UniversalToolchain/IdentifierModule/IdentifierModuleImpl.cs
+++ b/UniversalToolchain/IdentifierModule/IdentifierModuleImpl.cs
@@ -1,5 +1,6 @@
 namespace IdentifierModule;
 
+[UniversalToolchain.Dialects.Abstractions.DialectModuleAlias("Identifier")]
 [AutoRegisterService]
 public class IdentifierModuleImpl : IFrontendCoreModule
 {

--- a/UniversalToolchain/InternalPreprocessorLexemesModule/Class1.cs
+++ b/UniversalToolchain/InternalPreprocessorLexemesModule/Class1.cs
@@ -1,5 +1,6 @@
 namespace InternalPreprocessorLexemesModule;
 
+[UniversalToolchain.Dialects.Abstractions.DialectModuleAlias("InternalPreprocessorLexemes")]
 [AutoRegisterService]
 public class InternalPreprocessorLexemesModuleImpl : IFrontendCoreModule
 {

--- a/UniversalToolchain/InternalPreprocessorLexemesModule/InternalPreprocessorLexemesModule.csproj
+++ b/UniversalToolchain/InternalPreprocessorLexemesModule/InternalPreprocessorLexemesModule.csproj
@@ -7,6 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <ProjectReference Include="..\UniversalToolchain.Dialects.Abstractions\UniversalToolchain.Dialects.Abstractions.csproj"/>
         <ProjectReference Include="..\BasicCore\BasicCore.csproj"/>
     </ItemGroup>
 

--- a/UniversalToolchain/LabelsModule/LabelsModule.csproj
+++ b/UniversalToolchain/LabelsModule/LabelsModule.csproj
@@ -8,6 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <ProjectReference Include="..\UniversalToolchain.Dialects.Abstractions\UniversalToolchain.Dialects.Abstractions.csproj"/>
         <ProjectReference Include="..\BasicCore\BasicCore.csproj"/>
     </ItemGroup>
 

--- a/UniversalToolchain/LabelsModule/Module/LabelsModuleImpl.cs
+++ b/UniversalToolchain/LabelsModule/Module/LabelsModuleImpl.cs
@@ -1,5 +1,6 @@
 namespace LabelsModule.Module;
 
+[UniversalToolchain.Dialects.Abstractions.DialectModuleAlias("Labels")]
 [AutoRegisterService]
 public class LabelsModuleImpl : IFrontendCoreModule
 {

--- a/UniversalToolchain/LocalVariablesOptimizerModule/LocalVariablesOptimizer.cs
+++ b/UniversalToolchain/LocalVariablesOptimizerModule/LocalVariablesOptimizer.cs
@@ -1,5 +1,6 @@
 namespace LocalVariablesOptimizerModule;
 
+[UniversalToolchain.Dialects.Abstractions.DialectOptimizerAlias("LocalVariablesOptimization")]
 [AutoRegisterService]
 public class LocalVariablesOptimizer : IIRProcessingModule
 {

--- a/UniversalToolchain/LocalVariablesOptimizerModule/LocalVariablesOptimizerModule.csproj
+++ b/UniversalToolchain/LocalVariablesOptimizerModule/LocalVariablesOptimizerModule.csproj
@@ -7,6 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <ProjectReference Include="..\UniversalToolchain.Dialects.Abstractions\UniversalToolchain.Dialects.Abstractions.csproj"/>
         <ProjectReference Include="..\BasicCore\BasicCore.csproj"/>
         <ProjectReference Include="..\DotnetAirHelper\DotnetAirHelper.csproj"/>
         <ProjectReference Include="..\IntermediateRepresentationAbstractions\IntermediateRepresentationAbstractions.csproj"/>

--- a/UniversalToolchain/LoopsModule/LoopsModule.csproj
+++ b/UniversalToolchain/LoopsModule/LoopsModule.csproj
@@ -7,6 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <ProjectReference Include="..\UniversalToolchain.Dialects.Abstractions\UniversalToolchain.Dialects.Abstractions.csproj"/>
         <ProjectReference Include="..\BasicCore\BasicCore.csproj"/>
     </ItemGroup>
 

--- a/UniversalToolchain/LoopsModule/Module/LoopsModuleImpl.cs
+++ b/UniversalToolchain/LoopsModule/Module/LoopsModuleImpl.cs
@@ -1,5 +1,6 @@
 namespace LoopsModule.Module;
 
+[UniversalToolchain.Dialects.Abstractions.DialectModuleAlias("Loops")]
 [AutoRegisterService]
 public class LoopsModuleImpl : IFrontendCoreModule
 {

--- a/UniversalToolchain/NativeMathModule/ArithmeticOptimizerModule.cs
+++ b/UniversalToolchain/NativeMathModule/ArithmeticOptimizerModule.cs
@@ -1,5 +1,6 @@
 namespace NativeMathModule;
 
+[UniversalToolchain.Dialects.Abstractions.DialectOptimizerAlias("ArithmeticOptimization")]
 [AutoRegisterService]
 [UsedImplicitly]
 public class ArithmeticOptimizerModule : IIRProcessingModule

--- a/UniversalToolchain/NativeMathModule/EGraphOptimizerModule.cs
+++ b/UniversalToolchain/NativeMathModule/EGraphOptimizerModule.cs
@@ -1,5 +1,6 @@
 namespace NativeMathModule;
 
+[UniversalToolchain.Dialects.Abstractions.DialectOptimizerAlias("EGraphOptimization")]
 [AutoRegisterService]
 public class EGraphOptimizerModule : IIRProcessingModule
 {

--- a/UniversalToolchain/NativeMathModule/NativeCILOptimizerModule.cs
+++ b/UniversalToolchain/NativeMathModule/NativeCILOptimizerModule.cs
@@ -1,5 +1,6 @@
 namespace NativeMathModule;
 
+[UniversalToolchain.Dialects.Abstractions.DialectOptimizerAlias("NativeCilOptimization")]
 [AutoRegisterService]
 public class NativeCilOptimizerModule : IIRProcessingModule
 {

--- a/UniversalToolchain/NativeMathModule/NativeMathModule.csproj
+++ b/UniversalToolchain/NativeMathModule/NativeMathModule.csproj
@@ -7,6 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <ProjectReference Include="..\UniversalToolchain.Dialects.Abstractions\UniversalToolchain.Dialects.Abstractions.csproj"/>
         <ProjectReference Include="..\AbstractIrExtensions\AbstractIrExtensions.csproj"/>
         <ProjectReference Include="..\BasicCore\BasicCore.csproj"/>
         <ProjectReference Include="..\BasicTypesExtensions\BasicTypesExtensions.csproj"/>

--- a/UniversalToolchain/NativeMathModule/NativeTypesModuleImpl.cs
+++ b/UniversalToolchain/NativeMathModule/NativeTypesModuleImpl.cs
@@ -1,5 +1,6 @@
 namespace NativeMathModule;
 
+[UniversalToolchain.Dialects.Abstractions.DialectModuleAlias("NativeTypes")]
 [AutoRegisterService]
 public class NativeTypesModuleImpl : IFrontendCoreModule
 {

--- a/UniversalToolchain/NativeMathModule/NativeTypesOptimizerModule.cs
+++ b/UniversalToolchain/NativeMathModule/NativeTypesOptimizerModule.cs
@@ -1,5 +1,6 @@
 namespace NativeMathModule;
 
+[UniversalToolchain.Dialects.Abstractions.DialectOptimizerAlias("NativeTypesOptimization")]
 [AutoRegisterService]
 public class NativeTypesOptimizerModule : IIRProcessingModule
 {

--- a/UniversalToolchain/NumbersModule/Module/NumbersModuleImpl.cs
+++ b/UniversalToolchain/NumbersModule/Module/NumbersModuleImpl.cs
@@ -1,5 +1,6 @@
 namespace NumbersModule.Module;
 
+[UniversalToolchain.Dialects.Abstractions.DialectModuleAlias("Numbers")]
 [AutoRegisterService]
 public class NumbersModuleImpl : IFrontendCoreModule
 {

--- a/UniversalToolchain/NumbersModule/NumbersModule.csproj
+++ b/UniversalToolchain/NumbersModule/NumbersModule.csproj
@@ -8,6 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <ProjectReference Include="..\UniversalToolchain.Dialects.Abstractions\UniversalToolchain.Dialects.Abstractions.csproj"/>
         <ProjectReference Include="..\AbstractIrExtensions\AbstractIrExtensions.csproj"/>
         <ProjectReference Include="..\BasicCore\BasicCore.csproj"/>
         <ProjectReference Include="..\GenericMath\GenericMath.csproj"/>

--- a/UniversalToolchain/ParametersSetterModule/Class1.cs
+++ b/UniversalToolchain/ParametersSetterModule/Class1.cs
@@ -1,5 +1,6 @@
 namespace ParametersSetterModule;
 
+[UniversalToolchain.Dialects.Abstractions.DialectModuleAlias("ParametersSetter")]
 [AutoRegisterService]
 public class ParametersSetterModuleImpl : IFrontendCoreModule
 {

--- a/UniversalToolchain/ParametersSetterModule/ParametersSetterModule.csproj
+++ b/UniversalToolchain/ParametersSetterModule/ParametersSetterModule.csproj
@@ -7,6 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <ProjectReference Include="..\UniversalToolchain.Dialects.Abstractions\UniversalToolchain.Dialects.Abstractions.csproj"/>
         <ProjectReference Include="..\BasicCore\BasicCore.csproj"/>
     </ItemGroup>
 

--- a/UniversalToolchain/ScopesModule/Module/ScopesModuleImpl.cs
+++ b/UniversalToolchain/ScopesModule/Module/ScopesModuleImpl.cs
@@ -1,5 +1,6 @@
 namespace ScopesModule.Module;
 
+[UniversalToolchain.Dialects.Abstractions.DialectModuleAlias("Scopes")]
 [AutoRegisterService]
 public class ScopesModuleImpl : IFrontendCoreModule
 {

--- a/UniversalToolchain/ScopesModule/ScopesModule.csproj
+++ b/UniversalToolchain/ScopesModule/ScopesModule.csproj
@@ -8,6 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <ProjectReference Include="..\UniversalToolchain.Dialects.Abstractions\UniversalToolchain.Dialects.Abstractions.csproj"/>
         <ProjectReference Include="..\BasicCore\BasicCore.csproj"/>
         <ProjectReference Include="..\CommonExceptions\CommonExceptions.csproj"/>
     </ItemGroup>

--- a/UniversalToolchain/SemicolonAsNewLineModule/SemicolonAsNewLineModule.csproj
+++ b/UniversalToolchain/SemicolonAsNewLineModule/SemicolonAsNewLineModule.csproj
@@ -8,6 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <ProjectReference Include="..\UniversalToolchain.Dialects.Abstractions\UniversalToolchain.Dialects.Abstractions.csproj"/>
         <ProjectReference Include="..\BasicCore\BasicCore.csproj"/>
     </ItemGroup>
 

--- a/UniversalToolchain/SemicolonAsNewLineModule/SemicolonAsNewLineModuleImpl.cs
+++ b/UniversalToolchain/SemicolonAsNewLineModule/SemicolonAsNewLineModuleImpl.cs
@@ -1,5 +1,6 @@
 namespace SemicolonAsNewLineModule;
 
+[UniversalToolchain.Dialects.Abstractions.DialectModuleAlias("SemicolonAsNewLine")]
 [AutoRegisterService]
 public class SemicolonAsNewLineModuleImpl : IFrontendCoreModule
 {

--- a/UniversalToolchain/UniversalToolchain.Dialects.Abstractions/DialectAliasAttributeBase.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Abstractions/DialectAliasAttributeBase.cs
@@ -1,0 +1,32 @@
+using ExceptionsManager;
+
+namespace UniversalToolchain.Dialects.Abstractions;
+
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = false)]
+public abstract class DialectAliasAttributeBase : Attribute
+{
+    private readonly string[] _aliases;
+
+    protected DialectAliasAttributeBase(params string[] aliases)
+    {
+        if (aliases == null)
+            Thrower.ArgumentNull(nameof(aliases));
+
+        if (aliases.Length == 0)
+            Thrower.Argument(nameof(aliases), "At least one alias must be declared.");
+
+        _aliases = aliases
+            .Select(static x =>
+            {
+                if (string.IsNullOrWhiteSpace(x))
+                    Thrower.Argument(nameof(aliases), "Alias metadata must not contain empty values.");
+
+                return x;
+            })
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(static x => x, StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    public IReadOnlyList<string> Aliases => _aliases;
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Abstractions/DialectBackendAliasAttribute.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Abstractions/DialectBackendAliasAttribute.cs
@@ -1,0 +1,9 @@
+namespace UniversalToolchain.Dialects.Abstractions;
+
+public sealed class DialectBackendAliasAttribute : DialectAliasAttributeBase
+{
+    public DialectBackendAliasAttribute(params string[] aliases)
+        : base(aliases)
+    {
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Abstractions/DialectBackendDeclaration.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Abstractions/DialectBackendDeclaration.cs
@@ -1,0 +1,17 @@
+using ExceptionsManager;
+
+namespace UniversalToolchain.Dialects.Abstractions;
+
+public abstract class DialectBackendDeclaration
+{
+    public DialectBackendId GetBackendId()
+    {
+        var backendId = BackendId;
+        if (string.IsNullOrWhiteSpace(backendId.Value))
+            Thrower.InvalidOpEx($"Backend declaration '{GetType().FullName}' produced an empty backend identifier.");
+
+        return backendId;
+    }
+
+    public abstract DialectBackendId BackendId { get; }
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Abstractions/DialectModuleAliasAttribute.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Abstractions/DialectModuleAliasAttribute.cs
@@ -1,0 +1,9 @@
+namespace UniversalToolchain.Dialects.Abstractions;
+
+public sealed class DialectModuleAliasAttribute : DialectAliasAttributeBase
+{
+    public DialectModuleAliasAttribute(params string[] aliases)
+        : base(aliases)
+    {
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Abstractions/DialectOptimizerAliasAttribute.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Abstractions/DialectOptimizerAliasAttribute.cs
@@ -1,0 +1,9 @@
+namespace UniversalToolchain.Dialects.Abstractions;
+
+public sealed class DialectOptimizerAliasAttribute : DialectAliasAttributeBase
+{
+    public DialectOptimizerAliasAttribute(params string[] aliases)
+        : base(aliases)
+    {
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Integration/DialectRuntimeDescriptorAttributeDiscovery.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Integration/DialectRuntimeDescriptorAttributeDiscovery.cs
@@ -1,0 +1,142 @@
+using System.Reflection;
+using ExceptionsManager;
+using UniversalToolchain.Dialects.Abstractions;
+
+namespace UniversalToolchain.Dialects.Integration;
+
+internal static class DialectRuntimeDescriptorAttributeDiscovery
+{
+    public static IReadOnlyList<RuntimeModuleDescriptor> DiscoverModules(IEnumerable<Assembly> assemblies)
+    {
+        return DiscoverModules(EnumerateCandidateTypes(assemblies));
+    }
+
+    public static IReadOnlyList<RuntimeModuleDescriptor> DiscoverModules(IEnumerable<Type> types)
+    {
+        return DiscoverTypeDescriptors(
+            types,
+            static type => type.GetCustomAttributes<DialectModuleAliasAttribute>(false).ToArray(),
+            static (type, aliases) => new RuntimeModuleDescriptor(type, aliases));
+    }
+
+    public static IReadOnlyList<RuntimeOptimizerDescriptor> DiscoverOptimizers(IEnumerable<Assembly> assemblies)
+    {
+        return DiscoverOptimizers(EnumerateCandidateTypes(assemblies));
+    }
+
+    public static IReadOnlyList<RuntimeOptimizerDescriptor> DiscoverOptimizers(IEnumerable<Type> types)
+    {
+        return DiscoverTypeDescriptors(
+            types,
+            static type => type.GetCustomAttributes<DialectOptimizerAliasAttribute>(false).ToArray(),
+            static (type, aliases) => new RuntimeOptimizerDescriptor(type, aliases));
+    }
+
+    public static IReadOnlyList<RuntimeBackendDescriptor> DiscoverBackends(IEnumerable<Assembly> assemblies)
+    {
+        return DiscoverBackends(EnumerateCandidateTypes(assemblies));
+    }
+
+    public static IReadOnlyList<RuntimeBackendDescriptor> DiscoverBackends(IEnumerable<Type> types)
+    {
+        return DiscoverTypeDescriptors(
+            types,
+            static type => type.GetCustomAttributes<DialectBackendAliasAttribute>(false).ToArray(),
+            CreateBackendDescriptor);
+    }
+
+    private static IReadOnlyList<TDescriptor> DiscoverTypeDescriptors<TAttribute, TDescriptor>(
+        IEnumerable<Type> types,
+        Func<Type, IReadOnlyList<TAttribute>> getAttributes,
+        Func<Type, IReadOnlyList<string>, TDescriptor> createDescriptor)
+        where TAttribute : DialectAliasAttributeBase
+    {
+        if (types == null)
+            Thrower.ArgumentNull(nameof(types));
+
+        var result = new List<TDescriptor>();
+        foreach (var type in EnumerateCandidateTypes(types))
+        {
+            var attributes = getAttributes(type);
+            if (attributes.Count == 0)
+                continue;
+
+            var aliases = attributes
+                .SelectMany(static x => x.Aliases)
+                .Distinct(StringComparer.Ordinal)
+                .OrderBy(static x => x, StringComparer.Ordinal)
+                .ToArray();
+            result.Add(createDescriptor(type, aliases));
+        }
+
+        return result;
+    }
+
+    private static RuntimeBackendDescriptor CreateBackendDescriptor(Type type, IReadOnlyList<string> aliases)
+    {
+        if (!typeof(DialectBackendDeclaration).IsAssignableFrom(type))
+            Thrower.Argument(nameof(type), $"Backend declaration type '{type.FullName}' must inherit from '{typeof(DialectBackendDeclaration).FullName}'.");
+
+        var instance = Activator.CreateInstance(type);
+        if (instance is not DialectBackendDeclaration)
+            Thrower.InvalidOpEx($"Could not create backend declaration '{type.FullName}'.");
+
+        var declaration = (DialectBackendDeclaration)instance;
+        return new RuntimeBackendDescriptor(declaration.GetBackendId(), type, aliases);
+    }
+
+    private static IReadOnlyList<Type> EnumerateCandidateTypes(IEnumerable<Assembly> assemblies)
+    {
+        var assemblyList = assemblies
+            .Select(static x =>
+            {
+                if (x == null)
+                    Thrower.Argument(nameof(assemblies), "Assembly list must not contain null entries.");
+
+                return x;
+            })
+            .Distinct()
+            .OrderBy(static x => x.FullName, StringComparer.Ordinal)
+            .SelectMany(GetAssemblyTypes)
+            .Where(static x => x is { IsClass: true, IsAbstract: false })
+            .OrderBy(static x => x.FullName, StringComparer.Ordinal)
+            .ToArray();
+
+        return assemblyList;
+    }
+
+    private static IReadOnlyList<Type> EnumerateCandidateTypes(IEnumerable<Type> types)
+    {
+        return types
+            .Select(static x =>
+            {
+                if (x == null)
+                    Thrower.Argument(nameof(types), "Type list must not contain null entries.");
+
+                return x;
+            })
+            .Distinct()
+            .Where(static x => x is { IsClass: true, IsAbstract: false })
+            .OrderBy(static x => x.FullName, StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    private static IEnumerable<Type> GetAssemblyTypes(Assembly assembly)
+    {
+        try
+        {
+            return assembly.GetTypes();
+        }
+        catch (ReflectionTypeLoadException ex)
+        {
+            var loaderMessages = ex.LoaderExceptions
+                .Where(static x => x != null)
+                .Select(static x => x!.Message)
+                .OrderBy(static x => x, StringComparer.Ordinal)
+                .ToArray();
+            var details = loaderMessages.Length == 0 ? "No loader exceptions were provided." : string.Join(" | ", loaderMessages);
+            Thrower.InvalidOpEx($"Could not enumerate runtime descriptor types from assembly '{assembly.FullName}'. {details}");
+            return Array.Empty<Type>();
+        }
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Integration/DialectRuntimeDescriptorRegistryBuilder.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Integration/DialectRuntimeDescriptorRegistryBuilder.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using ExceptionsManager;
 using UniversalToolchain.Dialects.Abstractions;
 
@@ -17,12 +18,60 @@ public sealed class DialectRuntimeDescriptorRegistryBuilder
     private readonly Dictionary<string, RuntimeOptimizerDescriptor> _optimizerNameMap = new(StringComparer.Ordinal);
     private readonly Dictionary<string, RuntimeOptimizerDescriptor> _optimizers = new(StringComparer.Ordinal);
 
+    public DialectRuntimeDescriptorRegistryBuilder RegisterAttributedModulesFromAssemblies(params Assembly[] assemblies)
+    {
+        foreach (var descriptor in DialectRuntimeDescriptorAttributeDiscovery.DiscoverModules(assemblies))
+            RegisterModule(descriptor);
+
+        return this;
+    }
+
+    public DialectRuntimeDescriptorRegistryBuilder RegisterAttributedModules(params Type[] types)
+    {
+        foreach (var descriptor in DialectRuntimeDescriptorAttributeDiscovery.DiscoverModules(types))
+            RegisterModule(descriptor);
+
+        return this;
+    }
+
+    public DialectRuntimeDescriptorRegistryBuilder RegisterAttributedOptimizersFromAssemblies(params Assembly[] assemblies)
+    {
+        foreach (var descriptor in DialectRuntimeDescriptorAttributeDiscovery.DiscoverOptimizers(assemblies))
+            RegisterOptimizer(descriptor);
+
+        return this;
+    }
+
+    public DialectRuntimeDescriptorRegistryBuilder RegisterAttributedOptimizers(params Type[] types)
+    {
+        foreach (var descriptor in DialectRuntimeDescriptorAttributeDiscovery.DiscoverOptimizers(types))
+            RegisterOptimizer(descriptor);
+
+        return this;
+    }
+
+    public DialectRuntimeDescriptorRegistryBuilder RegisterAttributedBackendsFromAssemblies(params Assembly[] assemblies)
+    {
+        foreach (var descriptor in DialectRuntimeDescriptorAttributeDiscovery.DiscoverBackends(assemblies))
+            RegisterBackend(descriptor);
+
+        return this;
+    }
+
+    public DialectRuntimeDescriptorRegistryBuilder RegisterAttributedBackends(params Type[] types)
+    {
+        foreach (var descriptor in DialectRuntimeDescriptorAttributeDiscovery.DiscoverBackends(types))
+            RegisterBackend(descriptor);
+
+        return this;
+    }
+
     public DialectRuntimeDescriptorRegistryBuilder RegisterModule(RuntimeModuleDescriptor descriptor)
     {
         if (descriptor == null)
             Thrower.ArgumentNull(nameof(descriptor));
 
-        RegisterUniqueDescriptor(descriptor.CanonicalId, descriptor.AllNames, descriptor, _modules, _moduleNameMap, "module");
+        RegisterUniqueDescriptor(descriptor.CanonicalId, descriptor.AllNames, descriptor, _modules, _moduleNameMap, "module", static x => x.MetadataOwnerType);
         return this;
     }
 
@@ -31,7 +80,7 @@ public sealed class DialectRuntimeDescriptorRegistryBuilder
         if (descriptor == null)
             Thrower.ArgumentNull(nameof(descriptor));
 
-        RegisterUniqueDescriptor(descriptor.CanonicalId, descriptor.AllNames, descriptor, _optimizers, _optimizerNameMap, "optimizer");
+        RegisterUniqueDescriptor(descriptor.CanonicalId, descriptor.AllNames, descriptor, _optimizers, _optimizerNameMap, "optimizer", static x => x.MetadataOwnerType);
         return this;
     }
 
@@ -41,10 +90,15 @@ public sealed class DialectRuntimeDescriptorRegistryBuilder
             Thrower.ArgumentNull(nameof(descriptor));
 
         if (_backends.ContainsKey(descriptor.BackendId))
-            Thrower.Argument(nameof(descriptor), $"Backend descriptor for '{descriptor.CanonicalId}' is already registered.");
+        {
+            var existing = _backends[descriptor.BackendId];
+            Thrower.Argument(
+                nameof(descriptor),
+                $"backend canonical identifier '{descriptor.CanonicalId}' is declared by both '{existing.MetadataOwnerType.FullName}' and '{descriptor.MetadataOwnerType.FullName}'.");
+        }
 
         _backends.Add(descriptor.BackendId, descriptor);
-        RegisterNames(descriptor.AllNames, descriptor, _backendNameMap, "backend");
+        RegisterNames(descriptor.AllNames, descriptor, _backendNameMap, "backend", static x => x.MetadataOwnerType);
         return this;
     }
 
@@ -81,21 +135,37 @@ public sealed class DialectRuntimeDescriptorRegistryBuilder
         TDescriptor descriptor,
         IDictionary<string, TDescriptor> canonicalMap,
         IDictionary<string, TDescriptor> nameMap,
-        string kind)
+        string kind,
+        Func<TDescriptor, Type> getMetadataOwnerType)
     {
         if (canonicalMap.ContainsKey(canonicalId))
-            Thrower.Argument(nameof(descriptor), $"{kind} descriptor '{canonicalId}' is already registered.");
+        {
+            var existing = canonicalMap[canonicalId];
+            Thrower.Argument(
+                nameof(descriptor),
+                $"{kind} canonical identifier '{canonicalId}' is declared by both '{getMetadataOwnerType(existing).FullName}' and '{getMetadataOwnerType(descriptor).FullName}'.");
+        }
 
         canonicalMap.Add(canonicalId, descriptor);
-        RegisterNames(allNames, descriptor, nameMap, kind);
+        RegisterNames(allNames, descriptor, nameMap, kind, getMetadataOwnerType);
     }
 
-    private static void RegisterNames<TDescriptor>(IReadOnlyList<string> names, TDescriptor descriptor, IDictionary<string, TDescriptor> nameMap, string kind)
+    private static void RegisterNames<TDescriptor>(
+        IReadOnlyList<string> names,
+        TDescriptor descriptor,
+        IDictionary<string, TDescriptor> nameMap,
+        string kind,
+        Func<TDescriptor, Type> getMetadataOwnerType)
     {
         foreach (var name in names)
         {
             if (nameMap.ContainsKey(name))
-                Thrower.Argument(nameof(descriptor), $"{kind} alias '{name}' is already registered.");
+            {
+                var existing = nameMap[name];
+                Thrower.Argument(
+                    nameof(descriptor),
+                    $"{kind} alias '{name}' is declared by both '{getMetadataOwnerType(existing).FullName}' and '{getMetadataOwnerType(descriptor).FullName}'.");
+            }
 
             nameMap.Add(name, descriptor);
         }

--- a/UniversalToolchain/UniversalToolchain.Dialects.Integration/RuntimeBackendDescriptor.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Integration/RuntimeBackendDescriptor.cs
@@ -16,14 +16,22 @@ public sealed class RuntimeBackendDescriptor
     {
     }
 
-
-    public RuntimeBackendDescriptor(DialectBackendId backendId, IEnumerable<string>? aliases = null)
+    public RuntimeBackendDescriptor(DialectBackendId backendId, Type metadataOwnerType, IEnumerable<string>? aliases = null)
     {
+        if (metadataOwnerType == null)
+            Thrower.ArgumentNull(nameof(metadataOwnerType));
+
         if (string.IsNullOrWhiteSpace(backendId.Value))
             Thrower.Argument(nameof(backendId), "Runtime backend descriptor must contain a canonical backend identifier.");
 
         BackendId = backendId;
+        MetadataOwnerType = metadataOwnerType;
         _aliases = new ReadOnlyCollection<string>(SnapshotAliases(aliases, nameof(aliases), backendId.Value));
+    }
+
+    public RuntimeBackendDescriptor(DialectBackendId backendId, IEnumerable<string>? aliases = null)
+        : this(backendId, typeof(RuntimeBackendDescriptor), aliases)
+    {
     }
 
     public DialectBackendId BackendId { get; }
@@ -37,6 +45,8 @@ public sealed class RuntimeBackendDescriptor
     public IReadOnlyList<string> Aliases => _aliases;
 
     public IReadOnlyList<string> AllNames => [CanonicalId, .. _aliases];
+
+    public Type MetadataOwnerType { get; }
 
     private static List<string> SnapshotAliases(IEnumerable<string>? aliases, string paramName, string canonicalId)
     {

--- a/UniversalToolchain/UniversalToolchain.Dialects.Integration/RuntimeModuleDescriptor.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Integration/RuntimeModuleDescriptor.cs
@@ -50,6 +50,8 @@ public sealed class RuntimeModuleDescriptor
 
     public Type ImplementationType { get; }
 
+    public Type MetadataOwnerType => ImplementationType;
+
     public bool IsFrontendModule => typeof(IFrontendCoreModule).IsAssignableFrom(ImplementationType);
 
     public bool IsIrProcessingModule => typeof(IIRProcessingModule).IsAssignableFrom(ImplementationType);

--- a/UniversalToolchain/UniversalToolchain.Dialects.Integration/RuntimeOptimizerDescriptor.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Integration/RuntimeOptimizerDescriptor.cs
@@ -49,6 +49,8 @@ public sealed class RuntimeOptimizerDescriptor
 
     public Type ImplementationType { get; }
 
+    public Type MetadataOwnerType => ImplementationType;
+
     private static List<string> SnapshotAliases(IEnumerable<string>? aliases, string paramName, string canonicalId)
     {
         if (aliases == null)

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/DialectRuntimeAliasAttributeDiscoveryTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/DialectRuntimeAliasAttributeDiscoveryTests.cs
@@ -1,0 +1,251 @@
+using BasicCore.Contracts;
+using Microsoft.Extensions.DependencyInjection;
+using UniversalToolchain.Dialects.Abstractions;
+using UniversalToolchain.Dialects.Integration;
+using UniversalToolchain.Dialects.Wist;
+
+namespace UniversalToolchain.Dialects.Tests;
+
+public class DialectRuntimeAliasAttributeDiscoveryTests
+{
+    [Test]
+    public void AttributeDiscovery_ResolvesModuleOptimizerAndBackendAliases()
+    {
+        var registry = CreateAttributedRegistry();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(registry.TryResolveModule("AttributedModule", out var module), Is.True);
+            Assert.That(module!.ImplementationType, Is.EqualTo(typeof(AttributedModule)));
+            Assert.That(registry.TryResolveOptimizer("AttributedOptimizer", out var optimizer), Is.True);
+            Assert.That(optimizer!.ImplementationType, Is.EqualTo(typeof(AttributedOptimizer)));
+            Assert.That(registry.TryResolveBackend(new DialectBackendId("attributed-backend"), out var backendById), Is.True);
+            Assert.That(registry.TryResolveBackend(new DialectBackendId("attributed-runtime"), out var backendByAlias), Is.True);
+            Assert.That(backendById!.CanonicalId, Is.EqualTo(backendByAlias!.CanonicalId));
+            Assert.That(backendByAlias.MetadataOwnerType, Is.EqualTo(typeof(AttributedBackendDeclaration)));
+        });
+    }
+
+    [Test]
+    public void AttributeDiscovery_SupportsMultipleAliasesForTheSameComponent()
+    {
+        var registry = CreateAttributedRegistry();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(registry.TryResolveModule("MultiAliasModule", out var canonicalAlias), Is.True);
+            Assert.That(registry.TryResolveModule("MultiAliasModuleLegacy", out var legacyAlias), Is.True);
+            Assert.That(canonicalAlias, Is.SameAs(legacyAlias));
+            Assert.That(registry.TryResolveOptimizer("MultiAliasOptimizer", out var optimizerPrimary), Is.True);
+            Assert.That(registry.TryResolveOptimizer("MultiAliasOptimizerLegacy", out var optimizerLegacy), Is.True);
+            Assert.That(optimizerPrimary, Is.SameAs(optimizerLegacy));
+        });
+    }
+
+    [Test]
+    public void WistRuntimeProvider_ResolvesExistingAliasesFromAttributes()
+    {
+        var registry = DialectRuntimeDescriptorRegistryFactory.BuildFromProviders([new WistDialectRuntimeDescriptorProvider()]);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(registry.TryResolveModule("Arithmetic", out var arithmetic), Is.True);
+            Assert.That(arithmetic!.ImplementationType, Is.EqualTo(typeof(ArithmeticModule.Module.ArithmeticModuleImpl)));
+            Assert.That(registry.TryResolveOptimizer("LocalVariablesOptimization", out var localVariables), Is.True);
+            Assert.That(localVariables!.ImplementationType, Is.EqualTo(typeof(LocalVariablesOptimizerModule.LocalVariablesOptimizer)));
+            Assert.That(registry.TryResolveBackend(new DialectBackendId("cil"), out var cil), Is.True);
+            Assert.That(registry.TryResolveBackend(new DialectBackendId("compiler"), out var compiler), Is.True);
+            Assert.That(cil, Is.SameAs(compiler));
+            Assert.That(registry.TryResolveBackend(new DialectBackendId("interpreter"), out var interpreter), Is.True);
+            Assert.That(interpreter!.MetadataOwnerType.Name, Is.EqualTo("WistInterpreterBackendDeclaration"));
+        });
+    }
+
+    [Test]
+    public void WistWorkflow_ComposesExistingDialectFileWithAttributeDrivenAliases()
+    {
+        var services = new ServiceCollection();
+        services.AddWistDialectServices();
+
+        using var provider = services.BuildServiceProvider();
+        var workflow = provider.GetRequiredService<WistDialectExecutionWorkflow>();
+        var result = workflow.ComposeFile(Path.Combine(GetWistExamplesRoot(), "full-default", "dialect.wistdialect"));
+
+        Assert.That(result.IsSuccess, Is.True, string.Join(Environment.NewLine, result.ResolutionDiagnostics.Select(static x => x.Message)));
+        Assert.That(result.RuntimeComposition, Is.Not.Null);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                result.RuntimeComposition!.OrderedModules.Select(static x => x.ImplementationType.Name),
+                Is.EqualTo(new[]
+                {
+                    "ArithmeticModuleImpl",
+                    "BooleanOperations",
+                    "ComparisonOperations",
+                    "ConditionsModuleImpl",
+                    "EqualityModuleImpl",
+                    "IdentifierModuleImpl",
+                    "LabelsModuleImpl",
+                    "LoopsModuleImpl",
+                    "NumbersModuleImpl",
+                    "ScopesModuleImpl",
+                    "SemicolonAsNewLineModuleImpl",
+                    "VariablesModuleImpl",
+                    "WhitespaceModuleImpl"
+                }));
+            Assert.That(
+                result.RuntimeComposition.EnabledBackends.Select(static x => x.CanonicalId),
+                Is.EqualTo(new[] { "cil", "interpreter" }));
+            Assert.That(
+                result.RuntimeComposition.EnabledOptimizers.Select(static x => x.ImplementationType.Name),
+                Is.EqualTo(new[] { "LocalVariablesOptimizer" }));
+        });
+    }
+
+    [Test]
+    public void AttributeDiscovery_FailsFastForDuplicateAliasesAcrossModulesOptimizersAndBackends()
+    {
+        var moduleException = Assert.Throws<ArgumentException>(() => new DialectRuntimeDescriptorRegistryBuilder()
+            .RegisterAttributedModules(typeof(DuplicateAttributedModule), typeof(DuplicateAttributedModule2)));
+        var optimizerException = Assert.Throws<ArgumentException>(() => new DialectRuntimeDescriptorRegistryBuilder()
+            .RegisterAttributedOptimizers(typeof(DuplicateAttributedOptimizer), typeof(DuplicateAttributedOptimizer2)));
+        var backendException = Assert.Throws<ArgumentException>(() => new DialectRuntimeDescriptorRegistryBuilder()
+            .RegisterAttributedBackends(typeof(DuplicateAttributedBackendDeclaration), typeof(DuplicateAttributedBackendDeclaration2)));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(moduleException!.Message, Does.Contain("module alias 'DuplicateAttributedModuleAlias'"));
+            Assert.That(moduleException.Message, Does.Contain(typeof(DuplicateAttributedModule).FullName!));
+            Assert.That(moduleException.Message, Does.Contain(typeof(DuplicateAttributedModule2).FullName!));
+            Assert.That(optimizerException!.Message, Does.Contain("optimizer alias 'DuplicateAttributedOptimizerAlias'"));
+            Assert.That(optimizerException.Message, Does.Contain(typeof(DuplicateAttributedOptimizer).FullName!));
+            Assert.That(optimizerException.Message, Does.Contain(typeof(DuplicateAttributedOptimizer2).FullName!));
+            Assert.That(backendException!.Message, Does.Contain("backend alias 'duplicate-attributed-backend'"));
+            Assert.That(backendException.Message, Does.Contain(typeof(DuplicateAttributedBackendDeclaration).FullName!));
+            Assert.That(backendException.Message, Does.Contain(typeof(DuplicateAttributedBackendDeclaration2).FullName!));
+        });
+    }
+
+    [Test]
+    public void WistWorkflow_ReportsMissingAliasesThroughExistingResolutionDiagnostics()
+    {
+        var services = new ServiceCollection();
+        services.AddWistDialectServices();
+
+        using var provider = services.BuildServiceProvider();
+        var workflow = provider.GetRequiredService<WistDialectExecutionWorkflow>();
+        var result = workflow.ComposeText(
+            """
+            dialect MissingAlias
+            use UnknownModule
+            backend interpreter
+            enable UnknownOptimizer
+            """,
+            "missing-alias.wistdialect");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.False);
+            Assert.That(result.ResolutionDiagnostics.Select(static x => x.Code), Does.Contain("R001"));
+            Assert.That(result.ResolutionDiagnostics.Select(static x => x.Code), Does.Contain("R003"));
+            Assert.That(result.ResolutionDiagnostics.Select(static x => x.Message), Does.Contain("Runtime module descriptor 'UnknownModule' was not registered."));
+            Assert.That(result.ResolutionDiagnostics.Select(static x => x.Message), Does.Contain("Runtime optimizer descriptor 'UnknownOptimizer' was not registered."));
+        });
+    }
+
+    [Test]
+    public void AttributeDiscovery_IsDeterministicAcrossAssemblyOrderings()
+    {
+        var first = new DialectRuntimeDescriptorRegistryBuilder()
+            .RegisterAttributedModules(typeof(MultiAliasAttributedModule), typeof(AttributedModule))
+            .RegisterAttributedOptimizers(typeof(MultiAliasAttributedOptimizer), typeof(AttributedOptimizer))
+            .RegisterAttributedBackends(typeof(AttributedBackendDeclaration))
+            .Build();
+
+        var second = new DialectRuntimeDescriptorRegistryBuilder()
+            .RegisterAttributedModules(typeof(AttributedModule), typeof(MultiAliasAttributedModule))
+            .RegisterAttributedOptimizers(typeof(AttributedOptimizer), typeof(MultiAliasAttributedOptimizer))
+            .RegisterAttributedBackends(typeof(AttributedBackendDeclaration))
+            .Build();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(first.Modules.Keys, Is.EqualTo(second.Modules.Keys));
+            Assert.That(first.Optimizers.Keys, Is.EqualTo(second.Optimizers.Keys));
+            Assert.That(first.Backends.Keys, Is.EqualTo(second.Backends.Keys));
+        });
+    }
+
+    private static DialectRuntimeDescriptorRegistry CreateAttributedRegistry()
+    {
+        return new DialectRuntimeDescriptorRegistryBuilder()
+            .RegisterAttributedModules(typeof(AttributedModule), typeof(MultiAliasAttributedModule))
+            .RegisterAttributedOptimizers(typeof(AttributedOptimizer), typeof(MultiAliasAttributedOptimizer))
+            .RegisterAttributedBackends(typeof(AttributedBackendDeclaration))
+            .Build();
+    }
+
+    private static string GetWistExamplesRoot()
+    {
+        return Path.GetFullPath(Path.Combine(TestContext.CurrentContext.TestDirectory, "..", "..", "..", "..", "Dialects", "examples", "wist"));
+    }
+
+    [DialectModuleAlias("AttributedModule")]
+    private sealed class AttributedModule : IFrontendCoreModule
+    {
+    }
+
+    [DialectModuleAlias("MultiAliasModule", "MultiAliasModuleLegacy")]
+    private sealed class MultiAliasAttributedModule : IFrontendCoreModule
+    {
+    }
+
+    [DialectModuleAlias("DuplicateAttributedModuleAlias")]
+    private sealed class DuplicateAttributedModule : IFrontendCoreModule
+    {
+    }
+
+    [DialectModuleAlias("DuplicateAttributedModuleAlias")]
+    private sealed class DuplicateAttributedModule2 : IFrontendCoreModule
+    {
+    }
+
+    [DialectOptimizerAlias("AttributedOptimizer")]
+    private sealed class AttributedOptimizer : IIRProcessingModule
+    {
+    }
+
+    [DialectOptimizerAlias("MultiAliasOptimizer", "MultiAliasOptimizerLegacy")]
+    private sealed class MultiAliasAttributedOptimizer : IIRProcessingModule
+    {
+    }
+
+    [DialectOptimizerAlias("DuplicateAttributedOptimizerAlias")]
+    private sealed class DuplicateAttributedOptimizer : IIRProcessingModule
+    {
+    }
+
+    [DialectOptimizerAlias("DuplicateAttributedOptimizerAlias")]
+    private sealed class DuplicateAttributedOptimizer2 : IIRProcessingModule
+    {
+    }
+
+    [DialectBackendAlias("attributed-runtime")]
+    private sealed class AttributedBackendDeclaration : DialectBackendDeclaration
+    {
+        public override DialectBackendId BackendId => new("attributed-backend");
+    }
+
+    [DialectBackendAlias("duplicate-attributed-backend")]
+    private sealed class DuplicateAttributedBackendDeclaration : DialectBackendDeclaration
+    {
+        public override DialectBackendId BackendId => new("duplicate-attributed-backend-a");
+    }
+
+    [DialectBackendAlias("duplicate-attributed-backend")]
+    private sealed class DuplicateAttributedBackendDeclaration2 : DialectBackendDeclaration
+    {
+        public override DialectBackendId BackendId => new("duplicate-attributed-backend-b");
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistCilBackendDeclaration.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistCilBackendDeclaration.cs
@@ -1,0 +1,9 @@
+using UniversalToolchain.Dialects.Abstractions;
+
+namespace UniversalToolchain.Dialects.Wist;
+
+[DialectBackendAlias("compiler")]
+internal sealed class WistCilBackendDeclaration : DialectBackendDeclaration
+{
+    public override DialectBackendId BackendId => WistDialectBackendIds.Cil;
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistDialectRuntimeDescriptorProvider.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistDialectRuntimeDescriptorProvider.cs
@@ -1,11 +1,9 @@
+using System.Reflection;
 using ArithmeticModule.Module;
 using CommentsModule;
 using ConditionsModule.Enums;
-using ConditionsModule.Module;
-using ConditionsModule.Optimizers;
 using CSharpInteropModule.Module;
 using EqualityModule;
-using ExceptionsManager;
 using IdentifierModule;
 using InternalPreprocessorLexemesModule;
 using LabelsModule.Module;
@@ -16,6 +14,7 @@ using NumbersModule.Module;
 using ParametersSetterModule;
 using ScopesModule.Module;
 using SemicolonAsNewLineModule;
+using ExceptionsManager;
 using UniversalToolchain.Dialects.Integration;
 using VariablesModule;
 using WhitespacesModule;
@@ -34,57 +33,41 @@ public sealed class WistDialectRuntimeDescriptorProvider : IDialectRuntimeDescri
         if (builder == null)
             Thrower.ArgumentNull(nameof(builder));
 
-        RegisterModules(builder);
-        RegisterBackends(builder);
-        RegisterOptimizers(builder);
+        var runtimeAssemblies = GetRuntimeAssemblies();
+        builder
+            .RegisterAttributedModulesFromAssemblies(runtimeAssemblies)
+            .RegisterAttributedOptimizersFromAssemblies(runtimeAssemblies)
+            .RegisterAttributedBackendsFromAssemblies(typeof(WistDialectRuntimeDescriptorProvider).Assembly);
         RegisterIntrinsics(builder);
-    }
-
-    private static void RegisterModules(DialectRuntimeDescriptorRegistryBuilder builder)
-    {
-        builder
-            .RegisterModule(new RuntimeModuleDescriptor(typeof(ArithmeticModuleImpl), ["Arithmetic"]))
-            .RegisterModule(new RuntimeModuleDescriptor(typeof(BooleanOperations), ["BooleanConditions"]))
-            .RegisterModule(new RuntimeModuleDescriptor(typeof(CommentsModuleImpl), ["Comments"]))
-            .RegisterModule(new RuntimeModuleDescriptor(typeof(ComparisonOperations), ["ComparisonConditions"]))
-            .RegisterModule(new RuntimeModuleDescriptor(typeof(ConditionsModuleImpl), ["Conditions"]))
-            .RegisterModule(new RuntimeModuleDescriptor(typeof(CSharpInteropModuleImpl), ["CSharpInterop"]))
-            .RegisterModule(new RuntimeModuleDescriptor(typeof(EqualityModuleImpl), ["Equality"]))
-            .RegisterModule(new RuntimeModuleDescriptor(typeof(IdentifierModuleImpl), ["Identifier"]))
-            .RegisterModule(new RuntimeModuleDescriptor(typeof(InternalPreprocessorLexemesModuleImpl), ["InternalPreprocessorLexemes"]))
-            .RegisterModule(new RuntimeModuleDescriptor(typeof(LabelsModuleImpl), ["Labels"]))
-            .RegisterModule(new RuntimeModuleDescriptor(typeof(LoopsModuleImpl), ["Loops"]))
-            .RegisterModule(new RuntimeModuleDescriptor(typeof(NativeTypesModuleImpl), ["NativeTypes"]))
-            .RegisterModule(new RuntimeModuleDescriptor(typeof(NumbersModuleImpl), ["Numbers"]))
-            .RegisterModule(new RuntimeModuleDescriptor(typeof(ParametersSetterModuleImpl), ["ParametersSetter"]))
-            .RegisterModule(new RuntimeModuleDescriptor(typeof(ScopesModuleImpl), ["Scopes"]))
-            .RegisterModule(new RuntimeModuleDescriptor(typeof(SemicolonAsNewLineModuleImpl), ["SemicolonAsNewLine"]))
-            .RegisterModule(new RuntimeModuleDescriptor(typeof(VariablesModuleImpl), ["Variables"]))
-            .RegisterModule(new RuntimeModuleDescriptor(typeof(WhitespaceModuleImpl), ["Whitespaces"]));
-    }
-
-    private static void RegisterBackends(DialectRuntimeDescriptorRegistryBuilder builder)
-    {
-        builder
-            .RegisterBackend(new RuntimeBackendDescriptor(WistDialectBackendIds.Cil, ["compiler"]))
-            .RegisterBackend(new RuntimeBackendDescriptor(WistDialectBackendIds.Interpreter));
-    }
-
-    private static void RegisterOptimizers(DialectRuntimeDescriptorRegistryBuilder builder)
-    {
-        builder
-            .RegisterOptimizer(new RuntimeOptimizerDescriptor(typeof(ArithmeticOptimizerModule), ["ArithmeticOptimization"]))
-            .RegisterOptimizer(new RuntimeOptimizerDescriptor(typeof(BooleanOptimizerModule), ["BooleanOptimization"]))
-            .RegisterOptimizer(new RuntimeOptimizerDescriptor(typeof(ComparisonIntrinsicOptimizerModule), ["ComparisonIntrinsicOptimization"]))
-            .RegisterOptimizer(new RuntimeOptimizerDescriptor(typeof(EGraphOptimizerModule), ["EGraphOptimization"]))
-            .RegisterOptimizer(new RuntimeOptimizerDescriptor(typeof(LocalVariablesOptimizer), ["LocalVariablesOptimization"]))
-            .RegisterOptimizer(new RuntimeOptimizerDescriptor(typeof(NativeCilOptimizerModule), ["NativeCilOptimization"]))
-            .RegisterOptimizer(new RuntimeOptimizerDescriptor(typeof(NativeTypesOptimizerModule), ["NativeTypesOptimization"]));
     }
 
     private static void RegisterIntrinsics(DialectRuntimeDescriptorRegistryBuilder builder)
     {
         foreach (var intrinsic in WistDialectIntrinsicRegistry.CreateDescriptors())
             builder.RegisterIntrinsic(intrinsic);
+    }
+
+    private static Assembly[] GetRuntimeAssemblies()
+    {
+        return
+        [
+            typeof(ArithmeticModuleImpl).Assembly,
+            typeof(BooleanOperations).Assembly,
+            typeof(CommentsModuleImpl).Assembly,
+            typeof(CSharpInteropModuleImpl).Assembly,
+            typeof(EqualityModuleImpl).Assembly,
+            typeof(IdentifierModuleImpl).Assembly,
+            typeof(InternalPreprocessorLexemesModuleImpl).Assembly,
+            typeof(LabelsModuleImpl).Assembly,
+            typeof(LocalVariablesOptimizer).Assembly,
+            typeof(LoopsModuleImpl).Assembly,
+            typeof(NativeTypesModuleImpl).Assembly,
+            typeof(NumbersModuleImpl).Assembly,
+            typeof(ParametersSetterModuleImpl).Assembly,
+            typeof(ScopesModuleImpl).Assembly,
+            typeof(SemicolonAsNewLineModuleImpl).Assembly,
+            typeof(VariablesModuleImpl).Assembly,
+            typeof(WhitespaceModuleImpl).Assembly
+        ];
     }
 }

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistInterpreterBackendDeclaration.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistInterpreterBackendDeclaration.cs
@@ -1,0 +1,9 @@
+using UniversalToolchain.Dialects.Abstractions;
+
+namespace UniversalToolchain.Dialects.Wist;
+
+[DialectBackendAlias("interpreter")]
+internal sealed class WistInterpreterBackendDeclaration : DialectBackendDeclaration
+{
+    public override DialectBackendId BackendId => WistDialectBackendIds.Interpreter;
+}

--- a/UniversalToolchain/VariablesModule/VariablesModule.csproj
+++ b/UniversalToolchain/VariablesModule/VariablesModule.csproj
@@ -8,6 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <ProjectReference Include="..\UniversalToolchain.Dialects.Abstractions\UniversalToolchain.Dialects.Abstractions.csproj"/>
         <ProjectReference Include="..\AssemblyFinder\AssemblyFinder.csproj"/>
         <ProjectReference Include="..\BasicCore\BasicCore.csproj"/>
         <ProjectReference Include="..\DotnetAirHelper\DotnetAirHelper.csproj"/>

--- a/UniversalToolchain/VariablesModule/VariablesModuleImpl.cs
+++ b/UniversalToolchain/VariablesModule/VariablesModuleImpl.cs
@@ -1,5 +1,6 @@
 namespace VariablesModule;
 
+[UniversalToolchain.Dialects.Abstractions.DialectModuleAlias("Variables")]
 [AutoRegisterService]
 public class VariablesModuleImpl : IFrontendCoreModule
 {

--- a/UniversalToolchain/WhitespacesModule/WhitespaceModuleImpl.cs
+++ b/UniversalToolchain/WhitespacesModule/WhitespaceModuleImpl.cs
@@ -1,5 +1,6 @@
 namespace WhitespacesModule;
 
+[UniversalToolchain.Dialects.Abstractions.DialectModuleAlias("Whitespaces")]
 [AutoRegisterService]
 public class WhitespaceModuleImpl : IFrontendCoreModule
 {

--- a/UniversalToolchain/WhitespacesModule/WhitespacesModule.csproj
+++ b/UniversalToolchain/WhitespacesModule/WhitespacesModule.csproj
@@ -8,6 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <ProjectReference Include="..\UniversalToolchain.Dialects.Abstractions\UniversalToolchain.Dialects.Abstractions.csproj"/>
         <ProjectReference Include="..\BasicCore\BasicCore.csproj"/>
     </ItemGroup>
 


### PR DESCRIPTION
### Motivation
- Remove the handwritten, provider-side alias registry so alias mappings live on the runtime components themselves and are discoverable via metadata.
- Keep DSL files as the source-of-truth while making alias resolution deterministic, DI-friendly, and extensible without editing a central map.

### Description
- Introduced attribute-based alias metadata with `DialectModuleAliasAttribute`, `DialectOptimizerAliasAttribute`, and `DialectBackendAliasAttribute`, plus `DialectBackendDeclaration` for backend ownership (new files under `UniversalToolchain.Dialects.Abstractions`).
- Implemented deterministic discovery that reads those attributes from explicitly-provided assemblies/types in `DialectRuntimeDescriptorAttributeDiscovery` and wired registry helpers on `DialectRuntimeDescriptorRegistryBuilder` to register attributed descriptors.
- Replaced the hardcoded Wist alias tables in `WistDialectRuntimeDescriptorProvider` with assembly/type-driven discovery and added small backend declaration types `WistCilBackendDeclaration` and `WistInterpreterBackendDeclaration` that carry backend aliases.
- Added duplicate-alias validation that fails fast and reports the duplicate alias, category, and both conflicting metadata owner types, and added concise developer docs in `UniversalToolchain/Dialects/RuntimeAliasDiscovery.md`.

### Testing
- Ran unit/integration tests with `dotnet test UniversalToolchain/UniversalToolchain.Dialects.Tests/UniversalToolchain.Dialects.Tests.csproj --no-restore -v minimal` and all tests passed (`Passed 198, Failed 0`).
- Added focused tests in `DialectRuntimeAliasAttributeDiscoveryTests` covering positive resolution, multi-aliases, end-to-end Wist composition, duplicate alias failures, missing alias diagnostics, and determinism, and they passed as part of the test run.
- Performed a repo search (`rg ...`) to verify legacy alias strings now appear only in dialect files, tests, docs, or on attribute sites rather than in any central provider dictionary.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bda68b18888324bb9031c13da1aa68)