### PR TITLE
Refactor runtime catalog identity to component IDs

### DIFF
--- a/UniversalToolchain/UniversalToolchain.Dialects.Integration/DefaultRuntimeComponentResolver.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Integration/DefaultRuntimeComponentResolver.cs
@@ -1,0 +1,68 @@
+using System.Collections.Concurrent;
+using System.Reflection;
+using UniversalToolchain.Dialects.Abstractions;
+
+namespace UniversalToolchain.Dialects.Integration;
+
+public sealed class DefaultRuntimeComponentResolver(IRuntimeAssemblyLoadStrategy assemblyLoadStrategy) : IRuntimeComponentResolver
+{
+    private readonly IRuntimeAssemblyLoadStrategy _assemblyLoadStrategy = assemblyLoadStrategy ?? throw new ArgumentNullException(nameof(assemblyLoadStrategy));
+    private readonly ConcurrentDictionary<string, RuntimeComponentDescriptor> _cache = new(StringComparer.Ordinal);
+
+    public RuntimeComponentDescriptor Resolve(RuntimeComponentManifestEntry entry)
+    {
+        if (entry == null)
+            throw new ArgumentNullException(nameof(entry));
+
+        var key = $"{entry.AssemblySimpleName}|{entry.ComponentId.Value}";
+        return _cache.GetOrAdd(key, _ => ResolveCore(entry));
+    }
+
+    private RuntimeComponentDescriptor ResolveCore(RuntimeComponentManifestEntry entry)
+    {
+        var assembly = _assemblyLoadStrategy.LoadAssembly(entry.AssemblySimpleName);
+
+        foreach (var type in assembly.GetTypes())
+        {
+            if (!TryGetRuntimeExport(type, out var kind, out var canonicalAlias))
+                continue;
+
+            var id = RuntimeComponentIdFactory.Create(kind, canonicalAlias);
+            if (id != entry.ComponentId)
+                continue;
+
+            var aliases = GetRuntimeAliases(type);
+            return new RuntimeComponentDescriptor(id, kind, canonicalAlias, aliases, type);
+        }
+
+        throw new InvalidOperationException(
+            $"Runtime component '{entry.ComponentId}' was not found in assembly '{entry.AssemblySimpleName}'.");
+    }
+
+    private static bool TryGetRuntimeExport(Type type, out RuntimeComponentKind kind, out string canonicalAlias)
+    {
+        var export = type.GetCustomAttribute<DialectRuntimeExportAttribute>(false);
+        if (export == null)
+        {
+            kind = default;
+            canonicalAlias = string.Empty;
+            return false;
+        }
+
+        kind = RuntimeComponentKindCodec.Parse(export.ComponentKind, type.AssemblyQualifiedName ?? type.Name);
+        canonicalAlias = export.CanonicalAlias;
+        return true;
+    }
+
+    private static IReadOnlyList<string> GetRuntimeAliases(MemberInfo type)
+    {
+        return type
+            .GetCustomAttributes<DialectRuntimeAliasAttribute>(false)
+            .Select(x => x.Alias?.Trim())
+            .Where(static x => !string.IsNullOrWhiteSpace(x))
+            .Select(static x => x!)
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(static x => x, StringComparer.Ordinal)
+            .ToList();
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Integration/DefaultRuntimeComponentTypeLoader.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Integration/DefaultRuntimeComponentTypeLoader.cs
@@ -1,39 +1,22 @@
-using System.Collections.Concurrent;
 using ExceptionsManager;
 
 namespace UniversalToolchain.Dialects.Integration;
 
 public sealed class DefaultRuntimeComponentTypeLoader : IRuntimeComponentTypeLoader
 {
-    private readonly IRuntimeAssemblyLoadStrategy _assemblyLoadStrategy;
-    private readonly ConcurrentDictionary<string, Lazy<Type>> _cache = new(StringComparer.Ordinal);
+    private readonly IRuntimeComponentResolver _resolver;
 
-    public DefaultRuntimeComponentTypeLoader(IRuntimeAssemblyLoadStrategy assemblyLoadStrategy)
+    public DefaultRuntimeComponentTypeLoader(IRuntimeComponentResolver resolver)
     {
-        _assemblyLoadStrategy = assemblyLoadStrategy ?? throw new ArgumentNullException(nameof(assemblyLoadStrategy));
+        _resolver = resolver ?? throw new ArgumentNullException(nameof(resolver));
     }
+
 
     public Type LoadType(RuntimeComponentManifestEntry entry)
     {
         if (entry == null)
             Thrower.ArgumentNull(nameof(entry));
 
-        var typeReference = entry.TypeReference;
-        if (string.IsNullOrWhiteSpace(typeReference.AssemblySimpleName))
-            Thrower.Argument(nameof(entry), "Assembly simple name must not be empty.");
-
-        if (string.IsNullOrWhiteSpace(typeReference.TypeFullName))
-            Thrower.Argument(nameof(entry), "Type full name must not be empty.");
-
-        var key = $"{typeReference.AssemblySimpleName}|{typeReference.TypeFullName}";
-        var lazy = _cache.GetOrAdd(key, _ => new Lazy<Type>(() => ResolveType(typeReference), LazyThreadSafetyMode.ExecutionAndPublication));
-        return lazy.Value;
-    }
-
-    private Type ResolveType(RuntimeTypeReference typeReference)
-    {
-        var assembly = _assemblyLoadStrategy.LoadAssembly(typeReference.AssemblySimpleName);
-        return assembly.GetType(typeReference.TypeFullName, true, false)
-               ?? Thrower.InvalidOpEx<Type>($"Type '{typeReference.TypeFullName}' was not found in assembly '{typeReference.AssemblySimpleName}'.");
+        return _resolver.Resolve(entry).ActivationType;
     }
 }

--- a/UniversalToolchain/UniversalToolchain.Dialects.Integration/DialectRuntimeCatalogProviderAttribute.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Integration/DialectRuntimeCatalogProviderAttribute.cs
@@ -1,0 +1,14 @@
+namespace UniversalToolchain.Dialects.Integration;
+
+[AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
+public sealed class DialectRuntimeCatalogProviderAttribute : Attribute
+{
+    public DialectRuntimeCatalogProviderAttribute(Type providerType)
+    {
+        ProviderType = providerType ?? throw new ArgumentNullException(nameof(providerType));
+    }
+
+    public Type ProviderType { get; }
+
+    public Type GetProviderType() => ProviderType;
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Integration/FileBasedRuntimeComponentCatalog.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Integration/FileBasedRuntimeComponentCatalog.cs
@@ -64,18 +64,28 @@ public sealed class FileBasedRuntimeComponentCatalog : IRuntimeComponentCatalog
                 entries.Add(ToRuntimeEntry(component, assemblySimpleName!, manifestPath));
         }
 
+        ValidateUniqueIds(entries);
         return entries;
     }
 
     private static RuntimeComponentManifestEntry ToRuntimeEntry(
         FileDialectRuntimeComponentEntry component,
         string assemblySimpleName,
-        string manifestPath) =>
-        Normalize(new RuntimeComponentManifestEntry(
-            RuntimeComponentKindCodec.Parse(component.Kind, manifestPath),
-            component.CanonicalAlias,
+        string manifestPath)
+    {
+        var kind = RuntimeComponentKindCodec.Parse(component.Kind, manifestPath);
+        var canonicalAlias = component.CanonicalAlias;
+        var componentId = string.IsNullOrWhiteSpace(component.ComponentId)
+            ? RuntimeComponentIdFactory.Create(kind, canonicalAlias)
+            : new RuntimeComponentId(component.ComponentId);
+
+        return Normalize(new RuntimeComponentManifestEntry(
+            kind,
+            canonicalAlias,
             component.Aliases,
-            new RuntimeTypeReference(assemblySimpleName, component.TypeFullName)));
+            componentId,
+            assemblySimpleName));
+    }
 
     private static bool TryResolve(IReadOnlyDictionary<string, RuntimeComponentManifestEntry> map, string alias, out RuntimeComponentManifestEntry? entry)
     {
@@ -89,7 +99,7 @@ public sealed class FileBasedRuntimeComponentCatalog : IRuntimeComponentCatalog
     {
         return entries
             .OrderBy(static x => x.CanonicalAlias, StringComparer.Ordinal)
-            .ThenBy(static x => x.TypeReference.TypeFullName, StringComparer.Ordinal)
+            .ThenBy(static x => x.ComponentId.Value, StringComparer.Ordinal)
             .ToList();
     }
 
@@ -102,13 +112,9 @@ public sealed class FileBasedRuntimeComponentCatalog : IRuntimeComponentCatalog
         if (string.IsNullOrWhiteSpace(canonical))
             Thrower.Argument(nameof(entry), "Canonical alias must not be empty.");
 
-        var assemblySimpleName = entry.TypeReference.AssemblySimpleName?.Trim();
+        var assemblySimpleName = entry.AssemblySimpleName?.Trim();
         if (string.IsNullOrWhiteSpace(assemblySimpleName))
-            Thrower.Argument(nameof(entry), "TypeReference.AssemblySimpleName must not be empty.");
-
-        var typeFullName = entry.TypeReference.TypeFullName?.Trim();
-        if (string.IsNullOrWhiteSpace(typeFullName))
-            Thrower.Argument(nameof(entry), "TypeReference.TypeFullName must not be empty.");
+            Thrower.Argument(nameof(entry), "AssemblySimpleName must not be empty.");
 
         var aliases = (entry.Aliases ?? [])
             .Select(static x => x?.Trim())
@@ -124,7 +130,8 @@ public sealed class FileBasedRuntimeComponentCatalog : IRuntimeComponentCatalog
         {
             CanonicalAlias = canonical,
             Aliases = aliases,
-            TypeReference = new RuntimeTypeReference(assemblySimpleName, typeFullName)
+            AssemblySimpleName = assemblySimpleName,
+            ComponentId = new RuntimeComponentId(entry.ComponentId.Value.Trim())
         };
     }
 
@@ -141,5 +148,21 @@ public sealed class FileBasedRuntimeComponentCatalog : IRuntimeComponentCatalog
         }
 
         return map;
+    }
+
+    private static void ValidateUniqueIds(IEnumerable<RuntimeComponentManifestEntry> entries)
+    {
+        var ownersById = new Dictionary<RuntimeComponentId, RuntimeComponentManifestEntry>();
+
+        foreach (var entry in entries)
+        {
+            if (ownersById.TryGetValue(entry.ComponentId, out var existing))
+            {
+                Thrower.InvalidOpEx(
+                    $"Duplicate runtime component id '{entry.ComponentId}' for aliases '{existing.CanonicalAlias}' and '{entry.CanonicalAlias}'.");
+            }
+
+            ownersById.Add(entry.ComponentId, entry);
+        }
     }
 }

--- a/UniversalToolchain/UniversalToolchain.Dialects.Integration/FileDialectRuntimeComponentEntry.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Integration/FileDialectRuntimeComponentEntry.cs
@@ -4,4 +4,4 @@ public sealed record FileDialectRuntimeComponentEntry(
     string Kind,
     string CanonicalAlias,
     IReadOnlyList<string> Aliases,
-    string TypeFullName);
+    string ComponentId);

--- a/UniversalToolchain/UniversalToolchain.Dialects.Integration/IRuntimeComponentCatalogProvider.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Integration/IRuntimeComponentCatalogProvider.cs
@@ -1,0 +1,6 @@
+namespace UniversalToolchain.Dialects.Integration;
+
+public interface IRuntimeComponentCatalogProvider
+{
+    IReadOnlyList<RuntimeComponentDescriptor> GetComponents();
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Integration/IRuntimeComponentResolver.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Integration/IRuntimeComponentResolver.cs
@@ -1,0 +1,6 @@
+namespace UniversalToolchain.Dialects.Integration;
+
+public interface IRuntimeComponentResolver
+{
+    RuntimeComponentDescriptor Resolve(RuntimeComponentManifestEntry entry);
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Integration/RuntimeComponentDescriptor.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Integration/RuntimeComponentDescriptor.cs
@@ -1,0 +1,8 @@
+namespace UniversalToolchain.Dialects.Integration;
+
+public sealed record RuntimeComponentDescriptor(
+    RuntimeComponentId Id,
+    RuntimeComponentKind Kind,
+    string CanonicalAlias,
+    IReadOnlyList<string> Aliases,
+    Type ActivationType);

--- a/UniversalToolchain/UniversalToolchain.Dialects.Integration/RuntimeComponentId.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Integration/RuntimeComponentId.cs
@@ -1,0 +1,18 @@
+using ExceptionsManager;
+
+namespace UniversalToolchain.Dialects.Integration;
+
+public readonly record struct RuntimeComponentId
+{
+    public RuntimeComponentId(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            Thrower.Argument(nameof(value), "Runtime component id must not be empty.");
+
+        Value = value.Trim();
+    }
+
+    public string Value { get; }
+
+    public override string ToString() => Value;
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Integration/RuntimeComponentIdFactory.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Integration/RuntimeComponentIdFactory.cs
@@ -1,0 +1,17 @@
+namespace UniversalToolchain.Dialects.Integration;
+
+public static class RuntimeComponentIdFactory
+{
+    public static RuntimeComponentId Create(RuntimeComponentKind kind, string canonicalAlias)
+    {
+        var prefix = kind switch
+        {
+            RuntimeComponentKind.FrontendModule => "frontend",
+            RuntimeComponentKind.Optimizer => "optimizer",
+            RuntimeComponentKind.Backend => "backend",
+            _ => throw new ArgumentOutOfRangeException(nameof(kind), kind, "Unsupported runtime component kind.")
+        };
+
+        return new RuntimeComponentId($"{prefix}.{canonicalAlias.Trim().ToLowerInvariant()}");
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Integration/RuntimeComponentManifestEntry.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Integration/RuntimeComponentManifestEntry.cs
@@ -4,7 +4,8 @@ public sealed record RuntimeComponentManifestEntry(
     RuntimeComponentKind Kind,
     string CanonicalAlias,
     IReadOnlyList<string> Aliases,
-    RuntimeTypeReference TypeReference)
+    RuntimeComponentId ComponentId,
+    string AssemblySimpleName)
 {
     public IReadOnlyList<string> AllAliases => [CanonicalAlias, .. Aliases];
 }

--- a/UniversalToolchain/UniversalToolchain.Dialects.Integration/RuntimeManifestJsonSerializer.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Integration/RuntimeManifestJsonSerializer.cs
@@ -21,7 +21,7 @@ public sealed class RuntimeManifestJsonSerializer : IRuntimeManifestSerializer
                 RuntimeComponentKindCodec.Format(RuntimeComponentKindCodec.Parse(x.Kind ?? string.Empty, "runtime manifest")),
                 x.CanonicalAlias ?? string.Empty,
                 x.Aliases ?? [],
-                x.TypeFullName ?? string.Empty))
+                ResolveComponentId(x)))
             .ToList());
     }
 
@@ -36,12 +36,22 @@ public sealed class RuntimeManifestJsonSerializer : IRuntimeManifestSerializer
                     Kind = RuntimeComponentKindCodec.Format(RuntimeComponentKindCodec.Parse(x.Kind ?? string.Empty, "runtime manifest")),
                     CanonicalAlias = x.CanonicalAlias,
                     Aliases = x.Aliases,
-                    TypeFullName = x.TypeFullName
+                    ComponentId = x.ComponentId
                 })
                 .ToList()
         };
 
         return JsonSerializer.Serialize(payload, JsonOptions);
+    }
+
+    private static string ResolveComponentId(SerializableManifestComponentEntry entry)
+    {
+        if (!string.IsNullOrWhiteSpace(entry.ComponentId))
+            return entry.ComponentId;
+
+        var kind = RuntimeComponentKindCodec.Parse(entry.Kind ?? string.Empty, "runtime manifest");
+        var alias = entry.CanonicalAlias ?? string.Empty;
+        return RuntimeComponentIdFactory.Create(kind, alias).Value;
     }
 
     private sealed class SerializableManifestDocument
@@ -58,6 +68,8 @@ public sealed class RuntimeManifestJsonSerializer : IRuntimeManifestSerializer
         public string? CanonicalAlias { get; init; }
 
         public IReadOnlyList<string>? Aliases { get; init; }
+
+        public string? ComponentId { get; init; }
 
         public string? TypeFullName { get; init; }
     }

--- a/UniversalToolchain/UniversalToolchain.Dialects.Integration/SelectedRuntimePlanResolver.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Integration/SelectedRuntimePlanResolver.cs
@@ -67,7 +67,7 @@ public sealed class SelectedRuntimePlanResolver
 
         var orderedBackends = backends
             .OrderBy(x => x.CanonicalAlias, StringComparer.Ordinal)
-            .ThenBy(x => x.TypeReference.TypeFullName, StringComparer.Ordinal)
+                        .ThenBy(x => x.ComponentId.Value, StringComparer.Ordinal)
             .ToList();
 
         selectedBackendIds = backendIdSet;

--- a/UniversalToolchain/UniversalToolchain.Dialects.ManifestEmitter/Program.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.ManifestEmitter/Program.cs
@@ -37,9 +37,7 @@ internal static class ManifestEmitter
 
     public static ManifestDocument Emit(string assemblyPath)
     {
-        var runtimePaths = Directory.GetFiles(Path.GetDirectoryName(typeof(object).Assembly.Location)!, "*.dll", SearchOption.TopDirectoryOnly);
-        var localPaths = Directory.GetFiles(Path.GetDirectoryName(assemblyPath)!, "*.dll", SearchOption.TopDirectoryOnly);
-        var resolver = new PathAssemblyResolver(runtimePaths.Concat(localPaths).Append(assemblyPath).Distinct(StringComparer.Ordinal));
+        var resolver = new PathAssemblyResolver(BuildMetadataAssemblyPaths(assemblyPath));
 
         using var context = new MetadataLoadContext(resolver);
         var assembly = context.LoadFromAssemblyPath(assemblyPath);
@@ -49,10 +47,24 @@ internal static class ManifestEmitter
             .SelectMany(BuildEntry)
             .OrderBy(static x => x.Kind, StringComparer.Ordinal)
             .ThenBy(static x => x.CanonicalAlias, StringComparer.Ordinal)
-            .ThenBy(static x => x.TypeFullName, StringComparer.Ordinal)
+            .ThenBy(static x => x.ComponentId, StringComparer.Ordinal)
             .ToList();
 
         return new ManifestDocument(assembly.GetName().Name!, components);
+    }
+
+    private static IEnumerable<string> BuildMetadataAssemblyPaths(string assemblyPath)
+    {
+        var tpa = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string;
+        var runtimePaths = string.IsNullOrWhiteSpace(tpa)
+            ? []
+            : tpa.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+        var localPaths = Directory.EnumerateFiles(Path.GetDirectoryName(assemblyPath)!, "*.dll", SearchOption.TopDirectoryOnly);
+        return runtimePaths
+            .Concat(localPaths)
+            .Append(assemblyPath)
+            .Distinct(StringComparer.Ordinal);
     }
 
     private static IEnumerable<ManifestComponentEntry> BuildEntry(Type type)
@@ -65,6 +77,9 @@ internal static class ManifestEmitter
         if (values.Length < 2)
             return [];
 
+        var kind = values[0];
+        var canonicalAlias = values[1];
+
         var aliases = type.CustomAttributes
             .Where(static x => x.AttributeType.FullName == RuntimeAliasAttributeFullName)
             .Select(static x => x.ConstructorArguments[0].Value?.ToString())
@@ -74,13 +89,26 @@ internal static class ManifestEmitter
             .OrderBy(static x => x, StringComparer.Ordinal)
             .ToList();
 
-        return [new ManifestComponentEntry(values[0], values[1], aliases, type.FullName ?? type.Name)];
+        return [new ManifestComponentEntry(kind, canonicalAlias, aliases, RuntimeId(kind, canonicalAlias))];
+    }
+
+    private static string RuntimeId(string kind, string canonicalAlias)
+    {
+        var prefix = kind.Trim() switch
+        {
+            "FrontendModule" => "frontend",
+            "Optimizer" => "optimizer",
+            "Backend" => "backend",
+            _ => throw new InvalidOperationException($"Unknown runtime component kind '{kind}'.")
+        };
+
+        return $"{prefix}.{canonicalAlias.Trim().ToLowerInvariant()}";
     }
 }
 
 internal sealed record ManifestDocument(string AssemblySimpleName, IReadOnlyList<ManifestComponentEntry> Components);
 
-internal sealed record ManifestComponentEntry(string Kind, string CanonicalAlias, IReadOnlyList<string> Aliases, string TypeFullName);
+internal sealed record ManifestComponentEntry(string Kind, string CanonicalAlias, IReadOnlyList<string> Aliases, string ComponentId);
 
 internal static class JsonOptions
 {

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/Backends/RuntimeKnownBackendsProviderContractTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/Backends/RuntimeKnownBackendsProviderContractTests.cs
@@ -83,8 +83,8 @@ public class RuntimeKnownBackendsProviderContractTests
         Assert.That(aliases, Is.EqualTo(new[] { "a", "z" }));
     }
 
-    private static RuntimeComponentManifestEntry Entry(RuntimeComponentKind kind, string canonical, string type, params string[] aliases)
-        => new(kind, canonical, aliases, new RuntimeTypeReference("Assembly", type));
+    private static RuntimeComponentManifestEntry Entry(RuntimeComponentKind kind, string canonical, string _, params string[] aliases)
+        => new(kind, canonical, aliases, RuntimeComponentIdFactory.Create(kind, canonical), "Assembly");
 
     private sealed class StubRegistrar(string backend) : IDialectBackendRuntimeRegistrar
     {

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/RuntimeCatalog/RuntimeManifestCatalogContractTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/RuntimeCatalog/RuntimeManifestCatalogContractTests.cs
@@ -15,7 +15,7 @@ public class RuntimeManifestCatalogContractTests
 
         var catalog = new FileBasedRuntimeComponentCatalog(new StaticManifestLocator([zPath, aPath]), serializer);
 
-        Assert.That(catalog.GetModulesInDeterministicOrder().Select(static x => x.TypeReference.AssemblySimpleName), Is.EqualTo(new[] { "AAssembly", "ZAssembly" }));
+        Assert.That(catalog.GetModulesInDeterministicOrder().Select(static x => x.AssemblySimpleName), Is.EqualTo(new[] { "AAssembly", "ZAssembly" }));
     }
 
     [Test]
@@ -41,14 +41,15 @@ public class RuntimeManifestCatalogContractTests
     }
 
     [Test]
-    public void LoadEntries_ShouldRejectEmptyTypeFullName()
+    public void LoadEntries_ShouldDeriveComponentIdFromKindAndAlias_WhenMissingInManifest()
     {
         using var temp = new TempDirectory();
         var serializer = new RuntimeManifestJsonSerializer();
-        var path = WriteManifest(temp.Path, "empty-type.dialect.runtime.json", "Asm", [Module("Arithmetic", " ")], serializer);
+        var path = WriteManifest(temp.Path, "empty-type.dialect.runtime.json", "Asm", [new FileDialectRuntimeComponentEntry("FrontendModule", "Arithmetic", [], " ")], serializer);
 
-        var ex = Assert.Throws<ArgumentException>(() => new FileBasedRuntimeComponentCatalog(new StaticManifestLocator([path]), serializer));
-        Assert.That(ex!.Message, Does.Contain("TypeReference.TypeFullName must not be empty"));
+        var catalog = new FileBasedRuntimeComponentCatalog(new StaticManifestLocator([path]), serializer);
+        Assert.That(catalog.TryResolveModule("Arithmetic", out var entry), Is.True);
+        Assert.That(entry!.ComponentId.Value, Is.EqualTo("frontend.arithmetic"));
     }
 
     [Test]
@@ -100,7 +101,7 @@ public class RuntimeManifestCatalogContractTests
         {
             Assert.That(entry!.CanonicalAlias, Is.EqualTo("Arithmetic"));
             Assert.That(entry.Aliases, Is.EqualTo(new[] { "a", "b" }));
-            Assert.That(entry.TypeReference.TypeFullName, Is.EqualTo("Arithmetic.Module.Type"));
+            Assert.That(entry.ComponentId.Value, Is.EqualTo("frontend.arithmetic"));
         });
     }
 
@@ -116,14 +117,14 @@ public class RuntimeManifestCatalogContractTests
         return Assert.Throws<InvalidOperationException>(() => new FileBasedRuntimeComponentCatalog(new StaticManifestLocator([firstPath, secondPath]), serializer))!;
     }
 
-    private static FileDialectRuntimeComponentEntry Module(string alias, string type, params string[] aliases) =>
-        new("FrontendModule", alias, aliases, type);
+    private static FileDialectRuntimeComponentEntry Module(string alias, string _, params string[] aliases) =>
+        new("FrontendModule", alias, aliases, RuntimeComponentIdFactory.Create(RuntimeComponentKind.FrontendModule, alias).Value);
 
-    private static FileDialectRuntimeComponentEntry Optimizer(string alias, string type, params string[] aliases) =>
-        new("Optimizer", alias, aliases, type);
+    private static FileDialectRuntimeComponentEntry Optimizer(string alias, string _, params string[] aliases) =>
+        new("Optimizer", alias, aliases, RuntimeComponentIdFactory.Create(RuntimeComponentKind.Optimizer, alias).Value);
 
-    private static FileDialectRuntimeComponentEntry Backend(string alias, string type, params string[] aliases) =>
-        new("Backend", alias, aliases, type);
+    private static FileDialectRuntimeComponentEntry Backend(string alias, string _, params string[] aliases) =>
+        new("Backend", alias, aliases, RuntimeComponentIdFactory.Create(RuntimeComponentKind.Backend, alias).Value);
 
     private static string WriteManifest(string root, string fileName, string assemblySimpleName, IReadOnlyList<FileDialectRuntimeComponentEntry> components, IRuntimeManifestSerializer serializer)
     {

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/RuntimeCatalog/SelectedRuntimePlanResolverContractTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/RuntimeCatalog/SelectedRuntimePlanResolverContractTests.cs
@@ -149,8 +149,8 @@ public class SelectedRuntimePlanResolverContractTests
         return new SelectedRuntimePlanResolver(new StaticCatalog(entries));
     }
 
-    private static RuntimeComponentManifestEntry Entry(RuntimeComponentKind kind, string canonicalAlias, string type, params string[] aliases)
-        => new(kind, canonicalAlias, aliases, new RuntimeTypeReference("TestAssembly", type));
+    private static RuntimeComponentManifestEntry Entry(RuntimeComponentKind kind, string canonicalAlias, string _, params string[] aliases)
+        => new(kind, canonicalAlias, aliases, RuntimeComponentIdFactory.Create(kind, canonicalAlias), "TestAssembly");
 
     private sealed class StaticCatalog(IEnumerable<RuntimeComponentManifestEntry> entries) : IRuntimeComponentCatalog
     {

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/RuntimeComponentTypeLoaderTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/RuntimeComponentTypeLoaderTests.cs
@@ -8,8 +8,8 @@ public class RuntimeComponentTypeLoaderTests
     [Test]
     public void TypeLoader_LoadsOnlyRequestedAssembly()
     {
-        var loader = new DefaultRuntimeComponentTypeLoader(new DefaultRuntimeAssemblyLoadStrategy(new DefaultRuntimeAssemblyLocator(new RuntimeArtifactLocatorOptions())));
-        var entry = Entry("ArithmeticModule", "ArithmeticModule.Module.ArithmeticModuleImpl");
+        var loader = new DefaultRuntimeComponentTypeLoader(new DefaultRuntimeComponentResolver(new DefaultRuntimeAssemblyLoadStrategy(new DefaultRuntimeAssemblyLocator(new RuntimeArtifactLocatorOptions()))));
+        var entry = Entry("ArithmeticModule", "frontend.arithmetic");
 
         var type = loader.LoadType(entry);
 
@@ -23,8 +23,8 @@ public class RuntimeComponentTypeLoaderTests
     [Test]
     public void TypeLoader_RepeatedLoad_UsesCache()
     {
-        var loader = new DefaultRuntimeComponentTypeLoader(new DefaultRuntimeAssemblyLoadStrategy(new DefaultRuntimeAssemblyLocator(new RuntimeArtifactLocatorOptions())));
-        var entry = Entry("ArithmeticModule", "ArithmeticModule.Module.ArithmeticModuleImpl");
+        var loader = new DefaultRuntimeComponentTypeLoader(new DefaultRuntimeComponentResolver(new DefaultRuntimeAssemblyLoadStrategy(new DefaultRuntimeAssemblyLocator(new RuntimeArtifactLocatorOptions()))));
+        var entry = Entry("ArithmeticModule", "frontend.arithmetic");
 
         var first = loader.LoadType(entry);
         for (var i = 0; i < 20; i++)
@@ -39,9 +39,9 @@ public class RuntimeComponentTypeLoaderTests
     {
         _ = typeof(ArithmeticModuleImpl).Assembly;
         var locator = new CountingLocator(false, null);
-        var loader = new DefaultRuntimeComponentTypeLoader(new DefaultRuntimeAssemblyLoadStrategy(locator));
+        var loader = new DefaultRuntimeComponentTypeLoader(new DefaultRuntimeComponentResolver(new DefaultRuntimeAssemblyLoadStrategy(locator)));
 
-        var type = loader.LoadType(Entry("ArithmeticModule", "ArithmeticModule.Module.ArithmeticModuleImpl"));
+        var type = loader.LoadType(Entry("ArithmeticModule", "frontend.arithmetic"));
 
         Assert.Multiple(() =>
         {
@@ -55,9 +55,9 @@ public class RuntimeComponentTypeLoaderTests
     {
         var badAssembly = "DefinitelyMissing.Assembly.For.Loader.Test";
         var locator = new CountingLocator(true, Path.Combine(AppContext.BaseDirectory, "ArithmeticModule.dll"));
-        var loader = new DefaultRuntimeComponentTypeLoader(new DefaultRuntimeAssemblyLoadStrategy(locator));
+        var loader = new DefaultRuntimeComponentTypeLoader(new DefaultRuntimeComponentResolver(new DefaultRuntimeAssemblyLoadStrategy(locator)));
 
-        var type = loader.LoadType(Entry(badAssembly, "ArithmeticModule.Module.ArithmeticModuleImpl"));
+        var type = loader.LoadType(Entry(badAssembly, "frontend.arithmetic"));
 
         Assert.Multiple(() =>
         {
@@ -69,28 +69,28 @@ public class RuntimeComponentTypeLoaderTests
     [Test]
     public void TypeLoader_LoadFromAssemblyPath_RequiresAbsolutePath()
     {
-        var loader = new DefaultRuntimeComponentTypeLoader(new DefaultRuntimeAssemblyLoadStrategy(new CountingLocator(true, "relative/path/ArithmeticModule.dll")));
-        var ex = Assert.Throws<ArgumentException>(() => loader.LoadType(Entry("Missing.Assembly.With.Relative.Path", "ArithmeticModule.Module.ArithmeticModuleImpl")));
+        var loader = new DefaultRuntimeComponentTypeLoader(new DefaultRuntimeComponentResolver(new DefaultRuntimeAssemblyLoadStrategy(new CountingLocator(true, "relative/path/ArithmeticModule.dll"))));
+        var ex = Assert.Throws<ArgumentException>(() => loader.LoadType(Entry("Missing.Assembly.With.Relative.Path", "frontend.arithmetic")));
         Assert.That(ex!.Message, Does.Contain("non-absolute path"));
     }
 
     [Test]
     public void TypeLoader_InvalidAssembly_ThrowsClearError()
     {
-        var loader = new DefaultRuntimeComponentTypeLoader(new DefaultRuntimeAssemblyLoadStrategy(new DefaultRuntimeAssemblyLocator(new RuntimeArtifactLocatorOptions())));
-        var ex = Assert.Throws<FileNotFoundException>(() => loader.LoadType(Entry("NoSuchAssembly", "Missing.Type")));
+        var loader = new DefaultRuntimeComponentTypeLoader(new DefaultRuntimeComponentResolver(new DefaultRuntimeAssemblyLoadStrategy(new DefaultRuntimeAssemblyLocator(new RuntimeArtifactLocatorOptions()))));
+        var ex = Assert.Throws<FileNotFoundException>(() => loader.LoadType(Entry("NoSuchAssembly", "frontend.missing")));
         Assert.That(ex!.Message, Does.Contain("NoSuchAssembly"));
     }
 
     [Test]
     public void TypeLoader_InvalidType_ThrowsClearError()
     {
-        var loader = new DefaultRuntimeComponentTypeLoader(new DefaultRuntimeAssemblyLoadStrategy(new DefaultRuntimeAssemblyLocator(new RuntimeArtifactLocatorOptions())));
-        Assert.Throws<TypeLoadException>(() => loader.LoadType(Entry("ArithmeticModule", "Missing.Type")));
+        var loader = new DefaultRuntimeComponentTypeLoader(new DefaultRuntimeComponentResolver(new DefaultRuntimeAssemblyLoadStrategy(new DefaultRuntimeAssemblyLocator(new RuntimeArtifactLocatorOptions()))));
+        Assert.Throws<InvalidOperationException>(() => loader.LoadType(Entry("ArithmeticModule", "frontend.missing")));
     }
 
-    private static RuntimeComponentManifestEntry Entry(string assemblySimpleName, string typeFullName)
-        => new(RuntimeComponentKind.FrontendModule, "Any", [], new RuntimeTypeReference(assemblySimpleName, typeFullName));
+    private static RuntimeComponentManifestEntry Entry(string assemblySimpleName, string componentId)
+        => new(RuntimeComponentKind.FrontendModule, "Arithmetic", [], new RuntimeComponentId(componentId), assemblySimpleName);
 
     private sealed class CountingLocator(bool shouldResolve, string? path) : IRuntimeAssemblyLocator
     {

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/RuntimeLoading/RuntimeAssemblyLoadStrategyContractTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/RuntimeLoading/RuntimeAssemblyLoadStrategyContractTests.cs
@@ -10,9 +10,9 @@ public class RuntimeAssemblyLoadStrategyContractTests
     public void TypeLoader_ShouldUseInjectedAssemblyLoadStrategy()
     {
         var strategy = new CountingAssemblyLoadStrategy(typeof(ArithmeticModuleImpl).Assembly);
-        var loader = new DefaultRuntimeComponentTypeLoader(strategy);
+        var loader = new DefaultRuntimeComponentTypeLoader(new DefaultRuntimeComponentResolver(strategy));
 
-        var resolved = loader.LoadType(Entry("ArithmeticModule", "ArithmeticModule.Module.ArithmeticModuleImpl"));
+        var resolved = loader.LoadType(Entry("ArithmeticModule", "frontend.arithmetic"));
 
         Assert.Multiple(() =>
         {
@@ -26,9 +26,9 @@ public class RuntimeAssemblyLoadStrategyContractTests
     public void TypeLoader_ShouldThrowClearError_ForMissingAssembly()
     {
         var strategy = new ThrowingAssemblyLoadStrategy(new FileNotFoundException("Assembly 'Missing.Assembly' was not found."));
-        var loader = new DefaultRuntimeComponentTypeLoader(strategy);
+        var loader = new DefaultRuntimeComponentTypeLoader(new DefaultRuntimeComponentResolver(strategy));
 
-        var ex = Assert.Throws<FileNotFoundException>(() => loader.LoadType(Entry("Missing.Assembly", "Missing.Type")));
+        var ex = Assert.Throws<FileNotFoundException>(() => loader.LoadType(Entry("Missing.Assembly", "frontend.missing")));
 
         Assert.That(ex!.Message, Does.Contain("Missing.Assembly"));
     }
@@ -37,19 +37,19 @@ public class RuntimeAssemblyLoadStrategyContractTests
     public void TypeLoader_ShouldThrowClearError_ForMissingTypeInAssembly()
     {
         var strategy = new CountingAssemblyLoadStrategy(typeof(ArithmeticModuleImpl).Assembly);
-        var loader = new DefaultRuntimeComponentTypeLoader(strategy);
+        var loader = new DefaultRuntimeComponentTypeLoader(new DefaultRuntimeComponentResolver(strategy));
 
-        var ex = Assert.Throws<TypeLoadException>(() => loader.LoadType(Entry("ArithmeticModule", "ArithmeticModule.Module.DoesNotExist")));
+        var ex = Assert.Throws<InvalidOperationException>(() => loader.LoadType(Entry("ArithmeticModule", "frontend.missing")));
 
-        Assert.That(ex!.Message, Does.Contain("DoesNotExist"));
+        Assert.That(ex!.Message, Does.Contain("frontend.missing"));
     }
 
     [Test]
     public void TypeLoader_ShouldCacheResolvedTypeDeterministically()
     {
         var strategy = new CountingAssemblyLoadStrategy(typeof(ArithmeticModuleImpl).Assembly);
-        var loader = new DefaultRuntimeComponentTypeLoader(strategy);
-        var entry = Entry("ArithmeticModule", "ArithmeticModule.Module.ArithmeticModuleImpl");
+        var loader = new DefaultRuntimeComponentTypeLoader(new DefaultRuntimeComponentResolver(strategy));
+        var entry = Entry("ArithmeticModule", "frontend.arithmetic");
 
         var first = loader.LoadType(entry);
         var second = loader.LoadType(entry);
@@ -65,8 +65,8 @@ public class RuntimeAssemblyLoadStrategyContractTests
     public void TypeLoader_ShouldReturnSameType_ForRepeatedResolutions()
     {
         var strategy = new CountingAssemblyLoadStrategy(typeof(ArithmeticModuleImpl).Assembly);
-        var loader = new DefaultRuntimeComponentTypeLoader(strategy);
-        var entry = Entry("ArithmeticModule", "ArithmeticModule.Module.ArithmeticModuleImpl");
+        var loader = new DefaultRuntimeComponentTypeLoader(new DefaultRuntimeComponentResolver(strategy));
+        var entry = Entry("ArithmeticModule", "frontend.arithmetic");
 
         var baseline = loader.LoadType(entry);
         for (var i = 0; i < 50; i++)
@@ -77,8 +77,8 @@ public class RuntimeAssemblyLoadStrategyContractTests
     public async Task TypeLoader_ShouldBeSafe_ForParallelResolutionsOfSameType()
     {
         var strategy = new CountingAssemblyLoadStrategy(typeof(ArithmeticModuleImpl).Assembly);
-        var loader = new DefaultRuntimeComponentTypeLoader(strategy);
-        var entry = Entry("ArithmeticModule", "ArithmeticModule.Module.ArithmeticModuleImpl");
+        var loader = new DefaultRuntimeComponentTypeLoader(new DefaultRuntimeComponentResolver(strategy));
+        var entry = Entry("ArithmeticModule", "frontend.arithmetic");
 
         var tasks = Enumerable.Range(0, 64).Select(_ => Task.Run(() => loader.LoadType(entry))).ToArray();
         var types = await Task.WhenAll(tasks);
@@ -90,8 +90,8 @@ public class RuntimeAssemblyLoadStrategyContractTests
         });
     }
 
-    private static RuntimeComponentManifestEntry Entry(string assemblySimpleName, string fullTypeName) =>
-        new(RuntimeComponentKind.FrontendModule, "Any", [], new RuntimeTypeReference(assemblySimpleName, fullTypeName));
+    private static RuntimeComponentManifestEntry Entry(string assemblySimpleName, string componentId) =>
+        new(RuntimeComponentKind.FrontendModule, "Arithmetic", [], new RuntimeComponentId(componentId), assemblySimpleName);
 
     private sealed class CountingAssemblyLoadStrategy(Assembly assembly) : IRuntimeAssemblyLoadStrategy
     {

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/WistDialectBackendCompatibilityTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/WistDialectBackendCompatibilityTests.cs
@@ -84,7 +84,8 @@ public class WistDialectBackendCompatibilityTests
             RuntimeComponentKind.Backend,
             alias,
             aliases ?? [],
-            new RuntimeTypeReference("AnyAssembly", $"Any.Namespace.{alias}"));
+            RuntimeComponentIdFactory.Create(RuntimeComponentKind.Backend, alias),
+            "AnyAssembly");
 
     private sealed class StaticCatalog(params RuntimeComponentManifestEntry[] backends) : IRuntimeComponentCatalog
     {

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/WistRuntimeManifestMetadataValidationTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/WistRuntimeManifestMetadataValidationTests.cs
@@ -18,13 +18,13 @@ public class WistRuntimeManifestMetadataValidationTests
 
         var document = new FileDialectRuntimeManifestDocument(
             "ArithmeticModule",
-            [new FileDialectRuntimeComponentEntry("FrontendModule", "Arithmetic", [], "ArithmeticModule.Module.ArithmeticModuleImpl")]);
+            [new FileDialectRuntimeComponentEntry("FrontendModule", "Arithmetic", [], "frontend.arithmetic")]);
         File.WriteAllText(manifestPath, serializer.Serialize(document));
 
         var catalog = new FileBasedRuntimeComponentCatalog(new StaticManifestLocator([manifestPath]), serializer);
 
         Assert.That(catalog.TryResolveModule("Arithmetic", out var module), Is.True);
-        Assert.That(module!.TypeReference.AssemblySimpleName, Is.EqualTo("ArithmeticModule"));
+        Assert.That(module!.AssemblySimpleName, Is.EqualTo("ArithmeticModule"));
     }
 
     [Test]
@@ -187,10 +187,10 @@ public class WistRuntimeManifestMetadataValidationTests
 
         File.WriteAllText(first, serializer.Serialize(new FileDialectRuntimeManifestDocument(
             "AAssembly",
-            [new FileDialectRuntimeComponentEntry(kind, "Alias", [], "A.Type")])));
+            [new FileDialectRuntimeComponentEntry(kind, "Alias", [], $"{kind.ToLowerInvariant()}.alias")])));
         File.WriteAllText(second, serializer.Serialize(new FileDialectRuntimeManifestDocument(
             "BAssembly",
-            [new FileDialectRuntimeComponentEntry(kind, "Alias", [], "B.Type")])));
+            [new FileDialectRuntimeComponentEntry(kind, "Alias", [], $"{kind.ToLowerInvariant()}.alias2")])));
 
         return Assert.Throws<InvalidOperationException>(() => new FileBasedRuntimeComponentCatalog(new StaticManifestLocator([first, second]), serializer))!;
     }

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistDialectServiceCollectionExtensions.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistDialectServiceCollectionExtensions.cs
@@ -23,6 +23,7 @@ public static class WistDialectServiceCollectionExtensions
         services.TryAddSingleton<IRuntimeManifestSerializer, RuntimeManifestJsonSerializer>();
         services.TryAddSingleton<IRuntimeComponentCatalog, FileBasedRuntimeComponentCatalog>();
         services.TryAddSingleton<IRuntimeAssemblyLoadStrategy, DefaultRuntimeAssemblyLoadStrategy>();
+        services.TryAddSingleton<IRuntimeComponentResolver, DefaultRuntimeComponentResolver>();
         services.TryAddSingleton<IRuntimeComponentTypeLoader, DefaultRuntimeComponentTypeLoader>();
         services.TryAddSingleton<IRuntimeKnownBackendsProvider, RuntimeKnownBackendsProvider>();
 


### PR DESCRIPTION
### Motivation
- Remove runtime identity coupling to `Type.FullName`/namespace and broad assembly scanning so component composition is stable under renames and namespace moves.
- Introduce a small, stable id-based contract (`RuntimeComponentId`) as the canonical public identity for runtime components.
- Make discovery deterministic and explicit: manifests and catalogs must carry component ids and assembly simple names rather than type full names.
- Provide a clear migration path (compat derivation of ids when missing) while avoiding a big-bang rewrite.

### Description
- Added an id-based model: `RuntimeComponentId`, `RuntimeComponentDescriptor`, and `RuntimeComponentManifestEntry`, and replaced `TypeFullName`/`RuntimeTypeReference` in the canonical manifest/catalog path with `ComponentId` + `AssemblySimpleName` (`FileDialectRuntimeComponentEntry` now stores `ComponentId`).
- Implemented a provider/resolver layer: new `IRuntimeComponentResolver` and `DefaultRuntimeComponentResolver` resolve activation types by `ComponentId` from an explicitly loaded assembly; `IRuntimeComponentCatalogProvider` and `DialectRuntimeCatalogProviderAttribute` scaffolding were added for future provider-based discovery.
- Reworked file-based catalog and manifest serializer/emitter: `FileBasedRuntimeComponentCatalog` now builds entries by `ComponentId`, validates uniqueness of ids, normalizes aliases deterministically, and no longer depends on type full names; `RuntimeManifestJsonSerializer` supports `componentId` field and derives ids deterministically when missing; `ManifestEmitter` now emits `componentId` (metadata-only using `MetadataLoadContext`).
- Switched runtime loading flow to use resolver-based activation: `DefaultRuntimeComponentTypeLoader` delegates to `IRuntimeComponentResolver` instead of calling `Assembly.GetType(fullName)`; Wist DI bootstrap now registers `IRuntimeComponentResolver` and the new loader is wired in; test code was updated to the id-based model.

### Testing
- Installed .NET 10 SDK via the installer script: `bash /tmp/dotnet-install.sh --channel 10.0 --install-dir $HOME/.dotnet` and verified `dotnet --version`.
- Built the tests project with `dotnet build UniversalToolchain/UniversalToolchain.Dialects.Tests/UniversalToolchain.Dialects.Tests.csproj -v minimal` and then ran the full test suite with `dotnet test UniversalToolchain/UniversalToolchain.Dialects.Tests/UniversalToolchain.Dialects.Tests.csproj -v minimal`.
- Result: the test run completed successfully (all tests passed in the final run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c819f0f6388324b3367875493714db)