### PR TITLE
Introduce minimal Wist runtime selection and manifest; preserve legacy composition path

### DIFF
--- a/UniversalToolchain/UniversalToolchain.Dialects.Integration/DialectFrameworkCompositionResult.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Integration/DialectFrameworkCompositionResult.cs
@@ -20,7 +20,8 @@ public sealed class DialectFrameworkCompositionResult
         DialectBuildPlan? buildPlan,
         DialectRuntimeComposition? runtimeComposition,
         IEnumerable<DialectDiagnostic> semanticDiagnostics,
-        IEnumerable<DialectDiagnostic> resolutionDiagnostics)
+        IEnumerable<DialectDiagnostic> resolutionDiagnostics,
+        IDialectRuntimeSelection? runtimeSelection = null)
     {
         if (string.IsNullOrWhiteSpace(sourceName))
             Thrower.Argument(nameof(sourceName), "Source name must not be empty.");
@@ -31,6 +32,7 @@ public sealed class DialectFrameworkCompositionResult
         RuntimeComposition = runtimeComposition;
         _semanticDiagnostics = new ReadOnlyCollection<DialectDiagnostic>(Snapshot(semanticDiagnostics, nameof(semanticDiagnostics)));
         _resolutionDiagnostics = new ReadOnlyCollection<DialectDiagnostic>(Snapshot(resolutionDiagnostics, nameof(resolutionDiagnostics)));
+        RuntimeSelection = runtimeSelection;
     }
 
     public string SourceName { get; }
@@ -41,6 +43,8 @@ public sealed class DialectFrameworkCompositionResult
 
     public DialectRuntimeComposition? RuntimeComposition { get; }
 
+    public IDialectRuntimeSelection? RuntimeSelection { get; }
+
     public IReadOnlyList<DialectDiagnostic> SemanticDiagnostics => _semanticDiagnostics;
 
     public IReadOnlyList<DialectDiagnostic> ResolutionDiagnostics => _resolutionDiagnostics;
@@ -48,7 +52,6 @@ public sealed class DialectFrameworkCompositionResult
     public bool IsSuccess =>
         CompiledDialect != null &&
         BuildPlan != null &&
-        RuntimeComposition != null &&
         !_semanticDiagnostics.Any(x => x.Severity == DialectDiagnosticSeverity.Error) &&
         !_resolutionDiagnostics.Any(x => x.Severity == DialectDiagnosticSeverity.Error);
 

--- a/UniversalToolchain/UniversalToolchain.Dialects.Integration/IDialectRuntimeSelection.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Integration/IDialectRuntimeSelection.cs
@@ -1,0 +1,10 @@
+using UniversalToolchain.Dialects.Abstractions;
+
+namespace UniversalToolchain.Dialects.Integration;
+
+public interface IDialectRuntimeSelection
+{
+    bool IsResolved { get; }
+
+    IReadOnlyList<DialectDiagnostic> Diagnostics { get; }
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/DialectDeterminismAndSandboxContractsTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/DialectDeterminismAndSandboxContractsTests.cs
@@ -26,10 +26,11 @@ public class DialectDeterminismAndSandboxContractsTests
         using var provider = CreateProvider();
         var workflow = provider.GetRequiredService<WistDialectExecutionWorkflow>();
         var composition = workflow.ComposeFile(GetDialectPath("restricted-sandbox"));
+        var legacyComposition = provider.GetRequiredService<LegacyWistDialectCompositionService>().ComposeText(File.ReadAllText(GetDialectPath("restricted-sandbox")), "restricted-sandbox");
 
         Assert.That(composition.IsSuccess, Is.True);
-        Assert.That(composition.RuntimeComposition!.EnabledBackends.Select(x => x.CanonicalId), Is.EqualTo(new[] { "interpreter" }));
-        Assert.That(composition.RuntimeComposition.OrderedModules.Select(x => x.CanonicalId), Does.Not.Contain("CSharpInterop"));
+        Assert.That(legacyComposition.RuntimeComposition!.EnabledBackends.Select(x => x.CanonicalId), Is.EqualTo(new[] { "interpreter" }));
+        Assert.That(legacyComposition.RuntimeComposition.OrderedModules.Select(x => x.CanonicalId), Does.Not.Contain("CSharpInterop"));
     }
 
     [Test]
@@ -77,9 +78,9 @@ public class DialectDeterminismAndSandboxContractsTests
             result.IsSuccess.ToString(),
             string.Join(",", result.SemanticDiagnostics.Select(x => $"{x.Code}:{x.Message}")),
             string.Join(",", result.ResolutionDiagnostics.Select(x => $"{x.Code}:{x.Message}")),
-            string.Join(",", result.RuntimeComposition?.OrderedModules.Select(x => x.CanonicalId) ?? []),
-            string.Join(",", result.RuntimeComposition?.EnabledBackends.Select(x => x.CanonicalId) ?? []),
-            string.Join(",", result.RuntimeComposition?.EnabledOptimizers.Select(x => x.CanonicalId) ?? [])
+            string.Join(",", (result.RuntimeSelection as SelectedRuntimePlan)?.OrderedModules.Select(x => x.CanonicalAlias) ?? []),
+            string.Join(",", (result.RuntimeSelection as SelectedRuntimePlan)?.EnabledBackends.Select(x => x.CanonicalAlias) ?? []),
+            string.Join(",", (result.RuntimeSelection as SelectedRuntimePlan)?.EnabledOptimizers.Select(x => x.CanonicalAlias) ?? [])
         ]);
     }
 
@@ -89,7 +90,7 @@ public class DialectDeterminismAndSandboxContractsTests
     private static ServiceProvider CreateProvider()
     {
         var services = new ServiceCollection();
-        services.AddWistDialectServices();
+        services.AddWistDialectServicesLegacy();
         return services.BuildServiceProvider();
     }
 }

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/DialectRuntimeAliasAttributeDiscoveryTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/DialectRuntimeAliasAttributeDiscoveryTests.cs
@@ -65,28 +65,29 @@ public class DialectRuntimeAliasAttributeDiscoveryTests
     public void WistWorkflow_ComposesExistingDialectFileWithAttributeDrivenAliases()
     {
         var services = new ServiceCollection();
-        services.AddWistDialectServices();
+        services.AddWistDialectServicesLegacy();
 
         using var provider = services.BuildServiceProvider();
         var workflow = provider.GetRequiredService<WistDialectExecutionWorkflow>();
         var result = workflow.ComposeFile(Path.Combine(GetWistExamplesRoot(), "full-default", "dialect.wistdialect"));
 
         Assert.That(result.IsSuccess, Is.True, string.Join(Environment.NewLine, result.ResolutionDiagnostics.Select(static x => x.Message)));
-        Assert.That(result.RuntimeComposition, Is.Not.Null);
+        var legacyResult = provider.GetRequiredService<LegacyWistDialectCompositionService>().ComposeText(File.ReadAllText(Path.Combine(GetWistExamplesRoot(), "full-default", "dialect.wistdialect")), "full-default");
+        Assert.That(legacyResult.RuntimeComposition, Is.Not.Null);
 
         Assert.Multiple(() =>
         {
-            var moduleNames = result.RuntimeComposition!.OrderedModules.Select(static x => x.ImplementationType.Name).ToArray();
+            var moduleNames = legacyResult.RuntimeComposition!.OrderedModules.Select(static x => x.ImplementationType.Name).ToArray();
             Assert.That(moduleNames, Does.Contain("ArithmeticModuleImpl"));
             Assert.That(moduleNames, Does.Contain("CSharpInteropModuleImpl"));
             Assert.That(moduleNames, Does.Contain("VariablesModuleImpl"));
             Assert.That(Array.IndexOf(moduleNames, "ArithmeticModuleImpl"), Is.LessThan(Array.IndexOf(moduleNames, "VariablesModuleImpl")));
-            var backends = result.RuntimeComposition.EnabledBackends.Select(static x => x.CanonicalId).ToArray();
+            var backends = legacyResult.RuntimeComposition.EnabledBackends.Select(static x => x.CanonicalId).ToArray();
             Assert.That(backends, Has.Length.EqualTo(2));
             Assert.That(backends, Does.Contain("cil"));
             Assert.That(backends, Does.Contain("interpreter"));
 
-            var optimizers = result.RuntimeComposition.EnabledOptimizers.Select(static x => x.ImplementationType.Name).ToArray();
+            var optimizers = legacyResult.RuntimeComposition.EnabledOptimizers.Select(static x => x.ImplementationType.Name).ToArray();
             Assert.That(optimizers, Has.Length.EqualTo(1));
             Assert.That(optimizers[0], Is.EqualTo("LocalVariablesOptimizer"));
         });
@@ -120,7 +121,7 @@ public class DialectRuntimeAliasAttributeDiscoveryTests
     public void WistWorkflow_ReportsMissingAliasesThroughExistingResolutionDiagnostics()
     {
         var services = new ServiceCollection();
-        services.AddWistDialectServices();
+        services.AddWistDialectServicesLegacy();
 
         using var provider = services.BuildServiceProvider();
         var workflow = provider.GetRequiredService<WistDialectExecutionWorkflow>();
@@ -189,7 +190,7 @@ public class DialectRuntimeAliasAttributeDiscoveryTests
     private static DialectRuntimeDescriptorRegistry BuildRegistry()
     {
         var services = new ServiceCollection();
-        services.AddWistDialectServices();
+        services.AddWistDialectServicesLegacy();
 
         using var provider = services.BuildServiceProvider();
         return provider.GetRequiredService<DialectRuntimeDescriptorRegistry>();

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/DialectRuntimeArchitectureTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/DialectRuntimeArchitectureTests.cs
@@ -117,7 +117,7 @@ public class DialectRuntimeArchitectureTests
     private static ServiceProvider CreateProvider()
     {
         var services = new ServiceCollection();
-        services.AddWistDialectServices();
+        services.AddWistDialectServicesLegacy();
         return services.BuildServiceProvider();
     }
 

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/DialectRuntimeProfileRegressionTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/DialectRuntimeProfileRegressionTests.cs
@@ -12,6 +12,7 @@ public class DialectRuntimeProfileRegressionTests
         using var provider = CreateProvider();
         var workflow = provider.GetRequiredService<WistDialectExecutionWorkflow>();
         var composition = workflow.ComposeFile(GetDialectPath("full-default"));
+        var legacyComposition = provider.GetRequiredService<LegacyWistDialectCompositionService>().ComposeText(File.ReadAllText(GetDialectPath("full-default")), "full-default");
         using var host = workflow.CreateHost(composition);
 
         var compilerValue = host.Run(File.ReadAllText(GetProgramPath("full-default")), "compiler");
@@ -20,10 +21,10 @@ public class DialectRuntimeProfileRegressionTests
         Assert.Multiple(() =>
         {
             Assert.That(composition.IsSuccess, Is.True);
-            Assert.That(composition.RuntimeComposition, Is.Not.Null);
-            Assert.That(composition.RuntimeComposition!.EnabledBackends.Select(static x => x.CanonicalId), Does.Contain("cil"));
-            Assert.That(composition.RuntimeComposition.EnabledBackends.Select(static x => x.CanonicalId), Does.Contain("interpreter"));
-            Assert.That(composition.RuntimeComposition.EnabledOptimizers.Select(static x => x.ImplementationType.Name), Does.Contain("LocalVariablesOptimizer"));
+            Assert.That(legacyComposition.RuntimeComposition, Is.Not.Null);
+            Assert.That(legacyComposition.RuntimeComposition!.EnabledBackends.Select(static x => x.CanonicalId), Does.Contain("cil"));
+            Assert.That(legacyComposition.RuntimeComposition.EnabledBackends.Select(static x => x.CanonicalId), Does.Contain("interpreter"));
+            Assert.That(legacyComposition.RuntimeComposition.EnabledOptimizers.Select(static x => x.ImplementationType.Name), Does.Contain("LocalVariablesOptimizer"));
             Assert.That(interpreterValue, Is.EqualTo(compilerValue));
         });
     }
@@ -34,15 +35,16 @@ public class DialectRuntimeProfileRegressionTests
         using var provider = CreateProvider();
         var workflow = provider.GetRequiredService<WistDialectExecutionWorkflow>();
         var composition = workflow.ComposeFile(GetDialectPath("minimal-arithmetic"));
+        var legacyComposition = provider.GetRequiredService<LegacyWistDialectCompositionService>().ComposeText(File.ReadAllText(GetDialectPath("minimal-arithmetic")), "minimal-arithmetic");
         using var host = workflow.CreateHost(composition);
 
-        var moduleTypes = composition.RuntimeComposition!.OrderedModules.Select(static x => x.ImplementationType.Name).ToArray();
-        var backendIds = composition.RuntimeComposition.EnabledBackends.Select(static x => x.CanonicalId).ToArray();
+        var moduleTypes = legacyComposition.RuntimeComposition!.OrderedModules.Select(static x => x.ImplementationType.Name).ToArray();
+        var backendIds = legacyComposition.RuntimeComposition.EnabledBackends.Select(static x => x.CanonicalId).ToArray();
 
         Assert.Multiple(() =>
         {
             Assert.That(composition.IsSuccess, Is.True);
-            Assert.That(composition.RuntimeComposition, Is.Not.Null);
+            Assert.That(legacyComposition.RuntimeComposition, Is.Not.Null);
             Assert.That(backendIds, Is.EqualTo(new[] { "interpreter" }));
             Assert.That(moduleTypes, Is.EquivalentTo(new[] { "ArithmeticModuleImpl", "NumbersModuleImpl", "ScopesModuleImpl", "WhitespaceModuleImpl" }));
             Assert.That(moduleTypes, Does.Not.Contain("IdentifierModuleImpl"));
@@ -57,16 +59,17 @@ public class DialectRuntimeProfileRegressionTests
         using var provider = CreateProvider();
         var workflow = provider.GetRequiredService<WistDialectExecutionWorkflow>();
         var composition = workflow.ComposeFile(GetDialectPath("restricted-sandbox"));
+        var legacyComposition = provider.GetRequiredService<LegacyWistDialectCompositionService>().ComposeText(File.ReadAllText(GetDialectPath("restricted-sandbox")), "restricted-sandbox");
         using var host = workflow.CreateHost(composition);
 
-        var moduleTypes = composition.RuntimeComposition!.OrderedModules.Select(static x => x.ImplementationType.Name).ToArray();
-        var backendIds = composition.RuntimeComposition.EnabledBackends.Select(static x => x.CanonicalId).ToArray();
+        var moduleTypes = legacyComposition.RuntimeComposition!.OrderedModules.Select(static x => x.ImplementationType.Name).ToArray();
+        var backendIds = legacyComposition.RuntimeComposition.EnabledBackends.Select(static x => x.CanonicalId).ToArray();
         var compilerFailure = Assert.Catch(() => host.Run("1 + 1", "compiler"));
 
         Assert.Multiple(() =>
         {
             Assert.That(composition.IsSuccess, Is.True);
-            Assert.That(composition.RuntimeComposition, Is.Not.Null);
+            Assert.That(legacyComposition.RuntimeComposition, Is.Not.Null);
             Assert.That(backendIds, Is.EqualTo(new[] { "interpreter" }));
             Assert.That(moduleTypes, Does.Not.Contain("CSharpInteropModuleImpl"));
             Assert.That(moduleTypes, Does.Not.Contain("IdentifierModuleImpl"));
@@ -84,7 +87,7 @@ public class DialectRuntimeProfileRegressionTests
     private static ServiceProvider CreateProvider()
     {
         var services = new ServiceCollection();
-        services.AddWistDialectServices();
+        services.AddWistDialectServicesLegacy();
         return services.BuildServiceProvider();
     }
 }

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/MinimalRuntimeSelectionTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/MinimalRuntimeSelectionTests.cs
@@ -1,0 +1,119 @@
+using Microsoft.Extensions.DependencyInjection;
+using UniversalToolchain.Dialects.Abstractions;
+using UniversalToolchain.Dialects.Core;
+using UniversalToolchain.Dialects.Frontend;
+using UniversalToolchain.Dialects.Wist;
+
+namespace UniversalToolchain.Dialects.Tests;
+
+public class MinimalRuntimeSelectionTests
+{
+    [Test]
+    public void SelectionResolver_SameDialect_RepeatedRuns_ProduceSameSelectionOrder()
+    {
+        using var provider = CreateMinimalProvider();
+        var compiler = provider.GetRequiredService<DialectDslCompiler>();
+        var builder = provider.GetRequiredService<IDialectCompiledDialectBuildPlanBuilder>();
+        var resolver = provider.GetRequiredService<SelectedRuntimePlanResolver>();
+        const string source = """
+            dialect Deterministic
+            use Arithmetic,Numbers,Variables
+            backend interpreter,compiler
+            enable LocalVariablesOptimization
+            """;
+
+        string? signature = null;
+        for (var i = 0; i < 100; i++)
+        {
+            var plan = builder.Build(compiler.Compile(source));
+            var selection = resolver.Resolve(plan);
+            var current = string.Join("|", selection.OrderedModules.Select(x => x.CanonicalAlias)) + "::" + string.Join("|", selection.EnabledBackends.Select(x => x.CanonicalAlias)) + "::" + string.Join("|", selection.EnabledOptimizers.Select(x => x.CanonicalAlias));
+            signature ??= current;
+            Assert.That(current, Is.EqualTo(signature));
+        }
+    }
+
+    [Test]
+    public void SelectionResolver_MissingModule_AddsR001()
+    {
+        var resolver = new SelectedRuntimePlanResolver(new WistRuntimeManifest());
+        var plan = BuildPlan(modules: ["NoSuchModule"], backends: [WistDialectBackendIds.Interpreter], optimizers: []);
+        var selection = resolver.Resolve(plan);
+        Assert.That(selection.Diagnostics.Any(x => x.Code == "R001"), Is.True);
+    }
+
+    [Test]
+    public void SelectionResolver_MissingBackend_AddsR002()
+    {
+        var resolver = new SelectedRuntimePlanResolver(new WistRuntimeManifest());
+        var plan = BuildPlan(modules: ["Arithmetic"], backends: [new DialectBackendId("missing")], optimizers: []);
+        var selection = resolver.Resolve(plan);
+        Assert.That(selection.Diagnostics.Any(x => x.Code == "R002"), Is.True);
+    }
+
+    [Test]
+    public void SelectionResolver_MissingOptimizer_AddsR003()
+    {
+        var resolver = new SelectedRuntimePlanResolver(new WistRuntimeManifest());
+        var plan = BuildPlan(modules: ["Arithmetic"], backends: [WistDialectBackendIds.Interpreter], optimizers: [new OptimizerBuildDirective("missing-opt", true, DialectBackendSelector.Any)]);
+        var selection = resolver.Resolve(plan);
+        Assert.That(selection.Diagnostics.Any(x => x.Code == "R003"), Is.True);
+    }
+
+
+    [Test]
+    public void SelectionResolver_DropsDuplicateBackendSelections_Deterministically()
+    {
+        var resolver = new SelectedRuntimePlanResolver(new WistRuntimeManifest());
+        var plan = BuildPlan(modules: ["Arithmetic"], backends: [WistDialectBackendIds.Interpreter, WistDialectBackendIds.Interpreter, WistDialectBackendIds.Cil], optimizers: []);
+        var selection = resolver.Resolve(plan);
+
+        Assert.That(selection.EnabledBackends.Select(x => x.CanonicalAlias), Is.EqualTo(new[] { "cil", "interpreter" }));
+    }
+
+    [Test]
+    public void SelectionResolver_DropsDuplicateOptimizers_Deterministically()
+    {
+        var resolver = new SelectedRuntimePlanResolver(new WistRuntimeManifest());
+        var plan = BuildPlan(
+            modules: ["Arithmetic"],
+            backends: [WistDialectBackendIds.Interpreter],
+            optimizers:
+            [
+                new OptimizerBuildDirective("LocalVariablesOptimization", true, DialectBackendSelector.Any),
+                new OptimizerBuildDirective("LocalVariablesOptimization", true, DialectBackendSelector.Any)
+            ]);
+
+        var selection = resolver.Resolve(plan);
+        Assert.That(selection.EnabledOptimizers.Select(x => x.CanonicalAlias), Is.EqualTo(new[] { "LocalVariablesOptimization" }));
+    }
+
+    [Test]
+    public void SelectionResolver_DoesNotLoadFeatureAssemblies()
+    {
+        var resolver = new SelectedRuntimePlanResolver(new WistRuntimeManifest());
+        var before = AppDomain.CurrentDomain.GetAssemblies().Select(x => x.GetName().Name).ToHashSet(StringComparer.Ordinal);
+        var plan = BuildPlan(modules: ["Arithmetic"], backends: [WistDialectBackendIds.Interpreter], optimizers: []);
+        _ = resolver.Resolve(plan);
+        var after = AppDomain.CurrentDomain.GetAssemblies().Select(x => x.GetName().Name).ToHashSet(StringComparer.Ordinal);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(after.Contains("ArithmeticModule"), Is.EqualTo(before.Contains("ArithmeticModule")));
+            Assert.That(after.Contains("NativeMathModule"), Is.EqualTo(before.Contains("NativeMathModule")));
+            Assert.That(after.Contains("ConditionsModule"), Is.EqualTo(before.Contains("ConditionsModule")));
+        });
+    }
+
+    private static DialectBuildPlan BuildPlan(IReadOnlyList<string> modules, IReadOnlyList<DialectBackendId> backends, IReadOnlyList<OptimizerBuildDirective> optimizers)
+    {
+        return new DialectBuildPlan("Demo", null, modules, backends, [], [], optimizers, null, [], new DialectValidationResult([]));
+    }
+
+    private static ServiceProvider CreateMinimalProvider()
+    {
+        var services = new ServiceCollection();
+        services.AddWistDialectServicesMinimal();
+        return services.BuildServiceProvider();
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/RuntimeComponentTypeLoaderTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/RuntimeComponentTypeLoaderTests.cs
@@ -1,0 +1,105 @@
+using UniversalToolchain.Dialects.Wist;
+
+namespace UniversalToolchain.Dialects.Tests;
+
+public class RuntimeComponentTypeLoaderTests
+{
+    [Test]
+    public void TypeLoader_LoadsOnlyRequestedAssembly()
+    {
+        var loader = new DefaultRuntimeComponentTypeLoader(new DefaultRuntimeAssemblyLocator());
+        var entry = Entry("ArithmeticModule", "ArithmeticModule.Module.ArithmeticModuleImpl");
+
+        var type = loader.LoadType(entry);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(type.FullName, Is.EqualTo("ArithmeticModule.Module.ArithmeticModuleImpl"));
+            Assert.That(type.Assembly.GetName().Name, Is.EqualTo("ArithmeticModule"));
+        });
+    }
+
+    [Test]
+    public void TypeLoader_RepeatedLoad_UsesCache()
+    {
+        var loader = new DefaultRuntimeComponentTypeLoader(new DefaultRuntimeAssemblyLocator());
+        var entry = Entry("ArithmeticModule", "ArithmeticModule.Module.ArithmeticModuleImpl");
+
+        var first = loader.LoadType(entry);
+        for (var i = 0; i < 20; i++)
+        {
+            var current = loader.LoadType(entry);
+            Assert.That(ReferenceEquals(first, current), Is.True);
+        }
+    }
+
+    [Test]
+    public void TypeLoader_DoesNotUseLocator_WhenAssemblyAlreadyLoaded()
+    {
+        _ = typeof(ArithmeticModule.Module.ArithmeticModuleImpl).Assembly;
+        var locator = new CountingLocator(false, null);
+        var loader = new DefaultRuntimeComponentTypeLoader(locator);
+
+        var type = loader.LoadType(Entry("ArithmeticModule", "ArithmeticModule.Module.ArithmeticModuleImpl"));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(type, Is.Not.Null);
+            Assert.That(locator.Calls, Is.EqualTo(0));
+        });
+    }
+
+    [Test]
+    public void TypeLoader_UsesLocatorFallback_WhenLoadByNameFails()
+    {
+        var badAssembly = "DefinitelyMissing.Assembly.For.Loader.Test";
+        var locator = new CountingLocator(true, Path.Combine(AppContext.BaseDirectory, "ArithmeticModule.dll"));
+        var loader = new DefaultRuntimeComponentTypeLoader(locator);
+
+        var type = loader.LoadType(Entry(badAssembly, "ArithmeticModule.Module.ArithmeticModuleImpl"));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(type.FullName, Is.EqualTo("ArithmeticModule.Module.ArithmeticModuleImpl"));
+            Assert.That(locator.Calls, Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public void TypeLoader_LoadFromAssemblyPath_RequiresAbsolutePath()
+    {
+        var loader = new DefaultRuntimeComponentTypeLoader(new CountingLocator(true, "relative/path/ArithmeticModule.dll"));
+        var ex = Assert.Throws<ArgumentException>(() => loader.LoadType(Entry("Missing.Assembly.With.Relative.Path", "ArithmeticModule.Module.ArithmeticModuleImpl")));
+        Assert.That(ex!.Message, Does.Contain("non-absolute path"));
+    }
+
+    [Test]
+    public void TypeLoader_InvalidAssembly_ThrowsClearError()
+    {
+        var loader = new DefaultRuntimeComponentTypeLoader(new DefaultRuntimeAssemblyLocator());
+        var ex = Assert.Throws<FileNotFoundException>(() => loader.LoadType(Entry("NoSuchAssembly", "Missing.Type")));
+        Assert.That(ex!.Message, Does.Contain("NoSuchAssembly.dll"));
+    }
+
+    [Test]
+    public void TypeLoader_InvalidType_ThrowsClearError()
+    {
+        var loader = new DefaultRuntimeComponentTypeLoader(new DefaultRuntimeAssemblyLocator());
+        Assert.Throws<TypeLoadException>(() => loader.LoadType(Entry("ArithmeticModule", "Missing.Type")));
+    }
+
+    private static RuntimeComponentManifestEntry Entry(string assemblySimpleName, string typeFullName)
+        => new(RuntimeComponentKind.FrontendModule, "Any", [], new RuntimeTypeReference(assemblySimpleName, typeFullName));
+
+    private sealed class CountingLocator(bool shouldResolve, string? path) : IRuntimeAssemblyLocator
+    {
+        public int Calls { get; private set; }
+
+        public bool TryResolveAssemblyPath(string assemblySimpleName, out string? absolutePath)
+        {
+            Calls++;
+            absolutePath = path;
+            return shouldResolve;
+        }
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/UniversalToolchain.Dialects.Tests.csproj
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/UniversalToolchain.Dialects.Tests.csproj
@@ -15,6 +15,7 @@
         <PackageReference Include="NUnit" Version="4.2.2"/>
         <PackageReference Include="NUnit.Analyzers" Version="4.4.0"/>
         <PackageReference Include="NUnit3TestAdapter" Version="4.6.0"/>
+        <PackageReference Include="System.Reflection.MetadataLoadContext" Version="10.0.0"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/WistDialectBackendHardcodeTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/WistDialectBackendHardcodeTests.cs
@@ -154,7 +154,7 @@ public class WistDialectBackendHardcodeTests
     private static ServiceProvider CreateRootProvider()
     {
         var services = new ServiceCollection();
-        services.AddWistDialectServices();
+        services.AddWistDialectServicesLegacy();
         return services.BuildServiceProvider();
     }
 

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/WistDialectMinimalRuntimeIsolationTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/WistDialectMinimalRuntimeIsolationTests.cs
@@ -1,0 +1,103 @@
+using Microsoft.Extensions.DependencyInjection;
+using UniversalToolchain.Dialects.Wist;
+
+namespace UniversalToolchain.Dialects.Tests;
+
+public class WistDialectMinimalRuntimeIsolationTests
+{
+
+    [Test]
+    public void MinimalWorkflow_HasNoLegacyDependencies()
+    {
+        using var provider = CreateMinimalProvider();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(provider.GetService<UniversalToolchain.Dialects.Integration.DialectFrameworkCompositionWorkflow>(), Is.Null);
+            Assert.That(provider.GetService<UniversalToolchain.Dialects.Integration.DialectRuntimeDescriptorRegistry>(), Is.Null);
+            Assert.That(provider.GetService<LegacyWistDialectCompositionService>(), Is.Null);
+        });
+    }
+
+    [Test]
+    public void MinimalWorkflow_ComposeText_DoesNotPopulateRuntimeComposition()
+    {
+        using var provider = CreateMinimalProvider();
+        var workflow = provider.GetRequiredService<WistDialectExecutionWorkflow>();
+
+        var result = workflow.ComposeText("dialect Demo\nuse Arithmetic\nbackend interpreter", "inline");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.RuntimeComposition, Is.Null);
+            Assert.That(result.RuntimeSelection, Is.Not.Null);
+        });
+    }
+
+    [Test]
+    public async Task ComposeText_ParallelDifferentDialects_DoNotMixSelections()
+    {
+        using var provider = CreateMinimalProvider();
+        var workflow = provider.GetRequiredService<WistDialectExecutionWorkflow>();
+        var dialects = new[]
+        {
+            "dialect A\nuse Arithmetic,Numbers\nbackend interpreter",
+            "dialect B\nuse Arithmetic,Variables,Scopes\nbackend interpreter,compiler\nenable LocalVariablesOptimization",
+            "dialect C\nuse Arithmetic,Conditions,ComparisonConditions\nbackend compiler"
+        };
+
+        var tasks = Enumerable.Range(0, 30)
+            .Select(i => Task.Run(() => workflow.ComposeText(dialects[i % dialects.Length], $"d{i}")))
+            .ToArray();
+
+        var results = await Task.WhenAll(tasks);
+        var signatures = results
+            .Select(r => (SelectedRuntimePlan)r.RuntimeSelection!)
+            .Select(x => string.Join("|", x.OrderedModules.Select(m => m.CanonicalAlias)) + "::" + string.Join("|", x.EnabledBackends.Select(b => b.CanonicalAlias)))
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+
+        Assert.That(signatures.Count, Is.EqualTo(3));
+    }
+
+    [Test]
+    public void CreateHost_RepeatedCalls_DoNotRecomputeSelection()
+    {
+        using var provider = CreateMinimalProvider();
+        var workflow = provider.GetRequiredService<WistDialectExecutionWorkflow>();
+        var result = workflow.ComposeText("dialect Demo\nuse Arithmetic\nbackend interpreter", "inline");
+        var selection = result.RuntimeSelection;
+
+        using var host1 = workflow.CreateHost(result);
+        using var host2 = workflow.CreateHost(result);
+
+        Assert.That(ReferenceEquals(selection, result.RuntimeSelection), Is.True);
+    }
+
+    [Test]
+    public void ProviderFactory_RepeatedCreates_DoNotAccumulateRegistrations()
+    {
+        using var provider = CreateMinimalProvider();
+        var workflow = provider.GetRequiredService<WistDialectExecutionWorkflow>();
+        var result = workflow.ComposeText("dialect Demo\nuse Arithmetic,Numbers\nbackend interpreter", "inline");
+        var baselines = new List<(int Frontend, int Ir, int Runtime)>();
+
+        for (var i = 0; i < 30; i++)
+        {
+            using var host = workflow.CreateHost(result);
+            baselines.Add((
+                host.Configuration.FrontendModules.Count,
+                host.Configuration.IrModules.Count,
+                host.Configuration.BackendConfigurations.Count));
+        }
+
+        Assert.That(baselines.Distinct().Count(), Is.EqualTo(1));
+    }
+
+    private static ServiceProvider CreateMinimalProvider()
+    {
+        var services = new ServiceCollection();
+        services.AddWistDialectServicesMinimal();
+        return services.BuildServiceProvider();
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/WistDialectMinimalRuntimeParityTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/WistDialectMinimalRuntimeParityTests.cs
@@ -1,0 +1,97 @@
+using Microsoft.Extensions.DependencyInjection;
+using NumbersModule.Core;
+using UniversalToolchain.Dialects.Wist;
+
+namespace UniversalToolchain.Dialects.Tests;
+
+public class WistDialectMinimalRuntimeParityTests
+{
+    [Test]
+    public void MinimalPath_FullDefault_ProducesSameExecutionResult_AsLegacyPath() => AssertParityForExample("full-default", "interpreter", expected: 15d);
+
+    [Test]
+    public void MinimalPath_MinimalArithmetic_ProducesSameExecutionResult_AsLegacyPath() => AssertParityForExample("minimal-arithmetic", "interpreter", expected: 14d);
+
+
+    [Test]
+    public void MinimalPath_WithOptimizer_ProducesSameExecutionResult_AsLegacyPath()
+    {
+        var examplePath = ResolveExampleDirectory("full-default");
+        var dialectText = File.ReadAllText(Path.Combine(examplePath, "dialect.wistdialect"));
+        var code = File.ReadAllText(Path.Combine(examplePath, "program.wist"));
+
+        var minimal = Execute(CreateMinimalProvider(), dialectText, code, "interpreter");
+        var legacy = Execute(CreateLegacyProvider(), dialectText, code, "interpreter");
+
+        Assert.That(minimal, Is.EqualTo(legacy).Within(1e-9));
+    }
+
+    [Test]
+    public void MinimalPath_InterpreterOnly_ProducesSameExecutionResult_AsLegacyPath() => AssertParityForInlineDialect("dialect Demo\nuse Arithmetic,Numbers,Whitespaces\nbackend interpreter", "2 + 5", "interpreter");
+
+    [Test]
+    public void MinimalPath_CilOnly_ProducesSameExecutionResult_AsLegacyPath() => AssertParityForInlineDialect("dialect Demo\nuse Arithmetic,Numbers,Whitespaces\nbackend compiler", "2 + 5", "compiler");
+
+    private static void AssertParityForExample(string exampleName, string executionMode, double expected)
+    {
+        var examplePath = ResolveExampleDirectory(exampleName);
+        var dialectText = File.ReadAllText(Path.Combine(examplePath, "dialect.wistdialect"));
+        var code = File.ReadAllText(Path.Combine(examplePath, "program.wist"));
+        AssertParityForInlineDialect(dialectText, code, executionMode, expected);
+    }
+
+    private static void AssertParityForInlineDialect(string dialectText, string code, string executionMode, double? expected = null)
+    {
+        var minimal = Execute(CreateMinimalProvider(), dialectText, code, executionMode);
+        var legacy = Execute(CreateLegacyProvider(), dialectText, code, executionMode);
+
+        Assert.That(minimal, Is.EqualTo(legacy).Within(1e-9));
+        if (expected.HasValue)
+            Assert.That(minimal, Is.EqualTo(expected.Value).Within(1e-9));
+    }
+
+    private static double Execute(ServiceProvider provider, string dialectText, string code, string executionMode)
+    {
+        using (provider)
+        {
+            var workflow = provider.GetRequiredService<WistDialectExecutionWorkflow>();
+            var composition = workflow.ComposeText(dialectText, "inline");
+            using var host = workflow.CreateHost(composition);
+            return ToDouble(host.Run(code, executionMode));
+        }
+    }
+
+    private static ServiceProvider CreateMinimalProvider()
+    {
+        var services = new ServiceCollection();
+        services.AddWistDialectServicesMinimal();
+        return services.BuildServiceProvider();
+    }
+
+    private static ServiceProvider CreateLegacyProvider()
+    {
+        var services = new ServiceCollection();
+        services.AddWistDialectServicesLegacy();
+        return services.BuildServiceProvider();
+    }
+
+    private static string ResolveExampleDirectory(string name)
+    {
+        var path = Path.GetFullPath(Path.Combine(TestContext.CurrentContext.TestDirectory, "..", "..", "..", "..", "Dialects", "examples", "wist", name));
+        return path;
+    }
+
+    private static double ToDouble(object? value)
+    {
+        return value switch
+        {
+            RealNumberImpl number => number.GetValue(),
+            int intValue => intValue,
+            long longValue => longValue,
+            double doubleValue => doubleValue,
+            float floatValue => floatValue,
+            decimal decimalValue => (double)decimalValue,
+            _ => Convert.ToDouble(value, System.Globalization.CultureInfo.InvariantCulture)
+        };
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/WistDialectRuntimeDescriptorProviderTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/WistDialectRuntimeDescriptorProviderTests.cs
@@ -39,7 +39,7 @@ public class WistDialectRuntimeDescriptorProviderTests
     public void AddWistDialectServices_RegistersReusableWorkflowServices()
     {
         var services = new ServiceCollection();
-        services.AddWistDialectServices();
+        services.AddWistDialectServicesLegacy();
 
         using var provider = services.BuildServiceProvider();
         var registry = provider.GetRequiredService<DialectRuntimeDescriptorRegistry>();
@@ -56,7 +56,7 @@ public class WistDialectRuntimeDescriptorProviderTests
     public void AddWistDialectServices_AllowsExtendingRuntimeDescriptorDiscoveryViaProvider()
     {
         var services = new ServiceCollection();
-        services.AddWistDialectServices();
+        services.AddWistDialectServicesLegacy();
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IDialectRuntimeDescriptorProvider, TestOnlyRuntimeDescriptorProvider>());
 
         using var provider = services.BuildServiceProvider();
@@ -141,7 +141,7 @@ public class WistDialectRuntimeDescriptorProviderTests
     private static DialectRuntimeDescriptorRegistry BuildRegistryFromServices()
     {
         var services = new ServiceCollection();
-        services.AddWistDialectServices();
+        services.AddWistDialectServicesLegacy();
 
         using var provider = services.BuildServiceProvider();
         return provider.GetRequiredService<DialectRuntimeDescriptorRegistry>();

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/WistMinimalRuntimeMemorySmokeTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/WistMinimalRuntimeMemorySmokeTests.cs
@@ -1,0 +1,70 @@
+using Microsoft.Extensions.DependencyInjection;
+using UniversalToolchain.Dialects.Wist;
+
+namespace UniversalToolchain.Dialects.Tests;
+
+public class WistMinimalRuntimeMemorySmokeTests
+{
+    [Test]
+    public void MinimalPath_RepeatedComposeAndHostCreation_DoesNotGrowLoadedAssemblySetUnexpectedly()
+    {
+        using var provider = CreateMinimalProvider();
+        var workflow = provider.GetRequiredService<WistDialectExecutionWorkflow>();
+        var before = AppDomain.CurrentDomain.GetAssemblies().Select(x => x.GetName().Name).ToHashSet(StringComparer.Ordinal);
+
+        for (var i = 0; i < 20; i++)
+        {
+            var result = workflow.ComposeText("dialect Demo\nuse Arithmetic,Numbers,Whitespaces\nbackend interpreter", $"s{i}");
+            using var host = workflow.CreateHost(result);
+            _ = host.Run("2 + 3", "interpreter");
+        }
+
+        var after = AppDomain.CurrentDomain.GetAssemblies().Select(x => x.GetName().Name).ToHashSet(StringComparer.Ordinal);
+        Assert.That(after.Count - before.Count, Is.LessThanOrEqualTo(5));
+    }
+
+
+    [Test]
+    public void MinimalPath_RepeatedCompose_DoesNotLoadUnusedFeatureAssemblies()
+    {
+        using var provider = CreateMinimalProvider();
+        var workflow = provider.GetRequiredService<WistDialectExecutionWorkflow>();
+        var before = AppDomain.CurrentDomain.GetAssemblies().Select(x => x.GetName().Name).ToHashSet(StringComparer.Ordinal);
+
+        for (var i = 0; i < 25; i++)
+            _ = workflow.ComposeText("dialect Demo\nuse Arithmetic,Numbers,Whitespaces\nbackend interpreter", $"s{i}");
+
+        var afterCompose = AppDomain.CurrentDomain.GetAssemblies().Select(x => x.GetName().Name).ToHashSet(StringComparer.Ordinal);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(afterCompose.Contains("CommentsModule"), Is.EqualTo(before.Contains("CommentsModule")));
+            Assert.That(afterCompose.Contains("LabelsModule"), Is.EqualTo(before.Contains("LabelsModule")));
+            Assert.That(afterCompose.Contains("LocalVariablesOptimizerModule"), Is.EqualTo(before.Contains("LocalVariablesOptimizerModule")));
+        });
+    }
+
+    [Test]
+    public void MinimalPath_RepeatedOperations_DoNotGrowServiceCounts()
+    {
+        using var provider = CreateMinimalProvider();
+        var workflow = provider.GetRequiredService<WistDialectExecutionWorkflow>();
+        var result = workflow.ComposeText("dialect Demo\nuse Arithmetic,Numbers,Whitespaces\nbackend interpreter", "inline");
+        (int modules, int ir, int backends)? baseline = null;
+
+        for (var i = 0; i < 20; i++)
+        {
+            using var host = workflow.CreateHost(result);
+            var current = (host.Configuration.FrontendModules.Count, host.Configuration.IrModules.Count, host.Configuration.BackendConfigurations.Count);
+            baseline ??= current;
+            Assert.That(current, Is.EqualTo(baseline.Value));
+        }
+    }
+
+    private static ServiceProvider CreateMinimalProvider()
+    {
+        var services = new ServiceCollection();
+        services.AddWistDialectServicesMinimal();
+        return services.BuildServiceProvider();
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/WistRuntimeManifestMetadataValidationTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/WistRuntimeManifestMetadataValidationTests.cs
@@ -1,0 +1,65 @@
+using System.Reflection;
+using UniversalToolchain.Dialects.Wist;
+
+namespace UniversalToolchain.Dialects.Tests;
+
+public class WistRuntimeManifestMetadataValidationTests
+{
+    [Test]
+    public void ManifestEntries_ResolveTypes_AndMatchExpectedContracts()
+    {
+        var manifest = new WistRuntimeManifest();
+        var entries = manifest.Modules.Concat(manifest.Optimizers).Concat(manifest.Backends).ToList();
+
+        foreach (var entry in entries)
+        {
+            var entryPath = Path.Combine(AppContext.BaseDirectory, entry.TypeReference.AssemblySimpleName + ".dll");
+            Assert.That(File.Exists(entryPath), Is.True, $"Assembly is missing: {entryPath}");
+
+            var runtimeAssemblies = Directory.GetFiles(Path.GetDirectoryName(typeof(object).Assembly.Location)!, "*.dll");
+            var resolverPaths = runtimeAssemblies.Concat([entryPath, typeof(WistRuntimeManifest).Assembly.Location, typeof(BasicCore.Contracts.IFrontendCoreModule).Assembly.Location, typeof(UniversalToolchain.Dialects.Abstractions.DialectBackendDeclaration).Assembly.Location]).Distinct(StringComparer.Ordinal).ToArray();
+            var resolver = new PathAssemblyResolver(resolverPaths);
+            using var context = new MetadataLoadContext(resolver);
+            var assembly = context.LoadFromAssemblyPath(entryPath);
+            var type = assembly.GetType(entry.TypeReference.TypeFullName, throwOnError: false, ignoreCase: false);
+            Assert.That(type, Is.Not.Null, $"Type not found: {entry.TypeReference.TypeFullName}");
+
+            var frontendContract = context.LoadFromAssemblyName(typeof(BasicCore.Contracts.IFrontendCoreModule).Assembly.GetName().Name!).GetType("BasicCore.Contracts.IFrontendCoreModule")!;
+            var irContract = context.LoadFromAssemblyName(typeof(BasicCore.Contracts.IIRProcessingModule).Assembly.GetName().Name!).GetType("BasicCore.Contracts.IIRProcessingModule")!;
+            var backendContract = context.LoadFromAssemblyName(typeof(UniversalToolchain.Dialects.Abstractions.DialectBackendDeclaration).Assembly.GetName().Name!).GetType("UniversalToolchain.Dialects.Abstractions.DialectBackendDeclaration")!;
+
+            Assert.That(IsValidForKind(entry.Kind, type!, frontendContract, irContract, backendContract), Is.True, $"Unexpected contract mismatch for {entry.CanonicalAlias}");
+        }
+    }
+
+
+
+    [Test]
+    public void Manifest_DuplicateAlias_FailsFast_WithClearMessage()
+    {
+        var dup = new RuntimeComponentManifestEntry(
+            RuntimeComponentKind.FrontendModule,
+            "Arithmetic",
+            [],
+            new RuntimeTypeReference("AnyAssembly", "Any.Type"));
+
+        var ex = Assert.Throws<InvalidOperationException>(() => new WistRuntimeManifest([dup, dup], [], []));
+        Assert.That(ex!.Message, Does.Contain("Arithmetic").And.Contain("Modules"));
+    }
+
+    private static bool IsValidForKind(
+        RuntimeComponentKind kind,
+        Type type,
+        Type frontendContract,
+        Type irContract,
+        Type backendContract)
+    {
+        return kind switch
+        {
+            RuntimeComponentKind.FrontendModule => frontendContract.IsAssignableFrom(type) || irContract.IsAssignableFrom(type),
+            RuntimeComponentKind.Optimizer => irContract.IsAssignableFrom(type),
+            RuntimeComponentKind.Backend => backendContract.IsAssignableFrom(type),
+            _ => false
+        };
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/DefaultRuntimeAssemblyLocator.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/DefaultRuntimeAssemblyLocator.cs
@@ -1,0 +1,40 @@
+using ExceptionsManager;
+
+namespace UniversalToolchain.Dialects.Wist;
+
+public sealed class DefaultRuntimeAssemblyLocator : IRuntimeAssemblyLocator
+{
+    private readonly IReadOnlyList<string> _searchRoots;
+
+    public DefaultRuntimeAssemblyLocator(RuntimeAssemblyLocatorOptions? options = null)
+    {
+        options ??= new RuntimeAssemblyLocatorOptions();
+
+        _searchRoots = new[] { AppContext.BaseDirectory }
+            .Concat(options.AdditionalSearchDirectories ?? [])
+            .Where(x => !string.IsNullOrWhiteSpace(x))
+            .Select(Path.GetFullPath)
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+    }
+
+    public bool TryResolveAssemblyPath(string assemblySimpleName, out string? absolutePath)
+    {
+        if (string.IsNullOrWhiteSpace(assemblySimpleName))
+            Thrower.Argument(nameof(assemblySimpleName), "Assembly simple name must not be empty.");
+
+        var fileName = assemblySimpleName.Trim() + ".dll";
+        foreach (var root in _searchRoots)
+        {
+            var candidate = Path.Combine(root, fileName);
+            if (!File.Exists(candidate))
+                continue;
+
+            absolutePath = Path.GetFullPath(candidate);
+            return true;
+        }
+
+        absolutePath = null;
+        return false;
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/DefaultRuntimeComponentTypeLoader.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/DefaultRuntimeComponentTypeLoader.cs
@@ -1,0 +1,91 @@
+using System.Collections.Concurrent;
+using System.Reflection;
+using System.Runtime.Loader;
+using ExceptionsManager;
+
+namespace UniversalToolchain.Dialects.Wist;
+
+/// <summary>
+/// Runtime type-loading strategy. Current implementation uses the default load context,
+/// but callers should depend on <see cref="IRuntimeComponentTypeLoader"/> rather than context-specific behavior.
+/// </summary>
+public sealed class DefaultRuntimeComponentTypeLoader : IRuntimeComponentTypeLoader
+{
+    private readonly ConcurrentDictionary<string, Lazy<Type>> _cache = new(StringComparer.Ordinal);
+    private readonly IRuntimeAssemblyLocator _locator;
+
+    public DefaultRuntimeComponentTypeLoader(IRuntimeAssemblyLocator locator)
+    {
+        _locator = locator ?? throw new ArgumentNullException(nameof(locator));
+    }
+
+    public Type LoadType(RuntimeComponentManifestEntry entry)
+    {
+        if (entry == null)
+            Thrower.ArgumentNull(nameof(entry));
+
+        var typeReference = entry.TypeReference;
+        if (string.IsNullOrWhiteSpace(typeReference.AssemblySimpleName))
+            Thrower.Argument(nameof(entry), "Assembly simple name must not be empty.");
+
+        if (string.IsNullOrWhiteSpace(typeReference.TypeFullName))
+            Thrower.Argument(nameof(entry), "Type full name must not be empty.");
+
+        var key = $"{typeReference.AssemblySimpleName}|{typeReference.TypeFullName}";
+        var lazy = _cache.GetOrAdd(key, _ => new Lazy<Type>(() => ResolveType(typeReference), LazyThreadSafetyMode.ExecutionAndPublication));
+        return lazy.Value;
+    }
+
+    private Type ResolveType(RuntimeTypeReference typeReference)
+    {
+        var assembly = TryGetAlreadyLoadedAssembly(typeReference.AssemblySimpleName)
+                       ?? TryLoadBySimpleName(typeReference.AssemblySimpleName)
+                       ?? LoadAssemblyFromResolvedPath(typeReference.AssemblySimpleName);
+
+        return ResolveTypeFromAssembly(assembly, typeReference);
+    }
+
+    private static Assembly? TryGetAlreadyLoadedAssembly(string assemblySimpleName)
+    {
+        return AppDomain.CurrentDomain
+            .GetAssemblies()
+            .FirstOrDefault(x => string.Equals(x.GetName().Name, assemblySimpleName, StringComparison.Ordinal));
+    }
+
+    private static Assembly? TryLoadBySimpleName(string assemblySimpleName)
+    {
+        try
+        {
+            return Assembly.Load(new AssemblyName(assemblySimpleName));
+        }
+        catch (FileNotFoundException)
+        {
+            return null;
+        }
+        catch (FileLoadException)
+        {
+            return null;
+        }
+        catch (BadImageFormatException)
+        {
+            return null;
+        }
+    }
+
+    private Assembly LoadAssemblyFromResolvedPath(string assemblySimpleName)
+    {
+        if (!_locator.TryResolveAssemblyPath(assemblySimpleName, out var absolutePath) || string.IsNullOrWhiteSpace(absolutePath))
+            Thrower.FileNotFound(Path.Combine(AppContext.BaseDirectory, assemblySimpleName + ".dll"));
+
+        if (!Path.IsPathRooted(absolutePath))
+            Thrower.Argument(nameof(absolutePath), $"Assembly locator returned non-absolute path '{absolutePath}'.");
+
+        return AssemblyLoadContext.Default.LoadFromAssemblyPath(absolutePath);
+    }
+
+    private static Type ResolveTypeFromAssembly(Assembly assembly, RuntimeTypeReference typeReference)
+    {
+        return assembly.GetType(typeReference.TypeFullName, throwOnError: true, ignoreCase: false)
+               ?? Thrower.InvalidOpEx<Type>($"Type '{typeReference.TypeFullName}' was not found in assembly '{typeReference.AssemblySimpleName}'.");
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/DialectIntrinsicPolicyResolver.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/DialectIntrinsicPolicyResolver.cs
@@ -1,0 +1,34 @@
+using ExceptionsManager;
+using UniversalToolchain.Dialects.Abstractions;
+
+namespace UniversalToolchain.Dialects.Wist;
+
+public sealed class DialectIntrinsicPolicyResolver
+{
+    public (IReadOnlyList<string> Allowed, IReadOnlyList<string> Forbidden, bool HasExplicitAllowList) Resolve(
+        DialectBuildPlan buildPlan,
+        DialectBackendId backendId)
+    {
+        if (buildPlan == null)
+            Thrower.ArgumentNull(nameof(buildPlan));
+
+        var allowed = buildPlan.IntrinsicDirectives
+            .Where(x => x.Allowed && x.Target.Matches(backendId))
+            .Select(x => x.Name)
+            .Where(x => !string.IsNullOrWhiteSpace(x))
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(x => x, StringComparer.Ordinal)
+            .ToList();
+
+        var forbidden = buildPlan.IntrinsicDirectives
+            .Where(x => !x.Allowed && x.Target.Matches(backendId))
+            .Select(x => x.Name)
+            .Where(x => !string.IsNullOrWhiteSpace(x))
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(x => x, StringComparer.Ordinal)
+            .ToList();
+
+        var hasExplicitAllowList = buildPlan.IntrinsicDirectives.Any(x => x.Allowed && x.Target.Matches(backendId));
+        return (allowed, forbidden, hasExplicitAllowList);
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/IRuntimeAssemblyLocator.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/IRuntimeAssemblyLocator.cs
@@ -1,0 +1,6 @@
+namespace UniversalToolchain.Dialects.Wist;
+
+public interface IRuntimeAssemblyLocator
+{
+    bool TryResolveAssemblyPath(string assemblySimpleName, out string? absolutePath);
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/IRuntimeComponentTypeLoader.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/IRuntimeComponentTypeLoader.cs
@@ -1,0 +1,10 @@
+namespace UniversalToolchain.Dialects.Wist;
+
+/// <summary>
+/// Strategy for loading runtime component types from manifest metadata.
+/// Implementations may use default or custom assembly load contexts.
+/// </summary>
+public interface IRuntimeComponentTypeLoader
+{
+    Type LoadType(RuntimeComponentManifestEntry entry);
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/IWistRuntimeManifest.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/IWistRuntimeManifest.cs
@@ -1,0 +1,14 @@
+namespace UniversalToolchain.Dialects.Wist;
+
+public interface IWistRuntimeManifest
+{
+    bool TryResolveModule(string alias, out RuntimeComponentManifestEntry? entry);
+    bool TryResolveOptimizer(string alias, out RuntimeComponentManifestEntry? entry);
+    bool TryResolveBackend(string backendId, out RuntimeComponentManifestEntry? entry);
+
+    IReadOnlyCollection<RuntimeComponentManifestEntry> Modules { get; }
+    IReadOnlyCollection<RuntimeComponentManifestEntry> Optimizers { get; }
+    IReadOnlyCollection<RuntimeComponentManifestEntry> Backends { get; }
+
+    IReadOnlyList<RuntimeComponentManifestEntry> GetBackendsInDeterministicOrder();
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/LegacyWistDialectCompositionService.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/LegacyWistDialectCompositionService.cs
@@ -1,0 +1,29 @@
+using ExceptionsManager;
+using UniversalToolchain.Dialects.Integration;
+
+namespace UniversalToolchain.Dialects.Wist;
+
+public sealed class LegacyWistDialectCompositionService
+{
+    private readonly DialectFrameworkCompositionWorkflow _compositionWorkflow;
+    private readonly DialectRuntimeDescriptorRegistry _registry;
+
+    public LegacyWistDialectCompositionService(
+        DialectFrameworkCompositionWorkflow compositionWorkflow,
+        DialectRuntimeDescriptorRegistry registry)
+    {
+        _compositionWorkflow = compositionWorkflow ?? throw new ArgumentNullException(nameof(compositionWorkflow));
+        _registry = registry ?? throw new ArgumentNullException(nameof(registry));
+    }
+
+    public DialectFrameworkCompositionResult ComposeText(string sourceText, string sourceName = "inline")
+    {
+        if (sourceText == null)
+            Thrower.ArgumentNull(nameof(sourceText));
+
+        if (string.IsNullOrWhiteSpace(sourceName))
+            Thrower.Argument(nameof(sourceName), "Source name must not be empty.");
+
+        return _compositionWorkflow.ComposeText(sourceText, _registry, sourceName);
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/RuntimeAssemblyLocatorOptions.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/RuntimeAssemblyLocatorOptions.cs
@@ -1,0 +1,6 @@
+namespace UniversalToolchain.Dialects.Wist;
+
+public sealed class RuntimeAssemblyLocatorOptions
+{
+    public IReadOnlyList<string> AdditionalSearchDirectories { get; init; } = [];
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/RuntimeComponentKind.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/RuntimeComponentKind.cs
@@ -1,0 +1,8 @@
+namespace UniversalToolchain.Dialects.Wist;
+
+public enum RuntimeComponentKind
+{
+    FrontendModule = 0,
+    Optimizer = 1,
+    Backend = 2
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/RuntimeComponentManifestEntry.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/RuntimeComponentManifestEntry.cs
@@ -1,0 +1,10 @@
+namespace UniversalToolchain.Dialects.Wist;
+
+public sealed record RuntimeComponentManifestEntry(
+    RuntimeComponentKind Kind,
+    string CanonicalAlias,
+    IReadOnlyList<string> Aliases,
+    RuntimeTypeReference TypeReference)
+{
+    public IReadOnlyList<string> AllAliases => [CanonicalAlias, .. Aliases];
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/RuntimeTypeReference.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/RuntimeTypeReference.cs
@@ -1,0 +1,5 @@
+namespace UniversalToolchain.Dialects.Wist;
+
+public sealed record RuntimeTypeReference(
+    string AssemblySimpleName,
+    string TypeFullName);

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/SelectedRuntimePlan.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/SelectedRuntimePlan.cs
@@ -1,0 +1,13 @@
+using UniversalToolchain.Dialects.Abstractions;
+using UniversalToolchain.Dialects.Integration;
+
+namespace UniversalToolchain.Dialects.Wist;
+
+public sealed record SelectedRuntimePlan(
+    IReadOnlyList<RuntimeComponentManifestEntry> OrderedModules,
+    IReadOnlyList<RuntimeComponentManifestEntry> EnabledOptimizers,
+    IReadOnlyList<RuntimeComponentManifestEntry> EnabledBackends,
+    IReadOnlyList<DialectDiagnostic> Diagnostics) : IDialectRuntimeSelection
+{
+    public bool IsResolved => Diagnostics.All(x => x.Severity != DialectDiagnosticSeverity.Error);
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/SelectedRuntimePlanResolver.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/SelectedRuntimePlanResolver.cs
@@ -1,0 +1,105 @@
+using ExceptionsManager;
+using UniversalToolchain.Dialects.Abstractions;
+
+namespace UniversalToolchain.Dialects.Wist;
+
+public sealed class SelectedRuntimePlanResolver
+{
+    private readonly IWistRuntimeManifest _manifest;
+
+    public SelectedRuntimePlanResolver(IWistRuntimeManifest manifest)
+    {
+        _manifest = manifest ?? throw new ArgumentNullException(nameof(manifest));
+    }
+
+    public SelectedRuntimePlan Resolve(DialectBuildPlan buildPlan)
+    {
+        if (buildPlan == null)
+            Thrower.ArgumentNull(nameof(buildPlan));
+
+        var diagnostics = new List<DialectDiagnostic>(buildPlan.ValidationResult.Diagnostics);
+        var modules = ResolveModules(buildPlan, diagnostics);
+        var backends = ResolveBackends(buildPlan, diagnostics, out var selectedBackendIds);
+        var optimizers = ResolveOptimizers(buildPlan, diagnostics, selectedBackendIds);
+
+        return new SelectedRuntimePlan(modules, optimizers, backends, diagnostics);
+    }
+
+    private IReadOnlyList<RuntimeComponentManifestEntry> ResolveModules(DialectBuildPlan buildPlan, ICollection<DialectDiagnostic> diagnostics)
+    {
+        var modules = new List<RuntimeComponentManifestEntry>();
+        foreach (var moduleAlias in buildPlan.OrderedModules)
+        {
+            if (!_manifest.TryResolveModule(moduleAlias, out var entry) || entry == null)
+            {
+                diagnostics.Add(new DialectDiagnostic("R001", $"Runtime module descriptor '{moduleAlias}' was not registered.", DialectDiagnosticSeverity.Error));
+                continue;
+            }
+
+            modules.Add(entry);
+        }
+
+        return modules;
+    }
+
+    private IReadOnlyList<RuntimeComponentManifestEntry> ResolveBackends(
+        DialectBuildPlan buildPlan,
+        ICollection<DialectDiagnostic> diagnostics,
+        out IReadOnlySet<DialectBackendId> selectedBackendIds)
+    {
+        var backends = new List<RuntimeComponentManifestEntry>();
+        var backendIdSet = new SortedSet<DialectBackendId>();
+
+        foreach (var backendId in buildPlan.EnabledBackends.OrderBy(x => x))
+        {
+            if (!_manifest.TryResolveBackend(backendId.Value, out var entry) || entry == null)
+            {
+                diagnostics.Add(new DialectDiagnostic("R002", $"Runtime backend descriptor '{backendId.Value}' was not registered.", DialectDiagnosticSeverity.Error));
+                continue;
+            }
+
+            var resolvedBackendId = new DialectBackendId(entry.CanonicalAlias);
+            if (!backendIdSet.Add(resolvedBackendId))
+                continue;
+
+            backends.Add(entry);
+        }
+
+        var orderedBackends = backends
+            .OrderBy(x => x.CanonicalAlias, StringComparer.Ordinal)
+            .ThenBy(x => x.TypeReference.TypeFullName, StringComparer.Ordinal)
+            .ToList();
+
+        selectedBackendIds = backendIdSet;
+        return orderedBackends;
+    }
+
+    private IReadOnlyList<RuntimeComponentManifestEntry> ResolveOptimizers(
+        DialectBuildPlan buildPlan,
+        ICollection<DialectDiagnostic> diagnostics,
+        IReadOnlySet<DialectBackendId> selectedBackendIds)
+    {
+        var optimizers = new List<RuntimeComponentManifestEntry>();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var optimizer in buildPlan.OptimizerDirectives
+                     .Where(x => x.Enabled)
+                     .OrderBy(x => x.Name, StringComparer.Ordinal)
+                     .ThenBy(x => x.Target))
+        {
+            if (!selectedBackendIds.Any(optimizer.Target.Matches))
+                continue;
+
+            if (!_manifest.TryResolveOptimizer(optimizer.Name, out var entry) || entry == null)
+            {
+                diagnostics.Add(new DialectDiagnostic("R003", $"Runtime optimizer descriptor '{optimizer.Name}' was not registered.", DialectDiagnosticSeverity.Error));
+                continue;
+            }
+
+            if (seen.Add(entry.CanonicalAlias))
+                optimizers.Add(entry);
+        }
+
+        return optimizers;
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistDialectExecutionConfigurationBuilder.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistDialectExecutionConfigurationBuilder.cs
@@ -1,38 +1,60 @@
+using BasicCore.Contracts;
 using ExceptionsManager;
 using UniversalToolchain.Dialects.Abstractions;
 using UniversalToolchain.Dialects.Integration;
 
 namespace UniversalToolchain.Dialects.Wist;
 
-/// <summary>
-///     Converts resolved dialect composition into explicit Wist execution wiring.
-/// </summary>
 public sealed class WistDialectExecutionConfigurationBuilder
 {
-    public WistDialectExecutionConfiguration Build(DialectBuildPlan buildPlan, DialectRuntimeComposition runtimeComposition, DialectRuntimeDescriptorRegistry registry)
+    private readonly DialectIntrinsicPolicyResolver _intrinsicPolicyResolver;
+    private readonly IWistRuntimeManifest _manifest;
+    private readonly IRuntimeComponentTypeLoader _typeLoader;
+
+    public WistDialectExecutionConfigurationBuilder(
+        IRuntimeComponentTypeLoader typeLoader,
+        DialectIntrinsicPolicyResolver intrinsicPolicyResolver,
+        IWistRuntimeManifest manifest)
+    {
+        _typeLoader = typeLoader ?? throw new ArgumentNullException(nameof(typeLoader));
+        _intrinsicPolicyResolver = intrinsicPolicyResolver ?? throw new ArgumentNullException(nameof(intrinsicPolicyResolver));
+        _manifest = manifest ?? throw new ArgumentNullException(nameof(manifest));
+    }
+
+    public WistDialectExecutionConfiguration Build(DialectBuildPlan buildPlan, SelectedRuntimePlan selectedRuntimePlan)
     {
         if (buildPlan == null)
             Thrower.ArgumentNull(nameof(buildPlan));
 
-        if (runtimeComposition == null)
-            Thrower.ArgumentNull(nameof(runtimeComposition));
+        if (selectedRuntimePlan == null)
+            Thrower.ArgumentNull(nameof(selectedRuntimePlan));
 
-        if (registry == null)
-            Thrower.ArgumentNull(nameof(registry));
+        if (!selectedRuntimePlan.IsResolved)
+            Thrower.Argument(nameof(selectedRuntimePlan), "Selected runtime plan must be resolved before execution wiring is built.");
 
-        if (!runtimeComposition.IsResolved)
-            Thrower.Argument(nameof(runtimeComposition), "Runtime composition must be resolved before execution wiring is built.");
+        var frontendModules = new List<Type>();
+        var irModules = new List<Type>();
 
-        var frontendModules = runtimeComposition.OrderedModules
-            .Where(x => x.IsFrontendModule)
-            .Select(x => x.ImplementationType);
-        var irModules = runtimeComposition.OrderedModules
-            .Where(x => x.IsIrProcessingModule)
-            .Select(x => x.ImplementationType);
-        var optimizers = runtimeComposition.EnabledOptimizers
-            .Select(x => x.ImplementationType);
-        var backends = runtimeComposition.EnabledBackends
-            .Select(backend => BuildBackendConfiguration(backend, buildPlan, runtimeComposition))
+        foreach (var entry in selectedRuntimePlan.OrderedModules)
+        {
+            var type = _typeLoader.LoadType(entry);
+            if (typeof(IFrontendCoreModule).IsAssignableFrom(type))
+                frontendModules.Add(type);
+
+            if (typeof(IIRProcessingModule).IsAssignableFrom(type))
+                irModules.Add(type);
+        }
+
+        var optimizers = selectedRuntimePlan.EnabledOptimizers
+            .Select(_typeLoader.LoadType)
+            .ToList();
+
+        var backends = selectedRuntimePlan.EnabledBackends
+            .Select(x => BuildBackendConfiguration(x, buildPlan))
+            .ToList();
+
+        var knownBackends = _manifest.GetBackendsInDeterministicOrder()
+            .Select(x => new RuntimeBackendDescriptor(new DialectBackendId(x.CanonicalAlias), x.Aliases))
             .ToList();
 
         return new WistDialectExecutionConfiguration(
@@ -41,25 +63,17 @@ public sealed class WistDialectExecutionConfigurationBuilder
             irModules,
             optimizers,
             backends,
-            registry.Backends.Values);
+            knownBackends);
     }
 
-    private static WistDialectBackendConfiguration BuildBackendConfiguration(
-        RuntimeBackendDescriptor backend,
-        DialectBuildPlan buildPlan,
-        DialectRuntimeComposition runtimeComposition)
+    private WistDialectBackendConfiguration BuildBackendConfiguration(RuntimeComponentManifestEntry backend, DialectBuildPlan buildPlan)
     {
-        var allowedIntrinsics = runtimeComposition.AllowedIntrinsics
-            .Where(x => x.AppliesTo(backend.BackendId))
-            .Select(x => x.CanonicalId);
-        var hasExplicitAllowList = buildPlan.IntrinsicDirectives.Any(x => x.Allowed && x.Target.Matches(backend.BackendId));
-        var forbiddenIntrinsics = buildPlan.IntrinsicDirectives
-            .Where(x => !x.Allowed && x.Target.Matches(backend.BackendId))
-            .Select(x => x.Name)
-            .Distinct(StringComparer.Ordinal)
-            .OrderBy(x => x, StringComparer.Ordinal)
-            .ToList();
-
-        return new WistDialectBackendConfiguration(backend, allowedIntrinsics, forbiddenIntrinsics, hasExplicitAllowList);
+        var backendId = new DialectBackendId(backend.CanonicalAlias);
+        var policy = _intrinsicPolicyResolver.Resolve(buildPlan, backendId);
+        return new WistDialectBackendConfiguration(
+            new RuntimeBackendDescriptor(backendId, backend.Aliases),
+            policy.Allowed,
+            policy.Forbidden,
+            policy.HasExplicitAllowList);
     }
 }

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistDialectExecutionWorkflow.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistDialectExecutionWorkflow.cs
@@ -1,40 +1,31 @@
 using ExceptionsManager;
+using UniversalToolchain.Dialects.Abstractions;
+using UniversalToolchain.Dialects.Core;
+using UniversalToolchain.Dialects.Frontend;
 using UniversalToolchain.Dialects.Integration;
 
 namespace UniversalToolchain.Dialects.Wist;
 
-/// <summary>
-///     End-to-end Wist workflow that composes dialect DSL and materializes a runnable runtime host.
-/// </summary>
 public sealed class WistDialectExecutionWorkflow
 {
-    private readonly DialectFrameworkCompositionWorkflow _compositionWorkflow;
+    private readonly IDialectCompiledDialectBuildPlanBuilder _buildPlanBuilder;
+    private readonly DialectDslCompiler _compiler;
     private readonly WistDialectExecutionConfigurationBuilder _configurationBuilder;
-    private readonly DialectRuntimeDescriptorRegistry _registry;
+    private readonly SelectedRuntimePlanResolver _resolver;
     private readonly WistDialectServiceProviderFactory _serviceProviderFactory;
 
     public WistDialectExecutionWorkflow(
-        DialectFrameworkCompositionWorkflow compositionWorkflow,
-        DialectRuntimeDescriptorRegistry registry,
+        DialectDslCompiler compiler,
+        IDialectCompiledDialectBuildPlanBuilder buildPlanBuilder,
+        SelectedRuntimePlanResolver resolver,
         WistDialectExecutionConfigurationBuilder configurationBuilder,
         WistDialectServiceProviderFactory serviceProviderFactory)
     {
-        if (compositionWorkflow == null)
-            Thrower.ArgumentNull(nameof(compositionWorkflow));
-
-        if (registry == null)
-            Thrower.ArgumentNull(nameof(registry));
-
-        if (configurationBuilder == null)
-            Thrower.ArgumentNull(nameof(configurationBuilder));
-
-        if (serviceProviderFactory == null)
-            Thrower.ArgumentNull(nameof(serviceProviderFactory));
-
-        _compositionWorkflow = compositionWorkflow;
-        _registry = registry;
-        _configurationBuilder = configurationBuilder;
-        _serviceProviderFactory = serviceProviderFactory;
+        _compiler = compiler ?? throw new ArgumentNullException(nameof(compiler));
+        _buildPlanBuilder = buildPlanBuilder ?? throw new ArgumentNullException(nameof(buildPlanBuilder));
+        _resolver = resolver ?? throw new ArgumentNullException(nameof(resolver));
+        _configurationBuilder = configurationBuilder ?? throw new ArgumentNullException(nameof(configurationBuilder));
+        _serviceProviderFactory = serviceProviderFactory ?? throw new ArgumentNullException(nameof(serviceProviderFactory));
     }
 
     public DialectFrameworkCompositionResult ComposeFile(string filePath)
@@ -56,7 +47,20 @@ public sealed class WistDialectExecutionWorkflow
         if (string.IsNullOrWhiteSpace(sourceName))
             Thrower.Argument(nameof(sourceName), "Source name must not be empty.");
 
-        return _compositionWorkflow.ComposeText(sourceText, _registry, sourceName);
+        var compiled = _compiler.Compile(sourceText);
+        var buildPlan = _buildPlanBuilder.Build(compiled);
+        var semanticErrors = buildPlan.ValidationResult.Diagnostics.Where(x => x.Severity == DialectDiagnosticSeverity.Error).ToList();
+
+        if (!buildPlan.CanBuild)
+            return new DialectFrameworkCompositionResult(sourceName, compiled, buildPlan, null, semanticErrors, [], null);
+
+        var selectedRuntimePlan = _resolver.Resolve(buildPlan);
+        var resolutionErrors = selectedRuntimePlan.Diagnostics
+            .Where(x => x.Severity == DialectDiagnosticSeverity.Error)
+            .Where(x => !semanticErrors.Contains(x))
+            .ToList();
+
+        return new DialectFrameworkCompositionResult(sourceName, compiled, buildPlan, null, semanticErrors, resolutionErrors, selectedRuntimePlan);
     }
 
     public WistDialectExecutionHost CreateHost(DialectFrameworkCompositionResult compositionResult)
@@ -64,10 +68,13 @@ public sealed class WistDialectExecutionWorkflow
         if (compositionResult == null)
             Thrower.ArgumentNull(nameof(compositionResult));
 
-        if (!compositionResult.IsSuccess || compositionResult.BuildPlan == null || compositionResult.RuntimeComposition == null)
+        if (!compositionResult.IsSuccess || compositionResult.BuildPlan == null)
             Thrower.Argument(nameof(compositionResult), "Dialect composition result must be successful before a runtime host can be created.");
 
-        var configuration = _configurationBuilder.Build(compositionResult.BuildPlan, compositionResult.RuntimeComposition, _registry);
+        if (compositionResult.RuntimeSelection is not SelectedRuntimePlan selectedRuntimePlan)
+            throw new ArgumentException("Dialect composition result does not contain a selected runtime plan for Wist execution.", nameof(compositionResult));
+
+        var configuration = _configurationBuilder.Build(compositionResult.BuildPlan, selectedRuntimePlan);
         var provider = _serviceProviderFactory.Create(configuration);
         return new WistDialectExecutionHost(provider, configuration);
     }

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistDialectServiceCollectionExtensions.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistDialectServiceCollectionExtensions.cs
@@ -24,21 +24,57 @@ using WhitespacesModule;
 
 namespace UniversalToolchain.Dialects.Wist;
 
-/// <summary>
-///     Registers Wist-specific dialect services and descriptor catalogs.
-/// </summary>
 public static class WistDialectServiceCollectionExtensions
 {
-    public static IServiceCollection AddWistDialectServices(this IServiceCollection services)
+    public static IServiceCollection AddWistDialectServices(this IServiceCollection services) => AddWistDialectServicesMinimal(services);
+
+    public static IServiceCollection AddWistDialectServicesMinimal(this IServiceCollection services)
     {
         if (services == null)
-        {
             Thrower.ArgumentNull(nameof(services));
-        }
 
         services.AddDialectDslDefaultComposition();
+        AddSharedWistDialectServices(services);
+        AddMinimalCompositionServices(services);
+        return services;
+    }
+
+    public static IServiceCollection AddWistDialectServicesLegacy(this IServiceCollection services)
+    {
+        if (services == null)
+            Thrower.ArgumentNull(nameof(services));
+
+        services.AddDialectDslDefaultComposition();
+        AddSharedWistDialectServices(services);
+        AddLegacyCompositionServices(services);
+        return services;
+    }
+
+    private static void AddSharedWistDialectServices(IServiceCollection services)
+    {
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IWistDialectBackendServiceProvider, WistCilDialectBackendServiceProvider>());
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IWistDialectBackendServiceProvider, WistInterpreterDialectBackendServiceProvider>());
+
+        services.TryAddSingleton<IWistRuntimeManifest, WistRuntimeManifest>();
+        services.TryAddSingleton<SelectedRuntimePlanResolver>();
+        services.TryAddSingleton<RuntimeAssemblyLocatorOptions>();
+        services.TryAddSingleton<IRuntimeAssemblyLocator>(provider =>
+            new DefaultRuntimeAssemblyLocator(provider.GetRequiredService<RuntimeAssemblyLocatorOptions>()));
+        services.TryAddSingleton<IRuntimeComponentTypeLoader, DefaultRuntimeComponentTypeLoader>();
+        services.TryAddSingleton<DialectIntrinsicPolicyResolver>();
+        services.TryAddSingleton<IDialectCompiledDialectBuildPlanBuilder, DialectCompiledDialectBuildPlanBuilder>();
+        services.TryAddSingleton<WistDialectExecutionConfigurationBuilder>();
+        services.TryAddSingleton<WistDialectServiceProviderFactory>();
+        services.TryAddSingleton<WistDialectExecutionWorkflow>();
+    }
+
+    private static void AddMinimalCompositionServices(IServiceCollection services)
+    {
+        // minimal path intentionally avoids runtime descriptor discovery services.
+    }
+
+    private static void AddLegacyCompositionServices(IServiceCollection services)
+    {
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IDialectRuntimeDescriptorProvider, WistDialectRuntimeDescriptorProvider>());
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IDialectRuntimeDescriptorProvider, ArithmeticDialectRuntimeDescriptorProvider>());
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IDialectRuntimeDescriptorProvider, ConditionsDialectRuntimeDescriptorProvider>());
@@ -57,16 +93,13 @@ public static class WistDialectServiceCollectionExtensions
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IDialectRuntimeDescriptorProvider, LoopsDialectRuntimeDescriptorProvider>());
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IDialectRuntimeDescriptorProvider, CSharpInteropDialectRuntimeDescriptorProvider>());
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IDialectRuntimeDescriptorProvider, LocalVariablesOptimizerDialectRuntimeDescriptorProvider>());
+
         services.TryAddSingleton(static provider => DialectRuntimeDescriptorRegistryFactory.BuildFromProviders(provider.GetServices<IDialectRuntimeDescriptorProvider>()));
-        services.TryAddSingleton<IDialectCompiledDialectBuildPlanBuilder, DialectCompiledDialectBuildPlanBuilder>();
         services.TryAddSingleton<IDialectRuntimeCompositionResolver, DialectRuntimeCompositionResolver>();
         services.TryAddSingleton(static provider => new DialectFrameworkCompositionWorkflow(
             provider.GetRequiredService<DialectDslCompiler>(),
             provider.GetRequiredService<IDialectCompiledDialectBuildPlanBuilder>(),
             provider.GetRequiredService<IDialectRuntimeCompositionResolver>()));
-        services.TryAddSingleton<WistDialectExecutionConfigurationBuilder>();
-        services.TryAddSingleton<WistDialectServiceProviderFactory>();
-        services.TryAddSingleton<WistDialectExecutionWorkflow>();
-        return services;
+        services.TryAddSingleton<LegacyWistDialectCompositionService>();
     }
 }

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistRuntimeManifest.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistRuntimeManifest.cs
@@ -1,0 +1,151 @@
+using ExceptionsManager;
+
+namespace UniversalToolchain.Dialects.Wist;
+
+public sealed class WistRuntimeManifest : IWistRuntimeManifest
+{
+    private static readonly IReadOnlyList<RuntimeComponentManifestEntry> ModuleEntries =
+    [
+        Create(RuntimeComponentKind.FrontendModule, "Arithmetic", [], "ArithmeticModule", "ArithmeticModule.Module.ArithmeticModuleImpl"),
+        Create(RuntimeComponentKind.FrontendModule, "Comments", [], "CommentsModule", "CommentsModule.CommentsModuleImpl"),
+        Create(RuntimeComponentKind.FrontendModule, "Conditions", [], "ConditionsModule", "ConditionsModule.Module.ConditionsModuleImpl"),
+        Create(RuntimeComponentKind.FrontendModule, "ComparisonConditions", [], "ConditionsModule", "ConditionsModule.Enums.ComparisonOperations"),
+        Create(RuntimeComponentKind.FrontendModule, "BooleanConditions", [], "ConditionsModule", "ConditionsModule.Enums.BooleanOperations"),
+        Create(RuntimeComponentKind.FrontendModule, "CSharpInterop", [], "CSharpInteropModule", "CSharpInteropModule.Module.CSharpInteropModuleImpl"),
+        Create(RuntimeComponentKind.FrontendModule, "Equality", [], "EqualityModule", "EqualityModule.EqualityModuleImpl"),
+        Create(RuntimeComponentKind.FrontendModule, "Identifier", [], "IdentifierModule", "IdentifierModule.IdentifierModuleImpl"),
+        Create(RuntimeComponentKind.FrontendModule, "InternalPreprocessorLexemes", [], "InternalPreprocessorLexemesModule", "InternalPreprocessorLexemesModule.InternalPreprocessorLexemesModuleImpl"),
+        Create(RuntimeComponentKind.FrontendModule, "Labels", [], "LabelsModule", "LabelsModule.Module.LabelsModuleImpl"),
+        Create(RuntimeComponentKind.FrontendModule, "Loops", [], "LoopsModule", "LoopsModule.Module.LoopsModuleImpl"),
+        Create(RuntimeComponentKind.FrontendModule, "NativeTypes", [], "NativeMathModule", "NativeMathModule.NativeTypesModuleImpl"),
+        Create(RuntimeComponentKind.FrontendModule, "Numbers", [], "NumbersModule", "NumbersModule.Module.NumbersModuleImpl"),
+        Create(RuntimeComponentKind.FrontendModule, "ParametersSetter", [], "ParametersSetterModule", "ParametersSetterModule.ParametersSetterModuleImpl"),
+        Create(RuntimeComponentKind.FrontendModule, "Scopes", [], "ScopesModule", "ScopesModule.Module.ScopesModuleImpl"),
+        Create(RuntimeComponentKind.FrontendModule, "SemicolonAsNewLine", [], "SemicolonAsNewLineModule", "SemicolonAsNewLineModule.SemicolonAsNewLineModuleImpl"),
+        Create(RuntimeComponentKind.FrontendModule, "Variables", [], "VariablesModule", "VariablesModule.VariablesModuleImpl"),
+        Create(RuntimeComponentKind.FrontendModule, "Whitespaces", [], "WhitespacesModule", "WhitespacesModule.WhitespaceModuleImpl")
+    ];
+
+    private static readonly IReadOnlyList<RuntimeComponentManifestEntry> OptimizerEntries =
+    [
+        Create(RuntimeComponentKind.Optimizer, "ArithmeticOptimization", [], "NativeMathModule", "NativeMathModule.ArithmeticOptimizerModule"),
+        Create(RuntimeComponentKind.Optimizer, "BooleanOptimization", [], "ConditionsModule", "ConditionsModule.Optimizers.BooleanOptimizerModule"),
+        Create(RuntimeComponentKind.Optimizer, "ComparisonIntrinsicOptimization", [], "ConditionsModule", "ConditionsModule.Optimizers.ComparisonIntrinsicOptimizerModule"),
+        Create(RuntimeComponentKind.Optimizer, "EGraphOptimization", [], "NativeMathModule", "NativeMathModule.EGraphOptimizerModule"),
+        Create(RuntimeComponentKind.Optimizer, "LocalVariablesOptimization", [], "LocalVariablesOptimizerModule", "LocalVariablesOptimizerModule.LocalVariablesOptimizer"),
+        Create(RuntimeComponentKind.Optimizer, "NativeCilOptimization", [], "NativeMathModule", "NativeMathModule.NativeCilOptimizerModule"),
+        Create(RuntimeComponentKind.Optimizer, "NativeTypesOptimization", [], "NativeMathModule", "NativeMathModule.NativeTypesOptimizerModule")
+    ];
+
+    private static readonly IReadOnlyList<RuntimeComponentManifestEntry> BackendEntries =
+    [
+        Create(RuntimeComponentKind.Backend, "cil", ["compiler"], "UniversalToolchain.Dialects.Wist", "UniversalToolchain.Dialects.Wist.WistCilBackendDeclaration"),
+        Create(RuntimeComponentKind.Backend, "interpreter", [], "UniversalToolchain.Dialects.Wist", "UniversalToolchain.Dialects.Wist.WistInterpreterBackendDeclaration")
+    ];
+
+    private readonly IReadOnlyDictionary<string, RuntimeComponentManifestEntry> _backendsByAlias;
+    private readonly IReadOnlyDictionary<string, RuntimeComponentManifestEntry> _modulesByAlias;
+    private readonly IReadOnlyDictionary<string, RuntimeComponentManifestEntry> _optimizersByAlias;
+
+    public WistRuntimeManifest()
+        : this(ModuleEntries, OptimizerEntries, BackendEntries)
+    {
+    }
+
+    internal WistRuntimeManifest(
+        IEnumerable<RuntimeComponentManifestEntry> modules,
+        IEnumerable<RuntimeComponentManifestEntry> optimizers,
+        IEnumerable<RuntimeComponentManifestEntry> backends)
+    {
+        Modules = Sort(modules);
+        Optimizers = Sort(optimizers);
+        Backends = Sort(backends);
+
+        _modulesByAlias = CreateAliasMap(Modules, nameof(Modules));
+        _optimizersByAlias = CreateAliasMap(Optimizers, nameof(Optimizers));
+        _backendsByAlias = CreateAliasMap(Backends, nameof(Backends));
+    }
+
+    public IReadOnlyCollection<RuntimeComponentManifestEntry> Modules { get; }
+    public IReadOnlyCollection<RuntimeComponentManifestEntry> Optimizers { get; }
+    public IReadOnlyCollection<RuntimeComponentManifestEntry> Backends { get; }
+
+    public bool TryResolveModule(string alias, out RuntimeComponentManifestEntry? entry) => TryResolve(_modulesByAlias, alias, out entry);
+    public bool TryResolveOptimizer(string alias, out RuntimeComponentManifestEntry? entry) => TryResolve(_optimizersByAlias, alias, out entry);
+    public bool TryResolveBackend(string backendId, out RuntimeComponentManifestEntry? entry) => TryResolve(_backendsByAlias, backendId, out entry);
+
+    public IReadOnlyList<RuntimeComponentManifestEntry> GetBackendsInDeterministicOrder() =>
+        Backends.OrderBy(x => x.CanonicalAlias, StringComparer.Ordinal).ThenBy(x => x.TypeReference.TypeFullName, StringComparer.Ordinal).ToList();
+
+    private static bool TryResolve(IReadOnlyDictionary<string, RuntimeComponentManifestEntry> map, string alias, out RuntimeComponentManifestEntry? entry)
+    {
+        if (string.IsNullOrWhiteSpace(alias))
+            Thrower.Argument(nameof(alias), "Alias must not be empty.");
+
+        return map.TryGetValue(alias.Trim(), out entry);
+    }
+
+    private static RuntimeComponentManifestEntry Create(RuntimeComponentKind kind, string canonicalAlias, IReadOnlyList<string> aliases, string assemblySimpleName, string typeFullName)
+    {
+        return new RuntimeComponentManifestEntry(kind, canonicalAlias, aliases, new RuntimeTypeReference(assemblySimpleName, typeFullName));
+    }
+
+    private static IReadOnlyList<RuntimeComponentManifestEntry> Sort(IEnumerable<RuntimeComponentManifestEntry> entries)
+    {
+        return entries
+            .Select(Normalize)
+            .OrderBy(x => x.CanonicalAlias, StringComparer.Ordinal)
+            .ThenBy(x => x.TypeReference.TypeFullName, StringComparer.Ordinal)
+            .ToList();
+    }
+
+    private static RuntimeComponentManifestEntry Normalize(RuntimeComponentManifestEntry entry)
+    {
+        if (entry == null)
+            Thrower.ArgumentNull(nameof(entry));
+
+        var canonical = entry.CanonicalAlias?.Trim();
+        if (string.IsNullOrWhiteSpace(canonical))
+            Thrower.Argument(nameof(entry), "Canonical alias must not be empty.");
+
+        var assemblySimpleName = entry.TypeReference.AssemblySimpleName?.Trim();
+        if (string.IsNullOrWhiteSpace(assemblySimpleName))
+            Thrower.Argument(nameof(entry), "TypeReference.AssemblySimpleName must not be empty.");
+
+        var typeFullName = entry.TypeReference.TypeFullName?.Trim();
+        if (string.IsNullOrWhiteSpace(typeFullName))
+            Thrower.Argument(nameof(entry), "TypeReference.TypeFullName must not be empty.");
+
+        var aliases = (entry.Aliases ?? [])
+            .Select(x => x?.Trim())
+            .Where(x => !string.IsNullOrWhiteSpace(x))
+            .Select(x => x!)
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(x => x, StringComparer.Ordinal)
+            .ToList();
+
+        aliases.RemoveAll(x => string.Equals(x, canonical, StringComparison.Ordinal));
+
+        return entry with
+        {
+            CanonicalAlias = canonical,
+            Aliases = aliases,
+            TypeReference = new RuntimeTypeReference(assemblySimpleName, typeFullName)
+        };
+    }
+
+    private static IReadOnlyDictionary<string, RuntimeComponentManifestEntry> CreateAliasMap(IEnumerable<RuntimeComponentManifestEntry> entries, string collectionName)
+    {
+        var map = new Dictionary<string, RuntimeComponentManifestEntry>(StringComparer.Ordinal);
+        foreach (var entry in entries)
+        {
+            foreach (var alias in entry.AllAliases)
+            {
+                if (!map.TryAdd(alias, entry))
+                    Thrower.InvalidOpEx($"Duplicate runtime component alias '{alias}' in '{collectionName}'.");
+            }
+        }
+
+        return map;
+    }
+}


### PR DESCRIPTION
### Motivation
- Decouple dialect compilation/build-plan creation from the legacy runtime composition to allow a lightweight, minimal execution path. 
- Provide a deterministic, lazy runtime selection mechanism that avoids loading feature assemblies or constructing full runtime descriptors for minimal scenarios. 
- Preserve the existing (legacy) composition pipeline for backwards compatibility and allow both paths to coexist. 

### Description
- Add a minimal runtime selection API and model: `IWistRuntimeManifest`, `WistRuntimeManifest`, `SelectedRuntimePlan`, and `SelectedRuntimePlanResolver` to deterministically resolve modules, backends and optimizers from a manifest without loading runtime assemblies. 
- Introduce runtime type loading and assembly location helpers: `IRuntimeComponentTypeLoader`, `DefaultRuntimeComponentTypeLoader`, `IRuntimeAssemblyLocator`, and `DefaultRuntimeAssemblyLocator`, plus `RuntimeAssemblyLocatorOptions` for configurable search paths. 
- Add intrinsic policy resolution via `DialectIntrinsicPolicyResolver` and manifest-backed `RuntimeComponentManifestEntry` and `RuntimeTypeReference` types. 
- Update execution wiring to build from a `SelectedRuntimePlan` instead of a legacy runtime composition by changing `WistDialectExecutionConfigurationBuilder` to use the type loader and manifest and to validate resolution prior to building execution configuration. 
- Refactor `WistDialectExecutionWorkflow` to perform compile -> build plan -> selection, populate `DialectFrameworkCompositionResult.RuntimeSelection`, and avoid forcing the legacy runtime composition in the minimal path. 
- Extend `DialectFrameworkCompositionResult` with an optional `RuntimeSelection` (`IDialectRuntimeSelection`) and make `IsSuccess` independent of legacy `RuntimeComposition`. 
- Provide a `LegacyWistDialectCompositionService` and service registration variants `AddWistDialectServicesMinimal()` and `AddWistDialectServicesLegacy()` (with `AddWistDialectServices()` mapped to minimal) so consumers can opt into the legacy descriptor discovery and composition behavior. 
- Add `DefaultRuntimeComponentTypeLoader` caching and clear error messages for assembly/type load failures. 
- Update tests and test infra: many tests were adapted to explicitly use the legacy services when they require the legacy `RuntimeComposition`, and multiple new tests were added for minimal selection, type loading, manifest validation, runtime parity, isolation, and memory-smoke scenarios. 
- Add a `PackageReference` to `System.Reflection.MetadataLoadContext` for manifest metadata validation in tests. 

### Testing
- Ran the unit test suite in `UniversalToolchain.Dialects.Tests` including the new tests `MinimalRuntimeSelectionTests`, `RuntimeComponentTypeLoaderTests`, `WistDialectMinimalRuntimeParityTests`, `WistDialectMinimalRuntimeIsolationTests`, `WistMinimalRuntimeMemorySmokeTests`, and `WistRuntimeManifestMetadataValidationTests`. All automated tests completed successfully. 
- Verified deterministic selection behavior via repeated-run tests (`SelectionResolver_SameDialect_RepeatedRuns_ProduceSameSelectionOrder`) and end-to-end parity tests that compare the minimal path against the legacy composition for representative examples.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5a68788fc83248a72e1e37161b833)