### PR TITLE
Add deterministic selected-runtime pipeline for Wist dialect composition

### DIFF
--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/WistDialectRuntimeSelectionPipelineTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/WistDialectRuntimeSelectionPipelineTests.cs
@@ -1,0 +1,99 @@
+using Microsoft.Extensions.DependencyInjection;
+using UniversalToolchain.Dialects.Core;
+using UniversalToolchain.Dialects.Frontend;
+using UniversalToolchain.Dialects.Wist;
+
+namespace UniversalToolchain.Dialects.Tests;
+
+public class WistDialectRuntimeSelectionPipelineTests
+{
+    [Test]
+    public void SelectionResolver_SameDialect_RepeatedRuns_ProduceSameSelectionOrder()
+    {
+        using var provider = CreateProvider();
+        var compiler = provider.GetRequiredService<DialectDslCompiler>();
+        var buildPlanBuilder = provider.GetRequiredService<IDialectCompiledDialectBuildPlanBuilder>();
+        var resolver = provider.GetRequiredService<DialectRuntimeSelectionResolver>();
+
+        var sourceText = File.ReadAllText(Path.Combine(ResolveExampleDirectory("full-default"), "dialect.wistdialect"));
+        var expectedSignature = string.Empty;
+
+        for (var i = 0; i < 50; i++)
+        {
+            var buildPlan = buildPlanBuilder.Build(compiler.Compile(sourceText));
+            var selection = resolver.Resolve(buildPlan);
+            var signature = string.Join("|", selection.OrderedModules.Select(x => x.CanonicalAlias)) + ";" +
+                            string.Join("|", selection.EnabledOptimizers.Select(x => x.CanonicalAlias)) + ";" +
+                            string.Join("|", selection.EnabledBackends.Select(x => x.CanonicalId.Value));
+
+            if (i == 0)
+                expectedSignature = signature;
+            else
+                Assert.That(signature, Is.EqualTo(expectedSignature));
+        }
+    }
+
+    [Test]
+    public void SelectionResolver_MissingAlias_AddsDiagnostic()
+    {
+        var catalog = new DialectRuntimeCatalogBuilder().Build();
+        var resolver = new DialectRuntimeSelectionResolver(catalog);
+
+        var plan = new UniversalToolchain.Dialects.Abstractions.DialectBuildPlan(
+            "test",
+            null,
+            ["UnknownModule"],
+            [WistDialectBackendIds.Interpreter],
+            [],
+            [],
+            [],
+            null,
+            [],
+            new UniversalToolchain.Dialects.Abstractions.DialectValidationResult([]));
+
+        var selection = resolver.Resolve(plan);
+
+        Assert.That(selection.Diagnostics.Any(x => x.Code == "R001"), Is.True);
+    }
+
+    [Test]
+    public void DialectRuntimeProviderFactory_RepeatedCreates_DoNotAccumulateServices()
+    {
+        using var provider = CreateProvider();
+        var workflow = provider.GetRequiredService<WistDialectExecutionWorkflow>();
+
+        var composition = workflow.ComposeFile(Path.Combine(ResolveExampleDirectory("minimal-arithmetic"), "dialect.wistdialect"));
+        Assert.That(composition.IsSuccess, Is.True);
+
+        var resolver = provider.GetRequiredService<DialectRuntimeSelectionResolver>();
+        var factory = provider.GetRequiredService<DialectRuntimeProviderFactory>();
+        var selection = resolver.Resolve(composition.BuildPlan!);
+
+        var baselines = (frontend: 0, ir: 0, backends: 0);
+        for (var i = 0; i < 20; i++)
+        {
+            var scopedProvider = factory.CreateProvider(selection, composition.BuildPlan!);
+            using var disposableProvider = (IDisposable)scopedProvider;
+            var frontendCount = scopedProvider.GetServices<BasicCore.Contracts.IFrontendCoreModule>().Count();
+            var irCount = scopedProvider.GetServices<BasicCore.Contracts.IIRProcessingModule>().Count();
+            var backendCount = scopedProvider.GetServices<WistDialectBackendRuntime>().Count();
+
+            if (i == 0)
+                baselines = (frontendCount, irCount, backendCount);
+            else
+                Assert.That((frontendCount, irCount, backendCount), Is.EqualTo(baselines));
+        }
+    }
+
+    private static ServiceProvider CreateProvider()
+    {
+        var services = new ServiceCollection();
+        services.AddWistDialectServices();
+        return services.BuildServiceProvider();
+    }
+
+    private static string ResolveExampleDirectory(string name)
+    {
+        return Path.GetFullPath(Path.Combine(TestContext.CurrentContext.TestDirectory, "..", "..", "..", "..", "Dialects", "examples", "wist", name));
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/DialectResolvedRuntimeSelection.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/DialectResolvedRuntimeSelection.cs
@@ -1,0 +1,12 @@
+using UniversalToolchain.Dialects.Abstractions;
+
+namespace UniversalToolchain.Dialects.Wist;
+
+public sealed record DialectResolvedRuntimeSelection(
+    IReadOnlyList<DialectRuntimeModuleDescriptor> OrderedModules,
+    IReadOnlyList<DialectRuntimeOptimizerDescriptor> EnabledOptimizers,
+    IReadOnlyList<DialectRuntimeBackendDescriptor> EnabledBackends,
+    IReadOnlyList<DialectDiagnostic> Diagnostics)
+{
+    public bool IsResolved => Diagnostics.All(x => x.Severity != DialectDiagnosticSeverity.Error);
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/DialectRuntimeBackendDescriptor.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/DialectRuntimeBackendDescriptor.cs
@@ -1,0 +1,25 @@
+using ExceptionsManager;
+using UniversalToolchain.Dialects.Abstractions;
+
+namespace UniversalToolchain.Dialects.Wist;
+
+public sealed record DialectRuntimeBackendDescriptor(
+    DialectBackendId CanonicalId,
+    IReadOnlyList<string> Aliases,
+    Type ImplementationType,
+    string? AssemblyName = null)
+{
+    public IReadOnlyList<string> AllAliases => [CanonicalId.Value, .. Aliases];
+
+    public static DialectRuntimeBackendDescriptor Create(DialectBackendId canonicalId, IReadOnlyList<string> aliases, Type implementationType, string? assemblyName = null)
+    {
+        if (string.IsNullOrWhiteSpace(canonicalId.Value))
+            Thrower.Argument(nameof(canonicalId), "Backend canonical identifier must not be empty.");
+
+        if (implementationType == null)
+            Thrower.ArgumentNull(nameof(implementationType));
+
+        var values = (aliases ?? []).Where(x => !string.IsNullOrWhiteSpace(x)).Distinct(StringComparer.Ordinal).Where(x => x != canonicalId.Value).OrderBy(x => x, StringComparer.Ordinal).ToList();
+        return new DialectRuntimeBackendDescriptor(canonicalId, values, implementationType, assemblyName);
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/DialectRuntimeCatalog.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/DialectRuntimeCatalog.cs
@@ -1,0 +1,57 @@
+using ExceptionsManager;
+using UniversalToolchain.Dialects.Abstractions;
+
+namespace UniversalToolchain.Dialects.Wist;
+
+public sealed class DialectRuntimeCatalog : IDialectRuntimeCatalog
+{
+    private readonly IReadOnlyDictionary<string, DialectRuntimeBackendDescriptor> _backendMap;
+    private readonly IReadOnlyDictionary<string, DialectRuntimeModuleDescriptor> _moduleMap;
+    private readonly IReadOnlyDictionary<string, DialectRuntimeOptimizerDescriptor> _optimizerMap;
+
+    public DialectRuntimeCatalog(
+        IReadOnlyDictionary<string, DialectRuntimeModuleDescriptor> moduleMap,
+        IReadOnlyDictionary<string, DialectRuntimeOptimizerDescriptor> optimizerMap,
+        IReadOnlyDictionary<string, DialectRuntimeBackendDescriptor> backendMap,
+        IReadOnlyCollection<DialectRuntimeModuleDescriptor> modules,
+        IReadOnlyCollection<DialectRuntimeOptimizerDescriptor> optimizers,
+        IReadOnlyCollection<DialectRuntimeBackendDescriptor> backends)
+    {
+        if (moduleMap == null)
+            Thrower.ArgumentNull(nameof(moduleMap));
+
+        _moduleMap = moduleMap;
+        if (optimizerMap == null)
+            Thrower.ArgumentNull(nameof(optimizerMap));
+
+        _optimizerMap = optimizerMap;
+        if (backendMap == null)
+            Thrower.ArgumentNull(nameof(backendMap));
+
+        _backendMap = backendMap;
+        if (modules == null)
+            Thrower.ArgumentNull(nameof(modules));
+
+        Modules = modules;
+        if (optimizers == null)
+            Thrower.ArgumentNull(nameof(optimizers));
+
+        Optimizers = optimizers;
+        if (backends == null)
+            Thrower.ArgumentNull(nameof(backends));
+
+        Backends = backends;
+    }
+
+    public IReadOnlyCollection<DialectRuntimeModuleDescriptor> Modules { get; }
+
+    public IReadOnlyCollection<DialectRuntimeOptimizerDescriptor> Optimizers { get; }
+
+    public IReadOnlyCollection<DialectRuntimeBackendDescriptor> Backends { get; }
+
+    public bool TryResolveModule(string alias, out DialectRuntimeModuleDescriptor? descriptor) => _moduleMap.TryGetValue(alias, out descriptor);
+
+    public bool TryResolveOptimizer(string alias, out DialectRuntimeOptimizerDescriptor? descriptor) => _optimizerMap.TryGetValue(alias, out descriptor);
+
+    public bool TryResolveBackend(DialectBackendId id, out DialectRuntimeBackendDescriptor? descriptor) => _backendMap.TryGetValue(id.Value, out descriptor);
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/DialectRuntimeCatalogBuilder.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/DialectRuntimeCatalogBuilder.cs
@@ -1,0 +1,59 @@
+using ExceptionsManager;
+
+namespace UniversalToolchain.Dialects.Wist;
+
+public sealed class DialectRuntimeCatalogBuilder
+{
+    private readonly List<DialectRuntimeBackendDescriptor> _backends = [];
+    private readonly List<DialectRuntimeModuleDescriptor> _modules = [];
+    private readonly List<DialectRuntimeOptimizerDescriptor> _optimizers = [];
+
+    public DialectRuntimeCatalogBuilder RegisterModule(DialectRuntimeModuleDescriptor descriptor)
+    {
+        if (descriptor == null)
+            Thrower.ArgumentNull(nameof(descriptor));
+
+        _modules.Add(descriptor);
+        return this;
+    }
+
+    public DialectRuntimeCatalogBuilder RegisterOptimizer(DialectRuntimeOptimizerDescriptor descriptor)
+    {
+        if (descriptor == null)
+            Thrower.ArgumentNull(nameof(descriptor));
+
+        _optimizers.Add(descriptor);
+        return this;
+    }
+
+    public DialectRuntimeCatalogBuilder RegisterBackend(DialectRuntimeBackendDescriptor descriptor)
+    {
+        if (descriptor == null)
+            Thrower.ArgumentNull(nameof(descriptor));
+
+        _backends.Add(descriptor);
+        return this;
+    }
+
+    public DialectRuntimeCatalog Build()
+    {
+        var moduleMap = BuildMap(_modules.SelectMany(x => x.AllAliases.Select(a => (Alias: a, Descriptor: x))));
+        var optimizerMap = BuildMap(_optimizers.SelectMany(x => x.AllAliases.Select(a => (Alias: a, Descriptor: x))));
+        var backendMap = BuildMap(_backends.SelectMany(x => x.AllAliases.Select(a => (Alias: a, Descriptor: x))));
+        return new DialectRuntimeCatalog(moduleMap, optimizerMap, backendMap, _modules.AsReadOnly(), _optimizers.AsReadOnly(), _backends.AsReadOnly());
+    }
+
+    private static IReadOnlyDictionary<string, TDescriptor> BuildMap<TDescriptor>(IEnumerable<(string Alias, TDescriptor Descriptor)> pairs)
+    {
+        var map = new Dictionary<string, TDescriptor>(StringComparer.Ordinal);
+        foreach (var (alias, descriptor) in pairs.OrderBy(x => x.Alias, StringComparer.Ordinal))
+        {
+            if (map.ContainsKey(alias))
+                Thrower.Argument(nameof(pairs), $"Alias '{alias}' is duplicated in runtime catalog.");
+
+            map.Add(alias, descriptor);
+        }
+
+        return map;
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/DialectRuntimeModuleDescriptor.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/DialectRuntimeModuleDescriptor.cs
@@ -1,0 +1,37 @@
+using BasicCore.Contracts;
+using ExceptionsManager;
+
+namespace UniversalToolchain.Dialects.Wist;
+
+public sealed record DialectRuntimeModuleDescriptor(
+    string CanonicalAlias,
+    IReadOnlyList<string> Aliases,
+    Type ImplementationType,
+    string? AssemblyName = null)
+{
+    public IReadOnlyList<string> AllAliases => [CanonicalAlias, .. Aliases];
+
+    public bool IsFrontendModule => typeof(IFrontendCoreModule).IsAssignableFrom(ImplementationType);
+
+    public bool IsIrProcessingModule => typeof(IIRProcessingModule).IsAssignableFrom(ImplementationType);
+
+    public static DialectRuntimeModuleDescriptor Create(string canonicalAlias, IReadOnlyList<string> aliases, Type implementationType, string? assemblyName = null)
+    {
+        if (string.IsNullOrWhiteSpace(canonicalAlias))
+            Thrower.Argument(nameof(canonicalAlias), "Module canonical alias must not be empty.");
+
+        if (implementationType == null)
+            Thrower.ArgumentNull(nameof(implementationType));
+
+        if (!typeof(IFrontendCoreModule).IsAssignableFrom(implementationType) && !typeof(IIRProcessingModule).IsAssignableFrom(implementationType))
+            Thrower.Argument(nameof(implementationType), "Module implementation type must implement IFrontendCoreModule or IIRProcessingModule.");
+
+        return new DialectRuntimeModuleDescriptor(canonicalAlias, NormalizeAliases(aliases, canonicalAlias), implementationType, assemblyName);
+    }
+
+    private static IReadOnlyList<string> NormalizeAliases(IReadOnlyList<string> aliases, string canonicalAlias)
+    {
+        var values = (aliases ?? []).Where(x => !string.IsNullOrWhiteSpace(x)).Distinct(StringComparer.Ordinal).Where(x => x != canonicalAlias).OrderBy(x => x, StringComparer.Ordinal).ToList();
+        return values;
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/DialectRuntimeOptimizerDescriptor.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/DialectRuntimeOptimizerDescriptor.cs
@@ -1,0 +1,28 @@
+using BasicCore.Contracts;
+using ExceptionsManager;
+
+namespace UniversalToolchain.Dialects.Wist;
+
+public sealed record DialectRuntimeOptimizerDescriptor(
+    string CanonicalAlias,
+    IReadOnlyList<string> Aliases,
+    Type ImplementationType,
+    string? AssemblyName = null)
+{
+    public IReadOnlyList<string> AllAliases => [CanonicalAlias, .. Aliases];
+
+    public static DialectRuntimeOptimizerDescriptor Create(string canonicalAlias, IReadOnlyList<string> aliases, Type implementationType, string? assemblyName = null)
+    {
+        if (string.IsNullOrWhiteSpace(canonicalAlias))
+            Thrower.Argument(nameof(canonicalAlias), "Optimizer canonical alias must not be empty.");
+
+        if (implementationType == null)
+            Thrower.ArgumentNull(nameof(implementationType));
+
+        if (!typeof(IIRProcessingModule).IsAssignableFrom(implementationType))
+            Thrower.Argument(nameof(implementationType), "Optimizer implementation type must implement IIRProcessingModule.");
+
+        var values = (aliases ?? []).Where(x => !string.IsNullOrWhiteSpace(x)).Distinct(StringComparer.Ordinal).Where(x => x != canonicalAlias).OrderBy(x => x, StringComparer.Ordinal).ToList();
+        return new DialectRuntimeOptimizerDescriptor(canonicalAlias, values, implementationType, assemblyName);
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/DialectRuntimeProviderFactory.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/DialectRuntimeProviderFactory.cs
@@ -1,0 +1,78 @@
+using BasicCore.Contracts;
+using ExceptionsManager;
+using Microsoft.Extensions.DependencyInjection;
+using UniversalToolchain.Dialects.Abstractions;
+using UniversalToolchain.Dialects.Integration;
+
+namespace UniversalToolchain.Dialects.Wist;
+
+public sealed class DialectRuntimeProviderFactory
+{
+    private readonly IReadOnlyDictionary<DialectBackendId, IWistDialectBackendServiceProvider> _backendProviders;
+
+    public DialectRuntimeProviderFactory(IEnumerable<IWistDialectBackendServiceProvider> backendProviders)
+    {
+        if (backendProviders == null)
+            Thrower.ArgumentNull(nameof(backendProviders));
+
+        _backendProviders = backendProviders.ToDictionary(x => x.BackendId, x => x);
+    }
+
+    public IServiceProvider CreateProvider(DialectResolvedRuntimeSelection selection, DialectBuildPlan buildPlan)
+    {
+        var services = new ServiceCollection();
+        services.AddSelectedWistRuntimeServices(selection, _backendProviders.Values, buildPlan);
+        return services.BuildServiceProvider(validateScopes: true);
+    }
+
+    public WistDialectExecutionConfiguration CreateConfiguration(DialectResolvedRuntimeSelection selection, DialectBuildPlan buildPlan)
+    {
+        var backendConfigurations = selection.EnabledBackends.Select(backend =>
+        {
+            var allowedIntrinsics = BuildAllowedIntrinsics(buildPlan, backend.CanonicalId);
+            var forbiddenIntrinsics = buildPlan.IntrinsicDirectives
+                .Where(x => !x.Allowed && x.Target.Matches(backend.CanonicalId))
+                .Select(x => x.Name)
+                .Distinct(StringComparer.Ordinal)
+                .OrderBy(x => x, StringComparer.Ordinal)
+                .ToList();
+            var hasExplicitAllowList = buildPlan.IntrinsicDirectives.Any(x => x.Allowed && x.Target.Matches(backend.CanonicalId));
+            var runtimeDescriptor = new RuntimeBackendDescriptor(backend.CanonicalId, backend.ImplementationType, backend.Aliases);
+            return new WistDialectBackendConfiguration(runtimeDescriptor, allowedIntrinsics, forbiddenIntrinsics, hasExplicitAllowList);
+        }).ToList();
+
+        var knownBackends = new List<RuntimeBackendDescriptor>
+        {
+            new(WistDialectBackendIds.Cil, typeof(WistCilBackendDeclaration), ["compiler", "cil"]),
+            new(WistDialectBackendIds.Interpreter, typeof(WistInterpreterBackendDeclaration), ["interpreter"])
+        };
+
+        return new WistDialectExecutionConfiguration(
+            buildPlan.Name,
+            selection.OrderedModules.Where(x => x.IsFrontendModule).Select(x => x.ImplementationType),
+            selection.OrderedModules.Where(x => x.IsIrProcessingModule).Select(x => x.ImplementationType),
+            selection.EnabledOptimizers.Select(x => x.ImplementationType),
+            backendConfigurations,
+            knownBackends);
+    }
+
+    private List<string> BuildAllowedIntrinsics(DialectBuildPlan buildPlan, DialectBackendId backendId)
+    {
+        if (!_backendProviders.TryGetValue(backendId, out var backendProvider))
+            Thrower.InvalidOpEx<List<string>>($"No backend provider was registered for '{backendId.Value}'.");
+
+        var hasAnyAllowRule = buildPlan.IntrinsicDirectives.Any(x => x.Allowed && x.Target.Matches(backendId));
+        if (!hasAnyAllowRule)
+            return backendProvider.SupportedIntrinsics.ToList();
+
+        var allowed = buildPlan.IntrinsicDirectives
+            .Where(x => x.Allowed && x.Target.Matches(backendId))
+            .Select(x => x.Name)
+            .Distinct(StringComparer.Ordinal)
+            .Where(x => backendProvider.SupportedIntrinsics.Contains(x, StringComparer.Ordinal))
+            .OrderBy(x => x, StringComparer.Ordinal)
+            .ToList();
+
+        return allowed;
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/DialectRuntimeSelectionResolver.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/DialectRuntimeSelectionResolver.cs
@@ -1,0 +1,58 @@
+using UniversalToolchain.Dialects.Abstractions;
+
+namespace UniversalToolchain.Dialects.Wist;
+
+public sealed class DialectRuntimeSelectionResolver
+{
+    private readonly IDialectRuntimeCatalog _catalog;
+
+    public DialectRuntimeSelectionResolver(IDialectRuntimeCatalog catalog)
+    {
+        _catalog = catalog;
+    }
+
+    public DialectResolvedRuntimeSelection Resolve(DialectBuildPlan plan)
+    {
+        var diagnostics = new List<DialectDiagnostic>(plan.ValidationResult.Diagnostics);
+
+        var orderedModules = new List<DialectRuntimeModuleDescriptor>();
+        foreach (var moduleAlias in plan.OrderedModules)
+        {
+            if (!_catalog.TryResolveModule(moduleAlias, out var descriptor) || descriptor == null)
+            {
+                diagnostics.Add(new DialectDiagnostic("R001", $"Runtime module descriptor '{moduleAlias}' was not registered.", DialectDiagnosticSeverity.Error));
+                continue;
+            }
+
+            orderedModules.Add(descriptor);
+        }
+
+        var enabledBackends = new List<DialectRuntimeBackendDescriptor>();
+        foreach (var backend in plan.EnabledBackends.OrderBy(x => x))
+        {
+            if (!_catalog.TryResolveBackend(backend, out var descriptor) || descriptor == null)
+            {
+                diagnostics.Add(new DialectDiagnostic("R002", $"Runtime backend descriptor '{backend.Value}' was not registered.", DialectDiagnosticSeverity.Error));
+                continue;
+            }
+
+            if (enabledBackends.All(x => x.CanonicalId != descriptor.CanonicalId))
+                enabledBackends.Add(descriptor);
+        }
+
+        var enabledOptimizers = new List<DialectRuntimeOptimizerDescriptor>();
+        foreach (var optimizer in plan.OptimizerDirectives.Where(x => x.Enabled).OrderBy(x => x.Name, StringComparer.Ordinal).ThenBy(x => x.Target))
+        {
+            if (!_catalog.TryResolveOptimizer(optimizer.Name, out var descriptor) || descriptor == null)
+            {
+                diagnostics.Add(new DialectDiagnostic("R003", $"Runtime optimizer descriptor '{optimizer.Name}' was not registered.", DialectDiagnosticSeverity.Error));
+                continue;
+            }
+
+            if (enabledOptimizers.All(x => x.CanonicalAlias != descriptor.CanonicalAlias))
+                enabledOptimizers.Add(descriptor);
+        }
+
+        return new DialectResolvedRuntimeSelection(orderedModules, enabledOptimizers, enabledBackends, diagnostics);
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/IDialectRuntimeCatalog.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/IDialectRuntimeCatalog.cs
@@ -1,0 +1,18 @@
+using UniversalToolchain.Dialects.Abstractions;
+
+namespace UniversalToolchain.Dialects.Wist;
+
+public interface IDialectRuntimeCatalog
+{
+    bool TryResolveModule(string alias, out DialectRuntimeModuleDescriptor? descriptor);
+
+    bool TryResolveOptimizer(string alias, out DialectRuntimeOptimizerDescriptor? descriptor);
+
+    bool TryResolveBackend(DialectBackendId id, out DialectRuntimeBackendDescriptor? descriptor);
+
+    IReadOnlyCollection<DialectRuntimeModuleDescriptor> Modules { get; }
+
+    IReadOnlyCollection<DialectRuntimeOptimizerDescriptor> Optimizers { get; }
+
+    IReadOnlyCollection<DialectRuntimeBackendDescriptor> Backends { get; }
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistDialectExecutionWorkflow.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistDialectExecutionWorkflow.cs
@@ -1,4 +1,7 @@
 using ExceptionsManager;
+using UniversalToolchain.Dialects.Abstractions;
+using UniversalToolchain.Dialects.Core;
+using UniversalToolchain.Dialects.Frontend;
 using UniversalToolchain.Dialects.Integration;
 
 namespace UniversalToolchain.Dialects.Wist;
@@ -8,33 +11,33 @@ namespace UniversalToolchain.Dialects.Wist;
 /// </summary>
 public sealed class WistDialectExecutionWorkflow
 {
-    private readonly DialectFrameworkCompositionWorkflow _compositionWorkflow;
-    private readonly WistDialectExecutionConfigurationBuilder _configurationBuilder;
-    private readonly DialectRuntimeDescriptorRegistry _registry;
-    private readonly WistDialectServiceProviderFactory _serviceProviderFactory;
+    private readonly IDialectCompiledDialectBuildPlanBuilder _buildPlanBuilder;
+    private readonly DialectDslCompiler _compiler;
+    private readonly DialectRuntimeProviderFactory _providerFactory;
+    private readonly DialectRuntimeSelectionResolver _selectionResolver;
 
     public WistDialectExecutionWorkflow(
-        DialectFrameworkCompositionWorkflow compositionWorkflow,
-        DialectRuntimeDescriptorRegistry registry,
-        WistDialectExecutionConfigurationBuilder configurationBuilder,
-        WistDialectServiceProviderFactory serviceProviderFactory)
+        DialectDslCompiler compiler,
+        IDialectCompiledDialectBuildPlanBuilder buildPlanBuilder,
+        DialectRuntimeSelectionResolver selectionResolver,
+        DialectRuntimeProviderFactory providerFactory)
     {
-        if (compositionWorkflow == null)
-            Thrower.ArgumentNull(nameof(compositionWorkflow));
+        if (compiler == null)
+            Thrower.ArgumentNull(nameof(compiler));
 
-        if (registry == null)
-            Thrower.ArgumentNull(nameof(registry));
+        if (buildPlanBuilder == null)
+            Thrower.ArgumentNull(nameof(buildPlanBuilder));
 
-        if (configurationBuilder == null)
-            Thrower.ArgumentNull(nameof(configurationBuilder));
+        if (selectionResolver == null)
+            Thrower.ArgumentNull(nameof(selectionResolver));
 
-        if (serviceProviderFactory == null)
-            Thrower.ArgumentNull(nameof(serviceProviderFactory));
+        if (providerFactory == null)
+            Thrower.ArgumentNull(nameof(providerFactory));
 
-        _compositionWorkflow = compositionWorkflow;
-        _registry = registry;
-        _configurationBuilder = configurationBuilder;
-        _serviceProviderFactory = serviceProviderFactory;
+        _compiler = compiler;
+        _buildPlanBuilder = buildPlanBuilder;
+        _selectionResolver = selectionResolver;
+        _providerFactory = providerFactory;
     }
 
     public DialectFrameworkCompositionResult ComposeFile(string filePath)
@@ -56,7 +59,21 @@ public sealed class WistDialectExecutionWorkflow
         if (string.IsNullOrWhiteSpace(sourceName))
             Thrower.Argument(nameof(sourceName), "Source name must not be empty.");
 
-        return _compositionWorkflow.ComposeText(sourceText, _registry, sourceName);
+        var compiled = _compiler.Compile(sourceText);
+        var buildPlan = _buildPlanBuilder.Build(compiled);
+        var selection = _selectionResolver.Resolve(buildPlan);
+
+        var runtimeComposition = new DialectRuntimeComposition(
+            buildPlan.Name,
+            selection.OrderedModules.Select(x => new RuntimeModuleDescriptor(x.CanonicalAlias, x.ImplementationType, x.Aliases)),
+            selection.EnabledBackends.Select(x => new RuntimeBackendDescriptor(x.CanonicalId, x.ImplementationType, x.Aliases)),
+            selection.EnabledOptimizers.Select(x => new RuntimeOptimizerDescriptor(x.CanonicalAlias, x.ImplementationType, x.Aliases)),
+            [],
+            new DialectValidationResult(selection.Diagnostics));
+
+        var semanticErrors = buildPlan.ValidationResult.Diagnostics.Where(x => x.Severity == DialectDiagnosticSeverity.Error).ToList();
+        var resolutionErrors = selection.Diagnostics.Where(x => x.Severity == DialectDiagnosticSeverity.Error).Except(semanticErrors).ToList();
+        return new DialectFrameworkCompositionResult(sourceName, compiled, buildPlan, runtimeComposition, semanticErrors, resolutionErrors);
     }
 
     public WistDialectExecutionHost CreateHost(DialectFrameworkCompositionResult compositionResult)
@@ -67,8 +84,10 @@ public sealed class WistDialectExecutionWorkflow
         if (!compositionResult.IsSuccess || compositionResult.BuildPlan == null || compositionResult.RuntimeComposition == null)
             Thrower.Argument(nameof(compositionResult), "Dialect composition result must be successful before a runtime host can be created.");
 
-        var configuration = _configurationBuilder.Build(compositionResult.BuildPlan, compositionResult.RuntimeComposition, _registry);
-        var provider = _serviceProviderFactory.Create(configuration);
+        var selection = _selectionResolver.Resolve(compositionResult.BuildPlan);
+        var configuration = _providerFactory.CreateConfiguration(selection, compositionResult.BuildPlan);
+        var provider = _providerFactory.CreateProvider(selection, compositionResult.BuildPlan);
+
         return new WistDialectExecutionHost(provider, configuration);
     }
 }

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistDialectServiceCollectionExtensions.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistDialectServiceCollectionExtensions.cs
@@ -1,7 +1,9 @@
 using ArithmeticModule;
+using BasicCore.Contracts;
 using CommentsModule;
 using ConditionsModule;
 using CSharpInteropModule;
+using DependencyInjection;
 using EqualityModule;
 using ExceptionsManager;
 using IdentifierModule;
@@ -11,6 +13,7 @@ using LocalVariablesOptimizerModule;
 using LoopsModule;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using UniversalToolchain.Dialects.Abstractions;
 using NativeMathModule;
 using NumbersModule;
 using ParametersSetterModule;
@@ -29,6 +32,80 @@ namespace UniversalToolchain.Dialects.Wist;
 /// </summary>
 public static class WistDialectServiceCollectionExtensions
 {
+
+    /// <summary>
+    ///     Registers only pre-selected Wist runtime components without assembly auto-discovery.
+    /// </summary>
+    public static IServiceCollection AddSelectedWistRuntimeServices(
+        this IServiceCollection services,
+        DialectResolvedRuntimeSelection selection,
+        IEnumerable<IWistDialectBackendServiceProvider> backendProviders,
+        DialectBuildPlan buildPlan)
+    {
+        if (services == null)
+            Thrower.ArgumentNull(nameof(services));
+
+        if (selection == null)
+            Thrower.ArgumentNull(nameof(selection));
+
+        if (backendProviders == null)
+            Thrower.ArgumentNull(nameof(backendProviders));
+
+        if (buildPlan == null)
+            Thrower.ArgumentNull(nameof(buildPlan));
+
+        services.AddWistCoreServices();
+
+        foreach (var module in selection.OrderedModules)
+        {
+            if (module.IsFrontendModule)
+                services.AddSingleton(typeof(IFrontendCoreModule), module.ImplementationType);
+
+            if (module.IsIrProcessingModule)
+                services.AddTransient(typeof(IIRProcessingModule), module.ImplementationType);
+        }
+
+        foreach (var optimizer in selection.EnabledOptimizers)
+            services.AddTransient(typeof(IIRProcessingModule), optimizer.ImplementationType);
+
+        var providerMap = backendProviders.ToDictionary(x => x.BackendId, x => x);
+        foreach (var backend in selection.EnabledBackends.OrderBy(x => x.CanonicalId))
+        {
+            if (!providerMap.TryGetValue(backend.CanonicalId, out var backendProvider))
+                Thrower.InvalidOpEx($"No Wist backend service provider is registered for backend '{backend.CanonicalId.Value}'.");
+
+            var runtimeDescriptor = new RuntimeBackendDescriptor(backend.CanonicalId, backend.ImplementationType, backend.Aliases);
+            var allowedIntrinsics = ResolveAllowedIntrinsics(buildPlan, backendProvider, backend.CanonicalId);
+            var hasExplicitAllowList = buildPlan.IntrinsicDirectives.Any(x => x.Allowed && x.Target.Matches(backend.CanonicalId));
+            var forbiddenIntrinsics = buildPlan.IntrinsicDirectives
+                .Where(x => !x.Allowed && x.Target.Matches(backend.CanonicalId))
+                .Select(x => x.Name)
+                .Distinct(StringComparer.Ordinal)
+                .OrderBy(x => x, StringComparer.Ordinal)
+                .ToList();
+
+            var config = new WistDialectBackendConfiguration(runtimeDescriptor, allowedIntrinsics, forbiddenIntrinsics, hasExplicitAllowList);
+            backendProvider.RegisterRuntime(services, config);
+        }
+
+        return services;
+    }
+
+    private static IReadOnlyList<string> ResolveAllowedIntrinsics(DialectBuildPlan buildPlan, IWistDialectBackendServiceProvider backendProvider, DialectBackendId backendId)
+    {
+        var hasExplicitAllowList = buildPlan.IntrinsicDirectives.Any(x => x.Allowed && x.Target.Matches(backendId));
+        if (!hasExplicitAllowList)
+            return backendProvider.SupportedIntrinsics.ToList();
+
+        return buildPlan.IntrinsicDirectives
+            .Where(x => x.Allowed && x.Target.Matches(backendId))
+            .Select(x => x.Name)
+            .Distinct(StringComparer.Ordinal)
+            .Where(x => backendProvider.SupportedIntrinsics.Contains(x, StringComparer.Ordinal))
+            .OrderBy(x => x, StringComparer.Ordinal)
+            .ToList();
+    }
+
     public static IServiceCollection AddWistDialectServices(this IServiceCollection services)
     {
         if (services == null)
@@ -66,6 +143,9 @@ public static class WistDialectServiceCollectionExtensions
             provider.GetRequiredService<IDialectRuntimeCompositionResolver>()));
         services.TryAddSingleton<WistDialectExecutionConfigurationBuilder>();
         services.TryAddSingleton<WistDialectServiceProviderFactory>();
+        services.TryAddSingleton<IDialectRuntimeCatalog>(_ => WistRuntimeCatalogFactory.Create());
+        services.TryAddSingleton<DialectRuntimeSelectionResolver>();
+        services.TryAddSingleton<DialectRuntimeProviderFactory>();
         services.TryAddSingleton<WistDialectExecutionWorkflow>();
         return services;
     }

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistRuntimeCatalogFactory.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistRuntimeCatalogFactory.cs
@@ -1,0 +1,58 @@
+using ArithmeticModule.Module;
+using CommentsModule;
+using ConditionsModule.Enums;
+using ConditionsModule.Module;
+using ConditionsModule.Optimizers;
+using CSharpInteropModule.Module;
+using EqualityModule;
+using IdentifierModule;
+using InternalPreprocessorLexemesModule;
+using LabelsModule.Module;
+using LocalVariablesOptimizerModule;
+using LoopsModule.Module;
+using NativeMathModule;
+using NumbersModule.Module;
+using ParametersSetterModule;
+using ScopesModule.Module;
+using SemicolonAsNewLineModule;
+using UniversalToolchain.Dialects.Abstractions;
+using VariablesModule;
+using WhitespacesModule;
+
+namespace UniversalToolchain.Dialects.Wist;
+
+public static class WistRuntimeCatalogFactory
+{
+    public static IDialectRuntimeCatalog Create()
+    {
+        return new DialectRuntimeCatalogBuilder()
+            .RegisterModule(DialectRuntimeModuleDescriptor.Create("Arithmetic", ["Arithmetic"], typeof(ArithmeticModuleImpl), typeof(ArithmeticModuleImpl).Assembly.GetName().Name))
+            .RegisterModule(DialectRuntimeModuleDescriptor.Create("Conditions", ["Conditions"], typeof(ConditionsModuleImpl), typeof(ConditionsModuleImpl).Assembly.GetName().Name))
+            .RegisterModule(DialectRuntimeModuleDescriptor.Create("BooleanConditions", ["BooleanConditions"], typeof(BooleanOperations), typeof(BooleanOperations).Assembly.GetName().Name))
+            .RegisterModule(DialectRuntimeModuleDescriptor.Create("ComparisonConditions", ["ComparisonConditions"], typeof(ComparisonOperations), typeof(ComparisonOperations).Assembly.GetName().Name))
+            .RegisterModule(DialectRuntimeModuleDescriptor.Create("Equality", ["Equality"], typeof(EqualityModuleImpl), typeof(EqualityModuleImpl).Assembly.GetName().Name))
+            .RegisterModule(DialectRuntimeModuleDescriptor.Create("NativeTypes", ["NativeTypes"], typeof(NativeTypesModuleImpl), typeof(NativeTypesModuleImpl).Assembly.GetName().Name))
+            .RegisterModule(DialectRuntimeModuleDescriptor.Create("Numbers", ["Numbers"], typeof(NumbersModuleImpl), typeof(NumbersModuleImpl).Assembly.GetName().Name))
+            .RegisterModule(DialectRuntimeModuleDescriptor.Create("Comments", ["Comments"], typeof(CommentsModuleImpl), typeof(CommentsModuleImpl).Assembly.GetName().Name))
+            .RegisterModule(DialectRuntimeModuleDescriptor.Create("Identifier", ["Identifier"], typeof(IdentifierModuleImpl), typeof(IdentifierModuleImpl).Assembly.GetName().Name))
+            .RegisterModule(DialectRuntimeModuleDescriptor.Create("InternalPreprocessorLexemes", ["InternalPreprocessorLexemes"], typeof(InternalPreprocessorLexemesModuleImpl), typeof(InternalPreprocessorLexemesModuleImpl).Assembly.GetName().Name))
+            .RegisterModule(DialectRuntimeModuleDescriptor.Create("SemicolonAsNewLine", ["SemicolonAsNewLine"], typeof(SemicolonAsNewLineModuleImpl), typeof(SemicolonAsNewLineModuleImpl).Assembly.GetName().Name))
+            .RegisterModule(DialectRuntimeModuleDescriptor.Create("Whitespaces", ["Whitespaces"], typeof(WhitespaceModuleImpl), typeof(WhitespaceModuleImpl).Assembly.GetName().Name))
+            .RegisterModule(DialectRuntimeModuleDescriptor.Create("ParametersSetter", ["ParametersSetter"], typeof(ParametersSetterModuleImpl), typeof(ParametersSetterModuleImpl).Assembly.GetName().Name))
+            .RegisterModule(DialectRuntimeModuleDescriptor.Create("Scopes", ["Scopes"], typeof(ScopesModuleImpl), typeof(ScopesModuleImpl).Assembly.GetName().Name))
+            .RegisterModule(DialectRuntimeModuleDescriptor.Create("Variables", ["Variables"], typeof(VariablesModuleImpl), typeof(VariablesModuleImpl).Assembly.GetName().Name))
+            .RegisterModule(DialectRuntimeModuleDescriptor.Create("Labels", ["Labels"], typeof(LabelsModuleImpl), typeof(LabelsModuleImpl).Assembly.GetName().Name))
+            .RegisterModule(DialectRuntimeModuleDescriptor.Create("Loops", ["Loops"], typeof(LoopsModuleImpl), typeof(LoopsModuleImpl).Assembly.GetName().Name))
+            .RegisterModule(DialectRuntimeModuleDescriptor.Create("CSharpInterop", ["CSharpInterop"], typeof(CSharpInteropModuleImpl), typeof(CSharpInteropModuleImpl).Assembly.GetName().Name))
+            .RegisterOptimizer(DialectRuntimeOptimizerDescriptor.Create("LocalVariablesOptimization", ["LocalVariablesOptimization"], typeof(LocalVariablesOptimizer), typeof(LocalVariablesOptimizer).Assembly.GetName().Name))
+            .RegisterOptimizer(DialectRuntimeOptimizerDescriptor.Create("NativeCilOptimization", ["NativeCilOptimization"], typeof(NativeCilOptimizerModule), typeof(NativeCilOptimizerModule).Assembly.GetName().Name))
+            .RegisterOptimizer(DialectRuntimeOptimizerDescriptor.Create("ArithmeticOptimization", ["ArithmeticOptimization"], typeof(ArithmeticOptimizerModule), typeof(ArithmeticOptimizerModule).Assembly.GetName().Name))
+            .RegisterOptimizer(DialectRuntimeOptimizerDescriptor.Create("EGraphOptimization", ["EGraphOptimization"], typeof(EGraphOptimizerModule), typeof(EGraphOptimizerModule).Assembly.GetName().Name))
+            .RegisterOptimizer(DialectRuntimeOptimizerDescriptor.Create("NativeTypesOptimization", ["NativeTypesOptimization"], typeof(NativeTypesOptimizerModule), typeof(NativeTypesOptimizerModule).Assembly.GetName().Name))
+            .RegisterOptimizer(DialectRuntimeOptimizerDescriptor.Create("BooleanOptimization", ["BooleanOptimization"], typeof(BooleanOptimizerModule), typeof(BooleanOptimizerModule).Assembly.GetName().Name))
+            .RegisterOptimizer(DialectRuntimeOptimizerDescriptor.Create("ComparisonIntrinsicOptimization", ["ComparisonIntrinsicOptimization"], typeof(ComparisonIntrinsicOptimizerModule), typeof(ComparisonIntrinsicOptimizerModule).Assembly.GetName().Name))
+            .RegisterBackend(DialectRuntimeBackendDescriptor.Create(WistDialectBackendIds.Cil, ["compiler", "cil"], typeof(WistCilBackendDeclaration), typeof(WistCilBackendDeclaration).Assembly.GetName().Name))
+            .RegisterBackend(DialectRuntimeBackendDescriptor.Create(WistDialectBackendIds.Interpreter, ["interpreter"], typeof(WistInterpreterBackendDeclaration), typeof(WistInterpreterBackendDeclaration).Assembly.GetName().Name))
+            .Build();
+    }
+}


### PR DESCRIPTION
### Motivation

- Reduce runtime memory and eliminate broad assembly scanning during dialect composition by resolving and registering only the components required by a DialectBuildPlan. 
- Make runtime composition deterministic and isolated so repeated or parallel compositions produce stable, predictable selections and do not leak registrations between providers.

### Description

- Introduce lightweight descriptor records (`DialectRuntimeModuleDescriptor`, `DialectRuntimeOptimizerDescriptor`, `DialectRuntimeBackendDescriptor`) and an immutable catalog abstraction (`IDialectRuntimeCatalog` + `DialectRuntimeCatalog`/`DialectRuntimeCatalogBuilder`) for alias-based lookup. 
- Implement `DialectRuntimeSelectionResolver` that resolves a `DialectBuildPlan` to an ordered, deterministic `DialectResolvedRuntimeSelection` with diagnostics instead of performing reflection/discovery. 
- Add `DialectRuntimeProviderFactory` and the DI extension `AddSelectedWistRuntimeServices` to create a minimal `IServiceProvider` and register only selected frontend modules, IR/optimizer modules and backend runtimes (respecting intrinsic allow/deny rules). 
- Provide a hand-maintained `WistRuntimeCatalogFactory` with the initial table of Wist aliases/implementations to avoid assembly scanning on the dialect path, and wire new services into `AddWistDialectServices` while leaving the old auto-discovery path for compatibility. 
- Modernize `WistDialectExecutionWorkflow` to use the new pipeline (compile → build plan → resolve selection → create provider/configuration) and add unit tests covering determinism, missing-alias diagnostics, and provider creation stability.

### Testing

- Restored solution with `dotnet restore UniversalToolchain/Wist.sln` and ran the dialect test suite with `dotnet test UniversalToolchain/UniversalToolchain.Dialects.Tests/UniversalToolchain.Dialects.Tests.csproj -c Release --no-restore`. 
- Ran targeted tests during development (example: `--filter "FullDialect_RichProgram_RunsWithBothRealBackends|DialectProjectsSmokeTests"`) while iterating on fixes. 
- Final test run: the `UniversalToolchain.Dialects.Tests` project completed successfully with all tests passing (224 passed, 0 failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c597254144832490a839a1885aa638)