### PR TITLE
Isolate minimal dialect path and generalize runtime backend/catalog wiring

### DIFF
--- a/UniversalToolchain/Directory.Build.targets
+++ b/UniversalToolchain/Directory.Build.targets
@@ -2,13 +2,14 @@
 
   <PropertyGroup>
     <DialectRuntimeManifestEmitterProject>$(MSBuildThisFileDirectory)UniversalToolchain.Dialects.ManifestEmitter/UniversalToolchain.Dialects.ManifestEmitter.csproj</DialectRuntimeManifestEmitterProject>
+    <DialectRuntimeManifestSuffix>.dialect.runtime.json</DialectRuntimeManifestSuffix>
   </PropertyGroup>
 
   <Target Name="EmitDialectRuntimeManifest"
           AfterTargets="Build"
           Condition="'$(EmitDialectRuntimeManifest)' == 'true' and '$(DesignTimeBuild)' != 'true'">
     <PropertyGroup>
-      <DialectRuntimeManifestOutputPath>$(TargetDir)$(AssemblyName).dialect.runtime.json</DialectRuntimeManifestOutputPath>
+      <DialectRuntimeManifestOutputPath>$(TargetDir)$(AssemblyName)$(DialectRuntimeManifestSuffix)</DialectRuntimeManifestOutputPath>
     </PropertyGroup>
 
     <Exec Command="&quot;$(DOTNET_HOST_PATH)&quot; run --project &quot;$(DialectRuntimeManifestEmitterProject)&quot; -- --assembly &quot;$(TargetPath)&quot; --output &quot;$(DialectRuntimeManifestOutputPath)&quot;" />
@@ -22,7 +23,7 @@
           AfterTargets="Build"
           Condition="'$(DesignTimeBuild)' != 'true'">
     <ItemGroup>
-      <_ReferencedDialectRuntimeManifestCandidates Include="@(ReferenceCopyLocalPaths->'%(RootDir)%(Directory)%(Filename).dialect.runtime.json')" />
+      <_ReferencedDialectRuntimeManifestCandidates Include="@(ReferenceCopyLocalPaths->'%(RootDir)%(Directory)%(Filename)$(DialectRuntimeManifestSuffix)')" />
       <_ReferencedDialectRuntimeManifests Include="@(_ReferencedDialectRuntimeManifestCandidates)"
                                           Condition="Exists('%(Identity)')" />
     </ItemGroup>

--- a/UniversalToolchain/UniversalToolchain.Dialects.Integration/CatalogBackedDialectRuntimeDescriptorProvider.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Integration/CatalogBackedDialectRuntimeDescriptorProvider.cs
@@ -1,0 +1,38 @@
+using ExceptionsManager;
+using UniversalToolchain.Dialects.Abstractions;
+
+namespace UniversalToolchain.Dialects.Integration;
+
+/// <summary>
+/// Adapts runtime manifest catalog entries into legacy runtime descriptor registry registrations.
+/// </summary>
+public sealed class CatalogBackedDialectRuntimeDescriptorProvider : IDialectRuntimeDescriptorProvider
+{
+    private readonly IRuntimeComponentCatalog _catalog;
+    private readonly IRuntimeComponentTypeLoader _typeLoader;
+
+    public CatalogBackedDialectRuntimeDescriptorProvider(
+        IRuntimeComponentCatalog catalog,
+        IRuntimeComponentTypeLoader typeLoader)
+    {
+        _catalog = catalog ?? throw new ArgumentNullException(nameof(catalog));
+        _typeLoader = typeLoader ?? throw new ArgumentNullException(nameof(typeLoader));
+    }
+
+    public decimal Order => 100m;
+
+    public void Register(DialectRuntimeDescriptorRegistryBuilder builder)
+    {
+        if (builder == null)
+            Thrower.ArgumentNull(nameof(builder));
+
+        foreach (var moduleEntry in _catalog.GetModulesInDeterministicOrder())
+            builder.RegisterModule(new RuntimeModuleDescriptor(moduleEntry.CanonicalAlias, _typeLoader.LoadType(moduleEntry), moduleEntry.Aliases));
+
+        foreach (var optimizerEntry in _catalog.GetOptimizersInDeterministicOrder())
+            builder.RegisterOptimizer(new RuntimeOptimizerDescriptor(optimizerEntry.CanonicalAlias, _typeLoader.LoadType(optimizerEntry), optimizerEntry.Aliases));
+
+        foreach (var backendEntry in _catalog.GetBackendsInDeterministicOrder())
+            builder.RegisterBackend(new RuntimeBackendDescriptor(new DialectBackendId(backendEntry.CanonicalAlias), typeof(CatalogBackedDialectRuntimeDescriptorProvider), backendEntry.Aliases));
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Integration/DefaultRuntimeAssemblyLocator.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Integration/DefaultRuntimeAssemblyLocator.cs
@@ -4,18 +4,16 @@ namespace UniversalToolchain.Dialects.Integration;
 
 public sealed class DefaultRuntimeAssemblyLocator : IRuntimeAssemblyLocator
 {
+    private readonly string _assemblyFileSuffix;
     private readonly IReadOnlyList<string> _searchRoots;
 
-    public DefaultRuntimeAssemblyLocator(RuntimeArtifactLocatorOptions? options = null)
+    public DefaultRuntimeAssemblyLocator(RuntimeArtifactLocatorOptions options)
     {
-        options ??= new RuntimeArtifactLocatorOptions();
+        if (options == null)
+            Thrower.ArgumentNull(nameof(options));
 
-        _searchRoots = new[] { AppContext.BaseDirectory }
-            .Concat(options.AdditionalSearchDirectories ?? [])
-            .Where(x => !string.IsNullOrWhiteSpace(x))
-            .Select(Path.GetFullPath)
-            .Distinct(StringComparer.Ordinal)
-            .ToList();
+        _searchRoots = GetSearchRoots(options);
+        _assemblyFileSuffix = string.IsNullOrWhiteSpace(options.AssemblyFileSuffix) ? ".dll" : options.AssemblyFileSuffix.Trim();
     }
 
     public bool TryResolveAssemblyPath(string assemblySimpleName, out string? absolutePath)
@@ -23,7 +21,7 @@ public sealed class DefaultRuntimeAssemblyLocator : IRuntimeAssemblyLocator
         if (string.IsNullOrWhiteSpace(assemblySimpleName))
             Thrower.Argument(nameof(assemblySimpleName), "Assembly simple name must not be empty.");
 
-        var fileName = assemblySimpleName.Trim() + ".dll";
+        var fileName = assemblySimpleName.Trim() + _assemblyFileSuffix;
         foreach (var root in _searchRoots)
         {
             var candidate = Path.Combine(root, fileName);
@@ -36,5 +34,20 @@ public sealed class DefaultRuntimeAssemblyLocator : IRuntimeAssemblyLocator
 
         absolutePath = null;
         return false;
+    }
+
+    private static IReadOnlyList<string> GetSearchRoots(RuntimeArtifactLocatorOptions options)
+    {
+        var roots = Enumerable.Empty<string>();
+        if (options.IncludeAppContextBaseDirectory)
+            roots = roots.Append(AppContext.BaseDirectory);
+
+        return roots
+            .Concat(options.AdditionalSearchDirectories ?? [])
+            .Where(x => !string.IsNullOrWhiteSpace(x))
+            .Select(Path.GetFullPath)
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(static x => x, StringComparer.Ordinal)
+            .ToList();
     }
 }

--- a/UniversalToolchain/UniversalToolchain.Dialects.Integration/DefaultRuntimeManifestFileLocator.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Integration/DefaultRuntimeManifestFileLocator.cs
@@ -2,19 +2,17 @@ namespace UniversalToolchain.Dialects.Integration;
 
 public sealed class DefaultRuntimeManifestFileLocator : IRuntimeManifestFileLocator
 {
+    private readonly string _manifestFilePattern;
+    private readonly SearchOption _manifestSearchOption;
     private readonly IReadOnlyList<string> _searchRoots;
 
-    public DefaultRuntimeManifestFileLocator(RuntimeArtifactLocatorOptions? options = null)
+    public DefaultRuntimeManifestFileLocator(RuntimeArtifactLocatorOptions options)
     {
-        options ??= new RuntimeArtifactLocatorOptions();
+        ArgumentNullException.ThrowIfNull(options);
 
-        _searchRoots = new[] { AppContext.BaseDirectory }
-            .Concat(options.AdditionalSearchDirectories ?? [])
-            .Where(static x => !string.IsNullOrWhiteSpace(x))
-            .Select(Path.GetFullPath)
-            .Distinct(StringComparer.Ordinal)
-            .OrderBy(static x => x, StringComparer.Ordinal)
-            .ToList();
+        _searchRoots = GetSearchRoots(options);
+        _manifestFilePattern = string.IsNullOrWhiteSpace(options.ManifestFilePattern) ? "*.dialect.runtime.json" : options.ManifestFilePattern.Trim();
+        _manifestSearchOption = options.ManifestSearchOption;
     }
 
     public IReadOnlyList<string> GetManifestFilePaths()
@@ -26,11 +24,26 @@ public sealed class DefaultRuntimeManifestFileLocator : IRuntimeManifestFileLoca
             if (!Directory.Exists(root))
                 continue;
 
-            paths.AddRange(Directory.EnumerateFiles(root, "*.dialect.runtime.json", SearchOption.TopDirectoryOnly)
+            paths.AddRange(Directory.EnumerateFiles(root, _manifestFilePattern, _manifestSearchOption)
                 .Select(Path.GetFullPath));
         }
 
         return paths
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(static x => x, StringComparer.Ordinal)
+            .ToList();
+    }
+
+    private static IReadOnlyList<string> GetSearchRoots(RuntimeArtifactLocatorOptions options)
+    {
+        var roots = Enumerable.Empty<string>();
+        if (options.IncludeAppContextBaseDirectory)
+            roots = roots.Append(AppContext.BaseDirectory);
+
+        return roots
+            .Concat(options.AdditionalSearchDirectories ?? [])
+            .Where(static x => !string.IsNullOrWhiteSpace(x))
+            .Select(Path.GetFullPath)
             .Distinct(StringComparer.Ordinal)
             .OrderBy(static x => x, StringComparer.Ordinal)
             .ToList();

--- a/UniversalToolchain/UniversalToolchain.Dialects.Integration/DialectBackendRuntimeConfiguration.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Integration/DialectBackendRuntimeConfiguration.cs
@@ -1,0 +1,49 @@
+using System.Collections.ObjectModel;
+using ExceptionsManager;
+
+namespace UniversalToolchain.Dialects.Integration;
+
+/// <summary>
+/// Immutable execution configuration for one enabled runtime backend.
+/// </summary>
+public class DialectBackendRuntimeConfiguration
+{
+    private readonly ReadOnlyCollection<string> _allowedIntrinsics;
+    private readonly ReadOnlyCollection<string> _forbiddenIntrinsics;
+
+    public DialectBackendRuntimeConfiguration(
+        RuntimeBackendDescriptor backendDescriptor,
+        IEnumerable<string> allowedIntrinsics,
+        IEnumerable<string> forbiddenIntrinsics,
+        bool hasExplicitAllowList)
+    {
+        if (backendDescriptor == null)
+            Thrower.ArgumentNull(nameof(backendDescriptor));
+
+        BackendDescriptor = backendDescriptor;
+        _allowedIntrinsics = new ReadOnlyCollection<string>(Snapshot(allowedIntrinsics, nameof(allowedIntrinsics)));
+        _forbiddenIntrinsics = new ReadOnlyCollection<string>(Snapshot(forbiddenIntrinsics, nameof(forbiddenIntrinsics)));
+        HasExplicitAllowList = hasExplicitAllowList;
+    }
+
+    public RuntimeBackendDescriptor BackendDescriptor { get; }
+
+    public IReadOnlyList<string> AllowedIntrinsics => _allowedIntrinsics;
+
+    public IReadOnlyList<string> ForbiddenIntrinsics => _forbiddenIntrinsics;
+
+    public bool HasExplicitAllowList { get; }
+
+    private static List<string> Snapshot(IEnumerable<string> values, string paramName)
+    {
+        if (values == null)
+            Thrower.ArgumentNull(paramName);
+
+        return values
+            .Select(x => x.NotNull(paramName))
+            .Where(x => !string.IsNullOrWhiteSpace(x))
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(x => x, StringComparer.Ordinal)
+            .ToList();
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Integration/FileBasedRuntimeComponentCatalog.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Integration/FileBasedRuntimeComponentCatalog.cs
@@ -4,34 +4,32 @@ namespace UniversalToolchain.Dialects.Integration;
 
 public sealed class FileBasedRuntimeComponentCatalog : IRuntimeComponentCatalog
 {
+    private readonly IReadOnlyList<RuntimeComponentManifestEntry> _backends;
     private readonly IReadOnlyDictionary<string, RuntimeComponentManifestEntry> _backendsByAlias;
+    private readonly IReadOnlyList<RuntimeComponentManifestEntry> _modules;
     private readonly IReadOnlyDictionary<string, RuntimeComponentManifestEntry> _modulesByAlias;
+    private readonly IReadOnlyList<RuntimeComponentManifestEntry> _optimizers;
     private readonly IReadOnlyDictionary<string, RuntimeComponentManifestEntry> _optimizersByAlias;
-
-    public FileBasedRuntimeComponentCatalog()
-        : this(new DefaultRuntimeManifestFileLocator(), new RuntimeManifestJsonSerializer())
-    {
-    }
 
     public FileBasedRuntimeComponentCatalog(
         IRuntimeManifestFileLocator manifestFileLocator,
-        RuntimeManifestJsonSerializer jsonSerializer)
+        IRuntimeManifestSerializer serializer)
     {
         if (manifestFileLocator == null)
             Thrower.ArgumentNull(nameof(manifestFileLocator));
 
-        if (jsonSerializer == null)
-            Thrower.ArgumentNull(nameof(jsonSerializer));
+        if (serializer == null)
+            Thrower.ArgumentNull(nameof(serializer));
 
-        var entries = LoadEntries(manifestFileLocator.GetManifestFilePaths(), jsonSerializer);
+        var entries = LoadEntries(manifestFileLocator.GetManifestFilePaths(), serializer);
 
-        var modules = Sort(entries.Where(static x => x.Kind == RuntimeComponentKind.FrontendModule));
-        var optimizers = Sort(entries.Where(static x => x.Kind == RuntimeComponentKind.Optimizer));
-        var backends = Sort(entries.Where(static x => x.Kind == RuntimeComponentKind.Backend));
+        _modules = Sort(entries.Where(static x => x.Kind == RuntimeComponentKind.FrontendModule));
+        _optimizers = Sort(entries.Where(static x => x.Kind == RuntimeComponentKind.Optimizer));
+        _backends = Sort(entries.Where(static x => x.Kind == RuntimeComponentKind.Backend));
 
-        _modulesByAlias = CreateAliasMap(modules, "module");
-        _optimizersByAlias = CreateAliasMap(optimizers, "optimizer");
-        _backendsByAlias = CreateAliasMap(backends, "backend");
+        _modulesByAlias = CreateAliasMap(_modules, "module");
+        _optimizersByAlias = CreateAliasMap(_optimizers, "optimizer");
+        _backendsByAlias = CreateAliasMap(_backends, "backend");
     }
 
     public bool TryResolveModule(string alias, out RuntimeComponentManifestEntry? entry) => TryResolve(_modulesByAlias, alias, out entry);
@@ -40,18 +38,18 @@ public sealed class FileBasedRuntimeComponentCatalog : IRuntimeComponentCatalog
 
     public bool TryResolveBackend(string alias, out RuntimeComponentManifestEntry? entry) => TryResolve(_backendsByAlias, alias, out entry);
 
+    public IReadOnlyList<RuntimeComponentManifestEntry> GetModulesInDeterministicOrder() => _modules;
+
+    public IReadOnlyList<RuntimeComponentManifestEntry> GetOptimizersInDeterministicOrder() => _optimizers;
+
     public IReadOnlyList<RuntimeComponentManifestEntry> GetBackendsInDeterministicOrder()
     {
-        return _backendsByAlias.Values
-            .Distinct()
-            .OrderBy(static x => x.CanonicalAlias, StringComparer.Ordinal)
-            .ThenBy(static x => x.TypeReference.TypeFullName, StringComparer.Ordinal)
-            .ToList();
+        return _backends;
     }
 
     internal static IReadOnlyList<RuntimeComponentManifestEntry> LoadEntries(
         IEnumerable<string> manifestPaths,
-        RuntimeManifestJsonSerializer jsonSerializer)
+        IRuntimeManifestSerializer serializer)
     {
         var entries = new List<RuntimeComponentManifestEntry>();
 
@@ -60,7 +58,7 @@ public sealed class FileBasedRuntimeComponentCatalog : IRuntimeComponentCatalog
             if (!File.Exists(manifestPath))
                 continue;
 
-            var document = jsonSerializer.Deserialize(File.ReadAllText(manifestPath));
+            var document = serializer.Deserialize(File.ReadAllText(manifestPath));
             var assemblySimpleName = document.AssemblySimpleName?.Trim();
             if (string.IsNullOrWhiteSpace(assemblySimpleName))
                 Thrower.Argument(nameof(manifestPaths), $"Runtime manifest '{manifestPath}' has an empty assemblySimpleName.");
@@ -86,16 +84,7 @@ public sealed class FileBasedRuntimeComponentCatalog : IRuntimeComponentCatalog
             new RuntimeTypeReference(assemblySimpleName, component.TypeFullName)));
     }
 
-    private static RuntimeComponentKind ParseKind(string kind, string manifestPath)
-    {
-        return kind switch
-        {
-            "FrontendModule" => RuntimeComponentKind.FrontendModule,
-            "Optimizer" => RuntimeComponentKind.Optimizer,
-            "Backend" => RuntimeComponentKind.Backend,
-            _ => Thrower.InvalidOpEx<RuntimeComponentKind>($"Unsupported runtime component kind '{kind}' in '{manifestPath}'.")
-        };
-    }
+    private static RuntimeComponentKind ParseKind(string kind, string manifestPath) => RuntimeComponentKindCodec.Parse(kind, manifestPath);
 
     private static bool TryResolve(IReadOnlyDictionary<string, RuntimeComponentManifestEntry> map, string alias, out RuntimeComponentManifestEntry? entry)
     {

--- a/UniversalToolchain/UniversalToolchain.Dialects.Integration/IDialectBackendRuntimeRegistrar.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Integration/IDialectBackendRuntimeRegistrar.cs
@@ -1,0 +1,16 @@
+using Microsoft.Extensions.DependencyInjection;
+using UniversalToolchain.Dialects.Abstractions;
+
+namespace UniversalToolchain.Dialects.Integration;
+
+/// <summary>
+/// Registers runtime services needed to execute one backend in a composed dialect host.
+/// </summary>
+public interface IDialectBackendRuntimeRegistrar
+{
+    DialectBackendId BackendId { get; }
+
+    IReadOnlyList<string> SupportedIntrinsics { get; }
+
+    void RegisterRuntime(IServiceCollection services, DialectBackendRuntimeConfiguration configuration);
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Integration/IRuntimeComponentCatalog.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Integration/IRuntimeComponentCatalog.cs
@@ -8,5 +8,9 @@ public interface IRuntimeComponentCatalog
 
     bool TryResolveBackend(string alias, out RuntimeComponentManifestEntry? entry);
 
+    IReadOnlyList<RuntimeComponentManifestEntry> GetModulesInDeterministicOrder();
+
+    IReadOnlyList<RuntimeComponentManifestEntry> GetOptimizersInDeterministicOrder();
+
     IReadOnlyList<RuntimeComponentManifestEntry> GetBackendsInDeterministicOrder();
 }

--- a/UniversalToolchain/UniversalToolchain.Dialects.Integration/IRuntimeKnownBackendsProvider.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Integration/IRuntimeKnownBackendsProvider.cs
@@ -1,0 +1,6 @@
+namespace UniversalToolchain.Dialects.Integration;
+
+public interface IRuntimeKnownBackendsProvider
+{
+    IReadOnlyList<RuntimeBackendDescriptor> GetKnownBackends();
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Integration/IRuntimeManifestSerializer.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Integration/IRuntimeManifestSerializer.cs
@@ -1,0 +1,8 @@
+namespace UniversalToolchain.Dialects.Integration;
+
+public interface IRuntimeManifestSerializer
+{
+    FileDialectRuntimeManifestDocument Deserialize(string json);
+
+    string Serialize(FileDialectRuntimeManifestDocument document);
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Integration/RuntimeArtifactLocatorOptions.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Integration/RuntimeArtifactLocatorOptions.cs
@@ -2,5 +2,13 @@ namespace UniversalToolchain.Dialects.Integration;
 
 public sealed class RuntimeArtifactLocatorOptions
 {
+    public bool IncludeAppContextBaseDirectory { get; init; } = true;
+
     public IReadOnlyList<string> AdditionalSearchDirectories { get; init; } = [];
+
+    public string ManifestFilePattern { get; init; } = "*.dialect.runtime.json";
+
+    public SearchOption ManifestSearchOption { get; init; } = SearchOption.TopDirectoryOnly;
+
+    public string AssemblyFileSuffix { get; init; } = ".dll";
 }

--- a/UniversalToolchain/UniversalToolchain.Dialects.Integration/RuntimeBackendIntrinsicRegistry.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Integration/RuntimeBackendIntrinsicRegistry.cs
@@ -1,0 +1,60 @@
+using ExceptionsManager;
+using UniversalToolchain.Dialects.Abstractions;
+
+namespace UniversalToolchain.Dialects.Integration;
+
+public static class RuntimeBackendIntrinsicRegistry
+{
+    public static IReadOnlyList<RuntimeIntrinsicDescriptor> CreateDescriptors(IEnumerable<IDialectBackendRuntimeRegistrar> backendRegistrars)
+    {
+        var backendIntrinsics = CreateBackendIntrinsicMap(backendRegistrars);
+        var commonIntrinsics = GetCommonIntrinsics(backendIntrinsics);
+        var descriptors = new List<RuntimeIntrinsicDescriptor>();
+
+        foreach (var intrinsic in commonIntrinsics)
+            descriptors.Add(new RuntimeIntrinsicDescriptor(intrinsic, DialectBackendSelector.Any));
+
+        foreach (var backend in backendIntrinsics)
+        {
+            foreach (var intrinsic in backend.Value.Except(commonIntrinsics, StringComparer.Ordinal))
+                descriptors.Add(new RuntimeIntrinsicDescriptor(intrinsic, DialectBackendSelector.For(backend.Key)));
+        }
+
+        return descriptors
+            .OrderBy(x => x.CanonicalId, StringComparer.Ordinal)
+            .ThenBy(x => x.Target)
+            .ToList();
+    }
+
+    private static IReadOnlyDictionary<DialectBackendId, SortedSet<string>> CreateBackendIntrinsicMap(IEnumerable<IDialectBackendRuntimeRegistrar> backendRegistrars)
+    {
+        if (backendRegistrars == null)
+            Thrower.ArgumentNull(nameof(backendRegistrars));
+
+        var map = new SortedDictionary<DialectBackendId, SortedSet<string>>();
+        foreach (var backendRegistrar in backendRegistrars
+                     .Select(x => x.NotNull(nameof(backendRegistrars)))
+                     .OrderBy(x => x.BackendId))
+        {
+            var intrinsics = new SortedSet<string>(backendRegistrar.SupportedIntrinsics
+                                                   ?? Thrower.InvalidOpEx<IReadOnlyList<string>>($"Backend '{backendRegistrar.BackendId.Value}' returned null supported intrinsics."), StringComparer.Ordinal);
+            if (!map.TryAdd(backendRegistrar.BackendId, intrinsics))
+                Thrower.InvalidOpEx($"Duplicate runtime backend registrar registration for backend '{backendRegistrar.BackendId.Value}'.");
+        }
+
+        return map;
+    }
+
+    private static SortedSet<string> GetCommonIntrinsics(IReadOnlyDictionary<DialectBackendId, SortedSet<string>> backendIntrinsics)
+    {
+        var commonIntrinsics = new SortedSet<string>(StringComparer.Ordinal);
+        if (backendIntrinsics.Count == 0)
+            return commonIntrinsics;
+
+        commonIntrinsics.UnionWith(backendIntrinsics.First().Value);
+        foreach (var backend in backendIntrinsics.Skip(1))
+            commonIntrinsics.IntersectWith(backend.Value);
+
+        return commonIntrinsics;
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Integration/RuntimeComponentKindCodec.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Integration/RuntimeComponentKindCodec.cs
@@ -1,0 +1,38 @@
+using ExceptionsManager;
+
+namespace UniversalToolchain.Dialects.Integration;
+
+public static class RuntimeComponentKindCodec
+{
+    public static RuntimeComponentKind Parse(string value, string? sourceName = null)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            Thrower.Argument(nameof(value), "Runtime component kind must not be empty.");
+
+        var trimmed = value.Trim();
+        return trimmed switch
+        {
+            "FrontendModule" => RuntimeComponentKind.FrontendModule,
+            "Optimizer" => RuntimeComponentKind.Optimizer,
+            "Backend" => RuntimeComponentKind.Backend,
+            _ => ThrowUnsupported(trimmed, sourceName)
+        };
+    }
+
+    public static string Format(RuntimeComponentKind kind)
+    {
+        return kind switch
+        {
+            RuntimeComponentKind.FrontendModule => "FrontendModule",
+            RuntimeComponentKind.Optimizer => "Optimizer",
+            RuntimeComponentKind.Backend => "Backend",
+            _ => Thrower.InvalidOpEx<string>($"Unsupported runtime component kind value '{kind}'.")
+        };
+    }
+
+    private static RuntimeComponentKind ThrowUnsupported(string value, string? sourceName)
+    {
+        var sourceSuffix = string.IsNullOrWhiteSpace(sourceName) ? string.Empty : $" in '{sourceName}'";
+        return Thrower.InvalidOpEx<RuntimeComponentKind>($"Unsupported runtime component kind '{value}'{sourceSuffix}.");
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Integration/RuntimeKnownBackendsProvider.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Integration/RuntimeKnownBackendsProvider.cs
@@ -1,0 +1,63 @@
+using ExceptionsManager;
+using UniversalToolchain.Dialects.Abstractions;
+
+namespace UniversalToolchain.Dialects.Integration;
+
+public sealed class RuntimeKnownBackendsProvider : IRuntimeKnownBackendsProvider
+{
+    private readonly IReadOnlyList<RuntimeBackendDescriptor> _knownBackends;
+
+    public RuntimeKnownBackendsProvider(
+        IRuntimeComponentCatalog catalog,
+        IEnumerable<IDialectBackendRuntimeRegistrar> backendRegistrars)
+    {
+        if (catalog == null)
+            Thrower.ArgumentNull(nameof(catalog));
+
+        if (backendRegistrars == null)
+            Thrower.ArgumentNull(nameof(backendRegistrars));
+
+        var registrarsById = CreateRegistrarMap(backendRegistrars);
+        _knownBackends = BuildKnownBackends(catalog, registrarsById);
+    }
+
+    public IReadOnlyList<RuntimeBackendDescriptor> GetKnownBackends() => _knownBackends;
+
+    private static IReadOnlyDictionary<DialectBackendId, IDialectBackendRuntimeRegistrar> CreateRegistrarMap(
+        IEnumerable<IDialectBackendRuntimeRegistrar> backendRegistrars)
+    {
+        var map = new SortedDictionary<DialectBackendId, IDialectBackendRuntimeRegistrar>();
+        foreach (var registrar in backendRegistrars
+                     .Select(x => x.NotNull(nameof(backendRegistrars)))
+                     .OrderBy(x => x.BackendId))
+        {
+            if (!map.TryAdd(registrar.BackendId, registrar))
+                Thrower.InvalidOpEx($"Duplicate runtime backend registrar registration for backend '{registrar.BackendId.Value}'.");
+        }
+
+        return map;
+    }
+
+    private static IReadOnlyList<RuntimeBackendDescriptor> BuildKnownBackends(
+        IRuntimeComponentCatalog catalog,
+        IReadOnlyDictionary<DialectBackendId, IDialectBackendRuntimeRegistrar> registrarsById)
+    {
+        var descriptors = new List<RuntimeBackendDescriptor>();
+        foreach (var backendId in registrarsById.Keys)
+        {
+            if (!catalog.TryResolveBackend(backendId.Value, out var entry) || entry == null)
+                Thrower.InvalidOpEx($"Runtime backend registrar '{backendId.Value}' is registered, but no matching runtime backend metadata entry exists.");
+
+            var aliases = entry.Aliases
+                .OrderBy(static x => x, StringComparer.Ordinal)
+                .ToArray();
+
+            descriptors.Add(new RuntimeBackendDescriptor(new DialectBackendId(entry.CanonicalAlias), aliases));
+        }
+
+        return descriptors
+            .OrderBy(x => x.BackendId)
+            .ThenBy(x => string.Join("|", x.Aliases), StringComparer.Ordinal)
+            .ToList();
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Integration/RuntimeManifestJsonSerializer.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Integration/RuntimeManifestJsonSerializer.cs
@@ -2,7 +2,7 @@ using System.Text.Json;
 
 namespace UniversalToolchain.Dialects.Integration;
 
-public sealed class RuntimeManifestJsonSerializer
+public sealed class RuntimeManifestJsonSerializer : IRuntimeManifestSerializer
 {
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
@@ -18,7 +18,7 @@ public sealed class RuntimeManifestJsonSerializer
             document.AssemblySimpleName ?? string.Empty,
             (document.Components ?? [])
             .Select(static x => new FileDialectRuntimeComponentEntry(
-                x.Kind ?? string.Empty,
+                RuntimeComponentKindCodec.Format(RuntimeComponentKindCodec.Parse(x.Kind ?? string.Empty)),
                 x.CanonicalAlias ?? string.Empty,
                 x.Aliases ?? [],
                 x.TypeFullName ?? string.Empty))
@@ -33,7 +33,7 @@ public sealed class RuntimeManifestJsonSerializer
             Components = document.Components
                 .Select(static x => new SerializableManifestComponentEntry
                 {
-                    Kind = x.Kind,
+                    Kind = RuntimeComponentKindCodec.Format(RuntimeComponentKindCodec.Parse(x.Kind ?? string.Empty)),
                     CanonicalAlias = x.CanonicalAlias,
                     Aliases = x.Aliases,
                     TypeFullName = x.TypeFullName

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/DialectRuntimeAliasAttributeDiscoveryTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/DialectRuntimeAliasAttributeDiscoveryTests.cs
@@ -57,7 +57,7 @@ public class DialectRuntimeAliasAttributeDiscoveryTests
             Assert.That(registry.TryResolveBackend(new DialectBackendId("compiler"), out var compiler), Is.True);
             Assert.That(cil, Is.SameAs(compiler));
             Assert.That(registry.TryResolveBackend(new DialectBackendId("interpreter"), out var interpreter), Is.True);
-            Assert.That(interpreter!.MetadataOwnerType.Name, Is.EqualTo("WistInterpreterBackendDeclaration"));
+            Assert.That(interpreter!.MetadataOwnerType.Name, Is.EqualTo("CatalogBackedDialectRuntimeDescriptorProvider"));
         });
     }
 

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/MinimalRuntimeSelectionTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/MinimalRuntimeSelectionTests.cs
@@ -37,7 +37,7 @@ public class MinimalRuntimeSelectionTests
     [Test]
     public void SelectionResolver_MissingModule_AddsR001()
     {
-        var resolver = new SelectedRuntimePlanResolver(new FileBasedRuntimeComponentCatalog());
+        var resolver = new SelectedRuntimePlanResolver(CreateCatalog());
         var plan = BuildPlan(modules: ["NoSuchModule"], backends: [WistDialectBackendIds.Interpreter], optimizers: []);
         var selection = resolver.Resolve(plan);
         Assert.That(selection.Diagnostics.Any(x => x.Code == "R001"), Is.True);
@@ -46,7 +46,7 @@ public class MinimalRuntimeSelectionTests
     [Test]
     public void SelectionResolver_MissingBackend_AddsR002()
     {
-        var resolver = new SelectedRuntimePlanResolver(new FileBasedRuntimeComponentCatalog());
+        var resolver = new SelectedRuntimePlanResolver(CreateCatalog());
         var plan = BuildPlan(modules: ["Arithmetic"], backends: [new DialectBackendId("missing")], optimizers: []);
         var selection = resolver.Resolve(plan);
         Assert.That(selection.Diagnostics.Any(x => x.Code == "R002"), Is.True);
@@ -55,7 +55,7 @@ public class MinimalRuntimeSelectionTests
     [Test]
     public void SelectionResolver_MissingOptimizer_AddsR003()
     {
-        var resolver = new SelectedRuntimePlanResolver(new FileBasedRuntimeComponentCatalog());
+        var resolver = new SelectedRuntimePlanResolver(CreateCatalog());
         var plan = BuildPlan(modules: ["Arithmetic"], backends: [WistDialectBackendIds.Interpreter], optimizers: [new OptimizerBuildDirective("missing-opt", true, DialectBackendSelector.Any)]);
         var selection = resolver.Resolve(plan);
         Assert.That(selection.Diagnostics.Any(x => x.Code == "R003"), Is.True);
@@ -65,7 +65,7 @@ public class MinimalRuntimeSelectionTests
     [Test]
     public void SelectionResolver_DropsDuplicateBackendSelections_Deterministically()
     {
-        var resolver = new SelectedRuntimePlanResolver(new FileBasedRuntimeComponentCatalog());
+        var resolver = new SelectedRuntimePlanResolver(CreateCatalog());
         var plan = BuildPlan(modules: ["Arithmetic"], backends: [WistDialectBackendIds.Interpreter, WistDialectBackendIds.Interpreter, WistDialectBackendIds.Cil], optimizers: []);
         var selection = resolver.Resolve(plan);
 
@@ -75,7 +75,7 @@ public class MinimalRuntimeSelectionTests
     [Test]
     public void SelectionResolver_DropsDuplicateOptimizers_Deterministically()
     {
-        var resolver = new SelectedRuntimePlanResolver(new FileBasedRuntimeComponentCatalog());
+        var resolver = new SelectedRuntimePlanResolver(CreateCatalog());
         var plan = BuildPlan(
             modules: ["Arithmetic"],
             backends: [WistDialectBackendIds.Interpreter],
@@ -93,7 +93,7 @@ public class MinimalRuntimeSelectionTests
     [Test]
     public void SelectionResolver_DoesNotLoadFeatureAssemblies()
     {
-        var resolver = new SelectedRuntimePlanResolver(new FileBasedRuntimeComponentCatalog());
+        var resolver = new SelectedRuntimePlanResolver(CreateCatalog());
         var before = AppDomain.CurrentDomain.GetAssemblies().Select(x => x.GetName().Name).ToHashSet(StringComparer.Ordinal);
         var plan = BuildPlan(modules: ["Arithmetic"], backends: [WistDialectBackendIds.Interpreter], optimizers: []);
         _ = resolver.Resolve(plan);
@@ -110,6 +110,13 @@ public class MinimalRuntimeSelectionTests
     private static DialectBuildPlan BuildPlan(IReadOnlyList<string> modules, IReadOnlyList<DialectBackendId> backends, IReadOnlyList<OptimizerBuildDirective> optimizers)
     {
         return new DialectBuildPlan("Demo", null, modules, backends, [], [], optimizers, null, [], new DialectValidationResult([]));
+    }
+
+    private static IRuntimeComponentCatalog CreateCatalog()
+    {
+        return new FileBasedRuntimeComponentCatalog(
+            new DefaultRuntimeManifestFileLocator(new RuntimeArtifactLocatorOptions()),
+            new RuntimeManifestJsonSerializer());
     }
 
     private static ServiceProvider CreateMinimalProvider()

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/RuntimeComponentTypeLoaderTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/RuntimeComponentTypeLoaderTests.cs
@@ -7,7 +7,7 @@ public class RuntimeComponentTypeLoaderTests
     [Test]
     public void TypeLoader_LoadsOnlyRequestedAssembly()
     {
-        var loader = new DefaultRuntimeComponentTypeLoader(new DefaultRuntimeAssemblyLocator());
+        var loader = new DefaultRuntimeComponentTypeLoader(new DefaultRuntimeAssemblyLocator(new RuntimeArtifactLocatorOptions()));
         var entry = Entry("ArithmeticModule", "ArithmeticModule.Module.ArithmeticModuleImpl");
 
         var type = loader.LoadType(entry);
@@ -22,7 +22,7 @@ public class RuntimeComponentTypeLoaderTests
     [Test]
     public void TypeLoader_RepeatedLoad_UsesCache()
     {
-        var loader = new DefaultRuntimeComponentTypeLoader(new DefaultRuntimeAssemblyLocator());
+        var loader = new DefaultRuntimeComponentTypeLoader(new DefaultRuntimeAssemblyLocator(new RuntimeArtifactLocatorOptions()));
         var entry = Entry("ArithmeticModule", "ArithmeticModule.Module.ArithmeticModuleImpl");
 
         var first = loader.LoadType(entry);
@@ -76,7 +76,7 @@ public class RuntimeComponentTypeLoaderTests
     [Test]
     public void TypeLoader_InvalidAssembly_ThrowsClearError()
     {
-        var loader = new DefaultRuntimeComponentTypeLoader(new DefaultRuntimeAssemblyLocator());
+        var loader = new DefaultRuntimeComponentTypeLoader(new DefaultRuntimeAssemblyLocator(new RuntimeArtifactLocatorOptions()));
         var ex = Assert.Throws<FileNotFoundException>(() => loader.LoadType(Entry("NoSuchAssembly", "Missing.Type")));
         Assert.That(ex!.Message, Does.Contain("NoSuchAssembly.dll"));
     }
@@ -84,7 +84,7 @@ public class RuntimeComponentTypeLoaderTests
     [Test]
     public void TypeLoader_InvalidType_ThrowsClearError()
     {
-        var loader = new DefaultRuntimeComponentTypeLoader(new DefaultRuntimeAssemblyLocator());
+        var loader = new DefaultRuntimeComponentTypeLoader(new DefaultRuntimeAssemblyLocator(new RuntimeArtifactLocatorOptions()));
         Assert.Throws<TypeLoadException>(() => loader.LoadType(Entry("ArithmeticModule", "Missing.Type")));
     }
 

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/WistDialectBackendCompatibilityTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/WistDialectBackendCompatibilityTests.cs
@@ -15,11 +15,11 @@ public class WistDialectBackendCompatibilityTests
             Entry("interpreter"),
             Entry("foreign-backend", ["foreign"]));
 
-        var provider = new WistKnownBackendsProvider(
+        var provider = new RuntimeKnownBackendsProvider(
             catalog,
             [
-                new StubWistBackendProvider(new DialectBackendId("cil")),
-                new StubWistBackendProvider(new DialectBackendId("interpreter"))
+                new StubBackendRegistrar(new DialectBackendId("cil")),
+                new StubBackendRegistrar(new DialectBackendId("interpreter"))
             ]);
 
         var known = provider.GetKnownBackends();
@@ -36,7 +36,7 @@ public class WistDialectBackendCompatibilityTests
     {
         var catalog = new StaticCatalog(Entry("cil"));
         var exception = Assert.Throws<InvalidOperationException>(() =>
-            new WistKnownBackendsProvider(catalog, [new StubWistBackendProvider(new DialectBackendId("interpreter"))]));
+            new RuntimeKnownBackendsProvider(catalog, [new StubBackendRegistrar(new DialectBackendId("interpreter"))]));
 
         Assert.That(exception!.Message, Does.Contain("interpreter"));
     }
@@ -46,11 +46,11 @@ public class WistDialectBackendCompatibilityTests
     {
         var catalog = new StaticCatalog(Entry("cil"));
         var exception = Assert.Throws<InvalidOperationException>(() =>
-            new WistKnownBackendsProvider(
+            new RuntimeKnownBackendsProvider(
                 catalog,
                 [
-                    new StubWistBackendProvider(new DialectBackendId("cil")),
-                    new StubWistBackendProvider(new DialectBackendId("cil"))
+                    new StubBackendRegistrar(new DialectBackendId("cil")),
+                    new StubBackendRegistrar(new DialectBackendId("cil"))
                 ]));
 
         Assert.That(exception!.Message, Does.Contain("Duplicate").And.Contain("cil"));
@@ -108,16 +108,20 @@ public class WistDialectBackendCompatibilityTests
 
         public bool TryResolveBackend(string alias, out RuntimeComponentManifestEntry? entry) => _map.TryGetValue(alias, out entry);
 
+        public IReadOnlyList<RuntimeComponentManifestEntry> GetModulesInDeterministicOrder() => [];
+
+        public IReadOnlyList<RuntimeComponentManifestEntry> GetOptimizersInDeterministicOrder() => [];
+
         public IReadOnlyList<RuntimeComponentManifestEntry> GetBackendsInDeterministicOrder() => _map.Values.Distinct().OrderBy(x => x.CanonicalAlias, StringComparer.Ordinal).ToList();
     }
 
-    private sealed class StubWistBackendProvider(DialectBackendId backendId) : IWistDialectBackendServiceProvider
+    private sealed class StubBackendRegistrar(DialectBackendId backendId) : IDialectBackendRuntimeRegistrar
     {
         public DialectBackendId BackendId { get; } = backendId;
 
         public IReadOnlyList<string> SupportedIntrinsics => [];
 
-        public void RegisterRuntime(IServiceCollection services, WistDialectBackendConfiguration configuration)
+        public void RegisterRuntime(IServiceCollection services, DialectBackendRuntimeConfiguration configuration)
         {
         }
     }
@@ -127,7 +131,7 @@ public class WistDialectBackendCompatibilityTests
         public Type LoadType(RuntimeComponentManifestEntry entry) => typeof(object);
     }
 
-    private sealed class RecordingKnownBackendsProvider(IReadOnlyList<RuntimeBackendDescriptor> knownBackends) : IWistKnownBackendsProvider
+    private sealed class RecordingKnownBackendsProvider(IReadOnlyList<RuntimeBackendDescriptor> knownBackends) : IRuntimeKnownBackendsProvider
     {
         public int Calls { get; private set; }
 

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/WistDialectBackendHardcodeTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/WistDialectBackendHardcodeTests.cs
@@ -76,7 +76,7 @@ public class WistDialectBackendHardcodeTests
             new FakeBackendServiceProvider(backendId, ["second_intrinsic"])
         ]));
 
-        Assert.That(exception!.Message, Is.EqualTo("Duplicate Wist backend service provider registration for backend 'duplicate-backend'."));
+        Assert.That(exception!.Message, Is.EqualTo("Duplicate backend runtime registrar registration for backend 'duplicate-backend'."));
     }
 
     [Test]
@@ -87,7 +87,7 @@ public class WistDialectBackendHardcodeTests
 
         var exception = Assert.Throws<InvalidOperationException>(() => factory.Create(CreateConfiguration(requestedBackend)));
 
-        Assert.That(exception!.Message, Is.EqualTo("No Wist backend service provider is registered for backend 'missing-backend'."));
+        Assert.That(exception!.Message, Is.EqualTo("No backend runtime registrar is registered for backend 'missing-backend'."));
     }
 
     [Test]
@@ -119,12 +119,12 @@ public class WistDialectBackendHardcodeTests
         var backendA = new RuntimeBackendDescriptor(new DialectBackendId("backend-a"), "backend-a-runtime");
         var backendB = new RuntimeBackendDescriptor(new DialectBackendId("backend-b"), "backend-b-runtime");
         var configuration = CreateConfiguration(backendA, backendB);
-        var providersInDeclaredOrder = new IWistDialectBackendServiceProvider[]
+        var providersInDeclaredOrder = new IDialectBackendRuntimeRegistrar[]
         {
             new FakeBackendServiceProvider(backendA.BackendId, ["shared_intrinsic", "only_a"]),
             new FakeBackendServiceProvider(backendB.BackendId, ["shared_intrinsic", "only_b"])
         };
-        var providersInReverseOrder = new IWistDialectBackendServiceProvider[]
+        var providersInReverseOrder = new IDialectBackendRuntimeRegistrar[]
         {
             new FakeBackendServiceProvider(backendB.BackendId, ["shared_intrinsic", "only_b"]),
             new FakeBackendServiceProvider(backendA.BackendId, ["shared_intrinsic", "only_a"])
@@ -178,7 +178,7 @@ public class WistDialectBackendHardcodeTests
             backendDescriptors);
     }
 
-    private sealed class FakeBackendServiceProvider(DialectBackendId backendId, IReadOnlyList<string> supportedIntrinsics) : IWistDialectBackendServiceProvider
+    private sealed class FakeBackendServiceProvider(DialectBackendId backendId, IReadOnlyList<string> supportedIntrinsics) : IDialectBackendRuntimeRegistrar
     {
         private readonly IReadOnlyList<string> _supportedIntrinsics = supportedIntrinsics
             .Distinct(StringComparer.Ordinal)
@@ -189,7 +189,7 @@ public class WistDialectBackendHardcodeTests
 
         public IReadOnlyList<string> SupportedIntrinsics => _supportedIntrinsics;
 
-        public void RegisterRuntime(IServiceCollection services, WistDialectBackendConfiguration configuration)
+        public void RegisterRuntime(IServiceCollection services, DialectBackendRuntimeConfiguration configuration)
         {
             if (services == null)
                 Thrower.ArgumentNull(nameof(services));

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/WistDialectMinimalRuntimeIsolationTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/WistDialectMinimalRuntimeIsolationTests.cs
@@ -21,6 +21,21 @@ public class WistDialectMinimalRuntimeIsolationTests
     }
 
     [Test]
+    public void LegacyWorkflow_RegistersLegacyCompatibilityServices()
+    {
+        var services = new ServiceCollection();
+        services.AddWistDialectServicesLegacy();
+        using var provider = services.BuildServiceProvider();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(provider.GetService<DialectFrameworkCompositionWorkflow>(), Is.Not.Null);
+            Assert.That(provider.GetService<DialectRuntimeDescriptorRegistry>(), Is.Not.Null);
+            Assert.That(provider.GetService<LegacyWistDialectCompositionService>(), Is.Not.Null);
+        });
+    }
+
+    [Test]
     public void MinimalWorkflow_ComposeText_DoesNotPopulateRuntimeComposition()
     {
         using var provider = CreateMinimalProvider();

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/WistDialectRuntimeDescriptorProviderTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/WistDialectRuntimeDescriptorProviderTests.cs
@@ -25,11 +25,11 @@ public class WistDialectRuntimeDescriptorProviderTests
             Assert.That(first.Backends.Keys, Is.EqualTo(second.Backends.Keys));
             Assert.That(first.Intrinsics.Keys, Is.EqualTo(second.Intrinsics.Keys));
             Assert.That(first.TryResolveModule("Arithmetic", out var arithmeticModule), Is.True);
-            Assert.That(arithmeticModule!.CanonicalId, Does.Contain("ArithmeticModuleImpl"));
+            Assert.That(arithmeticModule!.CanonicalId, Is.EqualTo("Arithmetic"));
             Assert.That(first.TryResolveModule("Variables", out var variablesModule), Is.True);
-            Assert.That(variablesModule!.CanonicalId, Does.Contain("VariablesModuleImpl"));
+            Assert.That(variablesModule!.CanonicalId, Is.EqualTo("Variables"));
             Assert.That(first.TryResolveOptimizer("LocalVariablesOptimization", out var localVariablesOptimizer), Is.True);
-            Assert.That(localVariablesOptimizer!.CanonicalId, Does.Contain("LocalVariablesOptimizer"));
+            Assert.That(localVariablesOptimizer!.CanonicalId, Is.EqualTo("LocalVariablesOptimization"));
             Assert.That(first.Backends.Keys, Is.EqualTo(new[] { TestBackendIds.Cil, TestBackendIds.Interpreter }));
             Assert.That(first.Intrinsics.Keys, Does.Contain(("add_i32", TestBackendIds.CilSelector)));
         });
@@ -77,14 +77,14 @@ public class WistDialectRuntimeDescriptorProviderTests
         var first = DialectRuntimeDescriptorRegistryFactory.BuildFromProviders([
             new TestOnlyRuntimeDescriptorProvider(),
             new LocalVariablesOptimizerDialectRuntimeDescriptorProvider(),
-            new WistDialectRuntimeDescriptorProvider(Array.Empty<IWistDialectBackendServiceProvider>()),
+            new WistDialectRuntimeDescriptorProvider(Array.Empty<IDialectBackendRuntimeRegistrar>()),
             new ArithmeticDialectRuntimeDescriptorProvider(),
             new ConditionsDialectRuntimeDescriptorProvider()
         ]);
         var second = DialectRuntimeDescriptorRegistryFactory.BuildFromProviders([
             new ConditionsDialectRuntimeDescriptorProvider(),
             new ArithmeticDialectRuntimeDescriptorProvider(),
-            new WistDialectRuntimeDescriptorProvider(Array.Empty<IWistDialectBackendServiceProvider>()),
+            new WistDialectRuntimeDescriptorProvider(Array.Empty<IDialectBackendRuntimeRegistrar>()),
             new LocalVariablesOptimizerDialectRuntimeDescriptorProvider(),
             new TestOnlyRuntimeDescriptorProvider()
         ]);

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/WistRuntimeManifestMetadataValidationTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/WistRuntimeManifestMetadataValidationTests.cs
@@ -50,6 +50,39 @@ public class WistRuntimeManifestMetadataValidationTests
     }
 
     [Test]
+    public void FileBasedRuntimeComponentCatalog_EnumeratesModulesOptimizersAndBackends_Deterministically()
+    {
+        using var temp = new TempDirectory();
+        var serializer = new RuntimeManifestJsonSerializer();
+        var manifestA = Path.Combine(temp.Path, "a.dialect.runtime.json");
+        var manifestB = Path.Combine(temp.Path, "b.dialect.runtime.json");
+
+        File.WriteAllText(manifestA, serializer.Serialize(new FileDialectRuntimeManifestDocument(
+            "BAssembly",
+            [
+                new FileDialectRuntimeComponentEntry("Backend", "interpreter", [], "Runtime.Backends.Interpreter"),
+                new FileDialectRuntimeComponentEntry("Optimizer", "LocalVariablesOptimization", [], "Runtime.Optimizers.Local"),
+                new FileDialectRuntimeComponentEntry("FrontendModule", "Numbers", [], "Runtime.Modules.Numbers")
+            ])));
+        File.WriteAllText(manifestB, serializer.Serialize(new FileDialectRuntimeManifestDocument(
+            "AAssembly",
+            [
+                new FileDialectRuntimeComponentEntry("Backend", "cil", ["compiler"], "Runtime.Backends.Cil"),
+                new FileDialectRuntimeComponentEntry("FrontendModule", "Arithmetic", [], "Runtime.Modules.Arithmetic"),
+                new FileDialectRuntimeComponentEntry("Optimizer", "AlphaOptimization", [], "Runtime.Optimizers.Alpha")
+            ])));
+
+        var catalog = new FileBasedRuntimeComponentCatalog(new StaticManifestLocator([manifestA, manifestB]), serializer);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(catalog.GetModulesInDeterministicOrder().Select(static x => x.CanonicalAlias), Is.EqualTo(new[] { "Arithmetic", "Numbers" }));
+            Assert.That(catalog.GetOptimizersInDeterministicOrder().Select(static x => x.CanonicalAlias), Is.EqualTo(new[] { "AlphaOptimization", "LocalVariablesOptimization" }));
+            Assert.That(catalog.GetBackendsInDeterministicOrder().Select(static x => x.CanonicalAlias), Is.EqualTo(new[] { "cil", "interpreter" }));
+        });
+    }
+
+    [Test]
     public void SelectionResolver_UsesGlobalCatalogWithoutFamilyFiltering()
     {
         var services = new ServiceCollection();

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/IWistDialectBackendServiceProvider.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/IWistDialectBackendServiceProvider.cs
@@ -1,13 +1,10 @@
 using Microsoft.Extensions.DependencyInjection;
 using UniversalToolchain.Dialects.Abstractions;
+using UniversalToolchain.Dialects.Integration;
 
 namespace UniversalToolchain.Dialects.Wist;
 
-public interface IWistDialectBackendServiceProvider
+public interface IWistDialectBackendServiceProvider : IDialectBackendRuntimeRegistrar
 {
-    DialectBackendId BackendId { get; }
-
-    IReadOnlyList<string> SupportedIntrinsics { get; }
-
     void RegisterRuntime(IServiceCollection services, WistDialectBackendConfiguration configuration);
 }

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistCilDialectBackendServiceProvider.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistCilDialectBackendServiceProvider.cs
@@ -9,6 +9,7 @@ using BytecodeDynamicMethodsCompiler.Compilers;
 using ExceptionsManager;
 using Microsoft.Extensions.DependencyInjection;
 using UniversalToolchain.Dialects.Abstractions;
+using UniversalToolchain.Dialects.Integration;
 
 namespace UniversalToolchain.Dialects.Wist;
 
@@ -35,6 +36,15 @@ internal sealed class WistCilDialectBackendServiceProvider : IWistDialectBackend
         services.AddTransient<ICoreOptimizedRunnable>(provider => CreateCore(provider, configuration));
         services.AddTransient<IExecutableGiver<DynamicMethod>>(provider => CreateCore(provider, configuration));
         services.AddTransient(provider => new WistDialectBackendRuntime(configuration.BackendDescriptor, CreateCore(provider, configuration)));
+    }
+
+    void IDialectBackendRuntimeRegistrar.RegisterRuntime(IServiceCollection services, DialectBackendRuntimeConfiguration configuration)
+    {
+        var wistConfiguration = configuration as WistDialectBackendConfiguration;
+        if (wistConfiguration == null)
+            Thrower.Argument(nameof(configuration), $"Backend '{BackendId.Value}' requires '{nameof(WistDialectBackendConfiguration)}'.");
+
+        RegisterRuntime(services, wistConfiguration);
     }
 
     private static BasicCoreImpl<DynamicMethod> CreateCore(IServiceProvider provider, WistDialectBackendConfiguration configuration)

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistDialectBackendConfiguration.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistDialectBackendConfiguration.cs
@@ -1,5 +1,3 @@
-using System.Collections.ObjectModel;
-using ExceptionsManager;
 using UniversalToolchain.Dialects.Integration;
 
 namespace UniversalToolchain.Dialects.Wist;
@@ -7,44 +5,14 @@ namespace UniversalToolchain.Dialects.Wist;
 /// <summary>
 ///     Immutable backend-specific execution configuration for one enabled Wist backend.
 /// </summary>
-public sealed class WistDialectBackendConfiguration
+public sealed class WistDialectBackendConfiguration : DialectBackendRuntimeConfiguration
 {
-    private readonly ReadOnlyCollection<string> _allowedIntrinsics;
-    private readonly ReadOnlyCollection<string> _forbiddenIntrinsics;
-
     public WistDialectBackendConfiguration(
         RuntimeBackendDescriptor backendDescriptor,
         IEnumerable<string> allowedIntrinsics,
         IEnumerable<string> forbiddenIntrinsics,
         bool hasExplicitAllowList)
+        : base(backendDescriptor, allowedIntrinsics, forbiddenIntrinsics, hasExplicitAllowList)
     {
-        if (backendDescriptor == null)
-            Thrower.ArgumentNull(nameof(backendDescriptor));
-
-        BackendDescriptor = backendDescriptor;
-        _allowedIntrinsics = new ReadOnlyCollection<string>(Snapshot(allowedIntrinsics, nameof(allowedIntrinsics)));
-        _forbiddenIntrinsics = new ReadOnlyCollection<string>(Snapshot(forbiddenIntrinsics, nameof(forbiddenIntrinsics)));
-        HasExplicitAllowList = hasExplicitAllowList;
-    }
-
-    public RuntimeBackendDescriptor BackendDescriptor { get; }
-
-    public IReadOnlyList<string> AllowedIntrinsics => _allowedIntrinsics;
-
-    public IReadOnlyList<string> ForbiddenIntrinsics => _forbiddenIntrinsics;
-
-    public bool HasExplicitAllowList { get; }
-
-    private static List<string> Snapshot(IEnumerable<string> values, string paramName)
-    {
-        if (values == null)
-            Thrower.ArgumentNull(paramName);
-
-        return values
-            .Select(x => x.NotNull(paramName))
-            .Where(x => !string.IsNullOrWhiteSpace(x))
-            .Distinct(StringComparer.Ordinal)
-            .OrderBy(x => x, StringComparer.Ordinal)
-            .ToList();
     }
 }

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistDialectExecutionConfigurationBuilder.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistDialectExecutionConfigurationBuilder.cs
@@ -8,13 +8,13 @@ namespace UniversalToolchain.Dialects.Wist;
 public sealed class WistDialectExecutionConfigurationBuilder
 {
     private readonly DialectIntrinsicPolicyResolver _intrinsicPolicyResolver;
-    private readonly IWistKnownBackendsProvider _knownBackendsProvider;
+    private readonly IRuntimeKnownBackendsProvider _knownBackendsProvider;
     private readonly IRuntimeComponentTypeLoader _typeLoader;
 
     public WistDialectExecutionConfigurationBuilder(
         IRuntimeComponentTypeLoader typeLoader,
         DialectIntrinsicPolicyResolver intrinsicPolicyResolver,
-        IWistKnownBackendsProvider knownBackendsProvider)
+        IRuntimeKnownBackendsProvider knownBackendsProvider)
     {
         _typeLoader = typeLoader ?? throw new ArgumentNullException(nameof(typeLoader));
         _intrinsicPolicyResolver = intrinsicPolicyResolver ?? throw new ArgumentNullException(nameof(intrinsicPolicyResolver));

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistDialectIntrinsicRegistry.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistDialectIntrinsicRegistry.cs
@@ -1,60 +1,12 @@
-using ExceptionsManager;
-using UniversalToolchain.Dialects.Abstractions;
 using UniversalToolchain.Dialects.Integration;
 
 namespace UniversalToolchain.Dialects.Wist;
 
 internal static class WistDialectIntrinsicRegistry
 {
-    public static IReadOnlyList<RuntimeIntrinsicDescriptor> CreateDescriptors(IEnumerable<IWistDialectBackendServiceProvider> backendProviders)
-    {
-        var backendIntrinsics = CreateBackendIntrinsicMap(backendProviders);
-        var commonIntrinsics = GetCommonIntrinsics(backendIntrinsics);
-        var descriptors = new List<RuntimeIntrinsicDescriptor>();
+    public static IReadOnlyList<RuntimeIntrinsicDescriptor> CreateDescriptors(IEnumerable<IDialectBackendRuntimeRegistrar> backendRegistrars) =>
+        RuntimeBackendIntrinsicRegistry.CreateDescriptors(backendRegistrars);
 
-        foreach (var intrinsic in commonIntrinsics)
-            descriptors.Add(new RuntimeIntrinsicDescriptor(intrinsic, DialectBackendSelector.Any));
-
-        foreach (var backend in backendIntrinsics)
-        {
-            foreach (var intrinsic in backend.Value.Except(commonIntrinsics, StringComparer.Ordinal))
-                descriptors.Add(new RuntimeIntrinsicDescriptor(intrinsic, DialectBackendSelector.For(backend.Key)));
-        }
-
-        return descriptors
-            .OrderBy(x => x.CanonicalId, StringComparer.Ordinal)
-            .ThenBy(x => x.Target)
-            .ToList();
-    }
-
-    private static IReadOnlyDictionary<DialectBackendId, SortedSet<string>> CreateBackendIntrinsicMap(IEnumerable<IWistDialectBackendServiceProvider> backendProviders)
-    {
-        if (backendProviders == null)
-            Thrower.ArgumentNull(nameof(backendProviders));
-
-        var map = new SortedDictionary<DialectBackendId, SortedSet<string>>();
-        foreach (var backendProvider in backendProviders
-                     .Select(x => x.NotNull(nameof(backendProviders)))
-                     .OrderBy(x => x.BackendId))
-        {
-            var intrinsics = new SortedSet<string>(backendProvider.SupportedIntrinsics ?? Thrower.InvalidOpEx<IReadOnlyList<string>>($"Backend '{backendProvider.BackendId.Value}' returned null supported intrinsics."), StringComparer.Ordinal);
-            if (!map.TryAdd(backendProvider.BackendId, intrinsics))
-                Thrower.InvalidOpEx($"Duplicate Wist backend service provider registration for backend '{backendProvider.BackendId.Value}'.");
-        }
-
-        return map;
-    }
-
-    private static SortedSet<string> GetCommonIntrinsics(IReadOnlyDictionary<DialectBackendId, SortedSet<string>> backendIntrinsics)
-    {
-        var commonIntrinsics = new SortedSet<string>(StringComparer.Ordinal);
-        if (backendIntrinsics.Count == 0)
-            return commonIntrinsics;
-
-        commonIntrinsics.UnionWith(backendIntrinsics.First().Value);
-        foreach (var backend in backendIntrinsics.Skip(1))
-            commonIntrinsics.IntersectWith(backend.Value);
-
-        return commonIntrinsics;
-    }
+    public static IReadOnlyList<RuntimeIntrinsicDescriptor> CreateDescriptors(IEnumerable<IWistDialectBackendServiceProvider> backendProviders) =>
+        RuntimeBackendIntrinsicRegistry.CreateDescriptors(backendProviders);
 }

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistDialectRuntimeDescriptorProvider.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistDialectRuntimeDescriptorProvider.cs
@@ -8,9 +8,9 @@ namespace UniversalToolchain.Dialects.Wist;
 /// </summary>
 public sealed class WistDialectRuntimeDescriptorProvider : IDialectRuntimeDescriptorProvider
 {
-    private readonly IReadOnlyList<IWistDialectBackendServiceProvider> _backendProviders;
+    private readonly IReadOnlyList<IDialectBackendRuntimeRegistrar> _backendProviders;
 
-    public WistDialectRuntimeDescriptorProvider(IEnumerable<IWistDialectBackendServiceProvider> backendProviders)
+    public WistDialectRuntimeDescriptorProvider(IEnumerable<IDialectBackendRuntimeRegistrar> backendProviders)
     {
         if (backendProviders == null)
         {
@@ -29,7 +29,6 @@ public sealed class WistDialectRuntimeDescriptorProvider : IDialectRuntimeDescri
             Thrower.ArgumentNull(nameof(builder));
         }
 
-        builder.RegisterAttributedBackendsFromAssemblies(typeof(WistDialectRuntimeDescriptorProvider).Assembly);
         RegisterIntrinsics(builder);
     }
 

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistDialectServiceCollectionExtensions.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistDialectServiceCollectionExtensions.cs
@@ -1,26 +1,9 @@
-using ArithmeticModule;
-using CommentsModule;
-using ConditionsModule;
-using CSharpInteropModule;
-using EqualityModule;
 using ExceptionsManager;
-using IdentifierModule;
-using InternalPreprocessorLexemesModule;
-using LabelsModule;
-using LocalVariablesOptimizerModule;
-using LoopsModule;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
-using NativeMathModule;
-using NumbersModule;
-using ParametersSetterModule;
-using ScopesModule;
-using SemicolonAsNewLineModule;
 using UniversalToolchain.Dialects.Core;
 using UniversalToolchain.Dialects.Frontend;
 using UniversalToolchain.Dialects.Integration;
-using VariablesModule;
-using WhitespacesModule;
 
 namespace UniversalToolchain.Dialects.Wist;
 
@@ -44,14 +27,15 @@ public static class WistDialectServiceCollectionExtensions
         if (services == null)
             Thrower.ArgumentNull(nameof(services));
 
-        services.AddDialectDslDefaultComposition();
-        AddSharedWistDialectServices(services);
-        AddLegacyCompositionServices(services);
+        AddWistDialectServicesMinimal(services);
+        AddLegacyCompatibilityServices(services);
         return services;
     }
 
     private static void AddSharedWistDialectServices(IServiceCollection services)
     {
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IDialectBackendRuntimeRegistrar, WistCilDialectBackendServiceProvider>());
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IDialectBackendRuntimeRegistrar, WistInterpreterDialectBackendServiceProvider>());
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IWistDialectBackendServiceProvider, WistCilDialectBackendServiceProvider>());
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IWistDialectBackendServiceProvider, WistInterpreterDialectBackendServiceProvider>());
 
@@ -61,9 +45,10 @@ public static class WistDialectServiceCollectionExtensions
             new DefaultRuntimeManifestFileLocator(provider.GetRequiredService<RuntimeArtifactLocatorOptions>()));
         services.TryAddSingleton<IRuntimeAssemblyLocator>(provider =>
             new DefaultRuntimeAssemblyLocator(provider.GetRequiredService<RuntimeArtifactLocatorOptions>()));
-        services.TryAddSingleton<RuntimeManifestJsonSerializer>();
+        services.TryAddSingleton<IRuntimeManifestSerializer, RuntimeManifestJsonSerializer>();
         services.TryAddSingleton<IRuntimeComponentCatalog, FileBasedRuntimeComponentCatalog>();
         services.TryAddSingleton<IRuntimeComponentTypeLoader, DefaultRuntimeComponentTypeLoader>();
+        services.TryAddSingleton<IRuntimeKnownBackendsProvider, RuntimeKnownBackendsProvider>();
         services.TryAddSingleton<IWistKnownBackendsProvider, WistKnownBackendsProvider>();
         services.TryAddSingleton<DialectIntrinsicPolicyResolver>();
         services.TryAddSingleton<IDialectCompiledDialectBuildPlanBuilder, DialectCompiledDialectBuildPlanBuilder>();
@@ -77,26 +62,10 @@ public static class WistDialectServiceCollectionExtensions
         // minimal path intentionally avoids runtime descriptor discovery services.
     }
 
-    private static void AddLegacyCompositionServices(IServiceCollection services)
+    private static void AddLegacyCompatibilityServices(IServiceCollection services)
     {
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IDialectRuntimeDescriptorProvider, WistDialectRuntimeDescriptorProvider>());
-        services.TryAddEnumerable(ServiceDescriptor.Singleton<IDialectRuntimeDescriptorProvider, ArithmeticDialectRuntimeDescriptorProvider>());
-        services.TryAddEnumerable(ServiceDescriptor.Singleton<IDialectRuntimeDescriptorProvider, ConditionsDialectRuntimeDescriptorProvider>());
-        services.TryAddEnumerable(ServiceDescriptor.Singleton<IDialectRuntimeDescriptorProvider, EqualityDialectRuntimeDescriptorProvider>());
-        services.TryAddEnumerable(ServiceDescriptor.Singleton<IDialectRuntimeDescriptorProvider, NativeMathDialectRuntimeDescriptorProvider>());
-        services.TryAddEnumerable(ServiceDescriptor.Singleton<IDialectRuntimeDescriptorProvider, NumbersDialectRuntimeDescriptorProvider>());
-        services.TryAddEnumerable(ServiceDescriptor.Singleton<IDialectRuntimeDescriptorProvider, CommentsDialectRuntimeDescriptorProvider>());
-        services.TryAddEnumerable(ServiceDescriptor.Singleton<IDialectRuntimeDescriptorProvider, IdentifierDialectRuntimeDescriptorProvider>());
-        services.TryAddEnumerable(ServiceDescriptor.Singleton<IDialectRuntimeDescriptorProvider, InternalPreprocessorLexemesDialectRuntimeDescriptorProvider>());
-        services.TryAddEnumerable(ServiceDescriptor.Singleton<IDialectRuntimeDescriptorProvider, SemicolonAsNewLineDialectRuntimeDescriptorProvider>());
-        services.TryAddEnumerable(ServiceDescriptor.Singleton<IDialectRuntimeDescriptorProvider, WhitespacesDialectRuntimeDescriptorProvider>());
-        services.TryAddEnumerable(ServiceDescriptor.Singleton<IDialectRuntimeDescriptorProvider, ParametersSetterDialectRuntimeDescriptorProvider>());
-        services.TryAddEnumerable(ServiceDescriptor.Singleton<IDialectRuntimeDescriptorProvider, ScopesDialectRuntimeDescriptorProvider>());
-        services.TryAddEnumerable(ServiceDescriptor.Singleton<IDialectRuntimeDescriptorProvider, VariablesDialectRuntimeDescriptorProvider>());
-        services.TryAddEnumerable(ServiceDescriptor.Singleton<IDialectRuntimeDescriptorProvider, LabelsDialectRuntimeDescriptorProvider>());
-        services.TryAddEnumerable(ServiceDescriptor.Singleton<IDialectRuntimeDescriptorProvider, LoopsDialectRuntimeDescriptorProvider>());
-        services.TryAddEnumerable(ServiceDescriptor.Singleton<IDialectRuntimeDescriptorProvider, CSharpInteropDialectRuntimeDescriptorProvider>());
-        services.TryAddEnumerable(ServiceDescriptor.Singleton<IDialectRuntimeDescriptorProvider, LocalVariablesOptimizerDialectRuntimeDescriptorProvider>());
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IDialectRuntimeDescriptorProvider, CatalogBackedDialectRuntimeDescriptorProvider>());
 
         services.TryAddSingleton(static provider => DialectRuntimeDescriptorRegistryFactory.BuildFromProviders(provider.GetServices<IDialectRuntimeDescriptorProvider>()));
         services.TryAddSingleton<IDialectRuntimeCompositionResolver, DialectRuntimeCompositionResolver>();

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistDialectServiceProviderFactory.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistDialectServiceProviderFactory.cs
@@ -3,6 +3,7 @@ using DependencyInjection;
 using ExceptionsManager;
 using Microsoft.Extensions.DependencyInjection;
 using UniversalToolchain.Dialects.Abstractions;
+using UniversalToolchain.Dialects.Integration;
 using ServiceLifetime = Microsoft.Extensions.DependencyInjection.ServiceLifetime;
 
 namespace UniversalToolchain.Dialects.Wist;
@@ -12,9 +13,9 @@ namespace UniversalToolchain.Dialects.Wist;
 /// </summary>
 public sealed class WistDialectServiceProviderFactory
 {
-    private readonly IReadOnlyDictionary<DialectBackendId, IWistDialectBackendServiceProvider> _backendProviders;
+    private readonly IReadOnlyDictionary<DialectBackendId, IDialectBackendRuntimeRegistrar> _backendProviders;
 
-    public WistDialectServiceProviderFactory(IEnumerable<IWistDialectBackendServiceProvider> backendProviders)
+    public WistDialectServiceProviderFactory(IEnumerable<IDialectBackendRuntimeRegistrar> backendProviders)
     {
         _backendProviders = CreateBackendProviderMap(backendProviders);
     }
@@ -46,24 +47,24 @@ public sealed class WistDialectServiceProviderFactory
         foreach (var backend in configuration.BackendConfigurations.OrderBy(x => x.BackendDescriptor.BackendId))
         {
             if (!_backendProviders.TryGetValue(backend.BackendDescriptor.BackendId, out var backendProvider))
-                Thrower.InvalidOpEx($"No Wist backend service provider is registered for backend '{backend.BackendDescriptor.CanonicalId}'.");
+                Thrower.InvalidOpEx($"No backend runtime registrar is registered for backend '{backend.BackendDescriptor.CanonicalId}'.");
 
             backendProvider.RegisterRuntime(services, backend);
         }
     }
 
-    private static IReadOnlyDictionary<DialectBackendId, IWistDialectBackendServiceProvider> CreateBackendProviderMap(IEnumerable<IWistDialectBackendServiceProvider> backendProviders)
+    private static IReadOnlyDictionary<DialectBackendId, IDialectBackendRuntimeRegistrar> CreateBackendProviderMap(IEnumerable<IDialectBackendRuntimeRegistrar> backendProviders)
     {
         if (backendProviders == null)
             Thrower.ArgumentNull(nameof(backendProviders));
 
-        var map = new SortedDictionary<DialectBackendId, IWistDialectBackendServiceProvider>();
+        var map = new SortedDictionary<DialectBackendId, IDialectBackendRuntimeRegistrar>();
         foreach (var backendProvider in backendProviders
                      .Select(x => x.NotNull(nameof(backendProviders)))
                      .OrderBy(x => x.BackendId))
         {
             if (!map.TryAdd(backendProvider.BackendId, backendProvider))
-                Thrower.InvalidOpEx($"Duplicate Wist backend service provider registration for backend '{backendProvider.BackendId.Value}'.");
+                Thrower.InvalidOpEx($"Duplicate backend runtime registrar registration for backend '{backendProvider.BackendId.Value}'.");
         }
 
         return map;

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistDialectServicesRegistrar.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistDialectServicesRegistrar.cs
@@ -14,6 +14,6 @@ public sealed class WistDialectServicesRegistrar : IDialectServicesRegistrar
         if (services == null)
             Thrower.ArgumentNull(nameof(services));
 
-        services.AddWistDialectServices();
+        services.AddWistDialectServicesMinimal();
     }
 }

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistInterpreterDialectBackendServiceProvider.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistInterpreterDialectBackendServiceProvider.cs
@@ -9,6 +9,7 @@ using IntermediateRepresentationAbstractions;
 using Microsoft.Extensions.DependencyInjection;
 using ExceptionsManager;
 using UniversalToolchain.Dialects.Abstractions;
+using UniversalToolchain.Dialects.Integration;
 
 namespace UniversalToolchain.Dialects.Wist;
 
@@ -35,6 +36,15 @@ internal sealed class WistInterpreterDialectBackendServiceProvider : IWistDialec
         services.AddTransient<ICoreOptimizedRunnable>(provider => CreateCore(provider, configuration));
         services.AddTransient<IExecutableGiver<IAbstractIR>>(provider => CreateCore(provider, configuration));
         services.AddTransient(provider => new WistDialectBackendRuntime(configuration.BackendDescriptor, CreateCore(provider, configuration)));
+    }
+
+    void IDialectBackendRuntimeRegistrar.RegisterRuntime(IServiceCollection services, DialectBackendRuntimeConfiguration configuration)
+    {
+        var wistConfiguration = configuration as WistDialectBackendConfiguration;
+        if (wistConfiguration == null)
+            Thrower.Argument(nameof(configuration), $"Backend '{BackendId.Value}' requires '{nameof(WistDialectBackendConfiguration)}'.");
+
+        RegisterRuntime(services, wistConfiguration);
     }
 
     private static BasicCoreImpl<IAbstractIR> CreateCore(IServiceProvider provider, WistDialectBackendConfiguration configuration)

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistKnownBackendsProvider.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistKnownBackendsProvider.cs
@@ -1,64 +1,18 @@
-using ExceptionsManager;
-using UniversalToolchain.Dialects.Abstractions;
 using UniversalToolchain.Dialects.Integration;
 
 namespace UniversalToolchain.Dialects.Wist;
 
+/// <summary>
+/// Compatibility alias for existing Wist-facing wiring that delegates to generic runtime backend metadata provider.
+/// </summary>
 public sealed class WistKnownBackendsProvider : IWistKnownBackendsProvider
 {
-    private readonly IReadOnlyList<RuntimeBackendDescriptor> _knownBackends;
+    private readonly IRuntimeKnownBackendsProvider _inner;
 
-    public WistKnownBackendsProvider(
-        IRuntimeComponentCatalog catalog,
-        IEnumerable<IWistDialectBackendServiceProvider> backendProviders)
+    public WistKnownBackendsProvider(IRuntimeKnownBackendsProvider inner)
     {
-        if (catalog == null)
-            Thrower.ArgumentNull(nameof(catalog));
-
-        if (backendProviders == null)
-            Thrower.ArgumentNull(nameof(backendProviders));
-
-        var providersById = CreateProviderMap(backendProviders);
-        _knownBackends = BuildKnownBackends(catalog, providersById);
+        _inner = inner ?? throw new ArgumentNullException(nameof(inner));
     }
 
-    public IReadOnlyList<RuntimeBackendDescriptor> GetKnownBackends() => _knownBackends;
-
-    private static IReadOnlyDictionary<DialectBackendId, IWistDialectBackendServiceProvider> CreateProviderMap(
-        IEnumerable<IWistDialectBackendServiceProvider> backendProviders)
-    {
-        var map = new SortedDictionary<DialectBackendId, IWistDialectBackendServiceProvider>();
-        foreach (var backendProvider in backendProviders
-                     .Select(x => x.NotNull(nameof(backendProviders)))
-                     .OrderBy(x => x.BackendId))
-        {
-            if (!map.TryAdd(backendProvider.BackendId, backendProvider))
-                Thrower.InvalidOpEx($"Duplicate Wist backend provider registration for backend '{backendProvider.BackendId.Value}'.");
-        }
-
-        return map;
-    }
-
-    private static IReadOnlyList<RuntimeBackendDescriptor> BuildKnownBackends(
-        IRuntimeComponentCatalog catalog,
-        IReadOnlyDictionary<DialectBackendId, IWistDialectBackendServiceProvider> providersById)
-    {
-        var descriptors = new List<RuntimeBackendDescriptor>();
-        foreach (var backendId in providersById.Keys)
-        {
-            if (!catalog.TryResolveBackend(backendId.Value, out var entry) || entry == null)
-                Thrower.InvalidOpEx($"Wist backend provider '{backendId.Value}' is registered, but no matching runtime backend metadata entry exists.");
-
-            var aliases = entry.Aliases
-                .OrderBy(static x => x, StringComparer.Ordinal)
-                .ToArray();
-
-            descriptors.Add(new RuntimeBackendDescriptor(new DialectBackendId(entry.CanonicalAlias), aliases));
-        }
-
-        return descriptors
-            .OrderBy(x => x.BackendId)
-            .ThenBy(x => string.Join("|", x.Aliases), StringComparer.Ordinal)
-            .ToList();
-    }
+    public IReadOnlyList<RuntimeBackendDescriptor> GetKnownBackends() => _inner.GetKnownBackends();
 }

--- a/UniversalToolchain/Wistc/Program.cs
+++ b/UniversalToolchain/Wistc/Program.cs
@@ -304,7 +304,7 @@ WistDialectExecutionHost CreateDialectHost(string dialectFile)
 ServiceProvider CreateDialectWorkflowProvider()
 {
     var services = new ServiceCollection();
-    services.AddWistDialectServices();
+    services.AddWistDialectServicesLegacy();
     return services.BuildServiceProvider();
 }
 


### PR DESCRIPTION
### Motivation

- Enforce a selection-driven minimal dialect execution path that does not register legacy composition services by default. 
- Move Wist-specific runtime wiring to depend on neutral, generic integration abstractions so the minimal path is reusable and not tied to Wist internals. 
- Replace ad-hoc manifest/kind parsing, hidden ctor dependencies and hardcoded provider lists with DI-friendly, option-driven and deterministic implementations. 
- Provide a clear, isolated legacy compatibility registration path so legacy behavior remains available but no longer contaminates the minimal path.

### Description

- Split service registration into minimal vs legacy: `AddWistDialectServicesMinimal()` provides the minimal selection-driven runtime, and `AddWistDialectServicesLegacy()` layers explicit compatibility services on top; minimal path no longer registers legacy composition/registry/workflow services. (updated `WistDialectServiceCollectionExtensions`, `WistDialectServicesRegistrar`).
- Introduced neutral backend runtime abstractions and registrars: `IDialectBackendRuntimeRegistrar`, `DialectBackendRuntimeConfiguration`, `IRuntimeKnownBackendsProvider`/`RuntimeKnownBackendsProvider`, and `RuntimeBackendIntrinsicRegistry`; Wist backends now implement/adapt the generic registrar interface with thin compatibility shims (`IWistDialectBackendServiceProvider` now extends the generic registrar). (new files in Integration and updates under Wist).
- Reworked runtime catalog and manifest plumbing: `IRuntimeManifestSerializer` + `RuntimeManifestJsonSerializer`, `RuntimeComponentKindCodec` to centralize kind parse/format, and `FileBasedRuntimeComponentCatalog` now requires injected dependencies (no hidden parameterless ctor) and exposes deterministic enumeration APIs `GetModulesInDeterministicOrder()`, `GetOptimizersInDeterministicOrder()`, `GetBackendsInDeterministicOrder()`. Also added `CatalogBackedDialectRuntimeDescriptorProvider` to adapt manifest catalog entries into legacy descriptor registrations. (changes in UniversalToolchain.Dialects.Integration).
- Made artifact-location policy option-driven via `RuntimeArtifactLocatorOptions` and updated default locators (`DefaultRuntimeManifestFileLocator`, `DefaultRuntimeAssemblyLocator`) to respect options (search roots, manifest file pattern/search option, assembly suffix). Reduced build-target hardcoding by introducing a manifest suffix property in `Directory.Build.targets`.

### Testing

- Added/updated tests to lock behavior: minimal-vs-legacy isolation and explicit legacy registration, deterministic catalog enumeration, backend registrar determinism and duplicate rejection, and parity/no cross-run pollution tests (updated tests include `WistDialectMinimalRuntimeIsolationTests`, `WistRuntimeManifestMetadataValidationTests` with deterministic enumeration, `WistDialectBackendCompatibilityTests`, `WistDialectBackendHardcodeTests`, `WistDialectRuntimeDescriptorProviderTests`, and supporting unit tests).
- Ran the relevant test suites and verified they passed: `dotnet test UniversalToolchain.Dialects.Tests/UniversalToolchain.Dialects.Tests.csproj -v minimal` and `dotnet test Tests/Tests.csproj -v minimal` — both test runs completed successfully.
- All modified/added automated tests are green after the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7a4dbe5c4832499f41a2745bdb85d)