### PR TITLE
Update NativeNumber lexer regex to support long suffix

### DIFF
--- a/UniversalToolchain/NativeMathModule/NativeTypesModuleImpl.cs
+++ b/UniversalToolchain/NativeMathModule/NativeTypesModuleImpl.cs
@@ -9,7 +9,7 @@ public class NativeTypesModuleImpl : IFrontendCoreModule
     public void InitLexer(ILexer lexer)
     {
         lexer.Configuration.TryAddPattern(
-            new LexemePattern(@"[+-]?\d+(?:_?\d+)*(?:\.\d+(?:_?\d+)*)?(?:[eE][+-]?\d+(?:_?\d+)*)?[fdmFDM]?",
+            new LexemePattern(@"\d+(?:_?\d+)*(?:\.\d+(?:_?\d+)*)?(?:[eE][+-]?\d+(?:_?\d+)*)?[fdmlFDML]?",
                 ExtensibleEnum<LexemeTag>.CreateOrGet("NativeNumber")),
             priority: -20f
         );


### PR DESCRIPTION
### Motivation
- Support numeric literals with a long (`L`/`l`) suffix in the native lexer so the lexer recognizes `10L` and similar forms.
- Ensure runtime parsing logic remains consistent with lexer suffixes (`f/d/m/l`, case-insensitive) to avoid mismatches between tokenization and value construction.

### Description
- Replaced the `NativeNumber` lexeme pattern in `NativeTypesModuleImpl.InitLexer` with the requested regex `@"\d+(?:_?\d+)*(?:\.\d+(?:_?\d+)*)?(?:[eE][+-]?\d+(?:_?\d+)*)?[fdmlFDML]?"` so `L`/`l` suffixes are accepted.
- Left `ParseNumber(string text)` unchanged and confirmed it uses `char.ToLower(...)` and branches for `m`, `f`, `d`, and `l`, preserving suffix-to-type mapping.

### Testing
- Installed .NET SDK `10.0.103`, ran `dotnet restore` and `dotnet build` and the solution built successfully.
- Ran unit test suites: `UniversalToolchain/Tests` and `UniversalToolchain/UniversalToolchain.Dialects.Tests` passed, while `UniversalToolchain/UniversalToolchain.Modules.Tests` reported existing unrelated failures (12 failed, 106 passed) that are outside the scope of this regex-only change.
- Executed an ad-hoc verification program that confirmed `2+3` and `7+8` are not full `NativeNumber` matches and that `10L`, `3.14f`, and `2m` fully match the lexer and `ParseNumber` produces `Int64`, `Single`, and `Decimal` respectively.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc191ad3948324b543bffc4276a8ae)