### PR TITLE
Fix Wist example dialects: make full-default practical, add full-default-native, clarify restricted-sandbox, add tests

### DIFF
--- a/UniversalToolchain/Dialects/examples/wist/full-default-native/README.md
+++ b/UniversalToolchain/Dialects/examples/wist/full-default-native/README.md
@@ -1,0 +1,28 @@
+# Full default native-style dialect
+
+## What this example demonstrates
+This example shows a practical default profile that keeps the same language-level surface as `full-default`, but swaps to the native arithmetic/type stack and enables native optimizations.
+
+## Enabled modules/backends/features
+- Modules: `BooleanConditions`, `Comments`, `ComparisonConditions`, `Conditions`, `CSharpInterop`, `Equality`, `Identifier`, `Labels`, `Loops`, `NativeTypes`, `Scopes`, `SemicolonAsNewLine`, `Variables`, `Whitespaces`
+- Backends: `cil`, `interpreter`
+- Enabled optimizer flags: `ArithmeticOptimization`, `EGraphOptimization`, `LocalVariablesOptimization`, `NativeCilOptimization`, `NativeTypesOptimization`
+
+## Intentionally excluded capabilities
+- `Arithmetic` + `Numbers` are excluded to avoid mixing the standard arithmetic stack with `NativeTypes`.
+- No security/capability directives are used in this runnable example.
+
+## Exact CLI commands to run it
+From repository root:
+
+```bash
+dotnet run --project UniversalToolchain/Wistc/Wistc.csproj -- dialect-inspect --file UniversalToolchain/Dialects/examples/wist/full-default-native/dialect.wistdialect
+dotnet run --project UniversalToolchain/Wistc/Wistc.csproj -- run --dialect-file UniversalToolchain/Dialects/examples/wist/full-default-native/dialect.wistdialect --file UniversalToolchain/Dialects/examples/wist/full-default-native/program.wist --mode interpreter
+dotnet run --project UniversalToolchain/Wistc/Wistc.csproj -- run --dialect-file UniversalToolchain/Dialects/examples/wist/full-default-native/dialect.wistdialect --file UniversalToolchain/Dialects/examples/wist/full-default-native/program.wist --mode compiler
+```
+
+## Expected behavior/result
+`program.wist` computes the sum from 1 to 5 and returns `15`.
+
+## Why this example exists
+It provides a dedicated native arithmetic baseline for dialect composition checks without conflating it with the standard arithmetic stack.

--- a/UniversalToolchain/Dialects/examples/wist/full-default-native/dialect.wistdialect
+++ b/UniversalToolchain/Dialects/examples/wist/full-default-native/dialect.wistdialect
@@ -1,0 +1,8 @@
+dialect FullDefaultNative
+use BooleanConditions,Comments,ComparisonConditions,Conditions,CSharpInterop,Equality,Identifier,Labels,Loops,NativeTypes,Scopes,SemicolonAsNewLine,Variables,Whitespaces
+backend cil,interpreter
+enable ArithmeticOptimization
+enable EGraphOptimization
+enable LocalVariablesOptimization
+enable NativeCilOptimization
+enable NativeTypesOptimization

--- a/UniversalToolchain/Dialects/examples/wist/full-default-native/program.wist
+++ b/UniversalToolchain/Dialects/examples/wist/full-default-native/program.wist
@@ -1,0 +1,7 @@
+let sum = 0
+
+for (let i = 1) (i <= 5) (i = i + 1) (
+    sum = sum + i
+)
+
+sum

--- a/UniversalToolchain/Dialects/examples/wist/full-default/README.md
+++ b/UniversalToolchain/Dialects/examples/wist/full-default/README.md
@@ -4,12 +4,12 @@
 This example shows a practical default runtime profile expressed via dialect DSL, close to the default Wist feature set used in regular execution.
 
 ## Enabled modules/backends/features
-- Modules: `Arithmetic`, `BooleanConditions`, `ComparisonConditions`, `Conditions`, `Equality`, `Identifier`, `Labels`, `Loops`, `Numbers`, `Scopes`, `SemicolonAsNewLine`, `Variables`, `Whitespaces`
+- Modules: `Arithmetic`, `BooleanConditions`, `Comments`, `ComparisonConditions`, `Conditions`, `CSharpInterop`, `Equality`, `Identifier`, `Labels`, `Loops`, `Numbers`, `Scopes`, `SemicolonAsNewLine`, `Variables`, `Whitespaces`
 - Backends: `cil`, `interpreter`
 - Enabled feature flag: `LocalVariablesOptimization`
 
 ## Intentionally excluded capabilities
-- No explicit C# interop module declaration in this dialect file.
+- Native arithmetic/type stack (`NativeTypes`) and native optimizer set are intentionally not part of this default profile.
 - No security/capability enforcement directives beyond composition choices.
 
 ## Exact CLI commands to run it

--- a/UniversalToolchain/Dialects/examples/wist/full-default/dialect.wistdialect
+++ b/UniversalToolchain/Dialects/examples/wist/full-default/dialect.wistdialect
@@ -1,4 +1,4 @@
 dialect FullDefault
-use Arithmetic,BooleanConditions,ComparisonConditions,Conditions,Equality,Identifier,Labels,Loops,Numbers,Scopes,SemicolonAsNewLine,Variables,Whitespaces
+use Arithmetic,BooleanConditions,Comments,ComparisonConditions,Conditions,CSharpInterop,Equality,Identifier,Labels,Loops,Numbers,Scopes,SemicolonAsNewLine,Variables,Whitespaces
 backend cil,interpreter
 enable LocalVariablesOptimization

--- a/UniversalToolchain/Dialects/examples/wist/restricted-sandbox/README.md
+++ b/UniversalToolchain/Dialects/examples/wist/restricted-sandbox/README.md
@@ -9,7 +9,7 @@ This example demonstrates constrained composition aimed at a narrower runtime pr
 
 ## Intentionally excluded capabilities
 - No compiler backend.
-- No variables/identifiers, loops, labels, conditions, or interop-related capabilities.
+- Explicitly excludes `Variables`, `Identifier`, `Loops`, condition modules, comments, semicolon newline behavior, C# interop, and native arithmetic modules.
 - No claim of complete hardened sandboxing.
 
 ## Exact CLI commands to run it

--- a/UniversalToolchain/Dialects/examples/wist/restricted-sandbox/README.md
+++ b/UniversalToolchain/Dialects/examples/wist/restricted-sandbox/README.md
@@ -9,7 +9,7 @@ This example demonstrates constrained composition aimed at a narrower runtime pr
 
 ## Intentionally excluded capabilities
 - No compiler backend.
-- Explicitly excludes `Variables`, `Identifier`, `Loops`, condition modules, comments, semicolon newline behavior, C# interop, and native arithmetic modules.
+- Explicitly excludes `Variables`, `Identifier`, `Loops`, condition modules, comments, internal preprocessor lexemes, semicolon newline behavior, C# interop, and native arithmetic modules.
 - No claim of complete hardened sandboxing.
 
 ## Exact CLI commands to run it

--- a/UniversalToolchain/Dialects/examples/wist/restricted-sandbox/dialect.wistdialect
+++ b/UniversalToolchain/Dialects/examples/wist/restricted-sandbox/dialect.wistdialect
@@ -1,3 +1,4 @@
 dialect RestrictedSandbox
 use Arithmetic,Numbers,Scopes,Whitespaces
+exclude BooleanConditions,Comments,ComparisonConditions,Conditions,CSharpInterop,Equality,Identifier,Labels,Loops,NativeTypes,ParametersSetter,SemicolonAsNewLine,Variables
 backend interpreter

--- a/UniversalToolchain/Dialects/examples/wist/restricted-sandbox/dialect.wistdialect
+++ b/UniversalToolchain/Dialects/examples/wist/restricted-sandbox/dialect.wistdialect
@@ -1,4 +1,4 @@
 dialect RestrictedSandbox
 use Arithmetic,Numbers,Scopes,Whitespaces
-exclude BooleanConditions,Comments,ComparisonConditions,Conditions,CSharpInterop,Equality,Identifier,Labels,Loops,NativeTypes,ParametersSetter,SemicolonAsNewLine,Variables
+exclude BooleanConditions,Comments,ComparisonConditions,Conditions,CSharpInterop,Equality,Identifier,InternalPreprocessorLexemes,Labels,Loops,NativeTypes,ParametersSetter,SemicolonAsNewLine,Variables
 backend interpreter

--- a/UniversalToolchain/Example/Example.csproj
+++ b/UniversalToolchain/Example/Example.csproj
@@ -82,6 +82,15 @@
         <Content Include="..\Dialects\examples\wist\full-default\README.md">
             <Link>Dialects\examples\wist\full-default\README.md</Link>
         </Content>
+        <Content Include="..\Dialects\examples\wist\full-default-native\dialect.wistdialect">
+            <Link>Dialects\examples\wist\full-default-native\dialect.wistdialect</Link>
+        </Content>
+        <Content Include="..\Dialects\examples\wist\full-default-native\program.wist">
+            <Link>Dialects\examples\wist\full-default-native\program.wist</Link>
+        </Content>
+        <Content Include="..\Dialects\examples\wist\full-default-native\README.md">
+            <Link>Dialects\examples\wist\full-default-native\README.md</Link>
+        </Content>
         <Content Include="..\Dialects\examples\wist\minimal-arithmetic\dialect.wistdialect">
             <Link>Dialects\examples\wist\minimal-arithmetic\dialect.wistdialect</Link>
         </Content>

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/DialectProjectsSmokeTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/DialectProjectsSmokeTests.cs
@@ -16,6 +16,7 @@ public class DialectProjectsSmokeTests
         Assert.That(exampleDirectories.Select(Path.GetFileName), Is.EquivalentTo(new[]
         {
             "full-default",
+            "full-default-native",
             "minimal-arithmetic",
             "restricted-sandbox"
         }));

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/WistDialectExecutionIntegrationTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/WistDialectExecutionIntegrationTests.cs
@@ -46,6 +46,28 @@ public class WistDialectExecutionIntegrationTests
         });
     }
 
+
+    [Test]
+    public void FullNativeDialect_RichProgram_RunsWithBothRealBackends()
+    {
+        using var provider = CreateProvider();
+        var workflow = provider.GetRequiredService<WistDialectExecutionWorkflow>();
+        var example = ResolveExampleDirectory("full-default-native");
+        var code = File.ReadAllText(Path.Combine(example, "program.wist"));
+
+        var result = workflow.ComposeFile(Path.Combine(example, "dialect.wistdialect"));
+        using var host = workflow.CreateHost(result);
+        var interpreterValue = host.Run(code, "interpreter");
+        var compilerValue = host.Run(code, "compiler");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(ToDouble(interpreterValue), Is.EqualTo(15d).Within(1e-9));
+            Assert.That(ToDouble(compilerValue), Is.EqualTo(15d).Within(1e-9));
+        });
+    }
+
     [Test]
     public void RestrictedDialect_DisabledCompilerBackend_IsRejected()
     {

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/WistDialectExecutionIntegrationTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/WistDialectExecutionIntegrationTests.cs
@@ -68,6 +68,57 @@ public class WistDialectExecutionIntegrationTests
         });
     }
 
+
+    [Test]
+    public void FullDialect_CommentsProgram_RunsWithBothRealBackends()
+    {
+        using var provider = CreateProvider();
+        var workflow = provider.GetRequiredService<WistDialectExecutionWorkflow>();
+        var example = ResolveExampleDirectory("full-default");
+
+        var result = workflow.ComposeFile(Path.Combine(example, "dialect.wistdialect"));
+        using var host = workflow.CreateHost(result);
+        var code = """
+            // single line comment
+            let x = 2
+            /* block
+               comment */
+            x + 5
+            """;
+
+        var interpreterValue = host.Run(code, "interpreter");
+        var compilerValue = host.Run(code, "compiler");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(ToDouble(interpreterValue), Is.EqualTo(7d).Within(1e-9));
+            Assert.That(ToDouble(compilerValue), Is.EqualTo(7d).Within(1e-9));
+        });
+    }
+
+    [Test]
+    public void FullDialect_CSharpInteropProgram_RunsWithBothRealBackends()
+    {
+        using var provider = CreateProvider();
+        var workflow = provider.GetRequiredService<WistDialectExecutionWorkflow>();
+        var example = ResolveExampleDirectory("full-default");
+
+        var result = workflow.ComposeFile(Path.Combine(example, "dialect.wistdialect"));
+        using var host = workflow.CreateHost(result);
+        const string code = "NumbersModule.Core.RealNumberImpl.Add(2, 5)";
+
+        var interpreterValue = host.Run(code, "interpreter");
+        var compilerValue = host.Run(code, "compiler");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(ToDouble(interpreterValue), Is.EqualTo(7d).Within(1e-9));
+            Assert.That(ToDouble(compilerValue), Is.EqualTo(7d).Within(1e-9));
+        });
+    }
+
     [Test]
     public void RestrictedDialect_DisabledCompilerBackend_IsRejected()
     {


### PR DESCRIPTION
### Motivation
- Make the Wist "full-default" example a practical default profile by including obvious language features such as comments and C# interop.  
- Provide a separate, explicit native profile that uses the native arithmetic/type stack and enables native optimizations without mixing the standard arithmetic stack.  
- Remove ambiguity and accidental duplication by rewriting the restricted sandbox example to explicitly exclude wide-surface modules and by adding test coverage for the native example.

### Description
- Updated `UniversalToolchain/Dialects/examples/wist/full-default/dialect.wistdialect` to include `Comments` and `CSharpInterop` while keeping `Arithmetic`+`Numbers`, `backend cil,interpreter`, and `enable LocalVariablesOptimization`.  
- Added a new native example under `UniversalToolchain/Dialects/examples/wist/full-default-native/` with `dialect FullDefaultNative` that uses `NativeTypes` (and excludes `Arithmetic`/`Numbers`), enables `ArithmeticOptimization`, `EGraphOptimization`, `LocalVariablesOptimization`, `NativeCilOptimization`, and `NativeTypesOptimization`, and includes a `program.wist` and `README.md`.  
- Rewrote `UniversalToolchain/Dialects/examples/wist/restricted-sandbox/dialect.wistdialect` to explicitly `exclude` high-surface modules (CSharpInterop, Comments, condition modules, NativeTypes, ParametersSetter, SemicolonAsNewLine, Variables, etc.) so it is a clearly constrained profile.  
- Wired new example into project and tests: added the `full-default-native` files to `UniversalToolchain/Example/Example.csproj`, updated the smoke test expected example list in `UniversalToolchain/UniversalToolchain.Dialects.Tests/DialectProjectsSmokeTests.cs`, and added an integration test `FullNativeDialect_RichProgram_RunsWithBothRealBackends` to `UniversalToolchain/UniversalToolchain.Dialects.Tests/WistDialectExecutionIntegrationTests.cs` that composes and runs the native example on both `interpreter` and `compiler` backends.

### Testing
- Installed .NET SDK 10 locally and ran `dotnet run --project UniversalToolchain/Wistc/Wistc.csproj -- dialect-inspect --file UniversalToolchain/Dialects/examples/wist/full-default/dialect.wistdialect` which composed successfully.  
- Ran `dotnet run --project UniversalToolchain/Wistc/Wistc.csproj -- dialect-inspect --file UniversalToolchain/Dialects/examples/wist/full-default-native/dialect.wistdialect` and `.../restricted-sandbox/dialect.wistdialect` which both composed successfully after fixing an initial `enable` syntax (split into one `enable` per optimizer).  
- Executed `dotnet test UniversalToolchain/UniversalToolchain.Dialects.Tests/UniversalToolchain.Dialects.Tests.csproj --filter "FullyQualifiedName~WistDialectExecutionIntegrationTests|FullyQualifiedName~DialectProjectsSmokeTests"` and the filtered integration/smoke tests passed (Passed: 6, Failed: 0).

Notes: all module and optimizer aliases used in the new/modified configs are verified to be actually registered in the codebase (examples: `CSharpInterop`, `Comments`, `Arithmetic`, `Numbers`, `NativeTypes`, `LocalVariablesOptimization`, `NativeTypesOptimization`, `ArithmeticOptimization`, `EGraphOptimization`, `NativeCilOptimization`) via the runtime descriptor providers and attribute registrations, and the new dialect files pass the repository's dialect parser/inspector.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c426b4f55883248b177cdf69b75856)