### PR TITLE
Use Thrower.ArgumentNull guard in DefaultRuntimeComponentTypeLoader constructor

### DIFF
--- a/UniversalToolchain/UniversalToolchain.Dialects.Integration/DefaultRuntimeComponentTypeLoader.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Integration/DefaultRuntimeComponentTypeLoader.cs
@@ -8,7 +8,10 @@ public sealed class DefaultRuntimeComponentTypeLoader : IRuntimeComponentTypeLoa
 
     public DefaultRuntimeComponentTypeLoader(IRuntimeComponentResolver resolver)
     {
-        _resolver = resolver ?? throw new ArgumentNullException(nameof(resolver));
+        if (resolver == null)
+            Thrower.ArgumentNull(nameof(resolver));
+
+        _resolver = resolver;
     }
 
 


### PR DESCRIPTION
### Motivation
- Replace the inline `ArgumentNullException` guard with the project's centralized `Thrower.ArgumentNull` helper for consistent exception behavior in the runtime component type loader constructor.

### Description
- In `UniversalToolchain/UniversalToolchain.Dialects.Integration/DefaultRuntimeComponentTypeLoader.cs` the constructor now calls `Thrower.ArgumentNull(nameof(resolver))` when `resolver` is null and then assigns `_resolver`, and the `LoadType` method is left unchanged.

### Testing
- Ran `dotnet restore UniversalToolchain/Wist.sln` and `dotnet build UniversalToolchain/Wist.sln -c Release --no-restore` which succeeded, ran `dotnet test UniversalToolchain/Tests/Tests.csproj -c Release --no-build` which passed, and observed that `UniversalToolchain.Modules.Tests` and `UniversalToolchain.Dialects.Tests` contain pre-existing unrelated failing tests (failures reproduced when running `dotnet test` for those projects).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc198797088324b8b172c55fd96ffd)