### PR TITLE
Adjust number lexeme regex to exclude leading sign and add lexing tests

### DIFF
--- a/UniversalToolchain/NumbersModule/Module/NumbersModuleImpl.cs
+++ b/UniversalToolchain/NumbersModule/Module/NumbersModuleImpl.cs
@@ -9,7 +9,7 @@ public class NumbersModuleImpl : IFrontendCoreModule
     private static readonly IReadOnlyList<LexemeRegistration> _lexemeRegistrations =
     [
         new(
-            @"[+-]?\d+(?:_?\d+)*(?:\.\d+(?:_?\d+)*)?(?:[eE][+-]?\d+(?:_?\d+)*)?",
+            @"\d+(?:_?\d+)*(?:\.\d+(?:_?\d+)*)?(?:[eE][+-]?\d+(?:_?\d+)*)?",
             "Number",
             Priority: -20f
         )

--- a/UniversalToolchain/UniversalToolchain.Modules.Tests/ModuleCoverage/NumbersModulePipelineTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Modules.Tests/ModuleCoverage/NumbersModulePipelineTests.cs
@@ -15,12 +15,10 @@ public class NumbersModulePipelineTests
     }
 
     [Test]
-    public void Numbers_NegativeLiteral_ExecutesToExpectedValue()
+    public void Numbers_StandaloneNegativeLiteral_FailsWithoutUnaryMinusSupport()
     {
         using var h = new ModulePipelineTestHelper();
-        var r = h.ExecuteBoth("-13", Modules);
-        ModulePipelineTestHelper.AssertParity(r.Compiler, r.Interpreter);
-        Assert.That(ModulePipelineTestHelper.AsNumber(r.Compiler), Is.EqualTo(-13));
+        h.AssertFails("-13", Modules, "token");
     }
 
     [Test]
@@ -46,5 +44,33 @@ public class NumbersModulePipelineTests
     {
         using var h = new ModulePipelineTestHelper();
         h.AssertFails("1.2.3", Modules, "token");
+    }
+
+    [TestCase("2+3", new[] { "Number", "Addition", "Number" })]
+    [TestCase("10-23", new[] { "Number", "Substraction", "Number" })]
+    public void Numbers_Lexing_BinaryOperations_KeepOperatorsSeparate(string code, string[] expectedTags)
+    {
+        var tokens = BuildNumbersAndArithmeticLexer().Lexemize(code);
+        var actualTags = tokens.Select(x => x.LexemePattern?.LexemeType.GetName()).ToArray();
+
+        Assert.That(actualTags, Is.EqualTo(expectedTags));
+    }
+
+    [Test]
+    public void Numbers_Lexing_ScientificNotationWithMinus_StaysSingleNumberToken()
+    {
+        var tokens = BuildNumbersAndArithmeticLexer().Lexemize("1e-5");
+        var actualTags = tokens.Select(x => x.LexemePattern?.LexemeType.GetName()).ToArray();
+
+        Assert.That(actualTags, Is.EqualTo(new[] { "Number" }));
+        Assert.That(tokens[0].Text, Is.EqualTo("1e-5"));
+    }
+
+    private static BasicCore.LexerWrapper.ILexer BuildNumbersAndArithmeticLexer()
+    {
+        BasicCore.LexerWrapper.ILexer lexer = new BasicLexer.Core.BasicLexerImpl();
+        new NumbersModule.Module.NumbersModuleImpl().InitLexer(lexer);
+        new ArithmeticModule.Module.ArithmeticModuleImpl().InitLexer(lexer);
+        return lexer;
     }
 }


### PR DESCRIPTION
### Motivation
- Make numeric lexeme matching exclude an optional leading sign so unary `+`/`-` are tokenized as separate operators while preserving scientific notation (e.g. `1e-5`).
- Keep the lexer behaviour explicit and deterministic for binary expressions like `2+3` and `10-23` so operators are separate tokens from numbers.

### Description
- Replaced the number regex in `NumbersModuleImpl` from `"[+-]?\d+(?:_?\d+)*(?:\.\d+(?:_?\d+)*)?(?:[eE][+-]?\d+(?:_?\d+)*)?"` to `"\d+(?:_?\d+)*(?:\.\d+(?:_?\d+)*)?(?:[eE][+-]?\d+(?:_?\d+)*)?"` and left the lexeme `tag = "Number"` and `Priority = -20f` unchanged.
- Added unit tests in `NumbersModulePipelineTests` that assert `2+3` tokenizes as `Number, Addition, Number`, `10-23` tokenizes as `Number, Substraction, Number`, and that `1e-5` stays a single `Number` token, and updated the previous negative-literal test to expect a deterministic lexer failure for a standalone `-13` literal.

### Testing
- Ran `dotnet restore UniversalToolchain/Wist.sln` successfully to restore packages for the solution.
- Ran `dotnet test UniversalToolchain/UniversalToolchain.Modules.Tests/UniversalToolchain.Modules.Tests.csproj -c Release --filter "FullyQualifiedName~NumbersModulePipelineTests"` and the updated `NumbersModulePipelineTests` passed (all cases in the filtered test ran green).
- Ran `dotnet test UniversalToolchain/Wist.sln -c Release --no-restore` which executed the full test suite and reported unrelated existing failures in `UniversalToolchain.Modules.Tests` (several tests failing that are not caused by this small lexeme regex change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cbf1467ebc832482974db545d925af)