### PR TITLE
Decouple Wist backend wiring from central hardcode

### DIFF
--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/DialectRuntimeAliasAttributeDiscoveryTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/DialectRuntimeAliasAttributeDiscoveryTests.cs
@@ -45,7 +45,7 @@ public class DialectRuntimeAliasAttributeDiscoveryTests
     [Test]
     public void WistRuntimeProvider_ResolvesExistingAliasesFromAttributes()
     {
-        var registry = DialectRuntimeDescriptorRegistryFactory.BuildFromProviders([new WistDialectRuntimeDescriptorProvider()]);
+        var registry = BuildRegistry();
 
         Assert.Multiple(() =>
         {
@@ -184,6 +184,15 @@ public class DialectRuntimeAliasAttributeDiscoveryTests
             .RegisterAttributedOptimizers(typeof(AttributedOptimizer), typeof(MultiAliasAttributedOptimizer))
             .RegisterAttributedBackends(typeof(AttributedBackendDeclaration))
             .Build();
+    }
+
+    private static DialectRuntimeDescriptorRegistry BuildRegistry()
+    {
+        var services = new ServiceCollection();
+        services.AddWistDialectServices();
+
+        using var provider = services.BuildServiceProvider();
+        return provider.GetRequiredService<DialectRuntimeDescriptorRegistry>();
     }
 
     private static string GetWistExamplesRoot()

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/DialectRuntimeArchitectureTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/DialectRuntimeArchitectureTests.cs
@@ -60,7 +60,7 @@ public class DialectRuntimeArchitectureTests
     [Test]
     public void WistIntrinsicRegistry_ComesFromRealBackendCapabilities()
     {
-        var registry = DialectRuntimeDescriptorRegistryFactory.BuildFromProviders([new WistDialectRuntimeDescriptorProvider()]);
+        var registry = BuildRegistry();
 
         Assert.Multiple(() =>
         {
@@ -106,6 +106,12 @@ public class DialectRuntimeArchitectureTests
                 Assert.That(text, Does.Not.Contain("capability "));
             });
         }
+    }
+
+    private static DialectRuntimeDescriptorRegistry BuildRegistry()
+    {
+        using var provider = CreateProvider();
+        return provider.GetRequiredService<DialectRuntimeDescriptorRegistry>();
     }
 
     private static ServiceProvider CreateProvider()

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/WistDialectBackendHardcodeTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/WistDialectBackendHardcodeTests.cs
@@ -1,0 +1,209 @@
+using System.Reflection.Emit;
+using BasicCore.Contracts;
+using ExceptionsManager;
+using IntermediateRepresentationAbstractions;
+using Microsoft.Extensions.DependencyInjection;
+using UniversalToolchain.Dialects.Abstractions;
+using UniversalToolchain.Dialects.Integration;
+using UniversalToolchain.Dialects.Wist;
+
+namespace UniversalToolchain.Dialects.Tests;
+
+public class WistDialectBackendHardcodeTests
+{
+    [Test]
+    public void ExistingCilBackendStillWorks()
+    {
+        using var rootProvider = CreateRootProvider();
+        var factory = rootProvider.GetRequiredService<WistDialectServiceProviderFactory>();
+        var configuration = CreateConfiguration(rootProvider, WistDialectBackendIds.Cil);
+
+        using var runtimeProvider = (ServiceProvider)factory.Create(configuration);
+        var runtimes = runtimeProvider.GetServices<WistDialectBackendRuntime>().ToList();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(runtimeProvider.GetRequiredService<IExecutableGiver<DynamicMethod>>(), Is.Not.Null);
+            Assert.That(runtimes.Select(x => x.Descriptor.BackendId), Is.EqualTo(new[] { WistDialectBackendIds.Cil }));
+            Assert.That(runtimes[0].Core, Is.AssignableTo<ICoreRunnable>());
+        });
+    }
+
+    [Test]
+    public void ExistingInterpreterBackendStillWorks()
+    {
+        using var rootProvider = CreateRootProvider();
+        var factory = rootProvider.GetRequiredService<WistDialectServiceProviderFactory>();
+        var configuration = CreateConfiguration(rootProvider, WistDialectBackendIds.Interpreter);
+
+        using var runtimeProvider = (ServiceProvider)factory.Create(configuration);
+        var runtimes = runtimeProvider.GetServices<WistDialectBackendRuntime>().ToList();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(runtimeProvider.GetRequiredService<IExecutableGiver<IAbstractIR>>(), Is.Not.Null);
+            Assert.That(runtimes.Select(x => x.Descriptor.BackendId), Is.EqualTo(new[] { WistDialectBackendIds.Interpreter }));
+            Assert.That(runtimes[0].Core, Is.AssignableTo<ICoreRunnable>());
+        });
+    }
+
+    [Test]
+    public void CentralFactorySupportsFakeBackendPluginWithoutCodeChanges()
+    {
+        var backendId = new DialectBackendId("fake-backend");
+        var backendDescriptor = new RuntimeBackendDescriptor(backendId, "fake-runtime");
+        var factory = new WistDialectServiceProviderFactory([new FakeBackendServiceProvider(backendId, ["fake_intrinsic"]) ]);
+        var configuration = CreateConfiguration(backendDescriptor);
+
+        using var runtimeProvider = (ServiceProvider)factory.Create(configuration);
+        var runtime = runtimeProvider.GetServices<WistDialectBackendRuntime>().Single();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(runtime.Descriptor.BackendId, Is.EqualTo(backendId));
+            Assert.That(runtime.Core, Is.TypeOf<FakeCoreRunnable>());
+            Assert.That(runtimeProvider.GetRequiredService<ICoreRunnable>(), Is.TypeOf<FakeCoreRunnable>());
+        });
+    }
+
+    [Test]
+    public void DuplicateBackendProvidersAreRejectedDeterministically()
+    {
+        var backendId = new DialectBackendId("duplicate-backend");
+
+        var exception = Assert.Throws<InvalidOperationException>(() => new WistDialectServiceProviderFactory([
+            new FakeBackendServiceProvider(backendId, ["first_intrinsic"]),
+            new FakeBackendServiceProvider(backendId, ["second_intrinsic"])
+        ]));
+
+        Assert.That(exception!.Message, Is.EqualTo("Duplicate Wist backend service provider registration for backend 'duplicate-backend'."));
+    }
+
+    [Test]
+    public void MissingBackendProviderIsRejectedClearly()
+    {
+        var requestedBackend = new RuntimeBackendDescriptor(new DialectBackendId("missing-backend"), "missing-runtime");
+        var factory = new WistDialectServiceProviderFactory([new FakeBackendServiceProvider(new DialectBackendId("other-backend"), ["other_intrinsic"])]);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => factory.Create(CreateConfiguration(requestedBackend)));
+
+        Assert.That(exception!.Message, Is.EqualTo("No Wist backend service provider is registered for backend 'missing-backend'."));
+    }
+
+    [Test]
+    public void IntrinsicRegistryIsAssembledFromBackendPlugins()
+    {
+        var backendA = new DialectBackendId("backend-a");
+        var backendB = new DialectBackendId("backend-b");
+
+        var descriptors = WistDialectIntrinsicRegistry.CreateDescriptors([
+            new FakeBackendServiceProvider(backendA, ["shared_intrinsic", "only_a"]),
+            new FakeBackendServiceProvider(backendB, ["shared_intrinsic", "only_b"])
+        ]);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(descriptors.Select(x => $"{x.CanonicalId}@{DialectBackendSelectorText.ToText(x.Target)}"), Is.EqualTo(new[]
+            {
+                "only_a@backend-a",
+                "only_b@backend-b",
+                "shared_intrinsic@any"
+            }));
+            Assert.That(descriptors.Single(x => x.CanonicalId == "shared_intrinsic").Target, Is.EqualTo(DialectBackendSelector.Any));
+        });
+    }
+
+    [Test]
+    public void DeterministicOrderingDoesNotDependOnBackendProviderRegistrationOrder()
+    {
+        var backendA = new RuntimeBackendDescriptor(new DialectBackendId("backend-a"), "backend-a-runtime");
+        var backendB = new RuntimeBackendDescriptor(new DialectBackendId("backend-b"), "backend-b-runtime");
+        var configuration = CreateConfiguration(backendA, backendB);
+        var providersInDeclaredOrder = new IWistDialectBackendServiceProvider[]
+        {
+            new FakeBackendServiceProvider(backendA.BackendId, ["shared_intrinsic", "only_a"]),
+            new FakeBackendServiceProvider(backendB.BackendId, ["shared_intrinsic", "only_b"])
+        };
+        var providersInReverseOrder = new IWistDialectBackendServiceProvider[]
+        {
+            new FakeBackendServiceProvider(backendB.BackendId, ["shared_intrinsic", "only_b"]),
+            new FakeBackendServiceProvider(backendA.BackendId, ["shared_intrinsic", "only_a"])
+        };
+
+        var firstDescriptorSet = WistDialectIntrinsicRegistry.CreateDescriptors(providersInDeclaredOrder)
+            .Select(x => $"{x.CanonicalId}@{DialectBackendSelectorText.ToText(x.Target)}")
+            .ToList();
+        var secondDescriptorSet = WistDialectIntrinsicRegistry.CreateDescriptors(providersInReverseOrder)
+            .Select(x => $"{x.CanonicalId}@{DialectBackendSelectorText.ToText(x.Target)}")
+            .ToList();
+
+        using var firstRuntimeProvider = (ServiceProvider)new WistDialectServiceProviderFactory(providersInDeclaredOrder).Create(configuration);
+        using var secondRuntimeProvider = (ServiceProvider)new WistDialectServiceProviderFactory(providersInReverseOrder).Create(configuration);
+        var firstRuntimeOrder = firstRuntimeProvider.GetServices<WistDialectBackendRuntime>().Select(x => x.Descriptor.BackendId.Value).ToList();
+        var secondRuntimeOrder = secondRuntimeProvider.GetServices<WistDialectBackendRuntime>().Select(x => x.Descriptor.BackendId.Value).ToList();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(firstDescriptorSet, Is.EqualTo(secondDescriptorSet));
+            Assert.That(firstDescriptorSet, Is.EqualTo(new[] { "only_a@backend-a", "only_b@backend-b", "shared_intrinsic@any" }));
+            Assert.That(firstRuntimeOrder, Is.EqualTo(secondRuntimeOrder));
+            Assert.That(firstRuntimeOrder, Is.EqualTo(new[] { "backend-a", "backend-b" }));
+        });
+    }
+
+    private static ServiceProvider CreateRootProvider()
+    {
+        var services = new ServiceCollection();
+        services.AddWistDialectServices();
+        return services.BuildServiceProvider();
+    }
+
+    private static WistDialectExecutionConfiguration CreateConfiguration(ServiceProvider provider, DialectBackendId backendId)
+    {
+        var registry = provider.GetRequiredService<DialectRuntimeDescriptorRegistry>();
+        if (!registry.TryResolveBackend(backendId, out var backendDescriptor))
+            Thrower.InvalidOpEx($"Backend '{backendId.Value}' was not registered.");
+
+        return CreateConfiguration(backendDescriptor!);
+    }
+
+    private static WistDialectExecutionConfiguration CreateConfiguration(params RuntimeBackendDescriptor[] backendDescriptors)
+    {
+        return new WistDialectExecutionConfiguration(
+            "test-dialect",
+            [],
+            [],
+            [],
+            backendDescriptors.Select(static x => new WistDialectBackendConfiguration(x, [], [], false)),
+            backendDescriptors);
+    }
+
+    private sealed class FakeBackendServiceProvider(DialectBackendId backendId, IReadOnlyList<string> supportedIntrinsics) : IWistDialectBackendServiceProvider
+    {
+        private readonly IReadOnlyList<string> _supportedIntrinsics = supportedIntrinsics
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(x => x, StringComparer.Ordinal)
+            .ToList();
+
+        public DialectBackendId BackendId { get; } = backendId;
+
+        public IReadOnlyList<string> SupportedIntrinsics => _supportedIntrinsics;
+
+        public void RegisterRuntime(IServiceCollection services, WistDialectBackendConfiguration configuration)
+        {
+            if (services == null)
+                Thrower.ArgumentNull(nameof(services));
+
+            if (configuration == null)
+                Thrower.ArgumentNull(nameof(configuration));
+
+            services.AddTransient<ICoreRunnable, FakeCoreRunnable>();
+            services.AddTransient(provider => new WistDialectBackendRuntime(configuration.BackendDescriptor, provider.GetRequiredService<ICoreRunnable>()));
+        }
+    }
+
+    private sealed class FakeCoreRunnable : ICoreRunnable
+    {
+        public object? Run(string code, Dictionary<string, object>? args = null) => code;
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/WistDialectRuntimeDescriptorProviderTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/WistDialectRuntimeDescriptorProviderTests.cs
@@ -46,5 +46,12 @@ public class WistDialectRuntimeDescriptorProviderTests
         });
     }
 
-    private static DialectRuntimeDescriptorRegistry BuildRegistry() => DialectRuntimeDescriptorRegistryFactory.BuildFromProviders([new WistDialectRuntimeDescriptorProvider()]);
+    private static DialectRuntimeDescriptorRegistry BuildRegistry()
+    {
+        var services = new ServiceCollection();
+        services.AddWistDialectServices();
+
+        using var provider = services.BuildServiceProvider();
+        return provider.GetRequiredService<DialectRuntimeDescriptorRegistry>();
+    }
 }

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/AssemblyInternals.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/AssemblyInternals.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("UniversalToolchain.Dialects.Tests")]

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/IWistDialectBackendServiceProvider.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/IWistDialectBackendServiceProvider.cs
@@ -1,0 +1,13 @@
+using Microsoft.Extensions.DependencyInjection;
+using UniversalToolchain.Dialects.Abstractions;
+
+namespace UniversalToolchain.Dialects.Wist;
+
+public interface IWistDialectBackendServiceProvider
+{
+    DialectBackendId BackendId { get; }
+
+    IReadOnlyList<string> SupportedIntrinsics { get; }
+
+    void RegisterRuntime(IServiceCollection services, WistDialectBackendConfiguration configuration);
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistCilDialectBackendServiceProvider.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistCilDialectBackendServiceProvider.cs
@@ -1,0 +1,57 @@
+using System.Reflection.Emit;
+using BasicCore.Contracts;
+using BasicCore.Core;
+using BasicCore.ExecutorWrapper;
+using BasicCore.LexerWrapper;
+using BasicCore.ParserWrapper;
+using BasicCore.TranslatorWrapper;
+using BytecodeDynamicMethodsCompiler.Compilers;
+using ExceptionsManager;
+using Microsoft.Extensions.DependencyInjection;
+using UniversalToolchain.Dialects.Abstractions;
+
+namespace UniversalToolchain.Dialects.Wist;
+
+internal sealed class WistCilDialectBackendServiceProvider : IWistDialectBackendServiceProvider
+{
+    private static readonly IReadOnlyList<string> _supportedIntrinsics = new AbstractMethodsCompilerImpl().SupportedIntrinsics
+        .Distinct(StringComparer.Ordinal)
+        .OrderBy(x => x, StringComparer.Ordinal)
+        .ToList();
+
+    public DialectBackendId BackendId => WistDialectBackendIds.Cil;
+
+    public IReadOnlyList<string> SupportedIntrinsics => _supportedIntrinsics;
+
+    public void RegisterRuntime(IServiceCollection services, WistDialectBackendConfiguration configuration)
+    {
+        if (services == null)
+            Thrower.ArgumentNull(nameof(services));
+
+        if (configuration == null)
+            Thrower.ArgumentNull(nameof(configuration));
+
+        services.AddTransient<ICoreRunnable>(provider => CreateCore(provider, configuration));
+        services.AddTransient<ICoreOptimizedRunnable>(provider => CreateCore(provider, configuration));
+        services.AddTransient<IExecutableGiver<DynamicMethod>>(provider => CreateCore(provider, configuration));
+        services.AddTransient(provider => new WistDialectBackendRuntime(configuration.BackendDescriptor, CreateCore(provider, configuration)));
+    }
+
+    private static BasicCoreImpl<DynamicMethod> CreateCore(IServiceProvider provider, WistDialectBackendConfiguration configuration)
+    {
+        return new BasicCoreImpl<DynamicMethod>(
+            provider.GetRequiredService<Func<ILexer>>(),
+            provider.GetRequiredService<Func<IParser>>(),
+            provider.GetRequiredService<Func<IAstToBytecodeTranslator>>(),
+            provider.GetRequiredService<Func<IAbstractMethodsTranslator>>(),
+            () => new DialectIntrinsicPolicyCompiler<DynamicMethod>(
+                provider.GetRequiredService<AbstractMethodsCompilerImpl>(),
+                configuration.AllowedIntrinsics,
+                configuration.ForbiddenIntrinsics,
+                configuration.HasExplicitAllowList),
+            provider.GetRequiredService<Func<IExecutor<DynamicMethod>>>(),
+            provider.GetServices<IFrontendCoreModule>().ToList(),
+            provider.GetServices<IIRProcessingModule>().ToList(),
+            []);
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistDialectIntrinsicRegistry.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistDialectIntrinsicRegistry.cs
@@ -1,33 +1,21 @@
-using BytecodeDynamicMethodsCompiler.Compilers;
+using ExceptionsManager;
 using UniversalToolchain.Dialects.Abstractions;
 using UniversalToolchain.Dialects.Integration;
-using AbstractIrConverters;
 
 namespace UniversalToolchain.Dialects.Wist;
 
 internal static class WistDialectIntrinsicRegistry
 {
-    public static IReadOnlyList<RuntimeIntrinsicDescriptor> CreateDescriptors()
+    public static IReadOnlyList<RuntimeIntrinsicDescriptor> CreateDescriptors(IEnumerable<IWistDialectBackendServiceProvider> backendProviders)
     {
-        var backendIntrinsics = new Dictionary<DialectBackendId, SortedSet<string>>
-        {
-            [WistDialectBackendIds.Cil] = new(new AbstractMethodsCompilerImpl().SupportedIntrinsics, StringComparer.Ordinal),
-            [WistDialectBackendIds.Interpreter] = new(new AbstractIrToAbstractIrStub().SupportedIntrinsics, StringComparer.Ordinal)
-        };
-
-        var commonIntrinsics = backendIntrinsics.Values
-            .Skip(1)
-            .Aggregate(new SortedSet<string>(backendIntrinsics.Values.First(), StringComparer.Ordinal), (current, next) =>
-            {
-                current.IntersectWith(next);
-                return current;
-            });
-
+        var backendIntrinsics = CreateBackendIntrinsicMap(backendProviders);
+        var commonIntrinsics = GetCommonIntrinsics(backendIntrinsics);
         var descriptors = new List<RuntimeIntrinsicDescriptor>();
+
         foreach (var intrinsic in commonIntrinsics)
             descriptors.Add(new RuntimeIntrinsicDescriptor(intrinsic, DialectBackendSelector.Any));
 
-        foreach (var backend in backendIntrinsics.OrderBy(x => x.Key))
+        foreach (var backend in backendIntrinsics)
         {
             foreach (var intrinsic in backend.Value.Except(commonIntrinsics, StringComparer.Ordinal))
                 descriptors.Add(new RuntimeIntrinsicDescriptor(intrinsic, DialectBackendSelector.For(backend.Key)));
@@ -37,5 +25,36 @@ internal static class WistDialectIntrinsicRegistry
             .OrderBy(x => x.CanonicalId, StringComparer.Ordinal)
             .ThenBy(x => x.Target)
             .ToList();
+    }
+
+    private static IReadOnlyDictionary<DialectBackendId, SortedSet<string>> CreateBackendIntrinsicMap(IEnumerable<IWistDialectBackendServiceProvider> backendProviders)
+    {
+        if (backendProviders == null)
+            Thrower.ArgumentNull(nameof(backendProviders));
+
+        var map = new SortedDictionary<DialectBackendId, SortedSet<string>>();
+        foreach (var backendProvider in backendProviders
+                     .Select(x => x.NotNull(nameof(backendProviders)))
+                     .OrderBy(x => x.BackendId))
+        {
+            var intrinsics = new SortedSet<string>(backendProvider.SupportedIntrinsics ?? Thrower.InvalidOpEx<IReadOnlyList<string>>($"Backend '{backendProvider.BackendId.Value}' returned null supported intrinsics."), StringComparer.Ordinal);
+            if (!map.TryAdd(backendProvider.BackendId, intrinsics))
+                Thrower.InvalidOpEx($"Duplicate Wist backend service provider registration for backend '{backendProvider.BackendId.Value}'.");
+        }
+
+        return map;
+    }
+
+    private static SortedSet<string> GetCommonIntrinsics(IReadOnlyDictionary<DialectBackendId, SortedSet<string>> backendIntrinsics)
+    {
+        var commonIntrinsics = new SortedSet<string>(StringComparer.Ordinal);
+        if (backendIntrinsics.Count == 0)
+            return commonIntrinsics;
+
+        commonIntrinsics.UnionWith(backendIntrinsics.First().Value);
+        foreach (var backend in backendIntrinsics.Skip(1))
+            commonIntrinsics.IntersectWith(backend.Value);
+
+        return commonIntrinsics;
     }
 }

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistDialectRuntimeDescriptorProvider.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistDialectRuntimeDescriptorProvider.cs
@@ -4,6 +4,7 @@ using CommentsModule;
 using ConditionsModule.Enums;
 using CSharpInteropModule.Module;
 using EqualityModule;
+using ExceptionsManager;
 using IdentifierModule;
 using InternalPreprocessorLexemesModule;
 using LabelsModule.Module;
@@ -14,7 +15,6 @@ using NumbersModule.Module;
 using ParametersSetterModule;
 using ScopesModule.Module;
 using SemicolonAsNewLineModule;
-using ExceptionsManager;
 using UniversalToolchain.Dialects.Integration;
 using VariablesModule;
 using WhitespacesModule;
@@ -26,6 +26,16 @@ namespace UniversalToolchain.Dialects.Wist;
 /// </summary>
 public sealed class WistDialectRuntimeDescriptorProvider : IDialectRuntimeDescriptorProvider
 {
+    private readonly IReadOnlyList<IWistDialectBackendServiceProvider> _backendProviders;
+
+    public WistDialectRuntimeDescriptorProvider(IEnumerable<IWistDialectBackendServiceProvider> backendProviders)
+    {
+        if (backendProviders == null)
+            Thrower.ArgumentNull(nameof(backendProviders));
+
+        _backendProviders = backendProviders.ToList();
+    }
+
     public int Order => 0;
 
     public void Register(DialectRuntimeDescriptorRegistryBuilder builder)
@@ -41,9 +51,9 @@ public sealed class WistDialectRuntimeDescriptorProvider : IDialectRuntimeDescri
         RegisterIntrinsics(builder);
     }
 
-    private static void RegisterIntrinsics(DialectRuntimeDescriptorRegistryBuilder builder)
+    private void RegisterIntrinsics(DialectRuntimeDescriptorRegistryBuilder builder)
     {
-        foreach (var intrinsic in WistDialectIntrinsicRegistry.CreateDescriptors())
+        foreach (var intrinsic in WistDialectIntrinsicRegistry.CreateDescriptors(_backendProviders))
             builder.RegisterIntrinsic(intrinsic);
     }
 

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistDialectServiceCollectionExtensions.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistDialectServiceCollectionExtensions.cs
@@ -18,6 +18,8 @@ public static class WistDialectServiceCollectionExtensions
             Thrower.ArgumentNull(nameof(services));
 
         services.AddDialectDslDefaultComposition();
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IWistDialectBackendServiceProvider, WistCilDialectBackendServiceProvider>());
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IWistDialectBackendServiceProvider, WistInterpreterDialectBackendServiceProvider>());
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IDialectRuntimeDescriptorProvider, WistDialectRuntimeDescriptorProvider>());
         services.TryAddSingleton(static provider => DialectRuntimeDescriptorRegistryFactory.BuildFromProviders(provider.GetServices<IDialectRuntimeDescriptorProvider>()));
         services.TryAddSingleton<IDialectCompiledDialectBuildPlanBuilder, DialectCompiledDialectBuildPlanBuilder>();

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistDialectServiceProviderFactory.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistDialectServiceProviderFactory.cs
@@ -1,16 +1,8 @@
-using System.Reflection.Emit;
-using AbstractIrConverters;
 using BasicCore.Contracts;
-using BasicCore.Core;
-using BasicCore.ExecutorWrapper;
-using BasicCore.LexerWrapper;
-using BasicCore.ParserWrapper;
-using BasicCore.TranslatorWrapper;
-using BytecodeDynamicMethodsCompiler.Compilers;
 using DependencyInjection;
 using ExceptionsManager;
-using IntermediateRepresentationAbstractions;
 using Microsoft.Extensions.DependencyInjection;
+using UniversalToolchain.Dialects.Abstractions;
 using ServiceLifetime = Microsoft.Extensions.DependencyInjection.ServiceLifetime;
 
 namespace UniversalToolchain.Dialects.Wist;
@@ -20,6 +12,13 @@ namespace UniversalToolchain.Dialects.Wist;
 /// </summary>
 public sealed class WistDialectServiceProviderFactory
 {
+    private readonly IReadOnlyDictionary<DialectBackendId, IWistDialectBackendServiceProvider> _backendProviders;
+
+    public WistDialectServiceProviderFactory(IEnumerable<IWistDialectBackendServiceProvider> backendProviders)
+    {
+        _backendProviders = CreateBackendProviderMap(backendProviders);
+    }
+
     public IServiceProvider Create(WistDialectExecutionConfiguration configuration)
     {
         if (configuration == null)
@@ -42,70 +41,31 @@ public sealed class WistDialectServiceProviderFactory
             services.Add(new ServiceDescriptor(serviceType, type, lifetime));
     }
 
-    private static void RegisterBackendRuntimes(IServiceCollection services, WistDialectExecutionConfiguration configuration)
+    private void RegisterBackendRuntimes(IServiceCollection services, WistDialectExecutionConfiguration configuration)
     {
         foreach (var backend in configuration.BackendConfigurations.OrderBy(x => x.BackendDescriptor.BackendId))
         {
-            if (backend.BackendDescriptor.BackendId == WistDialectBackendIds.Cil)
-            {
-                RegisterCore<DynamicMethod>(services, provider => CreateCompilerCore(provider, backend));
-                services.AddTransient(provider => new WistDialectBackendRuntime(backend.BackendDescriptor, CreateCompilerCore(provider, backend)));
-                continue;
-            }
+            if (!_backendProviders.TryGetValue(backend.BackendDescriptor.BackendId, out var backendProvider))
+                Thrower.InvalidOpEx($"No Wist backend service provider is registered for backend '{backend.BackendDescriptor.CanonicalId}'.");
 
-            if (backend.BackendDescriptor.BackendId == WistDialectBackendIds.Interpreter)
-            {
-                RegisterCore<IAbstractIR>(services, provider => CreateInterpreterCore(provider, backend));
-                services.AddTransient(provider => new WistDialectBackendRuntime(backend.BackendDescriptor, CreateInterpreterCore(provider, backend)));
-                continue;
-            }
-
-            Thrower.InvalidOpEx($"Unsupported backend '{backend.BackendDescriptor.CanonicalId}'.");
+            backendProvider.RegisterRuntime(services, backend);
         }
     }
 
-    private static void RegisterCore<TCompilationOutput>(
-        IServiceCollection services,
-        Func<IServiceProvider, BasicCoreImpl<TCompilationOutput>> factory)
+    private static IReadOnlyDictionary<DialectBackendId, IWistDialectBackendServiceProvider> CreateBackendProviderMap(IEnumerable<IWistDialectBackendServiceProvider> backendProviders)
     {
-        services.AddTransient<ICoreRunnable>(provider => factory(provider));
-        services.AddTransient<ICoreOptimizedRunnable>(provider => factory(provider));
-        services.AddTransient<IExecutableGiver<TCompilationOutput>>(provider => factory(provider));
-    }
+        if (backendProviders == null)
+            Thrower.ArgumentNull(nameof(backendProviders));
 
-    private static BasicCoreImpl<DynamicMethod> CreateCompilerCore(IServiceProvider provider, WistDialectBackendConfiguration backend)
-    {
-        return new BasicCoreImpl<DynamicMethod>(
-            provider.GetRequiredService<Func<ILexer>>(),
-            provider.GetRequiredService<Func<IParser>>(),
-            provider.GetRequiredService<Func<IAstToBytecodeTranslator>>(),
-            provider.GetRequiredService<Func<IAbstractMethodsTranslator>>(),
-            () => new DialectIntrinsicPolicyCompiler<DynamicMethod>(
-                provider.GetRequiredService<AbstractMethodsCompilerImpl>(),
-                backend.AllowedIntrinsics,
-                backend.ForbiddenIntrinsics,
-                backend.HasExplicitAllowList),
-            provider.GetRequiredService<Func<IExecutor<DynamicMethod>>>(),
-            provider.GetServices<IFrontendCoreModule>().ToList(),
-            provider.GetServices<IIRProcessingModule>().ToList(),
-            []);
-    }
+        var map = new SortedDictionary<DialectBackendId, IWistDialectBackendServiceProvider>();
+        foreach (var backendProvider in backendProviders
+                     .Select(x => x.NotNull(nameof(backendProviders)))
+                     .OrderBy(x => x.BackendId))
+        {
+            if (!map.TryAdd(backendProvider.BackendId, backendProvider))
+                Thrower.InvalidOpEx($"Duplicate Wist backend service provider registration for backend '{backendProvider.BackendId.Value}'.");
+        }
 
-    private static BasicCoreImpl<IAbstractIR> CreateInterpreterCore(IServiceProvider provider, WistDialectBackendConfiguration backend)
-    {
-        return new BasicCoreImpl<IAbstractIR>(
-            provider.GetRequiredService<Func<ILexer>>(),
-            provider.GetRequiredService<Func<IParser>>(),
-            provider.GetRequiredService<Func<IAstToBytecodeTranslator>>(),
-            provider.GetRequiredService<Func<IAbstractMethodsTranslator>>(),
-            () => new DialectIntrinsicPolicyCompiler<IAbstractIR>(
-                provider.GetRequiredService<AbstractIrToAbstractIrStub>(),
-                backend.AllowedIntrinsics,
-                backend.ForbiddenIntrinsics,
-                backend.HasExplicitAllowList),
-            provider.GetRequiredService<Func<IExecutor<IAbstractIR>>>(),
-            provider.GetServices<IFrontendCoreModule>().ToList(),
-            provider.GetServices<IIRProcessingModule>().ToList(),
-            []);
+        return map;
     }
 }

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistInterpreterDialectBackendServiceProvider.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistInterpreterDialectBackendServiceProvider.cs
@@ -1,0 +1,57 @@
+using AbstractIrConverters;
+using BasicCore.Contracts;
+using BasicCore.Core;
+using BasicCore.ExecutorWrapper;
+using BasicCore.LexerWrapper;
+using BasicCore.ParserWrapper;
+using BasicCore.TranslatorWrapper;
+using IntermediateRepresentationAbstractions;
+using Microsoft.Extensions.DependencyInjection;
+using ExceptionsManager;
+using UniversalToolchain.Dialects.Abstractions;
+
+namespace UniversalToolchain.Dialects.Wist;
+
+internal sealed class WistInterpreterDialectBackendServiceProvider : IWistDialectBackendServiceProvider
+{
+    private static readonly IReadOnlyList<string> _supportedIntrinsics = new AbstractIrToAbstractIrStub().SupportedIntrinsics
+        .Distinct(StringComparer.Ordinal)
+        .OrderBy(x => x, StringComparer.Ordinal)
+        .ToList();
+
+    public DialectBackendId BackendId => WistDialectBackendIds.Interpreter;
+
+    public IReadOnlyList<string> SupportedIntrinsics => _supportedIntrinsics;
+
+    public void RegisterRuntime(IServiceCollection services, WistDialectBackendConfiguration configuration)
+    {
+        if (services == null)
+            Thrower.ArgumentNull(nameof(services));
+
+        if (configuration == null)
+            Thrower.ArgumentNull(nameof(configuration));
+
+        services.AddTransient<ICoreRunnable>(provider => CreateCore(provider, configuration));
+        services.AddTransient<ICoreOptimizedRunnable>(provider => CreateCore(provider, configuration));
+        services.AddTransient<IExecutableGiver<IAbstractIR>>(provider => CreateCore(provider, configuration));
+        services.AddTransient(provider => new WistDialectBackendRuntime(configuration.BackendDescriptor, CreateCore(provider, configuration)));
+    }
+
+    private static BasicCoreImpl<IAbstractIR> CreateCore(IServiceProvider provider, WistDialectBackendConfiguration configuration)
+    {
+        return new BasicCoreImpl<IAbstractIR>(
+            provider.GetRequiredService<Func<ILexer>>(),
+            provider.GetRequiredService<Func<IParser>>(),
+            provider.GetRequiredService<Func<IAstToBytecodeTranslator>>(),
+            provider.GetRequiredService<Func<IAbstractMethodsTranslator>>(),
+            () => new DialectIntrinsicPolicyCompiler<IAbstractIR>(
+                provider.GetRequiredService<AbstractIrToAbstractIrStub>(),
+                configuration.AllowedIntrinsics,
+                configuration.ForbiddenIntrinsics,
+                configuration.HasExplicitAllowList),
+            provider.GetRequiredService<Func<IExecutor<IAbstractIR>>>(),
+            provider.GetServices<IFrontendCoreModule>().ToList(),
+            provider.GetServices<IIRProcessingModule>().ToList(),
+            []);
+    }
+}


### PR DESCRIPTION
### Motivation
- The Wist dialect central infrastructure contained hardcoded backend branching and concrete backend classes, forcing edits to the central factory and registry to add new backends.
- Introduce a small backend-oriented plugin contract so backend-specific wiring and intrinsic capability information live inside backend implementations rather than the central dispatcher.

### Description
- Added a narrow backend plugin interface `IWistDialectBackendServiceProvider` with `BackendId`, `SupportedIntrinsics`, and `RegisterRuntime(IServiceCollection, WistDialectBackendConfiguration)`, and implemented it for the existing CIL and Interpreter backends. (`UniversalToolchain/UniversalToolchain.Dialects.Wist/IWistDialectBackendServiceProvider.cs`, `WistCilDialectBackendServiceProvider.cs`, `WistInterpreterDialectBackendServiceProvider.cs`).
- Reworked `WistDialectServiceProviderFactory` to accept a collection of backend providers via DI, build a deterministic backend map, validate duplicates, throw clear errors for missing providers, and delegate runtime registration to backend providers (removed `if/else` on `cil`/`interpreter`). (`WistDialectServiceProviderFactory.cs`).
- Reworked `WistDialectIntrinsicRegistry` and `WistDialectRuntimeDescriptorProvider` to source intrinsic descriptors from the backend providers instead of instantiating concrete compiler/runtime classes in the central registry; preserved common-intrinsic (`Any`) detection and deterministic ordering. (`WistDialectIntrinsicRegistry.cs`, `WistDialectRuntimeDescriptorProvider.cs`).
- Registered the two built-in backend providers explicitly and deterministically in `AddWistDialectServices()` (no reflection or registration-order heuristics). (`WistDialectServiceCollectionExtensions.cs`).
- Kept all previous runtime behavior for CIL and Interpreter by moving existing construction logic into backend-specific providers and preserving service lifetimes and factories.
- Added a focused test suite `WistDialectBackendHardcodeTests` and updated a few descriptor tests to obtain the registry through DI; tests exercise CIL/Interpreter behavior, extensibility with a fake backend, duplicate and missing provider errors, intrinsic assembly from plugins, and deterministic ordering. (`UniversalToolchain.Dialects.Tests/WistDialectBackendHardcodeTests.cs` and small test adjustments).

### Testing
- Ran the dialect tests with `dotnet test UniversalToolchain/UniversalToolchain.Dialects.Tests/UniversalToolchain.Dialects.Tests.csproj` and all tests passed: `Passed!  - Failed: 0, Passed: 205, Skipped: 0, Total: 205`.
- Added and executed focused unit tests that verify: existing CIL and Interpreter backends still work; a test-only fake backend can be handled without central changes; duplicate backend providers produce a deterministic error; missing backend provider yields a clear error; intrinsics are assembled from backend plugins; and ordering is deterministic — all covered by the test run above and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf08cb47d08324ab601bcd857ba500)