### PR TITLE
Add Strings module v1 with WistString runtime support and dialect integration

### DIFF
--- a/UniversalToolchain/ArithmeticModule/Visitors/ArithmeticAstVisitor.cs
+++ b/UniversalToolchain/ArithmeticModule/Visitors/ArithmeticAstVisitor.cs
@@ -25,7 +25,14 @@ public class ArithmeticAstVisitor : IAstVisitor
 
         var method = new AbstractMethodImpl(
             $"Op_{op}",
-            (il, context) => il.CallCSharp(context.Stack[^1].GetMethod(methodName).NotNull())
+            (il, context) =>
+            {
+                var leftType = context.Stack[^1];
+                var operationMethod = leftType.GetMethod(methodName);
+                if (operationMethod == null)
+                    Thrower.NotSupported<object>($"Operator '{op}' is not supported for type '{leftType.Name}'.");
+                il.CallCSharp(operationMethod!);
+            }
         );
 
         data.Bytecode.Instructions.Add(new BytecodeInstruction(method));

--- a/UniversalToolchain/AssemblyFinder/TypesFinder.cs
+++ b/UniversalToolchain/AssemblyFinder/TypesFinder.cs
@@ -7,6 +7,12 @@ public static class TypesFinder
     private static readonly Dictionary<string, Assembly> _assemblyCache = new(StringComparer.OrdinalIgnoreCase);
     private static readonly HashSet<string> _badAssemblies = new(StringComparer.OrdinalIgnoreCase);
 
+    private static readonly Dictionary<string, string> _typeAliases = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["string"] = "StringsModule.Core.WistStringImpl",
+        ["str"] = "StringsModule.Core.WistStringImpl"
+    };
+
     // Публичные свойства с ленивой инициализацией
     private static readonly Lazy<IReadOnlyList<Assembly>> _allAssemblies = new(() => LoadAllAssemblies(), true);
     private static readonly Lazy<IReadOnlyList<Type>> _allTypes = new(LoadAllTypes, true);
@@ -36,10 +42,19 @@ public static class TypesFinder
 
     public static Type GetType(string name)
     {
-        var type = AllTypes.FirstOrDefault(x => x.FullName == name);
-        if (type == null)
-            Thrower.InvalidOpEx($"Type '{name}' was not found among loaded assemblies.");
-        return type;
+        if (TryGetType(name, out var type))
+            return type!;
+
+        return Thrower.InvalidOpEx<Type>($"Type '{name}' was not found among loaded assemblies.");
+    }
+
+    public static bool TryGetType(string name, out Type? type)
+    {
+        if (_typeAliases.TryGetValue(name, out var aliasTarget))
+            name = aliasTarget;
+
+        type = AllTypes.FirstOrDefault(x => string.Equals(x.FullName, name, StringComparison.Ordinal));
+        return type != null;
     }
 
     private static bool IsValidAssembly(Assembly assembly)

--- a/UniversalToolchain/BasicCore/Binding/Binder.cs
+++ b/UniversalToolchain/BasicCore/Binding/Binder.cs
@@ -61,6 +61,12 @@ public sealed class Binder
         if (typeNode == null)
             return typeof(object);
 
-        return Type.GetType(typeNode.Text) ?? typeof(object);
+        var resolvedName = typeNode.Text switch
+        {
+            "string" or "String" or "str" => "StringsModule.Core.WistStringImpl, StringsModule",
+            _ => typeNode.Text
+        };
+
+        return Type.GetType(resolvedName) ?? typeof(object);
     }
 }

--- a/UniversalToolchain/Dialects/examples/wist/full-default/dialect.wistdialect
+++ b/UniversalToolchain/Dialects/examples/wist/full-default/dialect.wistdialect
@@ -1,5 +1,5 @@
 dialect FullDefault
-use Arithmetic,BooleanConditions,Comments,ComparisonConditions,Conditions,CSharpInterop,Equality,Identifier,Labels,Loops,Numbers,Scopes,SemicolonAsNewLine,Variables,Whitespaces
+use Arithmetic,BooleanConditions,Comments,ComparisonConditions,Conditions,CSharpInterop,Equality,Identifier,Labels,Loops,Numbers,Strings,Scopes,SemicolonAsNewLine,Variables,Whitespaces
 backend cil,interpreter
 enable BooleanOptimization
 enable ComparisonIntrinsicOptimization

--- a/UniversalToolchain/Dialects/examples/wist/restricted-sandbox/dialect.wistdialect
+++ b/UniversalToolchain/Dialects/examples/wist/restricted-sandbox/dialect.wistdialect
@@ -1,5 +1,5 @@
 dialect RestrictedSandbox
-use Arithmetic,BooleanConditions,Comments,ComparisonConditions,Conditions,Equality,Numbers,Scopes,Whitespaces
+use Arithmetic,BooleanConditions,Comments,ComparisonConditions,Conditions,Equality,Numbers,Strings,Scopes,Whitespaces
 exclude CSharpInterop,Identifier,InternalPreprocessorLexemes,Labels,Loops,NativeTypes,ParametersSetter,SemicolonAsNewLine,Variables
 backend interpreter
 security restricted

--- a/UniversalToolchain/StringsModule/Core/WistStringImpl.cs
+++ b/UniversalToolchain/StringsModule/Core/WistStringImpl.cs
@@ -1,0 +1,14 @@
+namespace StringsModule.Core;
+
+public readonly struct WistStringImpl(string value) : IComparable<WistStringImpl>
+{
+    public string GetValue() => value;
+
+    public static WistStringImpl Create(string value) => new(value);
+
+    public static WistStringImpl Add(WistStringImpl a, WistStringImpl b) => new(string.Concat(a.GetValue(), b.GetValue()));
+
+    public int CompareTo(WistStringImpl other) => string.CompareOrdinal(GetValue(), other.GetValue());
+
+    public override string ToString() => value;
+}

--- a/UniversalToolchain/StringsModule/GlobalUsings.cs
+++ b/UniversalToolchain/StringsModule/GlobalUsings.cs
@@ -1,0 +1,16 @@
+global using System.Text;
+global using AbstractIrExtensions;
+global using BasicCore.Attributes;
+global using BasicCore.Contracts;
+global using BasicCore.LexerWrapper;
+global using BasicCore.ParserWrapper;
+global using BasicCore.Registration;
+global using BasicCore.TranslatorWrapper;
+global using BasicTypesExtensions;
+global using DynamicMethodWrapper;
+global using ExceptionsManager;
+global using StringsModule.Core;
+global using StringsModule.Parsing;
+global using StringsModule.Visitors;
+global using UniversalToolchain.Dialects.Abstractions;
+global using StringsModule.Module;

--- a/UniversalToolchain/StringsModule/Module/StringsModuleImpl.cs
+++ b/UniversalToolchain/StringsModule/Module/StringsModuleImpl.cs
@@ -1,0 +1,17 @@
+namespace StringsModule.Module;
+
+[DialectModuleAlias("Strings")]
+[DialectRuntimeExport("FrontendModule", "Strings")]
+[AutoRegisterService]
+[ArithmeticModeCompatibility(ArithmeticMode.Universal)]
+public class StringsModuleImpl : IFrontendCoreModule
+{
+    private static readonly IReadOnlyList<LexemeRegistration> _lexemeRegistrations =
+    [
+        new("\"(?:\\\\.|[^\"\\\\])*\"", "String", Priority: -90f)
+    ];
+
+    public void InitLexer(ILexer lexer) => lexer.AddLexemes(_lexemeRegistrations);
+
+    public void InitAstTranslator(IAstToBytecodeTranslator translator) => translator.AddVisitors(new StringAstVisitor());
+}

--- a/UniversalToolchain/StringsModule/Parsing/StringLiteralDecoder.cs
+++ b/UniversalToolchain/StringsModule/Parsing/StringLiteralDecoder.cs
@@ -1,0 +1,42 @@
+namespace StringsModule.Parsing;
+
+public static class StringLiteralDecoder
+{
+    public static string Decode(string literalText)
+    {
+        if (literalText.Length < 2 || !literalText.StartsWith('"') || !literalText.EndsWith('"'))
+            Thrower.InvalidOpEx($"String literal '{literalText}' must be wrapped in double quotes.");
+
+        var source = literalText[1..^1];
+        var builder = new StringBuilder(source.Length);
+
+        for (var i = 0; i < source.Length; i++)
+        {
+            var current = source[i];
+            if (current != '\\')
+            {
+                builder.Append(current);
+                continue;
+            }
+
+            if (i == source.Length - 1)
+                Thrower.InvalidOpEx($"String literal '{literalText}' ends with incomplete escape sequence.");
+
+            i++;
+            var escaped = source[i] switch
+            {
+                '"' => '"',
+                '\\' => '\\',
+                'n' => '\n',
+                'r' => '\r',
+                't' => '\t',
+                '0' => '\0',
+                _ => Thrower.InvalidOpEx<char>($"Escape sequence '\\{source[i]}' is not supported.")
+            };
+
+            builder.Append(escaped);
+        }
+
+        return builder.ToString();
+    }
+}

--- a/UniversalToolchain/StringsModule/StringsModule.csproj
+++ b/UniversalToolchain/StringsModule/StringsModule.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <LangVersion>14</LangVersion>
+        <EmitDialectRuntimeManifest>true</EmitDialectRuntimeManifest>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\UniversalToolchain.Dialects.Abstractions\UniversalToolchain.Dialects.Abstractions.csproj"/>
+        <ProjectReference Include="..\AbstractIrExtensions\AbstractIrExtensions.csproj"/>
+        <ProjectReference Include="..\BasicCore\BasicCore.csproj"/>
+        <ProjectReference Include="..\UniversalIntermediateRepresentation\UniversalIntermediateRepresentation.csproj"/>
+        <ProjectReference Include="..\ExceptionsManager\ExceptionsManager.csproj"/>
+        <ProjectReference Include="..\UniversalToolchain.Dialects.Integration\UniversalToolchain.Dialects.Integration.csproj"/>
+    </ItemGroup>
+
+</Project>

--- a/UniversalToolchain/StringsModule/Visitors/StringAstVisitor.cs
+++ b/UniversalToolchain/StringsModule/Visitors/StringAstVisitor.cs
@@ -1,0 +1,24 @@
+namespace StringsModule.Visitors;
+
+[AutoRegisterService]
+public class StringAstVisitor : IAstVisitor
+{
+    public void TryVisit(BytecodeVisitorData data)
+    {
+        if (data.Node.NodeType != ExtensibleEnum<AstNodeTag>.CreateOrGet("String"))
+            return;
+
+        var literalText = (data.Node.LexemeValue?.Text).NotNull();
+        var value = StringLiteralDecoder.Decode(literalText);
+
+        var method = new AbstractMethodImpl(
+            $"PushString_{value}",
+            (il, _) =>
+            {
+                il.Push(value);
+                il.CallCSharp(typeof(WistStringImpl).GetMethod(nameof(WistStringImpl.Create), [typeof(string)]).NotNull());
+            });
+
+        data.Bytecode.Instructions.Add(new BytecodeInstruction(method));
+    }
+}

--- a/UniversalToolchain/Tests/TestBase.cs
+++ b/UniversalToolchain/Tests/TestBase.cs
@@ -108,14 +108,14 @@ public abstract class TestBase
 
     private const string UniversalDialect = """
                                           dialect TestUniversal
-                                          use Whitespaces,SemicolonAsNewLine,Comments,Numbers,Identifier,Arithmetic,Equality,Conditions,Loops,Variables,Scopes,Labels,InternalPreprocessorLexemes,CSharpInterop
+                                          use Whitespaces,SemicolonAsNewLine,Comments,Numbers,Strings,Identifier,Arithmetic,Equality,Conditions,Loops,Variables,Scopes,Labels,InternalPreprocessorLexemes,CSharpInterop
                                           enable LocalVariablesOptimization
                                           backend compiler,interpreter
                                           """;
 
     private const string NativeDialect = """
                                        dialect TestNative
-                                       use Whitespaces,SemicolonAsNewLine,Comments,Numbers,Identifier,Arithmetic,NativeMath,Equality,Conditions,Loops,Variables,Scopes,Labels,InternalPreprocessorLexemes,CSharpInterop
+                                       use Whitespaces,SemicolonAsNewLine,Comments,Numbers,Strings,Identifier,Arithmetic,NativeMath,Equality,Conditions,Loops,Variables,Scopes,Labels,InternalPreprocessorLexemes,CSharpInterop
                                        enable LocalVariablesOptimization
                                        backend compiler,interpreter
                                        """;

--- a/UniversalToolchain/Tests/Tests.csproj
+++ b/UniversalToolchain/Tests/Tests.csproj
@@ -43,6 +43,7 @@
         <ProjectReference Include="..\LoopsModule\LoopsModule.csproj"/>
         <ProjectReference Include="..\NativeMathModule\NativeMathModule.csproj"/>
         <ProjectReference Include="..\NumbersModule\NumbersModule.csproj"/>
+        <ProjectReference Include="..\StringsModule\StringsModule.csproj"/>
         <ProjectReference Include="..\ParserConfigurationModule\ParserConfigurationModule.csproj"/>
         <ProjectReference Include="..\ScopesModule\ScopesModule.csproj"/>
         <ProjectReference Include="..\SemicolonAsNewLineModule\SemicolonAsNewLineModule.csproj"/>

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/WistDialectExecutionIntegrationTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/WistDialectExecutionIntegrationTests.cs
@@ -1,6 +1,7 @@
 using ExceptionsManager;
 using Microsoft.Extensions.DependencyInjection;
 using NumbersModule.Core;
+using StringsModule.Core;
 using UniversalToolchain.Dialects.Wist;
 
 namespace UniversalToolchain.Dialects.Tests;
@@ -119,6 +120,33 @@ public class WistDialectExecutionIntegrationTests
         });
     }
 
+
+    [Test]
+    public void FullDialect_StringsSupport_WorksAcrossBackends()
+    {
+        using var provider = CreateProvider();
+        var workflow = provider.GetRequiredService<WistDialectExecutionWorkflow>();
+        var example = ResolveExampleDirectory("full-default");
+
+        var result = workflow.ComposeFile(Path.Combine(example, "dialect.wistdialect"));
+        using var host = workflow.CreateHost(result);
+        const string code = """
+                            let left = "http://x"
+                            let right: string = "api"
+                            left + "/" + right
+                            """;
+
+        var interpreterValue = host.Run(code, "interpreter");
+        var compilerValue = host.Run(code, "compiler");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(ToStringValue(interpreterValue), Is.EqualTo("http://x/api"));
+            Assert.That(ToStringValue(compilerValue), Is.EqualTo("http://x/api"));
+        });
+    }
+
     [Test]
     public void RestrictedDialect_DisabledCompilerBackend_IsRejected()
     {
@@ -212,6 +240,16 @@ public class WistDialectExecutionIntegrationTests
             float floatValue => floatValue,
             decimal decimalValue => (double)decimalValue,
             _ => Thrower.InvalidCast<double>($"Unsupported result value '{value?.GetType().FullName ?? "<null>"}'.")
+        };
+    }
+
+    private static string ToStringValue(object? value)
+    {
+        return value switch
+        {
+            WistStringImpl stringValue => stringValue.GetValue(),
+            string rawString => rawString,
+            _ => Thrower.InvalidCast<string>($"Unsupported result value '{value?.GetType().FullName ?? "<null>"}'.")
         };
     }
 }

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/WistDialectProfileContractTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/WistDialectProfileContractTests.cs
@@ -7,7 +7,7 @@ public class WistDialectProfileContractTests
     {
         var source = File.ReadAllText(GetDialectFilePath("full-default"));
 
-        Assert.That(source, Does.Contain("use Arithmetic,BooleanConditions,Comments,ComparisonConditions,Conditions,CSharpInterop,Equality,Identifier,Labels,Loops,Numbers,Scopes,SemicolonAsNewLine,Variables,Whitespaces"));
+        Assert.That(source, Does.Contain("use Arithmetic,BooleanConditions,Comments,ComparisonConditions,Conditions,CSharpInterop,Equality,Identifier,Labels,Loops,Numbers,Strings,Scopes,SemicolonAsNewLine,Variables,Whitespaces"));
     }
 
     [Test]

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/UniversalToolchain.Dialects.Wist.csproj
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/UniversalToolchain.Dialects.Wist.csproj
@@ -33,6 +33,7 @@
         <ProjectReference Include="..\NumbersModule\NumbersModule.csproj"/>
         <ProjectReference Include="..\ParametersSetterModule\ParametersSetterModule.csproj"/>
         <ProjectReference Include="..\ScopesModule\ScopesModule.csproj"/>
+        <ProjectReference Include="..\StringsModule\StringsModule.csproj"/>
         <ProjectReference Include="..\SemicolonAsNewLineModule\SemicolonAsNewLineModule.csproj"/>
         <ProjectReference Include="..\UniversalToolchain.Dialects.Core\UniversalToolchain.Dialects.Core.csproj"/>
         <ProjectReference Include="..\UniversalToolchain.Dialects.Frontend\UniversalToolchain.Dialects.Frontend.csproj"/>

--- a/UniversalToolchain/UniversalToolchain.Modules.Tests/ModuleCoverage/ModulePipelineTestHelper.cs
+++ b/UniversalToolchain/UniversalToolchain.Modules.Tests/ModuleCoverage/ModulePipelineTestHelper.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using NumbersModule.Core;
+using StringsModule.Core;
 using UniversalToolchain.Dialects.Integration;
 using UniversalToolchain.Dialects.Wist;
 
@@ -11,7 +12,7 @@ internal sealed class ModulePipelineTestHelper : IDisposable
     [
         "Whitespaces", "SemicolonAsNewLine", "Comments", "Numbers", "Identifier", "Arithmetic", "Equality",
         "Conditions", "ComparisonConditions", "BooleanConditions", "Loops", "Variables", "Scopes", "Labels",
-        "InternalPreprocessorLexemes", "CSharpInterop"
+        "InternalPreprocessorLexemes", "CSharpInterop", "Strings"
     ];
 
     private readonly ServiceProvider _provider;
@@ -98,6 +99,14 @@ internal sealed class ModulePipelineTestHelper : IDisposable
             _ => throw new InvalidCastException($"Cannot convert '{value?.GetType().Name ?? "null"}' to bool.")
         };
 
+    public static string AsString(object? value)
+        => value switch
+        {
+            WistStringImpl s => s.GetValue(),
+            string s => s,
+            _ => throw new InvalidCastException($"Cannot convert '{value?.GetType().Name ?? "null"}' to string.")
+        };
+
     public static void AssertParity(object? compiler, object? interpreter)
     {
         if (compiler is null || interpreter is null)
@@ -109,6 +118,12 @@ internal sealed class ModulePipelineTestHelper : IDisposable
         if (compiler is bool || interpreter is bool)
         {
             Assert.That(AsBool(compiler), Is.EqualTo(AsBool(interpreter)));
+            return;
+        }
+
+        if (compiler is WistStringImpl || interpreter is WistStringImpl || compiler is string || interpreter is string)
+        {
+            Assert.That(AsString(compiler), Is.EqualTo(AsString(interpreter)));
             return;
         }
 

--- a/UniversalToolchain/UniversalToolchain.Modules.Tests/ModuleCoverage/StringsModulePipelineTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Modules.Tests/ModuleCoverage/StringsModulePipelineTests.cs
@@ -1,0 +1,60 @@
+using StringsModule.Core;
+
+namespace UniversalToolchain.Modules.Tests.ModuleCoverage;
+
+[TestFixture]
+public class StringsModulePipelineTests
+{
+    private static readonly string[] Modules = ModulePipelineTestHelper.FullUniversalModules;
+
+    [Test]
+    public void Strings_LiteralAndEscapes_AreDecodedDeterministically()
+    {
+        using var h = new ModulePipelineTestHelper();
+        var result = h.ExecuteBoth("\"line1\\nline2\\t\\\"x\\\"\\\\\"", Modules);
+
+        ModulePipelineTestHelper.AssertParity(result.Compiler, result.Interpreter);
+        Assert.That(ModulePipelineTestHelper.AsString(result.Compiler), Is.EqualTo("line1\nline2\t\"x\"\\"));
+    }
+
+    [Test]
+    public void Strings_ConcatenationAndComparison_WorkWithVariables()
+    {
+        using var h = new ModulePipelineTestHelper();
+        var result = h.ExecuteBoth(
+            """
+            let a = "foo"
+            let b: string = "bar"
+            let c = a + b
+            if c == "foobar" (
+                c
+            ) else (
+                "bad"
+            )
+            """,
+            Modules);
+
+        ModulePipelineTestHelper.AssertParity(result.Compiler, result.Interpreter);
+        Assert.That(ModulePipelineTestHelper.AsString(result.Compiler), Is.EqualTo("foobar"));
+    }
+
+    [Test]
+    public void Strings_Literals_DoNotConflictWithCommentPatterns()
+    {
+        using var h = new ModulePipelineTestHelper();
+        var result = h.ExecuteBoth("\"http://x\" == \"http://x\"", Modules);
+
+        ModulePipelineTestHelper.AssertParity(result.Compiler, result.Interpreter);
+        Assert.That(ModulePipelineTestHelper.AsBool(result.Compiler), Is.True);
+    }
+
+    [Test]
+    public void Strings_UnsupportedArithmeticOperator_ThrowsReadableError()
+    {
+        using var h = new ModulePipelineTestHelper();
+
+        var ex = Assert.Throws<NotSupportedException>(() => h.ExecuteCompiler("\"a\" - \"b\"", Modules));
+
+        Assert.That(ex!.Message, Does.Contain("Operator '-'").And.Contain("WistStringImpl"));
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Modules.Tests/UniversalToolchain.Modules.Tests.csproj
+++ b/UniversalToolchain/UniversalToolchain.Modules.Tests/UniversalToolchain.Modules.Tests.csproj
@@ -21,6 +21,7 @@
         <ProjectReference Include="..\UniversalToolchain.Dialects.Integration\UniversalToolchain.Dialects.Integration.csproj"/>
         <ProjectReference Include="..\UniversalToolchain.Dialects.Wist\UniversalToolchain.Dialects.Wist.csproj"/>
         <ProjectReference Include="..\NumbersModule\NumbersModule.csproj"/>
+        <ProjectReference Include="..\StringsModule\StringsModule.csproj"/>
         <ProjectReference Include="..\ExecutorLoggerModule\ExecutorLoggerModule.csproj"/>
     </ItemGroup>
 

--- a/UniversalToolchain/Wist.sln
+++ b/UniversalToolchain/Wist.sln
@@ -124,6 +124,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UniversalToolchain.Dialects
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UniversalToolchain.Modules.Tests", "UniversalToolchain.Modules.Tests\UniversalToolchain.Modules.Tests.csproj", "{507806F7-75E5-4A6A-BF23-18992BF44B97}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StringsModule", "StringsModule\StringsModule.csproj", "{2E5DA412-3501-46B4-AC9F-46E05E89FA7D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -782,6 +784,18 @@ Global
 		{507806F7-75E5-4A6A-BF23-18992BF44B97}.Release|x64.Build.0 = Release|Any CPU
 		{507806F7-75E5-4A6A-BF23-18992BF44B97}.Release|x86.ActiveCfg = Release|Any CPU
 		{507806F7-75E5-4A6A-BF23-18992BF44B97}.Release|x86.Build.0 = Release|Any CPU
+		{2E5DA412-3501-46B4-AC9F-46E05E89FA7D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2E5DA412-3501-46B4-AC9F-46E05E89FA7D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2E5DA412-3501-46B4-AC9F-46E05E89FA7D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2E5DA412-3501-46B4-AC9F-46E05E89FA7D}.Debug|x64.Build.0 = Debug|Any CPU
+		{2E5DA412-3501-46B4-AC9F-46E05E89FA7D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2E5DA412-3501-46B4-AC9F-46E05E89FA7D}.Debug|x86.Build.0 = Debug|Any CPU
+		{2E5DA412-3501-46B4-AC9F-46E05E89FA7D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2E5DA412-3501-46B4-AC9F-46E05E89FA7D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2E5DA412-3501-46B4-AC9F-46E05E89FA7D}.Release|x64.ActiveCfg = Release|Any CPU
+		{2E5DA412-3501-46B4-AC9F-46E05E89FA7D}.Release|x64.Build.0 = Release|Any CPU
+		{2E5DA412-3501-46B4-AC9F-46E05E89FA7D}.Release|x86.ActiveCfg = Release|Any CPU
+		{2E5DA412-3501-46B4-AC9F-46E05E89FA7D}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
### Motivation
- Introduce a first-class immutable string value for the universal runtime instead of using raw CLR `string`, so string semantics (comparison, concatenation) integrate with existing generic arithmetic and comparison infrastructure.
- Provide a minimal, robust string-literal frontend (lexer + decoder + visitor) with a limited, well-defined escape set for a stable v1 surface.
- Ensure deterministic failures for unsupported operations (e.g. `"a" - "b"`) and provide tests and dialect integration so strings can be used end-to-end in Wist examples.

### Description
- Added new `StringsModule` project with runtime wrapper `WistStringImpl` implementing `Create`, `GetValue`, `Add`, `CompareTo`, and `ToString` (`UniversalToolchain/StringsModule/Core/WistStringImpl.cs`).
- Implemented string-literal lexer registration and frontend module `StringsModuleImpl` plus `StringAstVisitor` that decodes tokens and emits bytecode pushing `WistStringImpl` values (`StringsModule/Module/StringsModuleImpl.cs`, `StringsModule/Visitors/StringAstVisitor.cs`).
- Implemented `StringLiteralDecoder` to decode `\"`, `\\`, `\n`, `\r`, `\t`, and `\0` and to produce deterministic diagnostics on malformed or unsupported escapes (`StringsModule/Parsing/StringLiteralDecoder.cs`).
- Improved generic arithmetic dispatch to check the resolved operation method before calling and throw a readable `NotSupported` when missing (so `-` on strings errors deterministically) (`ArithmeticModule/Visitors/ArithmeticAstVisitor.cs`).
- Added type aliasing for `string`/`str` to map to `StringsModule.Core.WistStringImpl` and a `TryGetType` helper in `TypesFinder`, and updated binder logic to resolve `let x: string` to the `WistStringImpl` CLR type when present (`AssemblyFinder/TypesFinder.cs`, `BasicCore/Binding/Binder.cs`).
- Integrated `Strings` into Wist dialect examples (`full-default`, `restricted-sandbox`), added project references and solution entry, and updated test helpers to include `Strings` in the full-universal module set and conversion helpers (`Dialects/examples/wist/*`, `UniversalToolchain.Dialects.Wist/*.csproj`, `Wist.sln`, `Tests/TestBase.cs`, `ModulePipelineTestHelper.cs`).
- Added unit and integration tests covering literals, escapes, concatenation, comparisons, variable assignment and typed declarations, comment-pattern non-conflicts, and readable failure for unsupported operators (`UniversalToolchain.Modules.Tests/ModuleCoverage/StringsModulePipelineTests.cs`, `UniversalToolchain.Dialects.Tests/WistDialectExecutionIntegrationTests.cs` updates).

### Testing
- Ran `dotnet restore UniversalToolchain/Wist.sln` and `dotnet build UniversalToolchain/Wist.sln -c Release --no-restore` successfully to include the new `StringsModule` in the solution.
- Ran `dotnet test UniversalToolchain/Tests/Tests.csproj -c Release --no-build` and the test project passed (existing tests run successfully).
- Ran `dotnet test UniversalToolchain/UniversalToolchain.Dialects.Tests/UniversalToolchain.Dialects.Tests.csproj -c Release --no-build` and the dialect tests passed (including the updated integration test for strings).
- Ran `dotnet test UniversalToolchain/UniversalToolchain.Modules.Tests/UniversalToolchain.Modules.Tests.csproj -c Release --no-build` and verified the new `StringsModulePipelineTests` (and the modules test suite) passed; targeted filtered run for the strings tests also passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cae3ebd7cc8324a248000190888686)