### PR TITLE
Add unary minus AST creator and visitor

### DIFF
--- a/UniversalToolchain/ArithmeticModule/Creators/UnaryMinusOperationNodeCreator.cs
+++ b/UniversalToolchain/ArithmeticModule/Creators/UnaryMinusOperationNodeCreator.cs
@@ -1,0 +1,62 @@
+namespace ArithmeticModule.Creators;
+
+public class UnaryMinusOperationNodeCreator : IAstNodeCreator
+{
+    private static readonly ExtensibleEnum<AstNodeTag> _substractionNodeType = ExtensibleEnum<AstNodeTag>.CreateOrGet("Substraction");
+    private static readonly ExtensibleEnum<AstNodeTag> _unaryMinusNodeType = ExtensibleEnum<AstNodeTag>.CreateOrGet("UnaryMinus");
+
+    private static readonly HashSet<ExtensibleEnum<AstNodeTag>> _nonOperandNodeTypes =
+    [
+        ExtensibleEnum<AstNodeTag>.CreateOrGet("Addition"),
+        ExtensibleEnum<AstNodeTag>.CreateOrGet("Substraction"),
+        ExtensibleEnum<AstNodeTag>.CreateOrGet("Multiplication"),
+        ExtensibleEnum<AstNodeTag>.CreateOrGet("Division"),
+        ExtensibleEnum<AstNodeTag>.CreateOrGet("OpenPar"),
+        ExtensibleEnum<AstNodeTag>.CreateOrGet("ClosePar"),
+        ExtensibleEnum<AstNodeTag>.CreateOrGet("Let"),
+        ExtensibleEnum<AstNodeTag>.CreateOrGet("If"),
+        ExtensibleEnum<AstNodeTag>.CreateOrGet("Else"),
+        ExtensibleEnum<AstNodeTag>.CreateOrGet("While"),
+        ExtensibleEnum<AstNodeTag>.CreateOrGet("Equality"),
+        ExtensibleEnum<AstNodeTag>.CreateOrGet("Colon")
+    ];
+
+    public ExtensibleEnum<AstNodeTag> AstNodeType => _substractionNodeType;
+
+    public bool TryCreateNode(AstNode scope, int childIndex)
+    {
+        var currentNode = scope.SafeGet(childIndex);
+        if (currentNode?.NodeType != _substractionNodeType)
+            return false;
+
+        if (HasCompletedLeftOperand(scope, childIndex))
+            return false;
+
+        var rightOperand = scope.SafeGet(childIndex + 1);
+        if (rightOperand == null || !IsOperandNode(rightOperand))
+            return false;
+
+        currentNode.NodeType = _unaryMinusNodeType;
+        currentNode.Children.Add(rightOperand);
+        scope.Children.RemoveAt(childIndex + 1);
+
+        return true;
+    }
+
+    private bool HasCompletedLeftOperand(AstNode scope, int childIndex)
+    {
+        if (childIndex <= 0)
+            return false;
+
+        var leftNode = scope.SafeGet(childIndex - 1);
+        if (leftNode == null)
+            return false;
+
+        return IsOperandNode(leftNode);
+    }
+
+    private static bool IsOperandNode(AstNode node)
+    {
+        return !_nonOperandNodeTypes.Contains(node.NodeType);
+    }
+}

--- a/UniversalToolchain/ArithmeticModule/Module/ArithmeticModuleImpl.cs
+++ b/UniversalToolchain/ArithmeticModule/Module/ArithmeticModuleImpl.cs
@@ -18,6 +18,7 @@ public class ArithmeticModuleImpl : IFrontendCoreModule
 
     private static readonly IReadOnlyList<NodeCreatorRegistration> _nodeCreatorRegistrations =
     [
+        new(-40f, new UnaryMinusOperationNodeCreator()),
         new(-31f, new MultiplicationOperationNodeCreator()),
         new(-31f, new DivisionOperationNodeCreator()),
         new(-30f, new AdditionOperationNodeCreator()),
@@ -28,5 +29,6 @@ public class ArithmeticModuleImpl : IFrontendCoreModule
 
     public void InitParser(IParser parser) => parser.AddNodeCreators(_nodeCreatorRegistrations);
 
-    public void InitAstTranslator(IAstToBytecodeTranslator translator) => translator.AddVisitors(new ArithmeticAstVisitor());
+    public void InitAstTranslator(IAstToBytecodeTranslator translator) =>
+        translator.AddVisitors(new UnaryMinusAstVisitor(), new ArithmeticAstVisitor());
 }

--- a/UniversalToolchain/ArithmeticModule/Visitors/UnaryMinusAstVisitor.cs
+++ b/UniversalToolchain/ArithmeticModule/Visitors/UnaryMinusAstVisitor.cs
@@ -1,0 +1,31 @@
+namespace ArithmeticModule.Visitors;
+
+[AutoRegisterService]
+[ArithmeticModeCompatibility(ArithmeticMode.Universal)]
+public class UnaryMinusAstVisitor : IAstVisitor
+{
+    private static readonly ExtensibleEnum<AstNodeTag> _unaryMinusNodeType = ExtensibleEnum<AstNodeTag>.CreateOrGet("UnaryMinus");
+    private static readonly ExtensibleEnum<AstNodeTag> _numberNodeType = ExtensibleEnum<AstNodeTag>.CreateOrGet("Number");
+
+    public void TryVisit(BytecodeVisitorData data)
+    {
+        if (data.Node.NodeType != _unaryMinusNodeType)
+            return;
+
+        var zeroNode = new AstNode(_numberNodeType, new LexemeValue("0", null, -1, null), []);
+        data.AstToBytecodeTranslator.Translate(zeroNode);
+
+        var operand = data.Node.Children.FirstOrDefault();
+        if (operand == null)
+            return;
+
+        data.AstToBytecodeTranslator.Translate(operand);
+
+        var subMethod = new AbstractMethodImpl(
+            "Op_-",
+            (il, context) => il.CallCSharp(context.Stack[^1].GetMethod("Sub").NotNull())
+        );
+
+        data.Bytecode.Instructions.Add(new BytecodeInstruction(subMethod));
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Modules.Tests/ModuleCoverage/NumbersModulePipelineTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Modules.Tests/ModuleCoverage/NumbersModulePipelineTests.cs
@@ -15,10 +15,12 @@ public class NumbersModulePipelineTests
     }
 
     [Test]
-    public void Numbers_StandaloneNegativeLiteral_FailsWithoutUnaryMinusSupport()
+    public void Numbers_StandaloneNegativeLiteral_ExecutesToExpectedValue()
     {
         using var h = new ModulePipelineTestHelper();
-        h.AssertFails("-13", Modules, "token");
+        var r = h.ExecuteBoth("-13", Modules);
+        ModulePipelineTestHelper.AssertParity(r.Compiler, r.Interpreter);
+        Assert.That(ModulePipelineTestHelper.AsNumber(r.Compiler), Is.EqualTo(-13));
     }
 
     [Test]


### PR DESCRIPTION
### Motivation
- Support unary negation so expressions like `-13` and `10-23` are parsed and compiled as unary minus rather than only binary subtraction.
- Keep parsing/AST rules consistent with existing creator/visitor patterns and avoid hardcoding dialect-specific behavior.

### Description
- Added `UnaryMinusOperationNodeCreator` (`ArithmeticModule/Creators/UnaryMinusOperationNodeCreator.cs`) that only handles nodes of type `Substraction`, treats the token as unary when there is no completed left operand (via `HasCompletedLeftOperand`) and a valid right operand exists, replaces the node type with `UnaryMinus`, attaches the right operand as the single child and removes the right sibling from `scope.Children`.
- Introduced `HasCompletedLeftOperand(AstNode scope, int childIndex)` logic inside the creator that considers a set of non-operand boundary node types (scopes/operators/`(`/`let`/`if`/`else`/`while`/`=`/`:`) to determine whether the left side is a completed operand/expression.
- Added `UnaryMinusAstVisitor` (`ArithmeticModule/Visitors/UnaryMinusAstVisitor.cs`) that only visits `UnaryMinus` nodes, emits code by first pushing a synthetic `0` number node (reusing the `Number` translation path), then translates the operand and appends the same `Sub` bytecode instruction used for binary subtraction.
- Wired the new creator and visitor into the module: `ArithmeticModuleImpl` now registers the creator with stronger priority (`-40f`) before `*`/`/` and adds `UnaryMinusAstVisitor` to `InitAstTranslator` before the existing `ArithmeticAstVisitor`.
- Updated test expectation in `NumbersModulePipelineTests` to assert that `-13` evaluates to `-13` instead of failing.

### Testing
- `dotnet restore` and `dotnet build` for the solution succeeded (`dotnet build UniversalToolchain/Wist.sln -c Release --no-restore` passed).
- `dotnet test UniversalToolchain/Tests/Tests.csproj -c Release --no-build` passed (29 tests passed).
- `dotnet test UniversalToolchain/UniversalToolchain.Dialects.Tests/UniversalToolchain.Dialects.Tests.csproj -c Release --no-build` passed (261 tests passed).
- Full `UniversalToolchain.Modules.Tests` run failed with unrelated existing failures in several modules (12 failed, 106 passed); however the focused tests covering numbers and arithmetic passed when filtered: `NumbersModulePipelineTests` and `ArithmeticModuleIsolationTests` passed (20 tests passed in the filtered run).
- Local build of `ArithmeticModule` succeeded (`dotnet build UniversalToolchain/ArithmeticModule/ArithmeticModule.csproj` passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc193f7e0c8324a9986d0f5ccad5c4)