### PR TITLE
docs: align minimal-arithmetic-native run command with CIL backend

### DIFF
--- a/UniversalToolchain/Dialects/examples/wist/minimal-arithmetic-native/README.md
+++ b/UniversalToolchain/Dialects/examples/wist/minimal-arithmetic-native/README.md
@@ -21,7 +21,7 @@ From repository root:
 
 ```bash
 dotnet run --project UniversalToolchain/Wistc/Wistc.csproj -- dialect-inspect --file UniversalToolchain/Dialects/examples/wist/minimal-arithmetic-native/dialect.wistdialect
-dotnet run --project UniversalToolchain/Wistc/Wistc.csproj -- run --dialect-file UniversalToolchain/Dialects/examples/wist/minimal-arithmetic-native/dialect.wistdialect --file UniversalToolchain/Dialects/examples/wist/minimal-arithmetic-native/program.wist --mode interpreter
+dotnet run --project UniversalToolchain/Wistc/Wistc.csproj -- run --dialect-file UniversalToolchain/Dialects/examples/wist/minimal-arithmetic-native/dialect.wistdialect --file UniversalToolchain/Dialects/examples/wist/minimal-arithmetic-native/program.wist --mode compiler
 ```
 
 ## Expected behavior/result


### PR DESCRIPTION
### Motivation
- Ensure the example README accurately reflects the configured backend by aligning the `run` CLI example with the declared `Backend: cil` and the note that there is `No interpreter backend`.

### Description
- Updated `UniversalToolchain/Dialects/examples/wist/minimal-arithmetic-native/README.md` to replace the `run` example's `--mode interpreter` with `--mode compiler` so the CLI example and `Enabled modules/backends/features` are consistent.

### Testing
- Verified the README content change with file inspections using `sed -n '1,240p' UniversalToolchain/Dialects/examples/wist/minimal-arithmetic-native/README.md` and `nl -ba UniversalToolchain/Dialects/examples/wist/minimal-arithmetic-native/README.md`, and the checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc3ca2abcc8324a4cda5468e427826)