### PR TITLE
Add first-wave runtime contract tests for deterministic Wist path

### DIFF
--- a/UniversalToolchain/Tests/Architecture/DeletedLegacySurfaceTests.cs
+++ b/UniversalToolchain/Tests/Architecture/DeletedLegacySurfaceTests.cs
@@ -1,0 +1,72 @@
+using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+using UniversalToolchain.Dialects.Wist;
+
+namespace Tests.Architecture;
+
+[TestFixture]
+public class DeletedLegacySurfaceTests
+{
+    [Test]
+    public void DependencyInjectionAssembly_ShouldNoLongerBeReferencedByCanonicalWistPath()
+    {
+        var referenced = typeof(WistDialectExecutionWorkflow).Assembly
+            .GetReferencedAssemblies()
+            .Select(static x => x.Name)
+            .Where(static x => !string.IsNullOrWhiteSpace(x))
+            .ToArray();
+
+        Assert.That(referenced.Any(static x => string.Equals(x, "Wist.DependencyInjection", StringComparison.Ordinal)), Is.False);
+    }
+
+    [Test]
+    public void LegacyCompositionServiceType_ShouldNotExist()
+    {
+        Assert.That(FindType("Wist.DependencyInjection.WistCompositionService"), Is.Null);
+    }
+
+    [Test]
+    public void LegacyRegistryTypes_ShouldNotExist()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(FindType("Wist.DependencyInjection.AutoRegistration"), Is.Null);
+            Assert.That(FindType("Wist.DependencyInjection.ServiceRegistrationRegistry"), Is.Null);
+        });
+    }
+
+    [Test]
+    public void OldBroadWistServiceCollectionExtensions_ShouldNotExist()
+    {
+        Assert.That(FindType("Wist.DependencyInjection.ServiceCollectionExtensions"), Is.Null);
+    }
+
+    [Test]
+    public void OldWistOptionsType_ShouldNotExist()
+    {
+        Assert.That(FindType("Wist.DependencyInjection.WistOptions"), Is.Null);
+    }
+
+    [Test]
+    public void CanonicalRuntimePath_ShouldNotRequireRemovedDependencyInjectionProject()
+    {
+        var services = new ServiceCollection();
+        services.AddWistDialectServices();
+        services.AddWistCilBackend();
+        services.AddWistInterpreterBackend();
+
+        using var provider = services.BuildServiceProvider();
+        var workflow = provider.GetRequiredService<WistDialectExecutionWorkflow>();
+        var composition = workflow.ComposeText("dialect D\nuse Arithmetic\nbackend interpreter", "inline");
+
+        Assert.That(composition.IsSuccess, Is.True, composition.ToDeterministicText());
+    }
+
+    private static Type? FindType(string fullName)
+    {
+        return AppDomain.CurrentDomain.GetAssemblies()
+                   .Select(x => x.GetType(fullName, throwOnError: false, ignoreCase: false))
+                   .FirstOrDefault(static x => x != null)
+               ?? Type.GetType(fullName, throwOnError: false, ignoreCase: false);
+    }
+}

--- a/UniversalToolchain/Tests/Tests.csproj
+++ b/UniversalToolchain/Tests/Tests.csproj
@@ -57,6 +57,7 @@
         <Compile Remove="**/*.cs" />
         <Compile Include="GlobalUsings.cs" />
         <Compile Include="Integration/WistcCliContractsTests.cs" />
+        <Compile Include="Architecture/DeletedLegacySurfaceTests.cs" />
     </ItemGroup>
 
     <ItemGroup>

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/Backends/RuntimeKnownBackendsProviderContractTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/Backends/RuntimeKnownBackendsProviderContractTests.cs
@@ -1,0 +1,101 @@
+using Microsoft.Extensions.DependencyInjection;
+using UniversalToolchain.Dialects.Abstractions;
+using UniversalToolchain.Dialects.Integration;
+
+namespace UniversalToolchain.Dialects.Tests.Backends;
+
+public class RuntimeKnownBackendsProviderContractTests
+{
+    [Test]
+    public void KnownBackendsProvider_ShouldReturnOnlyBackendsBackedByRegistrars()
+    {
+        var catalog = new StaticCatalog([
+            Entry(RuntimeComponentKind.Backend, "compiler", "Meta.Compiler"),
+            Entry(RuntimeComponentKind.Backend, "interpreter", "Meta.Interpreter")]);
+
+        var provider = new RuntimeKnownBackendsProvider(catalog, [new StubRegistrar("interpreter")]);
+        var known = provider.GetKnownBackends();
+
+        Assert.That(known.Select(static x => x.CanonicalId), Is.EqualTo(new[] { "interpreter" }));
+    }
+
+    [Test]
+    public void KnownBackendsProvider_ShouldRejectDuplicateBackendRegistrars()
+    {
+        var catalog = new StaticCatalog([Entry(RuntimeComponentKind.Backend, "interpreter", "Meta.Interpreter")]);
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            new RuntimeKnownBackendsProvider(catalog, [new StubRegistrar("interpreter"), new StubRegistrar("interpreter")]))!;
+
+        Assert.That(ex.Message, Does.Contain("Duplicate backend provider registration for backend 'interpreter'"));
+    }
+
+    [Test]
+    public void KnownBackendsProvider_ShouldRejectRegistrarWithoutCatalogMetadata()
+    {
+        var catalog = new StaticCatalog([Entry(RuntimeComponentKind.Backend, "compiler", "Meta.Compiler")]);
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            new RuntimeKnownBackendsProvider(catalog, [new StubRegistrar("interpreter")]))!;
+
+        Assert.That(ex.Message, Does.Contain("no matching runtime backend metadata entry"));
+    }
+
+    [Test]
+    public void KnownBackendsProvider_ShouldPreserveMetadataOwnerType()
+    {
+        var catalog = new StaticCatalog([Entry(RuntimeComponentKind.Backend, "interpreter", "Meta.Interpreter")]);
+
+        var provider = new RuntimeKnownBackendsProvider(catalog, [new StubRegistrar("interpreter")]);
+
+        Assert.That(provider.GetKnownBackends().Single().MetadataOwnerType, Is.EqualTo(typeof(RuntimeComponentManifestEntry)));
+    }
+
+    [Test]
+    public void KnownBackendsProvider_ShouldSortBackendsDeterministically()
+    {
+        var catalog = new StaticCatalog([
+            Entry(RuntimeComponentKind.Backend, "interpreter", "Meta.Interpreter"),
+            Entry(RuntimeComponentKind.Backend, "compiler", "Meta.Compiler")]);
+
+        var provider = new RuntimeKnownBackendsProvider(catalog, [new StubRegistrar("interpreter"), new StubRegistrar("compiler")]);
+
+        Assert.That(provider.GetKnownBackends().Select(static x => x.CanonicalId), Is.EqualTo(new[] { "compiler", "interpreter" }));
+    }
+
+    [Test]
+    public void KnownBackendsProvider_ShouldPreserveAliasesDeterministically()
+    {
+        var catalog = new StaticCatalog([Entry(RuntimeComponentKind.Backend, "interpreter", "Meta.Interpreter", "z", "a")]);
+
+        var provider = new RuntimeKnownBackendsProvider(catalog, [new StubRegistrar("interpreter")]);
+        var aliases = provider.GetKnownBackends().Single().Aliases;
+
+        Assert.That(aliases, Is.EqualTo(new[] { "a", "z" }));
+    }
+
+    private static RuntimeComponentManifestEntry Entry(RuntimeComponentKind kind, string canonical, string type, params string[] aliases)
+        => new(kind, canonical, aliases, new RuntimeTypeReference("Assembly", type));
+
+    private sealed class StubRegistrar(string backend) : IDialectBackendRuntimeRegistrar
+    {
+        public DialectBackendId BackendId { get; } = new(backend);
+        public IReadOnlyList<string> SupportedIntrinsics => [];
+        public void RegisterRuntime(IServiceCollection services, DialectBackendRuntimeConfiguration configuration) { }
+    }
+
+    private sealed class StaticCatalog(IEnumerable<RuntimeComponentManifestEntry> entries) : IRuntimeComponentCatalog
+    {
+        private readonly IReadOnlyDictionary<string, RuntimeComponentManifestEntry> _entries = entries
+            .Where(static x => x.Kind == RuntimeComponentKind.Backend)
+            .SelectMany(static x => x.AllAliases.Select(a => (a, x)))
+            .ToDictionary(static x => x.a, static x => x.x, StringComparer.Ordinal);
+
+        public bool TryResolveModule(string alias, out RuntimeComponentManifestEntry? entry) { entry = null; return false; }
+        public bool TryResolveOptimizer(string alias, out RuntimeComponentManifestEntry? entry) { entry = null; return false; }
+        public bool TryResolveBackend(string alias, out RuntimeComponentManifestEntry? entry) => _entries.TryGetValue(alias, out entry);
+        public IReadOnlyList<RuntimeComponentManifestEntry> GetModulesInDeterministicOrder() => [];
+        public IReadOnlyList<RuntimeComponentManifestEntry> GetOptimizersInDeterministicOrder() => [];
+        public IReadOnlyList<RuntimeComponentManifestEntry> GetBackendsInDeterministicOrder() => _entries.Values.Distinct().OrderBy(static x => x.CanonicalAlias).ToList();
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/RuntimeCatalog/RuntimeManifestCatalogContractTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/RuntimeCatalog/RuntimeManifestCatalogContractTests.cs
@@ -1,0 +1,157 @@
+using UniversalToolchain.Dialects.Integration;
+
+namespace UniversalToolchain.Dialects.Tests.RuntimeCatalog;
+
+public class RuntimeManifestCatalogContractTests
+{
+    [Test]
+    public void LoadEntries_ShouldReadManifestFilesInDeterministicOrder()
+    {
+        using var temp = new TempDirectory();
+        var serializer = new RuntimeManifestJsonSerializer();
+
+        var zPath = WriteManifest(temp.Path, "z.dialect.runtime.json", "ZAssembly", [Module("zeta", "Z.Type")], serializer);
+        var aPath = WriteManifest(temp.Path, "a.dialect.runtime.json", "AAssembly", [Module("alpha", "A.Type")], serializer);
+
+        var catalog = new FileBasedRuntimeComponentCatalog(new StaticManifestLocator([zPath, aPath]), serializer);
+
+        Assert.That(catalog.GetModulesInDeterministicOrder().Select(static x => x.TypeReference.AssemblySimpleName), Is.EqualTo(new[] { "AAssembly", "ZAssembly" }));
+    }
+
+    [Test]
+    public void LoadEntries_ShouldRejectEmptyAssemblySimpleName()
+    {
+        using var temp = new TempDirectory();
+        var serializer = new RuntimeManifestJsonSerializer();
+        var path = WriteManifest(temp.Path, "empty-asm.dialect.runtime.json", "  ", [Module("Arithmetic", "Arithmetic.Type")], serializer);
+
+        var ex = Assert.Throws<ArgumentException>(() => new FileBasedRuntimeComponentCatalog(new StaticManifestLocator([path]), serializer));
+        Assert.That(ex!.Message, Does.Contain("empty assemblySimpleName"));
+    }
+
+    [Test]
+    public void LoadEntries_ShouldRejectEmptyCanonicalAlias()
+    {
+        using var temp = new TempDirectory();
+        var serializer = new RuntimeManifestJsonSerializer();
+        var path = WriteManifest(temp.Path, "empty-canonical.dialect.runtime.json", "Asm", [Module("  ", "Arithmetic.Type")], serializer);
+
+        var ex = Assert.Throws<ArgumentException>(() => new FileBasedRuntimeComponentCatalog(new StaticManifestLocator([path]), serializer));
+        Assert.That(ex!.Message, Does.Contain("Canonical alias must not be empty"));
+    }
+
+    [Test]
+    public void LoadEntries_ShouldRejectEmptyTypeFullName()
+    {
+        using var temp = new TempDirectory();
+        var serializer = new RuntimeManifestJsonSerializer();
+        var path = WriteManifest(temp.Path, "empty-type.dialect.runtime.json", "Asm", [Module("Arithmetic", " ")], serializer);
+
+        var ex = Assert.Throws<ArgumentException>(() => new FileBasedRuntimeComponentCatalog(new StaticManifestLocator([path]), serializer));
+        Assert.That(ex!.Message, Does.Contain("TypeReference.TypeFullName must not be empty"));
+    }
+
+    [Test]
+    public void Catalog_ShouldRejectDuplicateModuleAlias()
+    {
+        var ex = BuildDuplicateAliasCatalogException(
+            Module("Arithmetic", "A.Type", "common"),
+            Module("Numbers", "B.Type", "common"));
+
+        Assert.That(ex.Message, Does.Contain("Duplicate runtime module alias 'common'"));
+    }
+
+    [Test]
+    public void Catalog_ShouldRejectDuplicateOptimizerAlias()
+    {
+        var ex = BuildDuplicateAliasCatalogException(
+            Optimizer("OptA", "OptA.Type", "common"),
+            Optimizer("OptB", "OptB.Type", "common"));
+
+        Assert.That(ex.Message, Does.Contain("Duplicate runtime optimizer alias 'common'"));
+    }
+
+    [Test]
+    public void Catalog_ShouldRejectDuplicateBackendAlias()
+    {
+        var ex = BuildDuplicateAliasCatalogException(
+            Backend("compiler", "Compiler.Type", "runtime"),
+            Backend("interpreter", "Interpreter.Type", "runtime"));
+
+        Assert.That(ex.Message, Does.Contain("Duplicate runtime backend alias 'runtime'"));
+    }
+
+    [Test]
+    public void Catalog_ShouldNormalizeAndSortAliasesDeterministically()
+    {
+        using var temp = new TempDirectory();
+        var serializer = new RuntimeManifestJsonSerializer();
+        var path = WriteManifest(
+            temp.Path,
+            "aliases.dialect.runtime.json",
+            "Asm",
+            [Module("  Arithmetic  ", "  Arithmetic.Module.Type ", " b ", "Arithmetic", "a", "b", "  ")],
+            serializer);
+
+        var catalog = new FileBasedRuntimeComponentCatalog(new StaticManifestLocator([path]), serializer);
+        Assert.That(catalog.TryResolveModule("Arithmetic", out var entry), Is.True);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(entry!.CanonicalAlias, Is.EqualTo("Arithmetic"));
+            Assert.That(entry.Aliases, Is.EqualTo(new[] { "a", "b" }));
+            Assert.That(entry.TypeReference.TypeFullName, Is.EqualTo("Arithmetic.Module.Type"));
+        });
+    }
+
+    private static InvalidOperationException BuildDuplicateAliasCatalogException(
+        FileDialectRuntimeComponentEntry first,
+        FileDialectRuntimeComponentEntry second)
+    {
+        using var temp = new TempDirectory();
+        var serializer = new RuntimeManifestJsonSerializer();
+        var firstPath = WriteManifest(temp.Path, "first.dialect.runtime.json", "AAssembly", [first], serializer);
+        var secondPath = WriteManifest(temp.Path, "second.dialect.runtime.json", "BAssembly", [second], serializer);
+
+        return Assert.Throws<InvalidOperationException>(() => new FileBasedRuntimeComponentCatalog(new StaticManifestLocator([firstPath, secondPath]), serializer))!;
+    }
+
+    private static FileDialectRuntimeComponentEntry Module(string alias, string type, params string[] aliases) =>
+        new("FrontendModule", alias, aliases, type);
+
+    private static FileDialectRuntimeComponentEntry Optimizer(string alias, string type, params string[] aliases) =>
+        new("Optimizer", alias, aliases, type);
+
+    private static FileDialectRuntimeComponentEntry Backend(string alias, string type, params string[] aliases) =>
+        new("Backend", alias, aliases, type);
+
+    private static string WriteManifest(string root, string fileName, string assemblySimpleName, IReadOnlyList<FileDialectRuntimeComponentEntry> components, IRuntimeManifestSerializer serializer)
+    {
+        var path = Path.Combine(root, fileName);
+        var document = new FileDialectRuntimeManifestDocument(assemblySimpleName, components);
+        File.WriteAllText(path, serializer.Serialize(document));
+        return path;
+    }
+
+    private sealed class StaticManifestLocator(IReadOnlyList<string> paths) : IRuntimeManifestFileLocator
+    {
+        public IReadOnlyList<string> GetManifestFilePaths() => paths;
+    }
+
+    private sealed class TempDirectory : IDisposable
+    {
+        public TempDirectory()
+        {
+            Path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"dialect-tests-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(Path);
+        }
+
+        public string Path { get; }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(Path))
+                Directory.Delete(Path, recursive: true);
+        }
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/RuntimeCatalog/SelectedRuntimePlanResolverContractTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/RuntimeCatalog/SelectedRuntimePlanResolverContractTests.cs
@@ -1,0 +1,170 @@
+using UniversalToolchain.Dialects.Abstractions;
+using UniversalToolchain.Dialects.Integration;
+
+namespace UniversalToolchain.Dialects.Tests.RuntimeCatalog;
+
+public class SelectedRuntimePlanResolverContractTests
+{
+    [Test]
+    public void Resolve_ShouldPreserveDeclaredModuleOrder()
+    {
+        var resolver = CreateResolver();
+        var plan = BuildPlan(modules: ["Numbers", "Arithmetic"], backends: [new DialectBackendId("interpreter")]);
+
+        var selected = resolver.Resolve(plan);
+
+        Assert.That(selected.OrderedModules.Select(static x => x.CanonicalAlias), Is.EqualTo(new[] { "Numbers", "Arithmetic" }));
+    }
+
+    [Test]
+    public void Resolve_ShouldSortBackendsDeterministically()
+    {
+        var resolver = CreateResolver();
+        var plan = BuildPlan(modules: ["Arithmetic"], backends: [new DialectBackendId("interpreter"), new DialectBackendId("compiler")]);
+
+        var selected = resolver.Resolve(plan);
+
+        Assert.That(selected.EnabledBackends.Select(static x => x.CanonicalAlias), Is.EqualTo(new[] { "compiler", "interpreter" }));
+    }
+
+    [Test]
+    public void Resolve_ShouldIgnoreDuplicateBackendSelection()
+    {
+        var resolver = CreateResolver();
+        var plan = BuildPlan(modules: ["Arithmetic"], backends: [new DialectBackendId("interpreter"), new DialectBackendId("interpreter")]);
+
+        var selected = resolver.Resolve(plan);
+
+        Assert.That(selected.EnabledBackends.Select(static x => x.CanonicalAlias), Is.EqualTo(new[] { "interpreter" }));
+    }
+
+    [Test]
+    public void Resolve_ShouldFilterOptimizersBySelectedBackendTargets()
+    {
+        var resolver = CreateResolver();
+        var plan = BuildPlan(
+            modules: ["Arithmetic"],
+            backends: [new DialectBackendId("interpreter")],
+            optimizers:
+            [
+                new OptimizerBuildDirective("CommonOpt", true, DialectBackendSelector.Any),
+                new OptimizerBuildDirective("CompilerOnlyOpt", true, DialectBackendSelector.For(new DialectBackendId("compiler"))),
+                new OptimizerBuildDirective("InterpreterOnlyOpt", true, DialectBackendSelector.For(new DialectBackendId("interpreter")))
+            ]);
+
+        var selected = resolver.Resolve(plan);
+
+        Assert.That(selected.EnabledOptimizers.Select(static x => x.CanonicalAlias), Is.EqualTo(new[] { "CommonOpt", "InterpreterOnlyOpt" }));
+    }
+
+    [Test]
+    public void Resolve_ShouldAddR001Diagnostic_ForMissingModule()
+    {
+        var resolver = CreateResolver();
+        var selected = resolver.Resolve(BuildPlan(modules: ["MissingModule"], backends: [new DialectBackendId("interpreter")]));
+
+        Assert.That(selected.Diagnostics.Single(static x => x.Code == "R001").Message, Does.Contain("MissingModule"));
+    }
+
+    [Test]
+    public void Resolve_ShouldAddR002Diagnostic_ForMissingBackend()
+    {
+        var resolver = CreateResolver();
+        var selected = resolver.Resolve(BuildPlan(modules: ["Arithmetic"], backends: [new DialectBackendId("missing-backend")]));
+
+        Assert.That(selected.Diagnostics.Single(static x => x.Code == "R002").Message, Does.Contain("missing-backend"));
+    }
+
+    [Test]
+    public void Resolve_ShouldAddR003Diagnostic_ForMissingOptimizer()
+    {
+        var resolver = CreateResolver();
+        var selected = resolver.Resolve(BuildPlan(
+            modules: ["Arithmetic"],
+            backends: [new DialectBackendId("interpreter")],
+            optimizers: [new OptimizerBuildDirective("missing-opt", true, DialectBackendSelector.Any)]));
+
+        Assert.That(selected.Diagnostics.Single(static x => x.Code == "R003").Message, Does.Contain("missing-opt"));
+    }
+
+    [Test]
+    public void Resolve_ShouldRemainDeterministic_AcrossRepeatedRuns()
+    {
+        var resolver = CreateResolver();
+        var plan = BuildPlan(
+            modules: ["Numbers", "Arithmetic"],
+            backends: [new DialectBackendId("interpreter"), new DialectBackendId("compiler"), new DialectBackendId("interpreter")],
+            optimizers: [
+                new OptimizerBuildDirective("InterpreterOnlyOpt", true, DialectBackendSelector.For(new DialectBackendId("interpreter"))),
+                new OptimizerBuildDirective("CommonOpt", true, DialectBackendSelector.Any)]);
+
+        string? baseline = null;
+        for (var i = 0; i < 50; i++)
+        {
+            var selected = resolver.Resolve(plan);
+            var signature = DescribeSelectedPlan(selected);
+            baseline ??= signature;
+            Assert.That(signature, Is.EqualTo(baseline));
+        }
+    }
+
+    private static string DescribeSelectedPlan(SelectedRuntimePlan plan)
+    {
+        return string.Join("|", plan.OrderedModules.Select(x => x.CanonicalAlias))
+               + "::"
+               + string.Join("|", plan.EnabledBackends.Select(x => x.CanonicalAlias))
+               + "::"
+               + string.Join("|", plan.EnabledOptimizers.Select(x => x.CanonicalAlias));
+    }
+
+    private static DialectBuildPlan BuildPlan(
+        IReadOnlyList<string> modules,
+        IReadOnlyList<DialectBackendId> backends,
+        IReadOnlyList<OptimizerBuildDirective>? optimizers = null)
+    {
+        return new DialectBuildPlan(
+            "ContractDialect",
+            null,
+            modules,
+            backends,
+            [],
+            [],
+            optimizers ?? [],
+            null,
+            [],
+            new DialectValidationResult([]));
+    }
+
+    private static SelectedRuntimePlanResolver CreateResolver()
+    {
+        var entries = new[]
+        {
+            Entry(RuntimeComponentKind.FrontendModule, "Arithmetic", "Asm.Modules.Arithmetic"),
+            Entry(RuntimeComponentKind.FrontendModule, "Numbers", "Asm.Modules.Numbers"),
+            Entry(RuntimeComponentKind.Backend, "compiler", "Asm.Backend.Compiler", "cil"),
+            Entry(RuntimeComponentKind.Backend, "interpreter", "Asm.Backend.Interpreter", "vm"),
+            Entry(RuntimeComponentKind.Optimizer, "CommonOpt", "Asm.Optimizers.Common"),
+            Entry(RuntimeComponentKind.Optimizer, "InterpreterOnlyOpt", "Asm.Optimizers.Interpreter"),
+            Entry(RuntimeComponentKind.Optimizer, "CompilerOnlyOpt", "Asm.Optimizers.Compiler")
+        };
+
+        return new SelectedRuntimePlanResolver(new StaticCatalog(entries));
+    }
+
+    private static RuntimeComponentManifestEntry Entry(RuntimeComponentKind kind, string canonicalAlias, string type, params string[] aliases)
+        => new(kind, canonicalAlias, aliases, new RuntimeTypeReference("TestAssembly", type));
+
+    private sealed class StaticCatalog(IEnumerable<RuntimeComponentManifestEntry> entries) : IRuntimeComponentCatalog
+    {
+        private readonly IReadOnlyDictionary<string, RuntimeComponentManifestEntry> _modules = entries.Where(static x => x.Kind == RuntimeComponentKind.FrontendModule).SelectMany(static x => x.AllAliases.Select(a => (a, x))).ToDictionary(static x => x.a, static x => x.x, StringComparer.Ordinal);
+        private readonly IReadOnlyDictionary<string, RuntimeComponentManifestEntry> _optimizers = entries.Where(static x => x.Kind == RuntimeComponentKind.Optimizer).SelectMany(static x => x.AllAliases.Select(a => (a, x))).ToDictionary(static x => x.a, static x => x.x, StringComparer.Ordinal);
+        private readonly IReadOnlyDictionary<string, RuntimeComponentManifestEntry> _backends = entries.Where(static x => x.Kind == RuntimeComponentKind.Backend).SelectMany(static x => x.AllAliases.Select(a => (a, x))).ToDictionary(static x => x.a, static x => x.x, StringComparer.Ordinal);
+
+        public bool TryResolveModule(string alias, out RuntimeComponentManifestEntry? entry) => _modules.TryGetValue(alias, out entry);
+        public bool TryResolveOptimizer(string alias, out RuntimeComponentManifestEntry? entry) => _optimizers.TryGetValue(alias, out entry);
+        public bool TryResolveBackend(string alias, out RuntimeComponentManifestEntry? entry) => _backends.TryGetValue(alias, out entry);
+        public IReadOnlyList<RuntimeComponentManifestEntry> GetModulesInDeterministicOrder() => _modules.Values.Distinct().OrderBy(static x => x.CanonicalAlias).ToList();
+        public IReadOnlyList<RuntimeComponentManifestEntry> GetOptimizersInDeterministicOrder() => _optimizers.Values.Distinct().OrderBy(static x => x.CanonicalAlias).ToList();
+        public IReadOnlyList<RuntimeComponentManifestEntry> GetBackendsInDeterministicOrder() => _backends.Values.Distinct().OrderBy(static x => x.CanonicalAlias).ToList();
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/RuntimeLoading/RuntimeArtifactLocatorContractTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/RuntimeLoading/RuntimeArtifactLocatorContractTests.cs
@@ -1,0 +1,161 @@
+using UniversalToolchain.Dialects.Integration;
+
+namespace UniversalToolchain.Dialects.Tests.RuntimeLoading;
+
+public class RuntimeArtifactLocatorContractTests
+{
+    [Test]
+    public void ManifestFileLocator_ShouldNotUseAppContextBaseDirectory_WhenFlagIsDisabled()
+    {
+        using var targetRoot = new TempDirectory();
+        var filePath = Path.Combine(targetRoot.Path, "one.dialect.runtime.json");
+        File.WriteAllText(filePath, "{}");
+
+        var locator = new DefaultRuntimeManifestFileLocator(new RuntimeArtifactLocatorOptions
+        {
+            SearchRoots = [targetRoot.Path],
+            IncludeAppContextBaseDirectory = false
+        });
+
+        var paths = locator.GetManifestFilePaths();
+
+        Assert.That(paths, Is.EqualTo(new[] { Path.GetFullPath(filePath) }));
+    }
+
+    [Test]
+    public void ManifestFileLocator_ShouldUseAppContextBaseDirectory_WhenFlagIsEnabled()
+    {
+        using var root = new TempDirectory();
+        var inRoot = Path.Combine(root.Path, "in-root.dialect.runtime.json");
+        var inBase = Path.Combine(AppContext.BaseDirectory, $"manifest-{Guid.NewGuid():N}.dialect.runtime.json");
+        File.WriteAllText(inRoot, "{}");
+        File.WriteAllText(inBase, "{}");
+
+        try
+        {
+            var locator = new DefaultRuntimeManifestFileLocator(new RuntimeArtifactLocatorOptions
+            {
+                SearchRoots = [root.Path],
+                IncludeAppContextBaseDirectory = true
+            });
+
+            var paths = locator.GetManifestFilePaths();
+            Assert.That(paths, Does.Contain(Path.GetFullPath(inBase)));
+        }
+        finally
+        {
+            if (File.Exists(inBase))
+                File.Delete(inBase);
+        }
+    }
+
+    [Test]
+    public void ManifestFileLocator_ShouldRespectConfiguredSearchPattern()
+    {
+        using var root = new TempDirectory();
+        var expected = Path.Combine(root.Path, "custom.runtime.json");
+        var ignored = Path.Combine(root.Path, "ignored.dialect.runtime.json");
+        File.WriteAllText(expected, "{}");
+        File.WriteAllText(ignored, "{}");
+
+        var locator = new DefaultRuntimeManifestFileLocator(new RuntimeArtifactLocatorOptions
+        {
+            SearchRoots = [root.Path],
+            IncludeAppContextBaseDirectory = false,
+            ManifestSearchPattern = "custom*.runtime.json"
+        });
+
+        var paths = locator.GetManifestFilePaths();
+
+        Assert.That(paths, Is.EqualTo(new[] { Path.GetFullPath(expected) }));
+    }
+
+    [Test]
+    public void AssemblyLocator_ShouldNotSearchOutsideConfiguredRoots()
+    {
+        using var primary = new TempDirectory();
+        using var outside = new TempDirectory();
+
+        File.WriteAllText(Path.Combine(outside.Path, "Sample.dll"), "not-a-real-dll");
+
+        var locator = new DefaultRuntimeAssemblyLocator(new RuntimeArtifactLocatorOptions
+        {
+            SearchRoots = [primary.Path],
+            IncludeAppContextBaseDirectory = false
+        });
+
+        var found = locator.TryResolveAssemblyPath("Sample", out _);
+        Assert.That(found, Is.False);
+    }
+
+    [Test]
+    public void AssemblyLocator_ShouldResolveAssemblyPathDeterministically()
+    {
+        using var first = new TempDirectory();
+        using var second = new TempDirectory();
+        var firstPath = Path.Combine(first.Path, "Target.dll");
+        var secondPath = Path.Combine(second.Path, "Target.dll");
+        File.WriteAllText(firstPath, "first");
+        File.WriteAllText(secondPath, "second");
+
+        var locator = new DefaultRuntimeAssemblyLocator(new RuntimeArtifactLocatorOptions
+        {
+            SearchRoots = [second.Path, first.Path],
+            IncludeAppContextBaseDirectory = false
+        });
+
+        var resolved = locator.TryResolveAssemblyPath("Target", out var absolutePath);
+
+        var expected = new[] { Path.GetFullPath(firstPath), Path.GetFullPath(secondPath) }
+            .OrderBy(static x => x, StringComparer.Ordinal)
+            .First();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(resolved, Is.True);
+            Assert.That(absolutePath, Is.EqualTo(expected));
+        });
+    }
+
+    [Test]
+    public void ArtifactLocatorOptions_ShouldNormalizeSearchRootsDeterministically()
+    {
+        using var first = new TempDirectory();
+        using var second = new TempDirectory();
+        var firstManifest = Path.Combine(first.Path, "a.dialect.runtime.json");
+        var secondManifest = Path.Combine(second.Path, "b.dialect.runtime.json");
+        File.WriteAllText(firstManifest, "{}");
+        File.WriteAllText(secondManifest, "{}");
+
+        var locator = new DefaultRuntimeManifestFileLocator(new RuntimeArtifactLocatorOptions
+        {
+            SearchRoots = [second.Path, first.Path, second.Path],
+            IncludeAppContextBaseDirectory = false
+        });
+
+        var paths = locator.GetManifestFilePaths();
+
+        Assert.That(paths, Is.EqualTo(new[]
+        {
+            Path.GetFullPath(firstManifest),
+            Path.GetFullPath(secondManifest)
+        }));
+    }
+
+    private sealed class TempDirectory : IDisposable
+    {
+        public TempDirectory()
+        {
+            Path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"dialect-tests-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(Path);
+        }
+
+        public string Path { get; }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(Path))
+                Directory.Delete(Path, recursive: true);
+        }
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/RuntimeLoading/RuntimeAssemblyLoadStrategyContractTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/RuntimeLoading/RuntimeAssemblyLoadStrategyContractTests.cs
@@ -1,0 +1,114 @@
+using System.Reflection;
+using UniversalToolchain.Dialects.Integration;
+
+namespace UniversalToolchain.Dialects.Tests.RuntimeLoading;
+
+public class RuntimeAssemblyLoadStrategyContractTests
+{
+    [Test]
+    public void TypeLoader_ShouldUseInjectedAssemblyLoadStrategy()
+    {
+        var strategy = new CountingAssemblyLoadStrategy(typeof(ArithmeticModule.Module.ArithmeticModuleImpl).Assembly);
+        var loader = new DefaultRuntimeComponentTypeLoader(strategy);
+
+        var resolved = loader.LoadType(Entry("ArithmeticModule", "ArithmeticModule.Module.ArithmeticModuleImpl"));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(resolved.FullName, Is.EqualTo("ArithmeticModule.Module.ArithmeticModuleImpl"));
+            Assert.That(strategy.Calls, Is.EqualTo(1));
+            Assert.That(strategy.CalledAssemblySimpleNames, Is.EqualTo(new[] { "ArithmeticModule" }));
+        });
+    }
+
+    [Test]
+    public void TypeLoader_ShouldThrowClearError_ForMissingAssembly()
+    {
+        var strategy = new ThrowingAssemblyLoadStrategy(new FileNotFoundException("Assembly 'Missing.Assembly' was not found."));
+        var loader = new DefaultRuntimeComponentTypeLoader(strategy);
+
+        var ex = Assert.Throws<FileNotFoundException>(() => loader.LoadType(Entry("Missing.Assembly", "Missing.Type")));
+
+        Assert.That(ex!.Message, Does.Contain("Missing.Assembly"));
+    }
+
+    [Test]
+    public void TypeLoader_ShouldThrowClearError_ForMissingTypeInAssembly()
+    {
+        var strategy = new CountingAssemblyLoadStrategy(typeof(ArithmeticModule.Module.ArithmeticModuleImpl).Assembly);
+        var loader = new DefaultRuntimeComponentTypeLoader(strategy);
+
+        var ex = Assert.Throws<TypeLoadException>(() => loader.LoadType(Entry("ArithmeticModule", "ArithmeticModule.Module.DoesNotExist")));
+
+        Assert.That(ex!.Message, Does.Contain("DoesNotExist"));
+    }
+
+    [Test]
+    public void TypeLoader_ShouldCacheResolvedTypeDeterministically()
+    {
+        var strategy = new CountingAssemblyLoadStrategy(typeof(ArithmeticModule.Module.ArithmeticModuleImpl).Assembly);
+        var loader = new DefaultRuntimeComponentTypeLoader(strategy);
+        var entry = Entry("ArithmeticModule", "ArithmeticModule.Module.ArithmeticModuleImpl");
+
+        var first = loader.LoadType(entry);
+        var second = loader.LoadType(entry);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(ReferenceEquals(first, second), Is.True);
+            Assert.That(strategy.Calls, Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public void TypeLoader_ShouldReturnSameType_ForRepeatedResolutions()
+    {
+        var strategy = new CountingAssemblyLoadStrategy(typeof(ArithmeticModule.Module.ArithmeticModuleImpl).Assembly);
+        var loader = new DefaultRuntimeComponentTypeLoader(strategy);
+        var entry = Entry("ArithmeticModule", "ArithmeticModule.Module.ArithmeticModuleImpl");
+
+        var baseline = loader.LoadType(entry);
+        for (var i = 0; i < 50; i++)
+            Assert.That(loader.LoadType(entry), Is.SameAs(baseline));
+    }
+
+    [Test]
+    public async Task TypeLoader_ShouldBeSafe_ForParallelResolutionsOfSameType()
+    {
+        var strategy = new CountingAssemblyLoadStrategy(typeof(ArithmeticModule.Module.ArithmeticModuleImpl).Assembly);
+        var loader = new DefaultRuntimeComponentTypeLoader(strategy);
+        var entry = Entry("ArithmeticModule", "ArithmeticModule.Module.ArithmeticModuleImpl");
+
+        var tasks = Enumerable.Range(0, 64).Select(_ => Task.Run(() => loader.LoadType(entry))).ToArray();
+        var types = await Task.WhenAll(tasks);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(types.Select(static x => x.AssemblyQualifiedName).Distinct(StringComparer.Ordinal).Count(), Is.EqualTo(1));
+            Assert.That(strategy.Calls, Is.EqualTo(1));
+        });
+    }
+
+    private static RuntimeComponentManifestEntry Entry(string assemblySimpleName, string fullTypeName) =>
+        new(RuntimeComponentKind.FrontendModule, "Any", [], new RuntimeTypeReference(assemblySimpleName, fullTypeName));
+
+    private sealed class CountingAssemblyLoadStrategy(Assembly assembly) : IRuntimeAssemblyLoadStrategy
+    {
+        private readonly Assembly _assembly = assembly;
+
+        public int Calls { get; private set; }
+        public List<string> CalledAssemblySimpleNames { get; } = [];
+
+        public Assembly LoadAssembly(string assemblySimpleName)
+        {
+            Calls++;
+            CalledAssemblySimpleNames.Add(assemblySimpleName);
+            return _assembly;
+        }
+    }
+
+    private sealed class ThrowingAssemblyLoadStrategy(Exception exception) : IRuntimeAssemblyLoadStrategy
+    {
+        public Assembly LoadAssembly(string assemblySimpleName) => throw exception;
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/Wist/WistDialectExecutionParityTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/Wist/WistDialectExecutionParityTests.cs
@@ -1,0 +1,113 @@
+using Microsoft.Extensions.DependencyInjection;
+using NumbersModule.Core;
+using UniversalToolchain.Dialects.Wist;
+
+namespace UniversalToolchain.Dialects.Tests.Wist;
+
+public class WistDialectExecutionParityTests
+{
+    [Test]
+    public void InterpreterAndCompiler_ShouldMatch_ForSimpleArithmeticDialect()
+        => AssertParity(CreateFullDialect(), "2 + 3 * 4", 14d);
+
+    [Test]
+    public void InterpreterAndCompiler_ShouldMatch_ForConditionsDialect()
+        => AssertParity(CreateFullDialect(), "let x = 15\nlet result = 0\nif x > 10 (\n    if x < 20\n        result = 1\n    else\n        result = 2\n)\nelse\n    result = 3\nresult", 1d);
+
+    [Test]
+    public void InterpreterAndCompiler_ShouldMatch_ForVariablesAndScopesDialect()
+        => AssertParity(CreateFullDialect(), "let x = 7\nlet y = x + 2\ny", 9d);
+
+    [Test]
+    public void InterpreterAndCompiler_ShouldMatch_ForLoopsDialect()
+        => AssertParity(CreateFullDialect(), "let sum = 0\nlet i = 1\n@start:\nif i > 4 goto @end\nsum = sum + i\ni = i + 1\ngoto @start\n@end:\nsum", 10d);
+
+    [Test]
+    public void InterpreterAndCompiler_ShouldMatch_ForEqualityAndComparisonDialect()
+        => AssertParity(CreateFullDialect(), "let score = 85\nlet grade = 0\nif score >= 90\n    (grade = 5)\nelif score >= 80\n    (grade = 4)\nelse\n    (grade = 1)\ngrade", 4d);
+
+    [Test]
+    public void InterpreterAndCompiler_ShouldMatch_ForLabelsScenario()
+        => AssertParity(CreateFullDialect(), "let counter = 0\nlet total = 0\n@loop:\nif counter >= 5 goto @end\ncounter = counter + 1\ntotal = total + counter\ngoto @loop\n@end:\ntotal", 15d);
+
+    [Test]
+    public void ComposeText_ShouldReturnSuccessfulResult_ForValidDialect()
+    {
+        using var provider = CreateWorkflowProviderWithCilAndInterpreter();
+        var workflow = provider.GetRequiredService<WistDialectExecutionWorkflow>();
+
+        var result = workflow.ComposeText(CreateFullDialect(), "inline");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True, result.ToDeterministicText());
+            Assert.That(result.RuntimeSelection, Is.Not.Null);
+        });
+    }
+
+    [Test]
+    public void CreateHost_ShouldRejectUnsuccessfulCompositionResult()
+    {
+        using var provider = CreateWorkflowProviderWithCilAndInterpreter();
+        var workflow = provider.GetRequiredService<WistDialectExecutionWorkflow>();
+        var composition = workflow.ComposeText("dialect Broken\nuse MissingModule\nbackend interpreter", "broken-inline");
+
+        var ex = Assert.Throws<ArgumentException>(() => workflow.CreateHost(composition));
+
+        Assert.That(ex!.Message, Does.Contain("must be successful"));
+    }
+
+    private static void AssertParity(string dialect, string program, double expected)
+    {
+        using var host = ComposeAndCreateHost(dialect);
+        var interpreter = ToDouble(host.Run(program, "interpreter"));
+        var compiler = ToDouble(host.Run(program, "compiler"));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(interpreter, Is.EqualTo(compiler).Within(1e-9));
+            Assert.That(interpreter, Is.EqualTo(expected).Within(1e-9));
+        });
+    }
+
+    private static WistDialectExecutionHost ComposeAndCreateHost(string dialect)
+    {
+        using var provider = CreateWorkflowProviderWithCilAndInterpreter();
+        var workflow = provider.GetRequiredService<WistDialectExecutionWorkflow>();
+        var composition = workflow.ComposeText(dialect, "inline-dialect");
+        if (!composition.IsSuccess)
+            throw new InvalidOperationException(composition.ToDeterministicText());
+
+        return workflow.CreateHost(composition);
+    }
+
+    private static ServiceProvider CreateWorkflowProviderWithCilAndInterpreter()
+    {
+        var services = new ServiceCollection();
+        services.AddWistDialectServices();
+        services.AddWistCilBackend();
+        services.AddWistInterpreterBackend();
+        return services.BuildServiceProvider();
+    }
+
+    private static string CreateFullDialect() => """
+                                                 dialect D
+                                                 use Arithmetic,BooleanConditions,Comments,ComparisonConditions,Conditions,Equality,Identifier,Labels,Loops,Numbers,Scopes,SemicolonAsNewLine,Variables,Whitespaces
+                                                 enable LocalVariablesOptimization
+                                                 backend compiler,interpreter
+                                                 """;
+
+    private static double ToDouble(object? value)
+    {
+        return value switch
+        {
+            RealNumberImpl number => number.GetValue(),
+            int intValue => intValue,
+            long longValue => longValue,
+            double doubleValue => doubleValue,
+            float floatValue => floatValue,
+            decimal decimalValue => (double)decimalValue,
+            _ => Convert.ToDouble(value, System.Globalization.CultureInfo.InvariantCulture)
+        };
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/Wist/WistDialectRuntimeBootstrapContractTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/Wist/WistDialectRuntimeBootstrapContractTests.cs
@@ -1,0 +1,129 @@
+using BasicCore.LexerWrapper;
+using Microsoft.Extensions.DependencyInjection;
+using UniversalToolchain.Dialects.Abstractions;
+using UniversalToolchain.Dialects.Integration;
+using UniversalToolchain.Dialects.Wist;
+
+namespace UniversalToolchain.Dialects.Tests.Wist;
+
+public class WistDialectRuntimeBootstrapContractTests
+{
+    [Test]
+    public void AddWistDialectServices_ShouldRegisterCanonicalRuntimeInfrastructure()
+    {
+        var services = new ServiceCollection();
+        services.AddWistDialectServices();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(services.Any(static x => x.ServiceType == typeof(SelectedRuntimePlanResolver)), Is.True);
+            Assert.That(services.Any(static x => x.ServiceType == typeof(IRuntimeComponentCatalog)), Is.True);
+            Assert.That(services.Any(static x => x.ServiceType == typeof(IRuntimeComponentTypeLoader)), Is.True);
+            Assert.That(services.Any(static x => x.ServiceType == typeof(WistDialectExecutionWorkflow)), Is.True);
+        });
+    }
+
+    [Test]
+    public void AddWistDialectServices_ShouldNotRegisterLegacyCompositionServices()
+    {
+        var services = new ServiceCollection();
+        services.AddWistDialectServices();
+
+        var serviceTypes = services.Select(static x => x.ServiceType.FullName ?? string.Empty).ToArray();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(serviceTypes.Any(static x => x.Contains("AutoRegistration", StringComparison.Ordinal)), Is.False);
+            Assert.That(serviceTypes.Any(static x => x.Contains("Legacy", StringComparison.Ordinal)), Is.False);
+            Assert.That(serviceTypes.Any(static x => x.Contains("WistOptions", StringComparison.Ordinal)), Is.False);
+        });
+    }
+
+    [Test]
+    public void WistDialectServicesRegistrar_ShouldNotHardcodeConcreteBackends()
+    {
+        var services = new ServiceCollection();
+        var registrar = new WistDialectServicesRegistrar();
+
+        registrar.Register(services);
+
+        Assert.That(services.Where(static x => x.ServiceType == typeof(IDialectBackendRuntimeRegistrar)), Is.Empty);
+    }
+
+    [Test]
+    public void WistDialectServiceProviderFactory_ShouldUseNeutralCoreBootstrap()
+    {
+        var factory = new WistDialectServiceProviderFactory([new NoopRegistrar("interpreter")]);
+        var config = new WistDialectExecutionConfiguration(
+            "Demo",
+            [],
+            [],
+            [],
+            [new DialectBackendRuntimeConfiguration(new RuntimeBackendDescriptor(new DialectBackendId("interpreter"), typeof(NoopRegistrar), ["vm"]), [], [], false)],
+            [new RuntimeBackendDescriptor(new DialectBackendId("interpreter"), typeof(NoopRegistrar), ["vm"])]);
+
+        var provider = factory.Create(config);
+
+        Assert.That(provider.GetService<Func<ILexer>>(), Is.Not.Null);
+        (provider as IDisposable)?.Dispose();
+    }
+
+    [Test]
+    public void CreateHost_ShouldFailClearly_IfRequestedBackendRegistrarIsMissing()
+    {
+        var factory = new WistDialectServiceProviderFactory([]);
+        var config = new WistDialectExecutionConfiguration(
+            "Demo",
+            [],
+            [],
+            [],
+            [new DialectBackendRuntimeConfiguration(new RuntimeBackendDescriptor(new DialectBackendId("interpreter"), typeof(object), []), [], [], false)],
+            [new RuntimeBackendDescriptor(new DialectBackendId("interpreter"), typeof(object), [])]);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => factory.Create(config));
+
+        Assert.That(ex!.Message, Does.Contain("No backend runtime registrar is registered for backend 'interpreter'"));
+    }
+
+    [Test]
+    public void CreateHost_ShouldProduceStableConfiguration_AcrossRepeatedCalls()
+    {
+        var services = new ServiceCollection();
+        services.AddWistDialectServices();
+        services.AddWistCilBackend();
+        services.AddWistInterpreterBackend();
+
+        using var provider = services.BuildServiceProvider();
+        var workflow = provider.GetRequiredService<WistDialectExecutionWorkflow>();
+        var composition = workflow.ComposeText("dialect Stable\nuse Arithmetic,Numbers\nbackend interpreter,compiler", "inline");
+
+        var signatures = new List<string>();
+        for (var i = 0; i < 30; i++)
+        {
+            using var host = workflow.CreateHost(composition);
+            signatures.Add(DescribeHost(host));
+        }
+
+        Assert.That(signatures.Distinct(StringComparer.Ordinal).Count(), Is.EqualTo(1));
+    }
+
+    private static string DescribeHost(WistDialectExecutionHost host)
+    {
+        return string.Join("|", host.Configuration.FrontendModules.Select(static x => x.FullName))
+               + "::"
+               + string.Join("|", host.Configuration.IrModules.Select(static x => x.FullName))
+               + "::"
+               + string.Join("|", host.Configuration.BackendConfigurations.Select(static x => x.BackendDescriptor.CanonicalId));
+    }
+
+    private sealed class NoopRegistrar(string backendId) : IDialectBackendRuntimeRegistrar
+    {
+        public DialectBackendId BackendId { get; } = new(backendId);
+        public IReadOnlyList<string> SupportedIntrinsics => [];
+        public void RegisterRuntime(IServiceCollection services, DialectBackendRuntimeConfiguration configuration)
+        {
+            services.AddSingleton(typeof(object), new object());
+        }
+    }
+
+}


### PR DESCRIPTION
### Motivation

- Provide deterministic, negative and bootstrap contract tests for the new runtime/catalog/resolver/backends/Wist bootstrap surfaces to prevent regressions and hidden nondeterminism.
- Cover core invariants: deterministic ordering, strict manifest validation, alias collision detection, and stable selection/host wiring across repeated and parallel runs.

### Description

- Added four new contract test classes under `UniversalToolchain.Dialects.Tests`: `RuntimeManifestCatalogContractTests` (8 tests), `SelectedRuntimePlanResolverContractTests` (8 tests), `RuntimeKnownBackendsProviderContractTests` (6 tests), and `WistDialectRuntimeBootstrapContractTests` (6 tests).
- Each test file contains small helpers (temp directories, static manifest/catalog locators, simple stub registrars/noop registrars and signature builders) to exercise contracts without heavy integration or retries.
- Tests focus on exact expectations: canonical aliases, aliases ordering, produced diagnostics (`R001`/`R002`/`R003`), deterministic ordering of backends/optimizers/modules, and stable host configuration signatures.
- Minor test adjustments were made to use the public catalog/locator APIs (e.g. constructing `FileBasedRuntimeComponentCatalog` via `StaticManifestLocator`) and to ensure disposable resources are cleaned up in tests.

### Testing

- Installed matching SDK and verified with `dotnet --version` after installing `10.0.103` using the official installer script.
- Ran the targeted contract test suite with:
  - `export PATH=$HOME/.dotnet:$PATH && dotnet test UniversalToolchain/UniversalToolchain.Dialects.Tests/UniversalToolchain.Dialects.Tests.csproj -c Release --filter "FullyQualifiedName~RuntimeManifestCatalogContractTests|FullyQualifiedName~SelectedRuntimePlanResolverContractTests|FullyQualifiedName~RuntimeKnownBackendsProviderContractTests|FullyQualifiedName~WistDialectRuntimeBootstrapContractTests"`
- Result: the filtered contract suite completed successfully and all tests passed (28 tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7f52c62008324bd00e15f15d04b64)