### PR TITLE
Replace hardcoded Wist runtime manifest with build-time sidecar pipeline

### DIFF
--- a/UniversalToolchain/ArithmeticModule/Module/ArithmeticModuleImpl.cs
+++ b/UniversalToolchain/ArithmeticModule/Module/ArithmeticModuleImpl.cs
@@ -1,6 +1,7 @@
 namespace ArithmeticModule.Module;
 
 [UniversalToolchain.Dialects.Abstractions.DialectModuleAlias("Arithmetic")]
+[UniversalToolchain.Dialects.Abstractions.DialectRuntimeExport("wist", "FrontendModule", "Arithmetic")]
 [AutoRegisterService]
 public class ArithmeticModuleImpl : IFrontendCoreModule
 {

--- a/UniversalToolchain/CSharpInteropModule/Module/CSharpInteropModuleImpl.cs
+++ b/UniversalToolchain/CSharpInteropModule/Module/CSharpInteropModuleImpl.cs
@@ -1,6 +1,7 @@
 namespace CSharpInteropModule.Module;
 
 [UniversalToolchain.Dialects.Abstractions.DialectModuleAlias("CSharpInterop")]
+[UniversalToolchain.Dialects.Abstractions.DialectRuntimeExport("wist", "FrontendModule", "CSharpInterop")]
 [AutoRegisterService]
 public class CSharpInteropModuleImpl : IFrontendCoreModule
 {

--- a/UniversalToolchain/CommentsModule/CommentsModuleImpl.cs
+++ b/UniversalToolchain/CommentsModule/CommentsModuleImpl.cs
@@ -1,6 +1,7 @@
 namespace CommentsModule;
 
 [UniversalToolchain.Dialects.Abstractions.DialectModuleAlias("Comments")]
+[UniversalToolchain.Dialects.Abstractions.DialectRuntimeExport("wist", "FrontendModule", "Comments")]
 [AutoRegisterService]
 public class CommentsModuleImpl : IFrontendCoreModule
 {

--- a/UniversalToolchain/ConditionsModule/Enums/BooleanOperations.cs
+++ b/UniversalToolchain/ConditionsModule/Enums/BooleanOperations.cs
@@ -1,6 +1,7 @@
 namespace ConditionsModule.Enums;
 
 [UniversalToolchain.Dialects.Abstractions.DialectModuleAlias("BooleanConditions")]
+[UniversalToolchain.Dialects.Abstractions.DialectRuntimeExport("wist", "FrontendModule", "BooleanConditions")]
 [AutoRegisterService]
 public class BooleanOperations : IFrontendCoreModule
 {

--- a/UniversalToolchain/ConditionsModule/Enums/ComparisonOperations.cs
+++ b/UniversalToolchain/ConditionsModule/Enums/ComparisonOperations.cs
@@ -1,6 +1,7 @@
 namespace ConditionsModule.Enums;
 
 [UniversalToolchain.Dialects.Abstractions.DialectModuleAlias("ComparisonConditions")]
+[UniversalToolchain.Dialects.Abstractions.DialectRuntimeExport("wist", "FrontendModule", "ComparisonConditions")]
 [AutoRegisterService]
 public class ComparisonOperations : IFrontendCoreModule
 {

--- a/UniversalToolchain/ConditionsModule/Module/ConditionsModuleImpl.cs
+++ b/UniversalToolchain/ConditionsModule/Module/ConditionsModuleImpl.cs
@@ -1,6 +1,7 @@
 namespace ConditionsModule.Module;
 
 [UniversalToolchain.Dialects.Abstractions.DialectModuleAlias("Conditions")]
+[UniversalToolchain.Dialects.Abstractions.DialectRuntimeExport("wist", "FrontendModule", "Conditions")]
 [AutoRegisterService]
 public class ConditionsModuleImpl : IFrontendCoreModule
 {

--- a/UniversalToolchain/ConditionsModule/Optimizers/BooleanOptimizer.cs
+++ b/UniversalToolchain/ConditionsModule/Optimizers/BooleanOptimizer.cs
@@ -1,6 +1,7 @@
 namespace ConditionsModule.Optimizers;
 
 [UniversalToolchain.Dialects.Abstractions.DialectOptimizerAlias("BooleanOptimization")]
+[UniversalToolchain.Dialects.Abstractions.DialectRuntimeExport("wist", "Optimizer", "BooleanOptimization")]
 [AutoRegisterService]
 [UsedImplicitly]
 public class BooleanOptimizerModule : IIRProcessingModule

--- a/UniversalToolchain/ConditionsModule/Optimizers/ComparisonIntrinsicOptimizerModule.cs
+++ b/UniversalToolchain/ConditionsModule/Optimizers/ComparisonIntrinsicOptimizerModule.cs
@@ -1,6 +1,7 @@
 namespace ConditionsModule.Optimizers;
 
 [UniversalToolchain.Dialects.Abstractions.DialectOptimizerAlias("ComparisonIntrinsicOptimization")]
+[UniversalToolchain.Dialects.Abstractions.DialectRuntimeExport("wist", "Optimizer", "ComparisonIntrinsicOptimization")]
 [AutoRegisterService]
 [UsedImplicitly]
 public class ComparisonIntrinsicOptimizerModule : IIRProcessingModule

--- a/UniversalToolchain/Directory.Build.targets
+++ b/UniversalToolchain/Directory.Build.targets
@@ -1,0 +1,27 @@
+<Project>
+
+  <PropertyGroup>
+    <DialectRuntimeManifestEmitterProject>$(MSBuildThisFileDirectory)UniversalToolchain.Dialects.ManifestEmitter/UniversalToolchain.Dialects.ManifestEmitter.csproj</DialectRuntimeManifestEmitterProject>
+  </PropertyGroup>
+
+  <Target Name="EmitDialectRuntimeManifest"
+          AfterTargets="Build"
+          Condition="'$(EmitDialectRuntimeManifest)' == 'true' and '$(DesignTimeBuild)' != 'true'">
+    <PropertyGroup>
+      <DialectRuntimeManifestOutputPath>$(TargetDir)$(AssemblyName).dialect.runtime.json</DialectRuntimeManifestOutputPath>
+    </PropertyGroup>
+
+    <Exec Command="dotnet run --project &quot;$(DialectRuntimeManifestEmitterProject)&quot; -- --assembly &quot;$(TargetPath)&quot; --dialect-family &quot;$(DialectRuntimeManifestFamily)&quot; --output &quot;$(DialectRuntimeManifestOutputPath)&quot;" />
+
+    <ItemGroup>
+      <FileWrites Include="$(DialectRuntimeManifestOutputPath)" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="EmitDialectRuntimeManifestsForOutputDirectory"
+          AfterTargets="Build"
+          Condition="'$(GenerateDialectRuntimeManifestsInOutput)' == 'true' and '$(DesignTimeBuild)' != 'true'">
+    <Exec Command="bash -lc 'set -euo pipefail; shopt -s nullglob; for dll in &quot;$(TargetDir)&quot;*.dll; do name=${dll##*/}; name=${name%.dll}; if [[ $name == *Module || $name == UniversalToolchain.Dialects.Wist ]]; then dotnet run --project &quot;$(DialectRuntimeManifestEmitterProject)&quot; -- --assembly &quot;$dll&quot; --dialect-family &quot;$(DialectRuntimeManifestFamily)&quot; --output &quot;$(TargetDir)$name.dialect.runtime.json&quot;; fi; done'" />
+  </Target>
+
+</Project>

--- a/UniversalToolchain/EqualityModule/EqualityModuleImpl.cs
+++ b/UniversalToolchain/EqualityModule/EqualityModuleImpl.cs
@@ -1,6 +1,7 @@
 namespace EqualityModule;
 
 [UniversalToolchain.Dialects.Abstractions.DialectModuleAlias("Equality")]
+[UniversalToolchain.Dialects.Abstractions.DialectRuntimeExport("wist", "FrontendModule", "Equality")]
 [AutoRegisterService]
 public class EqualityModuleImpl : IFrontendCoreModule
 {

--- a/UniversalToolchain/Example/Example.csproj
+++ b/UniversalToolchain/Example/Example.csproj
@@ -6,6 +6,8 @@
         <Nullable>enable</Nullable>
         <OutputType>Exe</OutputType>
         <LangVersion>14</LangVersion>
+        <GenerateDialectRuntimeManifestsInOutput>true</GenerateDialectRuntimeManifestsInOutput>
+        <DialectRuntimeManifestFamily>wist</DialectRuntimeManifestFamily>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/UniversalToolchain/IdentifierModule/IdentifierModuleImpl.cs
+++ b/UniversalToolchain/IdentifierModule/IdentifierModuleImpl.cs
@@ -1,6 +1,7 @@
 namespace IdentifierModule;
 
 [UniversalToolchain.Dialects.Abstractions.DialectModuleAlias("Identifier")]
+[UniversalToolchain.Dialects.Abstractions.DialectRuntimeExport("wist", "FrontendModule", "Identifier")]
 [AutoRegisterService]
 public class IdentifierModuleImpl : IFrontendCoreModule
 {

--- a/UniversalToolchain/InternalPreprocessorLexemesModule/Class1.cs
+++ b/UniversalToolchain/InternalPreprocessorLexemesModule/Class1.cs
@@ -1,6 +1,7 @@
 namespace InternalPreprocessorLexemesModule;
 
 [UniversalToolchain.Dialects.Abstractions.DialectModuleAlias("InternalPreprocessorLexemes")]
+[UniversalToolchain.Dialects.Abstractions.DialectRuntimeExport("wist", "FrontendModule", "InternalPreprocessorLexemes")]
 [AutoRegisterService]
 public class InternalPreprocessorLexemesModuleImpl : IFrontendCoreModule
 {

--- a/UniversalToolchain/LabelsModule/Module/LabelsModuleImpl.cs
+++ b/UniversalToolchain/LabelsModule/Module/LabelsModuleImpl.cs
@@ -1,6 +1,7 @@
 namespace LabelsModule.Module;
 
 [UniversalToolchain.Dialects.Abstractions.DialectModuleAlias("Labels")]
+[UniversalToolchain.Dialects.Abstractions.DialectRuntimeExport("wist", "FrontendModule", "Labels")]
 [AutoRegisterService]
 public class LabelsModuleImpl : IFrontendCoreModule
 {

--- a/UniversalToolchain/LocalVariablesOptimizerModule/LocalVariablesOptimizer.cs
+++ b/UniversalToolchain/LocalVariablesOptimizerModule/LocalVariablesOptimizer.cs
@@ -1,6 +1,7 @@
 namespace LocalVariablesOptimizerModule;
 
 [UniversalToolchain.Dialects.Abstractions.DialectOptimizerAlias("LocalVariablesOptimization")]
+[UniversalToolchain.Dialects.Abstractions.DialectRuntimeExport("wist", "Optimizer", "LocalVariablesOptimization")]
 [AutoRegisterService]
 public class LocalVariablesOptimizer : IIRProcessingModule
 {

--- a/UniversalToolchain/LoopsModule/Module/LoopsModuleImpl.cs
+++ b/UniversalToolchain/LoopsModule/Module/LoopsModuleImpl.cs
@@ -1,6 +1,7 @@
 namespace LoopsModule.Module;
 
 [UniversalToolchain.Dialects.Abstractions.DialectModuleAlias("Loops")]
+[UniversalToolchain.Dialects.Abstractions.DialectRuntimeExport("wist", "FrontendModule", "Loops")]
 [AutoRegisterService]
 public class LoopsModuleImpl : IFrontendCoreModule
 {

--- a/UniversalToolchain/NativeMathModule/ArithmeticOptimizerModule.cs
+++ b/UniversalToolchain/NativeMathModule/ArithmeticOptimizerModule.cs
@@ -1,6 +1,7 @@
 namespace NativeMathModule;
 
 [UniversalToolchain.Dialects.Abstractions.DialectOptimizerAlias("ArithmeticOptimization")]
+[UniversalToolchain.Dialects.Abstractions.DialectRuntimeExport("wist", "Optimizer", "ArithmeticOptimization")]
 [AutoRegisterService]
 [UsedImplicitly]
 public class ArithmeticOptimizerModule : IIRProcessingModule

--- a/UniversalToolchain/NativeMathModule/EGraphOptimizerModule.cs
+++ b/UniversalToolchain/NativeMathModule/EGraphOptimizerModule.cs
@@ -1,6 +1,7 @@
 namespace NativeMathModule;
 
 [UniversalToolchain.Dialects.Abstractions.DialectOptimizerAlias("EGraphOptimization")]
+[UniversalToolchain.Dialects.Abstractions.DialectRuntimeExport("wist", "Optimizer", "EGraphOptimization")]
 [AutoRegisterService]
 public class EGraphOptimizerModule : IIRProcessingModule
 {

--- a/UniversalToolchain/NativeMathModule/NativeCILOptimizerModule.cs
+++ b/UniversalToolchain/NativeMathModule/NativeCILOptimizerModule.cs
@@ -1,6 +1,7 @@
 namespace NativeMathModule;
 
 [UniversalToolchain.Dialects.Abstractions.DialectOptimizerAlias("NativeCilOptimization")]
+[UniversalToolchain.Dialects.Abstractions.DialectRuntimeExport("wist", "Optimizer", "NativeCilOptimization")]
 [AutoRegisterService]
 public class NativeCilOptimizerModule : IIRProcessingModule
 {

--- a/UniversalToolchain/NativeMathModule/NativeTypesModuleImpl.cs
+++ b/UniversalToolchain/NativeMathModule/NativeTypesModuleImpl.cs
@@ -1,6 +1,7 @@
 namespace NativeMathModule;
 
 [UniversalToolchain.Dialects.Abstractions.DialectModuleAlias("NativeTypes")]
+[UniversalToolchain.Dialects.Abstractions.DialectRuntimeExport("wist", "FrontendModule", "NativeTypes")]
 [AutoRegisterService]
 public class NativeTypesModuleImpl : IFrontendCoreModule
 {

--- a/UniversalToolchain/NativeMathModule/NativeTypesOptimizerModule.cs
+++ b/UniversalToolchain/NativeMathModule/NativeTypesOptimizerModule.cs
@@ -1,6 +1,7 @@
 namespace NativeMathModule;
 
 [UniversalToolchain.Dialects.Abstractions.DialectOptimizerAlias("NativeTypesOptimization")]
+[UniversalToolchain.Dialects.Abstractions.DialectRuntimeExport("wist", "Optimizer", "NativeTypesOptimization")]
 [AutoRegisterService]
 public class NativeTypesOptimizerModule : IIRProcessingModule
 {

--- a/UniversalToolchain/NumbersModule/Module/NumbersModuleImpl.cs
+++ b/UniversalToolchain/NumbersModule/Module/NumbersModuleImpl.cs
@@ -1,6 +1,7 @@
 namespace NumbersModule.Module;
 
 [UniversalToolchain.Dialects.Abstractions.DialectModuleAlias("Numbers")]
+[UniversalToolchain.Dialects.Abstractions.DialectRuntimeExport("wist", "FrontendModule", "Numbers")]
 [AutoRegisterService]
 public class NumbersModuleImpl : IFrontendCoreModule
 {

--- a/UniversalToolchain/ParametersSetterModule/Class1.cs
+++ b/UniversalToolchain/ParametersSetterModule/Class1.cs
@@ -1,6 +1,7 @@
 namespace ParametersSetterModule;
 
 [UniversalToolchain.Dialects.Abstractions.DialectModuleAlias("ParametersSetter")]
+[UniversalToolchain.Dialects.Abstractions.DialectRuntimeExport("wist", "FrontendModule", "ParametersSetter")]
 [AutoRegisterService]
 public class ParametersSetterModuleImpl : IFrontendCoreModule
 {

--- a/UniversalToolchain/ScopesModule/Module/ScopesModuleImpl.cs
+++ b/UniversalToolchain/ScopesModule/Module/ScopesModuleImpl.cs
@@ -1,6 +1,7 @@
 namespace ScopesModule.Module;
 
 [UniversalToolchain.Dialects.Abstractions.DialectModuleAlias("Scopes")]
+[UniversalToolchain.Dialects.Abstractions.DialectRuntimeExport("wist", "FrontendModule", "Scopes")]
 [AutoRegisterService]
 public class ScopesModuleImpl : IFrontendCoreModule
 {

--- a/UniversalToolchain/SemicolonAsNewLineModule/SemicolonAsNewLineModuleImpl.cs
+++ b/UniversalToolchain/SemicolonAsNewLineModule/SemicolonAsNewLineModuleImpl.cs
@@ -1,6 +1,7 @@
 namespace SemicolonAsNewLineModule;
 
 [UniversalToolchain.Dialects.Abstractions.DialectModuleAlias("SemicolonAsNewLine")]
+[UniversalToolchain.Dialects.Abstractions.DialectRuntimeExport("wist", "FrontendModule", "SemicolonAsNewLine")]
 [AutoRegisterService]
 public class SemicolonAsNewLineModuleImpl : IFrontendCoreModule
 {

--- a/UniversalToolchain/UniversalToolchain.Dialects.Abstractions/DialectRuntimeAliasAttribute.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Abstractions/DialectRuntimeAliasAttribute.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace UniversalToolchain.Dialects.Abstractions;
+
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = false)]
+public sealed class DialectRuntimeAliasAttribute : Attribute
+{
+    public DialectRuntimeAliasAttribute(string alias)
+    {
+        Alias = alias;
+    }
+
+    public string Alias { get; }
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Abstractions/DialectRuntimeExportAttribute.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Abstractions/DialectRuntimeExportAttribute.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace UniversalToolchain.Dialects.Abstractions;
+
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+public sealed class DialectRuntimeExportAttribute : Attribute
+{
+    public DialectRuntimeExportAttribute(
+        string dialectFamily,
+        string componentKind,
+        string canonicalAlias)
+    {
+        DialectFamily = dialectFamily;
+        ComponentKind = componentKind;
+        CanonicalAlias = canonicalAlias;
+    }
+
+    public string DialectFamily { get; }
+
+    public string ComponentKind { get; }
+
+    public string CanonicalAlias { get; }
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.ManifestEmitter/Program.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.ManifestEmitter/Program.cs
@@ -1,0 +1,94 @@
+using System.Reflection;
+using System.Text.Json;
+
+var arguments = CliArguments.Parse(args);
+var manifest = ManifestEmitter.Emit(arguments.AssemblyPath, arguments.DialectFamily);
+Directory.CreateDirectory(Path.GetDirectoryName(arguments.OutputPath)!);
+File.WriteAllText(arguments.OutputPath, JsonSerializer.Serialize(manifest, JsonOptions.Instance));
+
+internal sealed record CliArguments(string AssemblyPath, string DialectFamily, string OutputPath)
+{
+    public static CliArguments Parse(string[] args)
+    {
+        var values = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        for (var i = 0; i < args.Length - 1; i += 2)
+            values[args[i]] = args[i + 1];
+
+        if (!values.TryGetValue("--assembly", out var assemblyPath) || string.IsNullOrWhiteSpace(assemblyPath))
+            throw new ArgumentException("Missing '--assembly <absolute path>' argument.");
+
+        if (!Path.IsPathRooted(assemblyPath))
+            throw new ArgumentException("--assembly must be an absolute path.");
+
+        if (!values.TryGetValue("--dialect-family", out var dialectFamily) || string.IsNullOrWhiteSpace(dialectFamily))
+            throw new ArgumentException("Missing '--dialect-family <name>' argument.");
+
+        if (!values.TryGetValue("--output", out var outputPath) || string.IsNullOrWhiteSpace(outputPath))
+            throw new ArgumentException("Missing '--output <absolute path>' argument.");
+
+        if (!Path.IsPathRooted(outputPath))
+            throw new ArgumentException("--output must be an absolute path.");
+
+        return new CliArguments(Path.GetFullPath(assemblyPath), dialectFamily.Trim(), Path.GetFullPath(outputPath));
+    }
+}
+
+internal static class ManifestEmitter
+{
+    private const string RuntimeExportAttributeFullName = "UniversalToolchain.Dialects.Abstractions.DialectRuntimeExportAttribute";
+    private const string RuntimeAliasAttributeFullName = "UniversalToolchain.Dialects.Abstractions.DialectRuntimeAliasAttribute";
+
+    public static ManifestDocument Emit(string assemblyPath, string dialectFamily)
+    {
+        var runtimePaths = Directory.GetFiles(Path.GetDirectoryName(typeof(object).Assembly.Location)!, "*.dll", SearchOption.TopDirectoryOnly);
+        var localPaths = Directory.GetFiles(Path.GetDirectoryName(assemblyPath)!, "*.dll", SearchOption.TopDirectoryOnly);
+        var resolver = new PathAssemblyResolver(runtimePaths.Concat(localPaths).Append(assemblyPath).Distinct(StringComparer.Ordinal));
+
+        using var context = new MetadataLoadContext(resolver);
+        var assembly = context.LoadFromAssemblyPath(assemblyPath);
+
+        var components = assembly
+            .GetTypes()
+            .SelectMany(type => BuildEntry(type, dialectFamily))
+            .OrderBy(static x => x.Kind, StringComparer.Ordinal)
+            .ThenBy(static x => x.CanonicalAlias, StringComparer.Ordinal)
+            .ThenBy(static x => x.TypeFullName, StringComparer.Ordinal)
+            .ToList();
+
+        return new ManifestDocument(dialectFamily, assembly.GetName().Name!, components);
+    }
+
+    private static IEnumerable<ManifestComponentEntry> BuildEntry(Type type, string dialectFamily)
+    {
+        var export = type.CustomAttributes.FirstOrDefault(static x => x.AttributeType.FullName == RuntimeExportAttributeFullName);
+        if (export == null)
+            return [];
+
+        var values = export.ConstructorArguments.Select(static x => x.Value?.ToString() ?? string.Empty).ToArray();
+        if (values.Length < 3 || !string.Equals(values[0], dialectFamily, StringComparison.Ordinal))
+            return [];
+
+        var aliases = type.CustomAttributes
+            .Where(static x => x.AttributeType.FullName == RuntimeAliasAttributeFullName)
+            .Select(static x => x.ConstructorArguments[0].Value?.ToString())
+            .Where(static x => !string.IsNullOrWhiteSpace(x))
+            .Select(static x => x!)
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(static x => x, StringComparer.Ordinal)
+            .ToList();
+
+        return [new ManifestComponentEntry(values[1], values[2], aliases, type.FullName ?? type.Name)];
+    }
+}
+
+internal sealed record ManifestDocument(string DialectFamily, string AssemblySimpleName, IReadOnlyList<ManifestComponentEntry> Components);
+
+internal sealed record ManifestComponentEntry(string Kind, string CanonicalAlias, IReadOnlyList<string> Aliases, string TypeFullName);
+
+internal static class JsonOptions
+{
+    public static readonly JsonSerializerOptions Instance = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.ManifestEmitter/UniversalToolchain.Dialects.ManifestEmitter.csproj
+++ b/UniversalToolchain/UniversalToolchain.Dialects.ManifestEmitter/UniversalToolchain.Dialects.ManifestEmitter.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net10.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <LangVersion>14</LangVersion>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="System.Reflection.MetadataLoadContext" Version="10.0.0"/>
+    </ItemGroup>
+
+</Project>

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/UniversalToolchain.Dialects.Tests.csproj
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/UniversalToolchain.Dialects.Tests.csproj
@@ -3,6 +3,8 @@
     <PropertyGroup>
         <TargetFramework>net10.0</TargetFramework>
         <LangVersion>14</LangVersion>
+        <GenerateDialectRuntimeManifestsInOutput>true</GenerateDialectRuntimeManifestsInOutput>
+        <DialectRuntimeManifestFamily>wist</DialectRuntimeManifestFamily>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/WistRuntimeManifestMetadataValidationTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/WistRuntimeManifestMetadataValidationTests.cs
@@ -1,4 +1,5 @@
-using System.Reflection;
+using System.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
 using UniversalToolchain.Dialects.Wist;
 
 namespace UniversalToolchain.Dialects.Tests;
@@ -6,60 +7,203 @@ namespace UniversalToolchain.Dialects.Tests;
 public class WistRuntimeManifestMetadataValidationTests
 {
     [Test]
-    public void ManifestEntries_ResolveTypes_AndMatchExpectedContracts()
+    public void WistRuntimeManifest_NoHardcodedEntries_RemainsFileBased()
     {
-        var manifest = new WistRuntimeManifest();
-        var entries = manifest.Modules.Concat(manifest.Optimizers).Concat(manifest.Backends).ToList();
+        using var temp = new TempDirectory();
+        var serializer = new RuntimeManifestJsonSerializer();
+        var manifestPath = Path.Combine(temp.Path, "ArithmeticModule.dialect.runtime.json");
 
-        foreach (var entry in entries)
+        var document = new FileDialectRuntimeManifestDocument(
+            "wist",
+            "ArithmeticModule",
+            [new FileDialectRuntimeComponentEntry("FrontendModule", "Arithmetic", [], "ArithmeticModule.Module.ArithmeticModuleImpl")]);
+        File.WriteAllText(manifestPath, serializer.Serialize(document));
+
+        var manifest = new WistRuntimeManifest(new StaticManifestLocator([manifestPath]), serializer);
+
+        Assert.Multiple(() =>
         {
-            var entryPath = Path.Combine(AppContext.BaseDirectory, entry.TypeReference.AssemblySimpleName + ".dll");
-            Assert.That(File.Exists(entryPath), Is.True, $"Assembly is missing: {entryPath}");
-
-            var runtimeAssemblies = Directory.GetFiles(Path.GetDirectoryName(typeof(object).Assembly.Location)!, "*.dll");
-            var resolverPaths = runtimeAssemblies.Concat([entryPath, typeof(WistRuntimeManifest).Assembly.Location, typeof(BasicCore.Contracts.IFrontendCoreModule).Assembly.Location, typeof(UniversalToolchain.Dialects.Abstractions.DialectBackendDeclaration).Assembly.Location]).Distinct(StringComparer.Ordinal).ToArray();
-            var resolver = new PathAssemblyResolver(resolverPaths);
-            using var context = new MetadataLoadContext(resolver);
-            var assembly = context.LoadFromAssemblyPath(entryPath);
-            var type = assembly.GetType(entry.TypeReference.TypeFullName, throwOnError: false, ignoreCase: false);
-            Assert.That(type, Is.Not.Null, $"Type not found: {entry.TypeReference.TypeFullName}");
-
-            var frontendContract = context.LoadFromAssemblyName(typeof(BasicCore.Contracts.IFrontendCoreModule).Assembly.GetName().Name!).GetType("BasicCore.Contracts.IFrontendCoreModule")!;
-            var irContract = context.LoadFromAssemblyName(typeof(BasicCore.Contracts.IIRProcessingModule).Assembly.GetName().Name!).GetType("BasicCore.Contracts.IIRProcessingModule")!;
-            var backendContract = context.LoadFromAssemblyName(typeof(UniversalToolchain.Dialects.Abstractions.DialectBackendDeclaration).Assembly.GetName().Name!).GetType("UniversalToolchain.Dialects.Abstractions.DialectBackendDeclaration")!;
-
-            Assert.That(IsValidForKind(entry.Kind, type!, frontendContract, irContract, backendContract), Is.True, $"Unexpected contract mismatch for {entry.CanonicalAlias}");
-        }
+            Assert.That(manifest.Modules.Select(static x => x.CanonicalAlias), Is.EqualTo(new[] { "Arithmetic" }));
+            Assert.That(manifest.Optimizers, Is.Empty);
+            Assert.That(manifest.Backends, Is.Empty);
+        });
     }
-
-
 
     [Test]
-    public void Manifest_DuplicateAlias_FailsFast_WithClearMessage()
+    public void ManifestAggregator_LoadsMultipleSidecarFiles_Deterministically()
     {
-        var dup = new RuntimeComponentManifestEntry(
-            RuntimeComponentKind.FrontendModule,
-            "Arithmetic",
-            [],
-            new RuntimeTypeReference("AnyAssembly", "Any.Type"));
+        using var temp = new TempDirectory();
+        var serializer = new RuntimeManifestJsonSerializer();
 
-        var ex = Assert.Throws<InvalidOperationException>(() => new WistRuntimeManifest([dup, dup], [], []));
-        Assert.That(ex!.Message, Does.Contain("Arithmetic").And.Contain("Modules"));
+        var paths = new[]
+        {
+            Path.Combine(temp.Path, "b.dialect.runtime.json"),
+            Path.Combine(temp.Path, "a.dialect.runtime.json")
+        };
+
+        File.WriteAllText(paths[0], serializer.Serialize(new FileDialectRuntimeManifestDocument(
+            "wist",
+            "BAssembly",
+            [new FileDialectRuntimeComponentEntry("FrontendModule", "B", [], "B.Type")])));
+        File.WriteAllText(paths[1], serializer.Serialize(new FileDialectRuntimeManifestDocument(
+            "wist",
+            "AAssembly",
+            [new FileDialectRuntimeComponentEntry("FrontendModule", "A", [], "A.Type")])));
+
+        var manifest = new WistRuntimeManifest(new StaticManifestLocator(paths), serializer);
+        Assert.That(manifest.Modules.Select(static x => x.CanonicalAlias), Is.EqualTo(new[] { "A", "B" }));
     }
 
-    private static bool IsValidForKind(
-        RuntimeComponentKind kind,
-        Type type,
-        Type frontendContract,
-        Type irContract,
-        Type backendContract)
+    [Test]
+    public void ManifestAggregator_DuplicateAliasAcrossAssemblies_FailsFast_WithClearMessage()
     {
-        return kind switch
+        using var temp = new TempDirectory();
+        var serializer = new RuntimeManifestJsonSerializer();
+
+        var first = Path.Combine(temp.Path, "first.dialect.runtime.json");
+        var second = Path.Combine(temp.Path, "second.dialect.runtime.json");
+
+        File.WriteAllText(first, serializer.Serialize(new FileDialectRuntimeManifestDocument(
+            "wist",
+            "AAssembly",
+            [new FileDialectRuntimeComponentEntry("FrontendModule", "Alias", [], "A.Type")])));
+        File.WriteAllText(second, serializer.Serialize(new FileDialectRuntimeManifestDocument(
+            "wist",
+            "BAssembly",
+            [new FileDialectRuntimeComponentEntry("FrontendModule", "Alias", [], "B.Type")])));
+
+        var exception = Assert.Throws<InvalidOperationException>(() => new WistRuntimeManifest(new StaticManifestLocator([first, second]), serializer));
+        Assert.That(exception!.Message, Does.Contain("Alias").And.Contain("Modules"));
+    }
+
+    [Test]
+    public void ManifestEmitter_WritesExpectedJson_ForSingleAssembly()
+    {
+        var testDir = TestContext.CurrentContext.TestDirectory;
+        var assemblyPath = Path.Combine(testDir, "ArithmeticModule.dll");
+        Assert.That(File.Exists(assemblyPath), Is.True, "ArithmeticModule.dll is required in the test output.");
+
+        using var temp = new TempDirectory();
+        var outputPath = Path.Combine(temp.Path, "ArithmeticModule.dialect.runtime.json");
+        var repoRoot = Path.GetFullPath(Path.Combine(testDir, "..", "..", "..", ".."));
+        var emitterProject = Path.Combine(repoRoot, "UniversalToolchain.Dialects.ManifestEmitter", "UniversalToolchain.Dialects.ManifestEmitter.csproj");
+
+        var start = new ProcessStartInfo("dotnet", $"run --project \"{emitterProject}\" -- --assembly \"{assemblyPath}\" --dialect-family wist --output \"{outputPath}\"")
         {
-            RuntimeComponentKind.FrontendModule => frontendContract.IsAssignableFrom(type) || irContract.IsAssignableFrom(type),
-            RuntimeComponentKind.Optimizer => irContract.IsAssignableFrom(type),
-            RuntimeComponentKind.Backend => backendContract.IsAssignableFrom(type),
-            _ => false
+            RedirectStandardError = true,
+            RedirectStandardOutput = true,
+            WorkingDirectory = repoRoot
         };
+
+        using var process = Process.Start(start)!;
+        process.WaitForExit();
+
+        Assert.That(process.ExitCode, Is.EqualTo(0), process.StandardError.ReadToEnd());
+
+        var serializer = new RuntimeManifestJsonSerializer();
+        var document = serializer.Deserialize(File.ReadAllText(outputPath));
+        var arithmeticEntry = document.Components.Single(static x => x.CanonicalAlias == "Arithmetic");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(document.DialectFamily, Is.EqualTo("wist"));
+            Assert.That(document.AssemblySimpleName, Is.EqualTo("ArithmeticModule"));
+            Assert.That(arithmeticEntry.Kind, Is.EqualTo("FrontendModule"));
+            Assert.That(arithmeticEntry.TypeFullName, Is.EqualTo("ArithmeticModule.Module.ArithmeticModuleImpl"));
+        });
+    }
+
+    [Test]
+    public void MetadataEmitter_UsesMetadataOnlyInspection()
+    {
+        var testDir = TestContext.CurrentContext.TestDirectory;
+        var sourcePath = Path.GetFullPath(Path.Combine(testDir, "..", "..", "..", "..", "UniversalToolchain.Dialects.ManifestEmitter", "Program.cs"));
+        var source = File.ReadAllText(sourcePath);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(source, Does.Contain("MetadataLoadContext"));
+            Assert.That(source, Does.Not.Contain("AssemblyLoadContext.Default.LoadFromAssemblyPath"));
+        });
+    }
+
+    [Test]
+    public void MinimalPath_Compose_DoesNotLoadFeatureAssemblyBeforeTypeLoad()
+    {
+        var before = GetLoadedModuleAssemblies();
+
+        var services = new ServiceCollection();
+        services.AddWistDialectServices();
+        using var provider = services.BuildServiceProvider();
+        var workflow = provider.GetRequiredService<WistDialectExecutionWorkflow>();
+
+        var composition = workflow.ComposeFile(GetDialectPath("minimal-arithmetic"));
+        var after = GetLoadedModuleAssemblies();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(composition.IsSuccess, Is.True, composition.ToDeterministicText());
+            Assert.That(after, Is.EqualTo(before), "Compose stage should not load additional feature assemblies.");
+        });
+    }
+
+    [Test]
+    public void MinimalPath_CreateHost_LoadsOnlySelectedAssemblies()
+    {
+        var before = GetLoadedModuleAssemblies();
+
+        var services = new ServiceCollection();
+        services.AddWistDialectServices();
+        using var provider = services.BuildServiceProvider();
+        var workflow = provider.GetRequiredService<WistDialectExecutionWorkflow>();
+
+        var composition = workflow.ComposeFile(GetDialectPath("minimal-arithmetic"));
+        using var host = workflow.CreateHost(composition);
+        var after = GetLoadedModuleAssemblies();
+        var loadedByHost = after.Except(before, StringComparer.Ordinal).ToHashSet(StringComparer.Ordinal);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(composition.IsSuccess, Is.True, composition.ToDeterministicText());
+            Assert.That(loadedByHost, Does.Not.Contain("VariablesModule"));
+            Assert.That(loadedByHost, Does.Not.Contain("IdentifierModule"));
+        });
+    }
+
+    private static string GetDialectPath(string dialectName)
+    {
+        return Path.GetFullPath(Path.Combine(TestContext.CurrentContext.TestDirectory, "..", "..", "..", "..", "Dialects", "examples", "wist", dialectName, "dialect.wistdialect"));
+    }
+
+    private static IReadOnlySet<string> GetLoadedModuleAssemblies()
+    {
+        return AppDomain.CurrentDomain.GetAssemblies()
+            .Select(static x => x.GetName().Name)
+            .Where(static x => !string.IsNullOrWhiteSpace(x))
+            .Select(static x => x!)
+            .Where(static x => x.EndsWith("Module", StringComparison.Ordinal) || x == "UniversalToolchain.Dialects.Wist")
+            .ToHashSet(StringComparer.Ordinal);
+    }
+
+    private sealed class StaticManifestLocator(IReadOnlyList<string> paths) : IRuntimeManifestFileLocator
+    {
+        public IReadOnlyList<string> GetManifestFilePaths() => paths;
+    }
+
+    private sealed class TempDirectory : IDisposable
+    {
+        public TempDirectory()
+        {
+            Path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"dialect-tests-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(Path);
+        }
+
+        public string Path { get; }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(Path))
+                Directory.Delete(Path, recursive: true);
+        }
     }
 }

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/DefaultRuntimeAssemblyLocator.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/DefaultRuntimeAssemblyLocator.cs
@@ -6,9 +6,9 @@ public sealed class DefaultRuntimeAssemblyLocator : IRuntimeAssemblyLocator
 {
     private readonly IReadOnlyList<string> _searchRoots;
 
-    public DefaultRuntimeAssemblyLocator(RuntimeAssemblyLocatorOptions? options = null)
+    public DefaultRuntimeAssemblyLocator(RuntimeArtifactLocatorOptions? options = null)
     {
-        options ??= new RuntimeAssemblyLocatorOptions();
+        options ??= new RuntimeArtifactLocatorOptions();
 
         _searchRoots = new[] { AppContext.BaseDirectory }
             .Concat(options.AdditionalSearchDirectories ?? [])

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/DefaultRuntimeManifestFileLocator.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/DefaultRuntimeManifestFileLocator.cs
@@ -1,0 +1,40 @@
+using ExceptionsManager;
+
+namespace UniversalToolchain.Dialects.Wist;
+
+public sealed class DefaultRuntimeManifestFileLocator : IRuntimeManifestFileLocator
+{
+    private readonly IReadOnlyList<string> _searchRoots;
+
+    public DefaultRuntimeManifestFileLocator(RuntimeArtifactLocatorOptions? options = null)
+    {
+        options ??= new RuntimeArtifactLocatorOptions();
+
+        _searchRoots = new[] { AppContext.BaseDirectory }
+            .Concat(options.AdditionalSearchDirectories ?? [])
+            .Where(static x => !string.IsNullOrWhiteSpace(x))
+            .Select(Path.GetFullPath)
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(static x => x, StringComparer.Ordinal)
+            .ToList();
+    }
+
+    public IReadOnlyList<string> GetManifestFilePaths()
+    {
+        var paths = new List<string>();
+
+        foreach (var root in _searchRoots)
+        {
+            if (!Directory.Exists(root))
+                continue;
+
+            paths.AddRange(Directory.EnumerateFiles(root, "*.dialect.runtime.json", SearchOption.TopDirectoryOnly)
+                .Select(Path.GetFullPath));
+        }
+
+        return paths
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(static x => x, StringComparer.Ordinal)
+            .ToList();
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/FileDialectRuntimeComponentEntry.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/FileDialectRuntimeComponentEntry.cs
@@ -1,0 +1,7 @@
+namespace UniversalToolchain.Dialects.Wist;
+
+public sealed record FileDialectRuntimeComponentEntry(
+    string Kind,
+    string CanonicalAlias,
+    IReadOnlyList<string> Aliases,
+    string TypeFullName);

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/FileDialectRuntimeManifestDocument.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/FileDialectRuntimeManifestDocument.cs
@@ -1,0 +1,6 @@
+namespace UniversalToolchain.Dialects.Wist;
+
+public sealed record FileDialectRuntimeManifestDocument(
+    string DialectFamily,
+    string AssemblySimpleName,
+    IReadOnlyList<FileDialectRuntimeComponentEntry> Components);

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/IRuntimeManifestFileLocator.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/IRuntimeManifestFileLocator.cs
@@ -1,0 +1,6 @@
+namespace UniversalToolchain.Dialects.Wist;
+
+public interface IRuntimeManifestFileLocator
+{
+    IReadOnlyList<string> GetManifestFilePaths();
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/RuntimeArtifactLocatorOptions.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/RuntimeArtifactLocatorOptions.cs
@@ -1,6 +1,6 @@
 namespace UniversalToolchain.Dialects.Wist;
 
-public sealed class RuntimeAssemblyLocatorOptions
+public sealed class RuntimeArtifactLocatorOptions
 {
     public IReadOnlyList<string> AdditionalSearchDirectories { get; init; } = [];
 }

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/RuntimeManifestJsonSerializer.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/RuntimeManifestJsonSerializer.cs
@@ -1,0 +1,68 @@
+using System.Text.Json;
+
+namespace UniversalToolchain.Dialects.Wist;
+
+public sealed class RuntimeManifestJsonSerializer
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    public FileDialectRuntimeManifestDocument Deserialize(string json)
+    {
+        var document = JsonSerializer.Deserialize<SerializableManifestDocument>(json, JsonOptions)
+                       ?? throw new InvalidOperationException("Failed to deserialize runtime manifest JSON.");
+
+        return new FileDialectRuntimeManifestDocument(
+            document.DialectFamily ?? string.Empty,
+            document.AssemblySimpleName ?? string.Empty,
+            (document.Components ?? [])
+            .Select(static x => new FileDialectRuntimeComponentEntry(
+                x.Kind ?? string.Empty,
+                x.CanonicalAlias ?? string.Empty,
+                x.Aliases ?? [],
+                x.TypeFullName ?? string.Empty))
+            .ToList());
+    }
+
+    public string Serialize(FileDialectRuntimeManifestDocument document)
+    {
+        var payload = new SerializableManifestDocument
+        {
+            DialectFamily = document.DialectFamily,
+            AssemblySimpleName = document.AssemblySimpleName,
+            Components = document.Components
+                .Select(static x => new SerializableManifestComponentEntry
+                {
+                    Kind = x.Kind,
+                    CanonicalAlias = x.CanonicalAlias,
+                    Aliases = x.Aliases,
+                    TypeFullName = x.TypeFullName
+                })
+                .ToList()
+        };
+
+        return JsonSerializer.Serialize(payload, JsonOptions);
+    }
+
+    private sealed class SerializableManifestDocument
+    {
+        public string? DialectFamily { get; init; }
+
+        public string? AssemblySimpleName { get; init; }
+
+        public List<SerializableManifestComponentEntry>? Components { get; init; }
+    }
+
+    private sealed class SerializableManifestComponentEntry
+    {
+        public string? Kind { get; init; }
+
+        public string? CanonicalAlias { get; init; }
+
+        public IReadOnlyList<string>? Aliases { get; init; }
+
+        public string? TypeFullName { get; init; }
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/UniversalToolchain.Dialects.Wist.csproj
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/UniversalToolchain.Dialects.Wist.csproj
@@ -5,6 +5,8 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <LangVersion>14</LangVersion>
+        <GenerateDialectRuntimeManifestsInOutput>true</GenerateDialectRuntimeManifestsInOutput>
+        <DialectRuntimeManifestFamily>wist</DialectRuntimeManifestFamily>
     </PropertyGroup>
 
     <ItemGroup>

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistCilBackendDeclaration.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistCilBackendDeclaration.cs
@@ -3,6 +3,8 @@ using UniversalToolchain.Dialects.Abstractions;
 namespace UniversalToolchain.Dialects.Wist;
 
 [DialectBackendAlias("compiler")]
+[DialectRuntimeExport("wist", "Backend", "cil")]
+[DialectRuntimeAlias("compiler")]
 internal sealed class WistCilBackendDeclaration : DialectBackendDeclaration
 {
     public override DialectBackendId BackendId => WistDialectBackendIds.Cil;

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistDialectServiceCollectionExtensions.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistDialectServiceCollectionExtensions.cs
@@ -57,9 +57,12 @@ public static class WistDialectServiceCollectionExtensions
 
         services.TryAddSingleton<IWistRuntimeManifest, WistRuntimeManifest>();
         services.TryAddSingleton<SelectedRuntimePlanResolver>();
-        services.TryAddSingleton<RuntimeAssemblyLocatorOptions>();
+        services.TryAddSingleton<RuntimeArtifactLocatorOptions>();
+        services.TryAddSingleton<IRuntimeManifestFileLocator>(provider =>
+            new DefaultRuntimeManifestFileLocator(provider.GetRequiredService<RuntimeArtifactLocatorOptions>()));
         services.TryAddSingleton<IRuntimeAssemblyLocator>(provider =>
-            new DefaultRuntimeAssemblyLocator(provider.GetRequiredService<RuntimeAssemblyLocatorOptions>()));
+            new DefaultRuntimeAssemblyLocator(provider.GetRequiredService<RuntimeArtifactLocatorOptions>()));
+        services.TryAddSingleton<RuntimeManifestJsonSerializer>();
         services.TryAddSingleton<IRuntimeComponentTypeLoader, DefaultRuntimeComponentTypeLoader>();
         services.TryAddSingleton<DialectIntrinsicPolicyResolver>();
         services.TryAddSingleton<IDialectCompiledDialectBuildPlanBuilder, DialectCompiledDialectBuildPlanBuilder>();

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistInterpreterBackendDeclaration.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistInterpreterBackendDeclaration.cs
@@ -3,6 +3,7 @@ using UniversalToolchain.Dialects.Abstractions;
 namespace UniversalToolchain.Dialects.Wist;
 
 [DialectBackendAlias("interpreter")]
+[DialectRuntimeExport("wist", "Backend", "interpreter")]
 internal sealed class WistInterpreterBackendDeclaration : DialectBackendDeclaration
 {
     public override DialectBackendId BackendId => WistDialectBackendIds.Interpreter;

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistRuntimeManifest.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistRuntimeManifest.cs
@@ -4,62 +4,32 @@ namespace UniversalToolchain.Dialects.Wist;
 
 public sealed class WistRuntimeManifest : IWistRuntimeManifest
 {
-    private static readonly IReadOnlyList<RuntimeComponentManifestEntry> ModuleEntries =
-    [
-        Create(RuntimeComponentKind.FrontendModule, "Arithmetic", [], "ArithmeticModule", "ArithmeticModule.Module.ArithmeticModuleImpl"),
-        Create(RuntimeComponentKind.FrontendModule, "Comments", [], "CommentsModule", "CommentsModule.CommentsModuleImpl"),
-        Create(RuntimeComponentKind.FrontendModule, "Conditions", [], "ConditionsModule", "ConditionsModule.Module.ConditionsModuleImpl"),
-        Create(RuntimeComponentKind.FrontendModule, "ComparisonConditions", [], "ConditionsModule", "ConditionsModule.Enums.ComparisonOperations"),
-        Create(RuntimeComponentKind.FrontendModule, "BooleanConditions", [], "ConditionsModule", "ConditionsModule.Enums.BooleanOperations"),
-        Create(RuntimeComponentKind.FrontendModule, "CSharpInterop", [], "CSharpInteropModule", "CSharpInteropModule.Module.CSharpInteropModuleImpl"),
-        Create(RuntimeComponentKind.FrontendModule, "Equality", [], "EqualityModule", "EqualityModule.EqualityModuleImpl"),
-        Create(RuntimeComponentKind.FrontendModule, "Identifier", [], "IdentifierModule", "IdentifierModule.IdentifierModuleImpl"),
-        Create(RuntimeComponentKind.FrontendModule, "InternalPreprocessorLexemes", [], "InternalPreprocessorLexemesModule", "InternalPreprocessorLexemesModule.InternalPreprocessorLexemesModuleImpl"),
-        Create(RuntimeComponentKind.FrontendModule, "Labels", [], "LabelsModule", "LabelsModule.Module.LabelsModuleImpl"),
-        Create(RuntimeComponentKind.FrontendModule, "Loops", [], "LoopsModule", "LoopsModule.Module.LoopsModuleImpl"),
-        Create(RuntimeComponentKind.FrontendModule, "NativeTypes", [], "NativeMathModule", "NativeMathModule.NativeTypesModuleImpl"),
-        Create(RuntimeComponentKind.FrontendModule, "Numbers", [], "NumbersModule", "NumbersModule.Module.NumbersModuleImpl"),
-        Create(RuntimeComponentKind.FrontendModule, "ParametersSetter", [], "ParametersSetterModule", "ParametersSetterModule.ParametersSetterModuleImpl"),
-        Create(RuntimeComponentKind.FrontendModule, "Scopes", [], "ScopesModule", "ScopesModule.Module.ScopesModuleImpl"),
-        Create(RuntimeComponentKind.FrontendModule, "SemicolonAsNewLine", [], "SemicolonAsNewLineModule", "SemicolonAsNewLineModule.SemicolonAsNewLineModuleImpl"),
-        Create(RuntimeComponentKind.FrontendModule, "Variables", [], "VariablesModule", "VariablesModule.VariablesModuleImpl"),
-        Create(RuntimeComponentKind.FrontendModule, "Whitespaces", [], "WhitespacesModule", "WhitespacesModule.WhitespaceModuleImpl")
-    ];
-
-    private static readonly IReadOnlyList<RuntimeComponentManifestEntry> OptimizerEntries =
-    [
-        Create(RuntimeComponentKind.Optimizer, "ArithmeticOptimization", [], "NativeMathModule", "NativeMathModule.ArithmeticOptimizerModule"),
-        Create(RuntimeComponentKind.Optimizer, "BooleanOptimization", [], "ConditionsModule", "ConditionsModule.Optimizers.BooleanOptimizerModule"),
-        Create(RuntimeComponentKind.Optimizer, "ComparisonIntrinsicOptimization", [], "ConditionsModule", "ConditionsModule.Optimizers.ComparisonIntrinsicOptimizerModule"),
-        Create(RuntimeComponentKind.Optimizer, "EGraphOptimization", [], "NativeMathModule", "NativeMathModule.EGraphOptimizerModule"),
-        Create(RuntimeComponentKind.Optimizer, "LocalVariablesOptimization", [], "LocalVariablesOptimizerModule", "LocalVariablesOptimizerModule.LocalVariablesOptimizer"),
-        Create(RuntimeComponentKind.Optimizer, "NativeCilOptimization", [], "NativeMathModule", "NativeMathModule.NativeCilOptimizerModule"),
-        Create(RuntimeComponentKind.Optimizer, "NativeTypesOptimization", [], "NativeMathModule", "NativeMathModule.NativeTypesOptimizerModule")
-    ];
-
-    private static readonly IReadOnlyList<RuntimeComponentManifestEntry> BackendEntries =
-    [
-        Create(RuntimeComponentKind.Backend, "cil", ["compiler"], "UniversalToolchain.Dialects.Wist", "UniversalToolchain.Dialects.Wist.WistCilBackendDeclaration"),
-        Create(RuntimeComponentKind.Backend, "interpreter", [], "UniversalToolchain.Dialects.Wist", "UniversalToolchain.Dialects.Wist.WistInterpreterBackendDeclaration")
-    ];
+    private const string WistDialectFamily = "wist";
 
     private readonly IReadOnlyDictionary<string, RuntimeComponentManifestEntry> _backendsByAlias;
     private readonly IReadOnlyDictionary<string, RuntimeComponentManifestEntry> _modulesByAlias;
     private readonly IReadOnlyDictionary<string, RuntimeComponentManifestEntry> _optimizersByAlias;
 
     public WistRuntimeManifest()
-        : this(ModuleEntries, OptimizerEntries, BackendEntries)
+        : this(new DefaultRuntimeManifestFileLocator(), new RuntimeManifestJsonSerializer())
     {
     }
 
-    internal WistRuntimeManifest(
-        IEnumerable<RuntimeComponentManifestEntry> modules,
-        IEnumerable<RuntimeComponentManifestEntry> optimizers,
-        IEnumerable<RuntimeComponentManifestEntry> backends)
+    public WistRuntimeManifest(
+        IRuntimeManifestFileLocator manifestFileLocator,
+        RuntimeManifestJsonSerializer jsonSerializer)
     {
-        Modules = Sort(modules);
-        Optimizers = Sort(optimizers);
-        Backends = Sort(backends);
+        if (manifestFileLocator == null)
+            Thrower.ArgumentNull(nameof(manifestFileLocator));
+
+        if (jsonSerializer == null)
+            Thrower.ArgumentNull(nameof(jsonSerializer));
+
+        var entries = LoadEntries(manifestFileLocator.GetManifestFilePaths(), jsonSerializer);
+
+        Modules = Sort(entries.Where(static x => x.Kind == RuntimeComponentKind.FrontendModule));
+        Optimizers = Sort(entries.Where(static x => x.Kind == RuntimeComponentKind.Optimizer));
+        Backends = Sort(entries.Where(static x => x.Kind == RuntimeComponentKind.Backend));
 
         _modulesByAlias = CreateAliasMap(Modules, nameof(Modules));
         _optimizersByAlias = CreateAliasMap(Optimizers, nameof(Optimizers));
@@ -67,15 +37,74 @@ public sealed class WistRuntimeManifest : IWistRuntimeManifest
     }
 
     public IReadOnlyCollection<RuntimeComponentManifestEntry> Modules { get; }
+
     public IReadOnlyCollection<RuntimeComponentManifestEntry> Optimizers { get; }
+
     public IReadOnlyCollection<RuntimeComponentManifestEntry> Backends { get; }
 
     public bool TryResolveModule(string alias, out RuntimeComponentManifestEntry? entry) => TryResolve(_modulesByAlias, alias, out entry);
+
     public bool TryResolveOptimizer(string alias, out RuntimeComponentManifestEntry? entry) => TryResolve(_optimizersByAlias, alias, out entry);
+
     public bool TryResolveBackend(string backendId, out RuntimeComponentManifestEntry? entry) => TryResolve(_backendsByAlias, backendId, out entry);
 
     public IReadOnlyList<RuntimeComponentManifestEntry> GetBackendsInDeterministicOrder() =>
-        Backends.OrderBy(x => x.CanonicalAlias, StringComparer.Ordinal).ThenBy(x => x.TypeReference.TypeFullName, StringComparer.Ordinal).ToList();
+        Backends.OrderBy(static x => x.CanonicalAlias, StringComparer.Ordinal)
+            .ThenBy(static x => x.TypeReference.TypeFullName, StringComparer.Ordinal)
+            .ToList();
+
+    internal static IReadOnlyList<RuntimeComponentManifestEntry> LoadEntries(
+        IEnumerable<string> manifestPaths,
+        RuntimeManifestJsonSerializer jsonSerializer)
+    {
+        var entries = new List<RuntimeComponentManifestEntry>();
+
+        foreach (var manifestPath in manifestPaths.OrderBy(static x => x, StringComparer.Ordinal))
+        {
+            if (!File.Exists(manifestPath))
+                continue;
+
+            var document = jsonSerializer.Deserialize(File.ReadAllText(manifestPath));
+            if (!string.Equals(document.DialectFamily?.Trim(), WistDialectFamily, StringComparison.Ordinal))
+                continue;
+
+            var assemblySimpleName = document.AssemblySimpleName?.Trim();
+            if (string.IsNullOrWhiteSpace(assemblySimpleName))
+                Thrower.Argument(nameof(manifestPaths), $"Runtime manifest '{manifestPath}' has an empty assemblySimpleName.");
+
+            foreach (var component in document.Components ?? [])
+            {
+                entries.Add(ToRuntimeEntry(component, assemblySimpleName!, manifestPath));
+            }
+        }
+
+        return entries;
+    }
+
+    private static RuntimeComponentManifestEntry ToRuntimeEntry(
+        FileDialectRuntimeComponentEntry component,
+        string assemblySimpleName,
+        string manifestPath)
+    {
+        var kind = ParseKind(component.Kind, manifestPath);
+
+        return Normalize(new RuntimeComponentManifestEntry(
+            kind,
+            component.CanonicalAlias,
+            component.Aliases,
+            new RuntimeTypeReference(assemblySimpleName, component.TypeFullName)));
+    }
+
+    private static RuntimeComponentKind ParseKind(string kind, string manifestPath)
+    {
+        return kind switch
+        {
+            "FrontendModule" => RuntimeComponentKind.FrontendModule,
+            "Optimizer" => RuntimeComponentKind.Optimizer,
+            "Backend" => RuntimeComponentKind.Backend,
+            _ => Thrower.InvalidOpEx<RuntimeComponentKind>($"Unsupported runtime component kind '{kind}' in '{manifestPath}'.")
+        };
+    }
 
     private static bool TryResolve(IReadOnlyDictionary<string, RuntimeComponentManifestEntry> map, string alias, out RuntimeComponentManifestEntry? entry)
     {
@@ -85,17 +114,11 @@ public sealed class WistRuntimeManifest : IWistRuntimeManifest
         return map.TryGetValue(alias.Trim(), out entry);
     }
 
-    private static RuntimeComponentManifestEntry Create(RuntimeComponentKind kind, string canonicalAlias, IReadOnlyList<string> aliases, string assemblySimpleName, string typeFullName)
-    {
-        return new RuntimeComponentManifestEntry(kind, canonicalAlias, aliases, new RuntimeTypeReference(assemblySimpleName, typeFullName));
-    }
-
     private static IReadOnlyList<RuntimeComponentManifestEntry> Sort(IEnumerable<RuntimeComponentManifestEntry> entries)
     {
         return entries
-            .Select(Normalize)
-            .OrderBy(x => x.CanonicalAlias, StringComparer.Ordinal)
-            .ThenBy(x => x.TypeReference.TypeFullName, StringComparer.Ordinal)
+            .OrderBy(static x => x.CanonicalAlias, StringComparer.Ordinal)
+            .ThenBy(static x => x.TypeReference.TypeFullName, StringComparer.Ordinal)
             .ToList();
     }
 
@@ -117,11 +140,11 @@ public sealed class WistRuntimeManifest : IWistRuntimeManifest
             Thrower.Argument(nameof(entry), "TypeReference.TypeFullName must not be empty.");
 
         var aliases = (entry.Aliases ?? [])
-            .Select(x => x?.Trim())
-            .Where(x => !string.IsNullOrWhiteSpace(x))
-            .Select(x => x!)
+            .Select(static x => x?.Trim())
+            .Where(static x => !string.IsNullOrWhiteSpace(x))
+            .Select(static x => x!)
             .Distinct(StringComparer.Ordinal)
-            .OrderBy(x => x, StringComparer.Ordinal)
+            .OrderBy(static x => x, StringComparer.Ordinal)
             .ToList();
 
         aliases.RemoveAll(x => string.Equals(x, canonical, StringComparison.Ordinal));

--- a/UniversalToolchain/VariablesModule/VariablesModuleImpl.cs
+++ b/UniversalToolchain/VariablesModule/VariablesModuleImpl.cs
@@ -1,6 +1,7 @@
 namespace VariablesModule;
 
 [UniversalToolchain.Dialects.Abstractions.DialectModuleAlias("Variables")]
+[UniversalToolchain.Dialects.Abstractions.DialectRuntimeExport("wist", "FrontendModule", "Variables")]
 [AutoRegisterService]
 public class VariablesModuleImpl : IFrontendCoreModule
 {

--- a/UniversalToolchain/WhitespacesModule/WhitespaceModuleImpl.cs
+++ b/UniversalToolchain/WhitespacesModule/WhitespaceModuleImpl.cs
@@ -1,6 +1,7 @@
 namespace WhitespacesModule;
 
 [UniversalToolchain.Dialects.Abstractions.DialectModuleAlias("Whitespaces")]
+[UniversalToolchain.Dialects.Abstractions.DialectRuntimeExport("wist", "FrontendModule", "Whitespaces")]
 [AutoRegisterService]
 public class WhitespaceModuleImpl : IFrontendCoreModule
 {

--- a/UniversalToolchain/Wistc/Wistc.csproj
+++ b/UniversalToolchain/Wistc/Wistc.csproj
@@ -6,6 +6,8 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <LangVersion>14</LangVersion>
+        <GenerateDialectRuntimeManifestsInOutput>true</GenerateDialectRuntimeManifestsInOutput>
+        <DialectRuntimeManifestFamily>wist</DialectRuntimeManifestFamily>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
### Motivation

- The previous `WistRuntimeManifest` contained a central hardcoded registry of modules/optimizers/backends which duplicated metadata and was brittle for refactors.  
- Metadata must live next to implementations so it remains the single source of truth and survives renames/refactors.  
- The minimal runtime loading path must continue to select by metadata without loading all feature assemblies eagerly.

### Description

- Introduced attribute-driven runtime metadata by adding `DialectRuntimeExportAttribute` and `DialectRuntimeAliasAttribute` in `UniversalToolchain.Dialects.Abstractions` and annotated Wist implementation types with these attributes (modules, optimizers, backend declarations) so metadata lives next to implementations.  
- Added a build-time manifest emitter tool `UniversalToolchain.Dialects.ManifestEmitter` that uses `MetadataLoadContext` to inspect assemblies and emit sidecar JSON manifests (`*.dialect.runtime.json`) using the new `ManifestEmitter` CLI, and added MSBuild hooks in `Directory.Build.targets` to produce these sidecars.  
- Replaced the hardcoded registry in `WistRuntimeManifest` with a file-based aggregator that loads `*.dialect.runtime.json` via a new `IRuntimeManifestFileLocator`/`DefaultRuntimeManifestFileLocator`, deserializes with `RuntimeManifestJsonSerializer` into `FileDialectRuntimeManifestDocument`/`FileDialectRuntimeComponentEntry`, normalizes/sorts entries, builds alias maps and fails fast on duplicates.  
- Unified artifact locator options by renaming `RuntimeAssemblyLocatorOptions` -> `RuntimeArtifactLocatorOptions`, wired both assembly and manifest locators to it, and updated DI wiring in `WistDialectServiceCollectionExtensions` to register `IRuntimeManifestFileLocator`, `RuntimeManifestJsonSerializer`, `IWistRuntimeManifest` (file-based) and kept legacy descriptor providers isolated in the legacy path.

### Testing

- Built repository: `dotnet restore UniversalToolchain/Wist.sln` and `dotnet build UniversalToolchain/Wist.sln -c Release --no-restore` completed successfully.  
- Built tests project: `dotnet build UniversalToolchain/UniversalToolchain.Dialects.Tests/UniversalToolchain.Dialects.Tests.csproj -c Release --no-restore` completed successfully.  
- Ran the new/updated manifest tests: `dotnet test UniversalToolchain/UniversalToolchain.Dialects.Tests/UniversalToolchain.Dialects.Tests.csproj -c Release --no-build --filter "FullyQualifiedName~WistRuntimeManifestMetadataValidationTests"` and all tests in that group passed.  
- Ran a small selection of integration/selection tests (`DialectProjectsSmokeTests`, `WistDialectExecutionIntegrationTests.MinimalDialect_ArithmeticProgram_RunsThroughRealExecutionPath`, `MinimalRuntimeSelectionTests.SelectionResolver_DropsDuplicateBackendSelections_Deterministically`) and they passed under the updated pipeline.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c64704a6688324bfec431d4cb4fe4d)