### PR TITLE
ci: enforce required dotnet test projects in CI test step

### DIFF
--- a/.github/workflows/dotnet-ci.yml
+++ b/.github/workflows/dotnet-ci.yml
@@ -25,4 +25,13 @@ jobs:
         run: dotnet build UniversalToolchain/Wist.sln -c Release --no-restore
 
       - name: Test
-        run: dotnet test UniversalToolchain/Tests/Tests.csproj -c Release --no-build
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          dotnet test UniversalToolchain/Tests/Tests.csproj -c Release --no-build
+          dotnet test UniversalToolchain/UniversalToolchain.Dialects.Tests/UniversalToolchain.Dialects.Tests.csproj -c Release --no-build
+
+          if [ -f UniversalToolchain/UniversalToolchain.Modules.Tests/UniversalToolchain.Modules.Tests.csproj ]; then
+            dotnet test UniversalToolchain/UniversalToolchain.Modules.Tests/UniversalToolchain.Modules.Tests.csproj -c Release --no-build
+          fi


### PR DESCRIPTION
### Motivation
- Ensure the CI `Test` step runs the required test projects and fails the job when any required `dotnet test` run fails.

### Description
- Update `.github/workflows/dotnet-ci.yml` `Test` step to run `UniversalToolchain/Tests/Tests.csproj` and `UniversalToolchain/UniversalToolchain.Dialects.Tests/UniversalToolchain.Dialects.Tests.csproj`, add a conditional run for `UniversalToolchain.Modules.Tests` if its `.csproj` exists, and use `set -euo pipefail` so any failing test command makes the job fail.

### Testing
- Installed .NET SDK `10.0.103`, ran `dotnet restore` and `dotnet build`, then ran `dotnet test UniversalToolchain/Tests/Tests.csproj -c Release --no-build` which passed; running `dotnet test UniversalToolchain/UniversalToolchain.Dialects.Tests/UniversalToolchain.Dialects.Tests.csproj` in this environment hit a 300s timeout (non-success); `UniversalToolchain.Modules.Tests` project file was not present so its conditional block was not executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca84d64128832498acdf238c388908)