### PR TITLE
Use lazy thread-safe cache and Thrower-based guards in DefaultRuntimeComponentResolver

### DIFF
--- a/UniversalToolchain/UniversalToolchain.Dialects.Integration/DefaultRuntimeComponentResolver.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Integration/DefaultRuntimeComponentResolver.cs
@@ -1,21 +1,37 @@
 using System.Collections.Concurrent;
 using System.Reflection;
+using System.Threading;
+using ExceptionsManager;
 using UniversalToolchain.Dialects.Abstractions;
 
 namespace UniversalToolchain.Dialects.Integration;
 
-public sealed class DefaultRuntimeComponentResolver(IRuntimeAssemblyLoadStrategy assemblyLoadStrategy) : IRuntimeComponentResolver
+public sealed class DefaultRuntimeComponentResolver : IRuntimeComponentResolver
 {
-    private readonly IRuntimeAssemblyLoadStrategy _assemblyLoadStrategy = assemblyLoadStrategy ?? throw new ArgumentNullException(nameof(assemblyLoadStrategy));
-    private readonly ConcurrentDictionary<string, RuntimeComponentDescriptor> _cache = new(StringComparer.Ordinal);
+    private readonly IRuntimeAssemblyLoadStrategy _assemblyLoadStrategy;
+    private readonly ConcurrentDictionary<string, Lazy<RuntimeComponentDescriptor>> _cache = new(StringComparer.Ordinal);
+
+    public DefaultRuntimeComponentResolver(IRuntimeAssemblyLoadStrategy assemblyLoadStrategy)
+    {
+        if (assemblyLoadStrategy == null)
+            Thrower.ArgumentNull(nameof(assemblyLoadStrategy));
+
+        _assemblyLoadStrategy = assemblyLoadStrategy;
+    }
 
     public RuntimeComponentDescriptor Resolve(RuntimeComponentManifestEntry entry)
     {
         if (entry == null)
-            throw new ArgumentNullException(nameof(entry));
+            Thrower.ArgumentNull(nameof(entry));
 
         var key = $"{entry.AssemblySimpleName}|{entry.ComponentId.Value}";
-        return _cache.GetOrAdd(key, _ => ResolveCore(entry));
+        var lazy = _cache.GetOrAdd(
+            key,
+            _ => new Lazy<RuntimeComponentDescriptor>(
+                () => ResolveCore(entry),
+                LazyThreadSafetyMode.ExecutionAndPublication));
+
+        return lazy.Value;
     }
 
     private RuntimeComponentDescriptor ResolveCore(RuntimeComponentManifestEntry entry)
@@ -35,7 +51,7 @@ public sealed class DefaultRuntimeComponentResolver(IRuntimeAssemblyLoadStrategy
             return new RuntimeComponentDescriptor(id, kind, canonicalAlias, aliases, type);
         }
 
-        throw new InvalidOperationException(
+        return Thrower.InvalidOpEx<RuntimeComponentDescriptor>(
             $"Runtime component '{entry.ComponentId}' was not found in assembly '{entry.AssemblySimpleName}'.");
     }
 


### PR DESCRIPTION
### Motivation

- Ensure resolved `RuntimeComponentDescriptor` instances are initialized lazily and safely under concurrent access, and align null/exception handling with the project `Thrower` policy.

### Description

- Change `_cache` to `ConcurrentDictionary<string, Lazy<RuntimeComponentDescriptor>>` and store entries using `new Lazy<RuntimeComponentDescriptor>(() => ResolveCore(entry), LazyThreadSafetyMode.ExecutionAndPublication)` via `GetOrAdd`.
- Return the resolved descriptor via `lazy.Value` instead of returning the value directly from the dictionary factory.
- Replace direct null checks/throws with `Thrower.ArgumentNull(...)` in the constructor and in `Resolve(RuntimeComponentManifestEntry entry)`.
- Replace the direct `InvalidOperationException` in the not-found case with `Thrower.InvalidOpEx<RuntimeComponentDescriptor>(...)`, and add the required `using` directives for `ExceptionsManager` and `System.Threading`.

### Testing

- Ran `dotnet restore` and `dotnet build` for the solution and the build succeeded.
- Ran `dotnet test` for `UniversalToolchain/Tests/Tests.csproj` which passed (29 tests passed).
- Ran `dotnet test` for `UniversalToolchain/UniversalToolchain.Modules.Tests/UniversalToolchain.Modules.Tests.csproj` which produced failures (12 failed, 106 passed), which appear unrelated to this change.
- Ran `dotnet test` for `UniversalToolchain/UniversalToolchain.Dialects.Tests/UniversalToolchain.Dialects.Tests.csproj` which passed (261 tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc197b73b8832496d894c74d9b5b03)