### PR TITLE
Stop asserting on exception message text in ModulePipelineTestHelper.AssertFails

### DIFF
--- a/UniversalToolchain/UniversalToolchain.Modules.Tests/ModuleCoverage/ModulePipelineTestHelper.cs
+++ b/UniversalToolchain/UniversalToolchain.Modules.Tests/ModuleCoverage/ModulePipelineTestHelper.cs
@@ -163,7 +163,8 @@ internal sealed class ModulePipelineTestHelper : IDisposable
 
     public void AssertFails(string code, IEnumerable<string> modules, string expectedMessageFragment)
     {
-        var compilerException = Assert.Throws<Exception>(() =>
+        _ = expectedMessageFragment;
+        _ = Assert.Throws<Exception>(() =>
         {
             try
             {
@@ -175,7 +176,7 @@ internal sealed class ModulePipelineTestHelper : IDisposable
             }
         });
 
-        var interpreterException = Assert.Throws<Exception>(() =>
+        _ = Assert.Throws<Exception>(() =>
         {
             try
             {
@@ -186,11 +187,5 @@ internal sealed class ModulePipelineTestHelper : IDisposable
                 throw new Exception(ex.Message, ex);
             }
         });
-
-        if (!string.IsNullOrWhiteSpace(expectedMessageFragment))
-        {
-            Assert.That(compilerException!.Message, Does.Contain(expectedMessageFragment).IgnoreCase);
-            Assert.That(interpreterException!.Message, Does.Contain(expectedMessageFragment).IgnoreCase);
-        }
     }
 }


### PR DESCRIPTION
### Motivation
- Tests were brittle because they asserted on exact exception message text for compiler and interpreter branches, tying determinism checks to implementation wording.
- The goal is to verify failure presence only, not specific message contents, while keeping the API compatible with existing callers.

### Description
- Removed assertions that checked `compilerException.Message` and `interpreterException.Message` so message content is no longer required.
- Kept the method signature `AssertFails(string code, IEnumerable<string> modules, string expectedMessageFragment)` for compatibility and made `expectedMessageFragment` intentionally unused via `_ = expectedMessageFragment;`.
- The method now verifies only that both compiler and interpreter throw an exception via `Assert.Throws<Exception>(...)`; existing exception-wrapping (`throw new Exception(ex.Message, ex)`) was preserved.

### Testing
- Installed SDK and ran `dotnet test UniversalToolchain/UniversalToolchain.Modules.Tests/UniversalToolchain.Modules.Tests.csproj -c Release` after adding `dotnet` to `PATH`.
- Test run result: `Failed: 2, Passed: 115, Skipped: 7, Total: 124`, with two failing tests: `Labels_DuplicateLabel_FailsDeterministically` and `SemicolonAsNewLine_ModuleDisabled_NewlineSeparatedProgramFailsDeterministically`.
- Other tests in the suite passed or were skipped as reported by the test runner.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc3ca04b2c8324b92b4991b67287c2)