### PR TITLE
Stabilize deterministic backend metadata in Wist known backends provider

### DIFF
--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistKnownBackendsProvider.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistKnownBackendsProvider.cs
@@ -49,7 +49,11 @@ public sealed class WistKnownBackendsProvider : IWistKnownBackendsProvider
             if (!catalog.TryResolveBackend(backendId.Value, out var entry) || entry == null)
                 Thrower.InvalidOpEx($"Wist backend provider '{backendId.Value}' is registered, but no matching runtime backend metadata entry exists.");
 
-            descriptors.Add(new RuntimeBackendDescriptor(new DialectBackendId(entry.CanonicalAlias), entry.Aliases));
+            var aliases = entry.Aliases
+                .OrderBy(static x => x, StringComparer.Ordinal)
+                .ToArray();
+
+            descriptors.Add(new RuntimeBackendDescriptor(new DialectBackendId(entry.CanonicalAlias), aliases));
         }
 
         return descriptors


### PR DESCRIPTION
### Motivation

- Ensure Wist host produces deterministic `RuntimeBackendDescriptor` metadata by removing nondeterminism in alias ordering coming from catalog manifests.

### Description

- Sort `entry.Aliases` with `StringComparer.Ordinal` before constructing `RuntimeBackendDescriptor` in `WistKnownBackendsProvider.BuildKnownBackends`. 
- Keep existing provider mapping behavior including fail-fast on duplicate providers and fail-fast when a provider's `BackendId` is missing from the global catalog. 
- Preserve final deterministic ordering of returned descriptors by `BackendId` and then by joined alias string.

### Testing

- Installed SDK matching `global.json` and ran `dotnet test` for relevant projects. 
- Executed `dotnet test UniversalToolchain/Wist.sln --filter "FullyQualifiedName~WistDialectBackendCompatibilityTests|FullyQualifiedName~WistDialectMinimalRuntimeIsolationTests"` and targeted tests passed. 
- Noted that an additional `Tests.dll` had no matching testcases for the filter, which is expected for this filter and did not affect the successful test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6f397939c83248059e6669a249b01)