### PR TITLE
Introduce contributor-based runtime assembly discovery for Wist

### DIFF
--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/WistDialectRuntimeDescriptorProviderTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/WistDialectRuntimeDescriptorProviderTests.cs
@@ -1,4 +1,10 @@
+using System.Reflection;
+using System.Reflection.Emit;
+using ArithmeticModule.Module;
+using LocalVariablesOptimizerModule;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using UniversalToolchain.Dialects.Abstractions;
 using UniversalToolchain.Dialects.Integration;
 using UniversalToolchain.Dialects.Wist;
 
@@ -6,6 +12,8 @@ namespace UniversalToolchain.Dialects.Tests;
 
 public class WistDialectRuntimeDescriptorProviderTests
 {
+    private static readonly Assembly TestRuntimeExtensionAssembly = CreateTestRuntimeExtensionAssembly();
+
     [Test]
     public void RegistryFactory_BuildsDeterministicRealWistCatalog()
     {
@@ -46,6 +54,75 @@ public class WistDialectRuntimeDescriptorProviderTests
         });
     }
 
+    [Test]
+    public void AddWistDialectServices_AllowsExtendingRuntimeAssemblyDiscoveryViaContributor()
+    {
+        var services = new ServiceCollection();
+        services.AddWistDialectServices();
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IWistDialectRuntimeAssemblyContributor, TestOnlyRuntimeAssemblyContributor>());
+
+        using var provider = services.BuildServiceProvider();
+        var registry = provider.GetRequiredService<DialectRuntimeDescriptorRegistry>();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(registry.TryResolveModule("TestOnlyFrontend", out var module), Is.True);
+            Assert.That(module!.CanonicalId, Does.Contain("TestOnlyAttributedFrontendModule"));
+            Assert.That(registry.TryResolveOptimizer("TestOnlyOptimizer", out var optimizer), Is.True);
+            Assert.That(optimizer!.CanonicalId, Does.Contain("TestOnlyAttributedOptimizer"));
+        });
+    }
+
+    [Test]
+    public void WistDialectRuntimeDescriptorProvider_DeduplicatesDuplicateAssemblies()
+    {
+        var registry = BuildRegistry(
+            new DuplicateTestAssemblyContributor(),
+            new TestOnlyRuntimeAssemblyContributor());
+        var assemblies = WistDialectRuntimeAssemblyCatalog.Build(
+            [new DuplicateTestAssemblyContributor(), new TestOnlyRuntimeAssemblyContributor()]);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(assemblies.Select(static x => x.FullName), Is.EqualTo(new[] { TestRuntimeExtensionAssembly.FullName }));
+            Assert.That(registry.TryResolveModule("TestOnlyFrontend", out _), Is.True);
+            Assert.That(registry.TryResolveOptimizer("TestOnlyOptimizer", out _), Is.True);
+            Assert.That(registry.Modules.Keys.Count(static x => x.Contains("TestOnlyAttributedFrontendModule", StringComparison.Ordinal)), Is.EqualTo(1));
+            Assert.That(registry.Optimizers.Keys.Count(static x => x.Contains("TestOnlyAttributedOptimizer", StringComparison.Ordinal)), Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public void WistDialectRuntimeAssemblyCatalog_OrderDoesNotDependOnContributorRegistrationOrder()
+    {
+        var first = WistDialectRuntimeAssemblyCatalog.Build([new ZuluAssemblyContributor(), new AlphaAssemblyContributor()]);
+        var second = WistDialectRuntimeAssemblyCatalog.Build([new AlphaAssemblyContributor(), new ZuluAssemblyContributor()]);
+
+        Assert.That(
+            first.Select(static x => x.FullName),
+            Is.EqualTo(second.Select(static x => x.FullName)));
+    }
+
+    [Test]
+    public void WistDialectRuntimeDescriptorProvider_RejectsInvalidContributorInputClearly()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                () => new WistDialectRuntimeDescriptorProvider(Array.Empty<IWistDialectBackendServiceProvider>(), null!),
+                Throws.ArgumentNullException.With.Property("ParamName").EqualTo("runtimeAssemblyContributors"));
+            Assert.That(
+                () => new WistDialectRuntimeDescriptorProvider(Array.Empty<IWistDialectBackendServiceProvider>(), new IWistDialectRuntimeAssemblyContributor[] { null! }),
+                Throws.ArgumentException.With.Message.Contains("Contributor collection must not contain null entries."));
+            Assert.That(
+                () => new WistDialectRuntimeDescriptorProvider(Array.Empty<IWistDialectBackendServiceProvider>(), [new NullAssembliesContributor()]),
+                Throws.InvalidOperationException.With.Message.Contains("returned null assemblies"));
+            Assert.That(
+                () => new WistDialectRuntimeDescriptorProvider(Array.Empty<IWistDialectBackendServiceProvider>(), [new NullAssemblyEntryContributor()]),
+                Throws.InvalidOperationException.With.Message.Contains("returned a null assembly"));
+        });
+    }
+
     private static DialectRuntimeDescriptorRegistry BuildRegistry()
     {
         var services = new ServiceCollection();
@@ -53,5 +130,114 @@ public class WistDialectRuntimeDescriptorProviderTests
 
         using var provider = services.BuildServiceProvider();
         return provider.GetRequiredService<DialectRuntimeDescriptorRegistry>();
+    }
+
+    private static DialectRuntimeDescriptorRegistry BuildRegistry(params IWistDialectRuntimeAssemblyContributor[] contributors)
+    {
+        var provider = new WistDialectRuntimeDescriptorProvider(Array.Empty<IWistDialectBackendServiceProvider>(), contributors);
+        var builder = new DialectRuntimeDescriptorRegistryBuilder();
+        provider.Register(builder);
+        return builder.Build();
+    }
+
+    private static Assembly CreateTestRuntimeExtensionAssembly()
+    {
+        var assemblyName = new AssemblyName("UniversalToolchain.Dialects.Tests.RuntimeExtension");
+        var assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.Run);
+        var moduleBuilder = assemblyBuilder.DefineDynamicModule("RuntimeExtensionModule");
+
+        CreateAttributedDerivedType(moduleBuilder, "TestOnlyAttributedFrontendModule", typeof(ArithmeticModuleImpl), typeof(DialectModuleAliasAttribute), "TestOnlyFrontend");
+        CreateAttributedDerivedType(moduleBuilder, "TestOnlyAttributedOptimizer", typeof(LocalVariablesOptimizer), typeof(DialectOptimizerAliasAttribute), "TestOnlyOptimizer");
+        return assemblyBuilder;
+    }
+
+    private static void CreateAttributedDerivedType(
+        ModuleBuilder moduleBuilder,
+        string typeName,
+        Type baseType,
+        Type attributeType,
+        string alias)
+    {
+        var typeBuilder = moduleBuilder.DefineType(typeName, TypeAttributes.Public | TypeAttributes.Class, baseType);
+        var attributeConstructor = attributeType.GetConstructor([typeof(string[])])!;
+        var attribute = new CustomAttributeBuilder(attributeConstructor, new object[] { new[] { alias } });
+        typeBuilder.SetCustomAttribute(attribute);
+        _ = typeBuilder.CreateType();
+    }
+
+    private sealed class TestOnlyRuntimeAssemblyContributor : IWistDialectRuntimeAssemblyContributor
+    {
+        public int Order => 700;
+
+        public IReadOnlyList<Assembly> GetAssemblies()
+        {
+            return
+            [
+                TestRuntimeExtensionAssembly
+            ];
+        }
+    }
+
+    private sealed class DuplicateTestAssemblyContributor : IWistDialectRuntimeAssemblyContributor
+    {
+        public int Order => 700;
+
+        public IReadOnlyList<Assembly> GetAssemblies()
+        {
+            return
+            [
+                TestRuntimeExtensionAssembly,
+                TestRuntimeExtensionAssembly
+            ];
+        }
+    }
+
+    private sealed class AlphaAssemblyContributor : IWistDialectRuntimeAssemblyContributor
+    {
+        public int Order => 900;
+
+        public IReadOnlyList<Assembly> GetAssemblies()
+        {
+            return
+            [
+                typeof(WistDialectRuntimeDescriptorProvider).Assembly
+            ];
+        }
+    }
+
+    private sealed class ZuluAssemblyContributor : IWistDialectRuntimeAssemblyContributor
+    {
+        public int Order => 900;
+
+        public IReadOnlyList<Assembly> GetAssemblies()
+        {
+            return
+            [
+                TestRuntimeExtensionAssembly
+            ];
+        }
+    }
+
+    private sealed class NullAssembliesContributor : IWistDialectRuntimeAssemblyContributor
+    {
+        public int Order => 0;
+
+        public IReadOnlyList<Assembly> GetAssemblies()
+        {
+            return null!;
+        }
+    }
+
+    private sealed class NullAssemblyEntryContributor : IWistDialectRuntimeAssemblyContributor
+    {
+        public int Order => 0;
+
+        public IReadOnlyList<Assembly> GetAssemblies()
+        {
+            return
+            [
+                null!
+            ];
+        }
     }
 }

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistDialectRuntimeAssemblyContributor.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistDialectRuntimeAssemblyContributor.cs
@@ -1,0 +1,175 @@
+using System.Reflection;
+using ArithmeticModule.Module;
+using CommentsModule;
+using ConditionsModule.Enums;
+using CSharpInteropModule.Module;
+using EqualityModule;
+using ExceptionsManager;
+using IdentifierModule;
+using InternalPreprocessorLexemesModule;
+using LabelsModule.Module;
+using LocalVariablesOptimizerModule;
+using LoopsModule.Module;
+using NativeMathModule;
+using NumbersModule.Module;
+using ParametersSetterModule;
+using ScopesModule.Module;
+using SemicolonAsNewLineModule;
+using VariablesModule;
+using WhitespacesModule;
+
+namespace UniversalToolchain.Dialects.Wist;
+
+public interface IWistDialectRuntimeAssemblyContributor
+{
+    int Order { get; }
+
+    IReadOnlyList<Assembly> GetAssemblies();
+}
+
+internal static class WistDialectRuntimeAssemblyCatalog
+{
+    public static IReadOnlyList<Assembly> Build(IEnumerable<IWistDialectRuntimeAssemblyContributor> contributors)
+    {
+        if (contributors == null)
+            Thrower.ArgumentNull(nameof(contributors));
+
+        var assemblies = new List<Assembly>();
+        var seenAssemblyNames = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var contributor in contributors
+                     .Select(static contributor => contributor ?? ThrowContributorCollectionContainsNull())
+                     .OrderBy(static contributor => contributor.Order)
+                     .ThenBy(static contributor => contributor.GetType().FullName, StringComparer.Ordinal))
+        {
+            var contributedAssemblies = contributor.GetAssemblies() ?? ThrowContributorReturnedNullAssemblies(contributor);
+            foreach (var assembly in contributedAssemblies
+                         .Select(static assembly => assembly ?? ThrowContributorReturnedNullAssembly())
+                         .Select(static assembly => CreateAssemblyEntry(assembly))
+                         .OrderBy(static assembly => assembly.FullName, StringComparer.Ordinal))
+            {
+                if (seenAssemblyNames.Add(assembly.FullName))
+                    assemblies.Add(assembly.Assembly);
+            }
+        }
+
+        return assemblies;
+    }
+
+    private static (Assembly Assembly, string FullName) CreateAssemblyEntry(Assembly assembly)
+    {
+        if (string.IsNullOrWhiteSpace(assembly.FullName))
+            return ThrowContributorReturnedAssemblyWithoutFullName();
+
+        return (assembly, assembly.FullName);
+    }
+
+    private static IWistDialectRuntimeAssemblyContributor ThrowContributorCollectionContainsNull()
+    {
+        Thrower.Argument("contributors", "Contributor collection must not contain null entries.");
+        return null!;
+    }
+
+    private static IReadOnlyList<Assembly> ThrowContributorReturnedNullAssemblies(IWistDialectRuntimeAssemblyContributor contributor)
+    {
+        return Thrower.InvalidOpEx<IReadOnlyList<Assembly>>($"Contributor '{contributor.GetType().FullName}' returned null assemblies.");
+    }
+
+    private static Assembly ThrowContributorReturnedNullAssembly()
+    {
+        return Thrower.InvalidOpEx<Assembly>("Contributor returned a null assembly.");
+    }
+
+    private static (Assembly Assembly, string FullName) ThrowContributorReturnedAssemblyWithoutFullName()
+    {
+        return Thrower.InvalidOpEx<(Assembly Assembly, string FullName)>("Contributor returned an assembly without a full name.");
+    }
+}
+
+internal sealed class WistExpressionRuntimeAssemblyContributor : IWistDialectRuntimeAssemblyContributor
+{
+    public int Order => 100;
+
+    public IReadOnlyList<Assembly> GetAssemblies()
+    {
+        return
+        [
+            typeof(ArithmeticModuleImpl).Assembly,
+            typeof(BooleanOperations).Assembly,
+            typeof(EqualityModuleImpl).Assembly,
+            typeof(NativeTypesModuleImpl).Assembly,
+            typeof(NumbersModuleImpl).Assembly
+        ];
+    }
+}
+
+internal sealed class WistSyntaxRuntimeAssemblyContributor : IWistDialectRuntimeAssemblyContributor
+{
+    public int Order => 200;
+
+    public IReadOnlyList<Assembly> GetAssemblies()
+    {
+        return
+        [
+            typeof(CommentsModuleImpl).Assembly,
+            typeof(IdentifierModuleImpl).Assembly,
+            typeof(InternalPreprocessorLexemesModuleImpl).Assembly,
+            typeof(SemicolonAsNewLineModuleImpl).Assembly,
+            typeof(WhitespaceModuleImpl).Assembly
+        ];
+    }
+}
+
+internal sealed class WistStateRuntimeAssemblyContributor : IWistDialectRuntimeAssemblyContributor
+{
+    public int Order => 300;
+
+    public IReadOnlyList<Assembly> GetAssemblies()
+    {
+        return
+        [
+            typeof(ParametersSetterModuleImpl).Assembly,
+            typeof(ScopesModuleImpl).Assembly,
+            typeof(VariablesModuleImpl).Assembly
+        ];
+    }
+}
+
+internal sealed class WistControlFlowRuntimeAssemblyContributor : IWistDialectRuntimeAssemblyContributor
+{
+    public int Order => 400;
+
+    public IReadOnlyList<Assembly> GetAssemblies()
+    {
+        return
+        [
+            typeof(LabelsModuleImpl).Assembly,
+            typeof(LoopsModuleImpl).Assembly
+        ];
+    }
+}
+
+internal sealed class WistInteropRuntimeAssemblyContributor : IWistDialectRuntimeAssemblyContributor
+{
+    public int Order => 500;
+
+    public IReadOnlyList<Assembly> GetAssemblies()
+    {
+        return
+        [
+            typeof(CSharpInteropModuleImpl).Assembly
+        ];
+    }
+}
+
+internal sealed class WistOptimizerRuntimeAssemblyContributor : IWistDialectRuntimeAssemblyContributor
+{
+    public int Order => 600;
+
+    public IReadOnlyList<Assembly> GetAssemblies()
+    {
+        return
+        [
+            typeof(LocalVariablesOptimizer).Assembly
+        ];
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistDialectRuntimeDescriptorProvider.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistDialectRuntimeDescriptorProvider.cs
@@ -1,23 +1,6 @@
 using System.Reflection;
-using ArithmeticModule.Module;
-using CommentsModule;
-using ConditionsModule.Enums;
-using CSharpInteropModule.Module;
-using EqualityModule;
 using ExceptionsManager;
-using IdentifierModule;
-using InternalPreprocessorLexemesModule;
-using LabelsModule.Module;
-using LocalVariablesOptimizerModule;
-using LoopsModule.Module;
-using NativeMathModule;
-using NumbersModule.Module;
-using ParametersSetterModule;
-using ScopesModule.Module;
-using SemicolonAsNewLineModule;
 using UniversalToolchain.Dialects.Integration;
-using VariablesModule;
-using WhitespacesModule;
 
 namespace UniversalToolchain.Dialects.Wist;
 
@@ -26,14 +9,21 @@ namespace UniversalToolchain.Dialects.Wist;
 /// </summary>
 public sealed class WistDialectRuntimeDescriptorProvider : IDialectRuntimeDescriptorProvider
 {
+    private readonly IReadOnlyList<Assembly> _runtimeAssemblies;
     private readonly IReadOnlyList<IWistDialectBackendServiceProvider> _backendProviders;
 
-    public WistDialectRuntimeDescriptorProvider(IEnumerable<IWistDialectBackendServiceProvider> backendProviders)
+    public WistDialectRuntimeDescriptorProvider(
+        IEnumerable<IWistDialectBackendServiceProvider> backendProviders,
+        IEnumerable<IWistDialectRuntimeAssemblyContributor> runtimeAssemblyContributors)
     {
         if (backendProviders == null)
             Thrower.ArgumentNull(nameof(backendProviders));
 
+        if (runtimeAssemblyContributors == null)
+            Thrower.ArgumentNull(nameof(runtimeAssemblyContributors));
+
         _backendProviders = backendProviders.ToList();
+        _runtimeAssemblies = WistDialectRuntimeAssemblyCatalog.Build(runtimeAssemblyContributors).ToList();
     }
 
     public int Order => 0;
@@ -43,10 +33,9 @@ public sealed class WistDialectRuntimeDescriptorProvider : IDialectRuntimeDescri
         if (builder == null)
             Thrower.ArgumentNull(nameof(builder));
 
-        var runtimeAssemblies = GetRuntimeAssemblies();
         builder
-            .RegisterAttributedModulesFromAssemblies(runtimeAssemblies)
-            .RegisterAttributedOptimizersFromAssemblies(runtimeAssemblies)
+            .RegisterAttributedModulesFromAssemblies(_runtimeAssemblies.ToArray())
+            .RegisterAttributedOptimizersFromAssemblies(_runtimeAssemblies.ToArray())
             .RegisterAttributedBackendsFromAssemblies(typeof(WistDialectRuntimeDescriptorProvider).Assembly);
         RegisterIntrinsics(builder);
     }
@@ -55,29 +44,5 @@ public sealed class WistDialectRuntimeDescriptorProvider : IDialectRuntimeDescri
     {
         foreach (var intrinsic in WistDialectIntrinsicRegistry.CreateDescriptors(_backendProviders))
             builder.RegisterIntrinsic(intrinsic);
-    }
-
-    private static Assembly[] GetRuntimeAssemblies()
-    {
-        return
-        [
-            typeof(ArithmeticModuleImpl).Assembly,
-            typeof(BooleanOperations).Assembly,
-            typeof(CommentsModuleImpl).Assembly,
-            typeof(CSharpInteropModuleImpl).Assembly,
-            typeof(EqualityModuleImpl).Assembly,
-            typeof(IdentifierModuleImpl).Assembly,
-            typeof(InternalPreprocessorLexemesModuleImpl).Assembly,
-            typeof(LabelsModuleImpl).Assembly,
-            typeof(LocalVariablesOptimizer).Assembly,
-            typeof(LoopsModuleImpl).Assembly,
-            typeof(NativeTypesModuleImpl).Assembly,
-            typeof(NumbersModuleImpl).Assembly,
-            typeof(ParametersSetterModuleImpl).Assembly,
-            typeof(ScopesModuleImpl).Assembly,
-            typeof(SemicolonAsNewLineModuleImpl).Assembly,
-            typeof(VariablesModuleImpl).Assembly,
-            typeof(WhitespaceModuleImpl).Assembly
-        ];
     }
 }

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistDialectServiceCollectionExtensions.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistDialectServiceCollectionExtensions.cs
@@ -20,6 +20,12 @@ public static class WistDialectServiceCollectionExtensions
         services.AddDialectDslDefaultComposition();
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IWistDialectBackendServiceProvider, WistCilDialectBackendServiceProvider>());
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IWistDialectBackendServiceProvider, WistInterpreterDialectBackendServiceProvider>());
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IWistDialectRuntimeAssemblyContributor, WistExpressionRuntimeAssemblyContributor>());
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IWistDialectRuntimeAssemblyContributor, WistSyntaxRuntimeAssemblyContributor>());
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IWistDialectRuntimeAssemblyContributor, WistStateRuntimeAssemblyContributor>());
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IWistDialectRuntimeAssemblyContributor, WistControlFlowRuntimeAssemblyContributor>());
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IWistDialectRuntimeAssemblyContributor, WistInteropRuntimeAssemblyContributor>());
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IWistDialectRuntimeAssemblyContributor, WistOptimizerRuntimeAssemblyContributor>());
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IDialectRuntimeDescriptorProvider, WistDialectRuntimeDescriptorProvider>());
         services.TryAddSingleton(static provider => DialectRuntimeDescriptorRegistryFactory.BuildFromProviders(provider.GetServices<IDialectRuntimeDescriptorProvider>()));
         services.TryAddSingleton<IDialectCompiledDialectBuildPlanBuilder, DialectCompiledDialectBuildPlanBuilder>();


### PR DESCRIPTION
### Motivation
- Remove the brittle manual runtime assembly whitelist in the Wist dialect provider so adding new runtime modules/optimizers no longer requires editing the central provider.
- Provide a small, explicit, DI-driven extensibility seam that is deterministic, validated, and minimal in scope (no global assembly scans or wholesale discovery changes). 

### Description
- Add a narrow contract `IWistDialectRuntimeAssemblyContributor` and a deterministic aggregator `WistDialectRuntimeAssemblyCatalog.Build(...)` that validates contributors, orders them, sorts and deduplicates assemblies by `Assembly.FullName`, and returns a stable assembly list.
- Replace the hardcoded `GetRuntimeAssemblies()` in `WistDialectRuntimeDescriptorProvider` with constructor-injected `IEnumerable<IWistDialectRuntimeAssemblyContributor>` and use the aggregated `_runtimeAssemblies` for `RegisterAttributedModulesFromAssemblies(...)` and `RegisterAttributedOptimizersFromAssemblies(...)`.
- Provide built-in, small contributors split by logical ownership (`WistExpressionRuntimeAssemblyContributor`, `WistSyntaxRuntimeAssemblyContributor`, `WistStateRuntimeAssemblyContributor`, `WistControlFlowRuntimeAssemblyContributor`, `WistInteropRuntimeAssemblyContributor`, `WistOptimizerRuntimeAssemblyContributor`) and register them explicitly in `AddWistDialectServices`.
- Add focused tests in `WistDialectRuntimeDescriptorProviderTests` that exercise: built-in discovery remains unchanged, test-only contributor extension works without provider edits, duplicate assembly contributions are collapsed deterministically, contributor-order independence, and explicit rejection of null/invalid contributor inputs.

### Testing
- Executed `dotnet test UniversalToolchain.Dialects.Tests/UniversalToolchain.Dialects.Tests.csproj` and the test suite passed locally (all added and existing tests passed).
- Added and ran tests: `AddWistDialectServices_AllowsExtendingRuntimeAssemblyDiscoveryViaContributor` which verifies test-only contributor discovery succeeded, and `WistDialectRuntimeDescriptorProvider_DeduplicatesDuplicateAssemblies`, `WistDialectRuntimeAssemblyCatalog_OrderDoesNotDependOnContributorRegistrationOrder`, and `WistDialectRuntimeDescriptorProvider_RejectsInvalidContributorInputClearly`, all of which passed.
- Kept the change narrowly scoped: no global assembly scanning, no movement of the same monolithic whitelist into a single new helper, and no changes to backend/plugin abstractions beyond the minimal DI registrations required for compilation and runtime behavior preservation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf0f3422a08324a79cc730aef71aeb)