### PR TITLE
Add immutable compiled artifact contract and implementation

### DIFF
--- a/UniversalToolchain/BasicCore/Compilation/CompiledArtifact.cs
+++ b/UniversalToolchain/BasicCore/Compilation/CompiledArtifact.cs
@@ -1,0 +1,78 @@
+namespace BasicCore.Compilation;
+
+/// <summary>
+/// Default immutable implementation of <see cref="ICompiledArtifact{TCompilationOutput}"/>.
+/// </summary>
+/// <typeparam name="TCompilationOutput">Compilation backend output type.</typeparam>
+public sealed class CompiledArtifact<TCompilationOutput> : ICompiledArtifact<TCompilationOutput>
+{
+    private readonly ExternalBinding[] _declaredBindings;
+    private readonly IReadOnlyDictionary<string, int> _slotsByName;
+
+    public CompiledArtifact(string sourceText, IReadOnlyList<ExternalBinding> declaredBindings, TCompilationOutput compilationOutput)
+    {
+        if (sourceText is null)
+            Thrower.ArgumentNull(nameof(sourceText));
+
+        if (declaredBindings is null)
+            Thrower.ArgumentNull(nameof(declaredBindings));
+
+        _declaredBindings = SnapshotBindings(declaredBindings);
+        _slotsByName = BuildSlots(_declaredBindings);
+
+        SourceText = sourceText;
+        CompilationOutput = compilationOutput;
+    }
+
+    public string SourceText { get; }
+
+    public IReadOnlyList<ExternalBinding> DeclaredBindings => _declaredBindings;
+
+    public IReadOnlyDictionary<string, int> SlotsByName => _slotsByName;
+
+    public TCompilationOutput CompilationOutput { get; }
+
+    public IExecutionEnvironment CreateSession() => new ExecutionEnvironment(_declaredBindings);
+
+    private static ExternalBinding[] SnapshotBindings(IReadOnlyList<ExternalBinding> declaredBindings)
+    {
+        var snapshot = new ExternalBinding[declaredBindings.Count];
+
+        for (var i = 0; i < declaredBindings.Count; i++)
+        {
+            var binding = declaredBindings[i];
+            if (binding is null)
+                Thrower.Argument(nameof(declaredBindings), "Declared bindings must not contain null entries.");
+
+            if (string.IsNullOrWhiteSpace(binding.Name))
+                Thrower.Argument(nameof(declaredBindings), "Declared binding name must not be empty.");
+
+            if (binding.Type is null)
+                Thrower.Argument(nameof(declaredBindings), "Declared binding type must not be null.");
+
+            snapshot[i] = new ExternalBinding
+            {
+                Name = binding.Name,
+                Type = binding.Type,
+                Value = binding.Value,
+                Kind = binding.Kind
+            };
+        }
+
+        return snapshot;
+    }
+
+    private static IReadOnlyDictionary<string, int> BuildSlots(IReadOnlyList<ExternalBinding> declaredBindings)
+    {
+        var slots = new Dictionary<string, int>(declaredBindings.Count, StringComparer.Ordinal);
+
+        for (var i = 0; i < declaredBindings.Count; i++)
+        {
+            var name = declaredBindings[i].Name;
+            if (!slots.TryAdd(name, i))
+                Thrower.Argument(nameof(declaredBindings), $"Declared binding '{name}' is duplicated.");
+        }
+
+        return slots;
+    }
+}

--- a/UniversalToolchain/BasicCore/Compilation/ICompiledArtifact.cs
+++ b/UniversalToolchain/BasicCore/Compilation/ICompiledArtifact.cs
@@ -1,0 +1,33 @@
+namespace BasicCore.Compilation;
+
+/// <summary>
+/// Represents an immutable compiled artifact snapshot that can spawn execution sessions.
+/// </summary>
+/// <typeparam name="TCompilationOutput">Compilation backend output type.</typeparam>
+public interface ICompiledArtifact<out TCompilationOutput>
+{
+    /// <summary>
+    /// Gets source text used to produce this artifact.
+    /// </summary>
+    string SourceText { get; }
+
+    /// <summary>
+    /// Gets declared external bindings snapshot used at compilation time.
+    /// </summary>
+    IReadOnlyList<ExternalBinding> DeclaredBindings { get; }
+
+    /// <summary>
+    /// Gets name-to-slot mapping for external bindings.
+    /// </summary>
+    IReadOnlyDictionary<string, int> SlotsByName { get; }
+
+    /// <summary>
+    /// Gets compiled output payload.
+    /// </summary>
+    TCompilationOutput CompilationOutput { get; }
+
+    /// <summary>
+    /// Creates a new execution session initialized with declared binding values.
+    /// </summary>
+    IExecutionEnvironment CreateSession();
+}

--- a/UniversalToolchain/Tests/Infrastructure/CompiledArtifactTests.cs
+++ b/UniversalToolchain/Tests/Infrastructure/CompiledArtifactTests.cs
@@ -1,0 +1,67 @@
+namespace Tests.Infrastructure;
+
+[TestFixture]
+public class CompiledArtifactTests
+{
+    [Test]
+    public void Constructor_ShouldCopyDeclaredBindingsSnapshot()
+    {
+        var sourceBindings = new List<ExternalBinding>
+        {
+            new() { Name = "x", Type = typeof(int), Value = 10, Kind = ExternalBindingKind.Variable }
+        };
+
+        var artifact = new CompiledArtifact<string>("x", sourceBindings, "compiled");
+        sourceBindings[0] = new ExternalBinding { Name = "changed", Type = typeof(string), Value = "bad", Kind = ExternalBindingKind.Constant };
+
+        Assert.That(artifact.DeclaredBindings, Has.Count.EqualTo(1));
+        Assert.That(artifact.DeclaredBindings[0].Name, Is.EqualTo("x"));
+        Assert.That(artifact.DeclaredBindings[0].Type, Is.EqualTo(typeof(int)));
+        Assert.That(artifact.DeclaredBindings[0].Value, Is.EqualTo(10));
+    }
+
+    [Test]
+    public void Constructor_ShouldUseOrdinalSlotsAndAllowCaseDistinctNames()
+    {
+        var bindings = new List<ExternalBinding>
+        {
+            new() { Name = "x", Type = typeof(int), Value = 1, Kind = ExternalBindingKind.Variable },
+            new() { Name = "X", Type = typeof(int), Value = 2, Kind = ExternalBindingKind.Variable }
+        };
+
+        var artifact = new CompiledArtifact<int>("x + X", bindings, 123);
+
+        Assert.That(artifact.SlotsByName["x"], Is.EqualTo(0));
+        Assert.That(artifact.SlotsByName["X"], Is.EqualTo(1));
+    }
+
+    [Test]
+    public void CreateSession_ShouldCreateIndependentExecutionEnvironmentWithDeclaredValues()
+    {
+        var bindings = new List<ExternalBinding>
+        {
+            new() { Name = "x", Type = typeof(int), Value = 5, Kind = ExternalBindingKind.Variable }
+        };
+
+        var artifact = new CompiledArtifact<string>("x", bindings, "compiled");
+
+        var first = artifact.CreateSession();
+        var second = artifact.CreateSession();
+        first.SetExternalValue(0, 42);
+
+        Assert.That(first.GetExternalValue(0), Is.EqualTo(42));
+        Assert.That(second.GetExternalValue(0), Is.EqualTo(5));
+    }
+
+    [Test]
+    public void Constructor_WithDuplicateBindingName_ShouldThrow()
+    {
+        var bindings = new List<ExternalBinding>
+        {
+            new() { Name = "x", Type = typeof(int), Kind = ExternalBindingKind.Variable },
+            new() { Name = "x", Type = typeof(int), Kind = ExternalBindingKind.Variable }
+        };
+
+        Assert.Throws<ArgumentException>(() => new CompiledArtifact<string>("x", bindings, "compiled"));
+    }
+}


### PR DESCRIPTION
### Motivation

- Provide a reusable contract and concrete implementation for an immutable compiled artifact snapshot that can spawn execution sessions. 
- Capture compilation-time declared bindings and mapping to external slots so downstream runtime code can create consistent environments. 
- Keep the implementation framework-agnostic and avoid any Wist-specific logic or hardcoded dialect assumptions.

### Description

- Add `ICompiledArtifact<TCompilationOutput>` with members `SourceText`, `DeclaredBindings`, `SlotsByName`, `CompilationOutput`, and `CreateSession()` in `BasicCore/Compilation/ICompiledArtifact.cs`. 
- Implement `CompiledArtifact<TCompilationOutput>` in `BasicCore/Compilation/CompiledArtifact.cs` which validates inputs via `Thrower`, snapshots declared bindings into an internal immutable array, builds `SlotsByName` using `StringComparer.Ordinal`, and exposes `CreateSession()` that returns an `ExecutionEnvironment` backed by the snapshot. 
- Validation covers null inputs, missing binding names/types, null entries, and duplicate binding names. 
- Add unit tests `UniversalToolchain/Tests/Infrastructure/CompiledArtifactTests.cs` covering snapshot isolation, case-sensitive slot mapping, independent sessions, and duplicate-name rejection.

### Testing

- Restored the solution with `dotnet restore UniversalToolchain/Wist.sln` successfully. 
- Ran full test suite with `/tmp/dotnet/dotnet test UniversalToolchain/Wist.sln -c Release --no-restore` and observed all tests pass for the affected projects. 
- New artifact tests executed as part of the above run and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ccf50815908324912808fcaabb847e)