### PR TITLE
Refactor whitespace module lexer setup to use registrations

### DIFF
--- a/UniversalToolchain/WhitespacesModule/WhitespaceModuleImpl.cs
+++ b/UniversalToolchain/WhitespacesModule/WhitespaceModuleImpl.cs
@@ -1,3 +1,4 @@
+using BasicCore.Registration;
 using UniversalToolchain.Dialects.Abstractions;
 
 namespace WhitespacesModule;
@@ -7,15 +8,10 @@ namespace WhitespacesModule;
 [AutoRegisterService]
 public class WhitespaceModuleImpl : IFrontendCoreModule
 {
-    public void InitLexer(ILexer lexer)
-    {
-        var lexemes = (List<LexemePattern>)
-        [
-            new LexemePattern(" ", LexemeType.CreateOrGet("Space")),
-            new LexemePattern(@"\n", LexemeType.CreateOrGet("NewLine"))
-        ];
+    private static readonly IReadOnlyList<LexemeRegistration> _lexemeRegistrations =
+    [
+        new(@"[ \t\r\n]+", "Whitespace", Ignore: true)
+    ];
 
-        foreach (var lexemePattern in lexemes) lexer.Configuration.TryUncheckedAddPattern(lexemePattern);
-        lexer.Configuration.LexemesToIgnore.AddRange(lexemes.Select(x => x.LexemeType));
-    }
+    public void InitLexer(ILexer lexer) => lexer.AddLexemes(_lexemeRegistrations);
 }


### PR DESCRIPTION
### Motivation
- Replace manual construction and ad-hoc lexer configuration in `WhitespaceModuleImpl` with the standardized lexeme registration pattern used across modules to keep lexer setup consistent and composable.

### Description
- Replace the `List<LexemePattern>` + `TryUncheckedAddPattern` loop and `LexemesToIgnore.AddRange` with a static `IReadOnlyList<LexemeRegistration>` named `_lexemeRegistrations` containing `new(@"[ \t\r\n]+", "Whitespace", Ignore: true)` and implement `InitLexer` as `public void InitLexer(ILexer lexer) => lexer.AddLexemes(_lexemeRegistrations);` while preserving module attributes and the public `WhitespaceModuleImpl : IFrontendCoreModule` contract; also added the missing `using BasicCore.Registration;`.

### Testing
- Installed .NET SDK `10.0.103`, ran `dotnet restore UniversalToolchain/Wist.sln` and `dotnet build UniversalToolchain/Wist.sln -c Release --no-restore`, and the solution built successfully.
- Ran `dotnet test UniversalToolchain/Tests/Tests.csproj -c Release --no-build` which passed (`29` tests), and `dotnet test UniversalToolchain/UniversalToolchain.Dialects.Tests/UniversalToolchain.Dialects.Tests.csproj -c Release --no-build` which passed (`261` tests); `dotnet test UniversalToolchain/UniversalToolchain.Modules.Tests/UniversalToolchain.Modules.Tests.csproj -c Release --no-build` failed with existing unrelated test failures in the repository state.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc19692f8083249953d5f6e4853674)