### PR TITLE
Refactor BasicCore prepared execution to use compiled artifacts

### DIFF
--- a/UniversalToolchain/BasicCore/Core/BasicCoreImpl.cs
+++ b/UniversalToolchain/BasicCore/Core/BasicCoreImpl.cs
@@ -37,7 +37,7 @@ public class BasicCoreImpl<TCompilationOutput>(
     {
         var prepared = _prepared.Value;
         Thrower.AssertAlways(prepared != null);
-        return prepared.Executor.Execute(prepared.CompilationOutput, prepared.ExecutionEnvironment);
+        return prepared.Session.Run();
     }
 
     public object? Run(string code, Dictionary<string, object>? parameters = null)
@@ -48,13 +48,16 @@ public class BasicCoreImpl<TCompilationOutput>(
     }
 
     public TCompilationOutput GetExecutable(string code, OrderedDictionary<string, Type>? parameters = null)
-    {
-        PrepareToRun(code, parameters);
-        return _prepared.Value!.CompilationOutput;
-    }
+        => Compile(code, parameters).CompilationOutput;
 
     public void PrepareToRun(CompilationInput input)
     {
         _prepared.Value = _preparedExecutionBuilder.Build(input);
     }
+
+    public ICompiledArtifact<TCompilationOutput> Compile(string code, OrderedDictionary<string, Type>? parameters = null)
+        => Compile(_inputNormalizer.NormalizeDeclaredInput(code, parameters));
+
+    public ICompiledArtifact<TCompilationOutput> Compile(CompilationInput input)
+        => _preparedExecutionBuilder.Compile(input);
 }

--- a/UniversalToolchain/BasicCore/Core/PreparedExecution.cs
+++ b/UniversalToolchain/BasicCore/Core/PreparedExecution.cs
@@ -2,15 +2,12 @@ namespace BasicCore.Core;
 
 internal sealed class PreparedExecution<TCompilationOutput>(
     string sourceText,
-    TCompilationOutput compilationOutput,
-    IExecutor<TCompilationOutput> executor,
-    IExecutionEnvironment executionEnvironment)
+    ICompiledArtifact<TCompilationOutput> artifact,
+    ICompiledArtifactSession session)
 {
     public string SourceText { get; } = sourceText;
 
-    public TCompilationOutput CompilationOutput { get; } = compilationOutput;
+    public ICompiledArtifact<TCompilationOutput> Artifact { get; } = artifact;
 
-    public IExecutor<TCompilationOutput> Executor { get; } = executor;
-
-    public IExecutionEnvironment ExecutionEnvironment { get; } = executionEnvironment;
+    public ICompiledArtifactSession Session { get; } = session;
 }

--- a/UniversalToolchain/BasicCore/Core/PreparedExecutionBuilder.cs
+++ b/UniversalToolchain/BasicCore/Core/PreparedExecutionBuilder.cs
@@ -11,7 +11,7 @@ internal sealed class PreparedExecutionBuilder<TCompilationOutput>(
     IReadOnlyList<IIRProcessingModule> optimizers,
     IReadOnlyList<IMiddleEndCoreModule<TCompilationOutput>> middleEndModules)
 {
-    public PreparedExecution<TCompilationOutput> Build(CompilationInput input)
+    public ICompiledArtifact<TCompilationOutput> Compile(CompilationInput input)
     {
         var lexer = lexerFactory();
         var parser = parserFactory();
@@ -45,10 +45,34 @@ internal sealed class PreparedExecutionBuilder<TCompilationOutput>(
         var compilationOutput = middleEndModules.Aggregate(compiled, (current, module) => module.ProcessCompilation(current));
         middleEndModules.ForEach(module => module.InitExecutor(executor));
 
-        return new PreparedExecution<TCompilationOutput>(
+        var slotsByName = new Dictionary<string, int>(input.ExternalBindings.Count, StringComparer.Ordinal);
+        for (var i = 0; i < input.ExternalBindings.Count; i++)
+        {
+            var binding = input.ExternalBindings[i];
+            if (!slotsByName.TryAdd(binding.Name, i))
+                Thrower.Argument(nameof(input), $"Declared binding '{binding.Name}' is duplicated.");
+        }
+
+        _ = slotsByName;
+
+        return new CompiledArtifact<TCompilationOutput>(
             input.SourceText,
-            compilationOutput,
-            executor,
-            new ExecutionEnvironment(input.ExternalBindings));
+            input.ExternalBindings,
+            compilationOutput);
+    }
+
+    public PreparedExecution<TCompilationOutput> Build(CompilationInput input)
+    {
+        var artifact = Compile(input);
+        var session = new CompiledArtifactSession<TCompilationOutput>(
+            artifact.CompilationOutput,
+            executorFactory(),
+            artifact.CreateSession(),
+            artifact.DeclaredBindings);
+
+        return new PreparedExecution<TCompilationOutput>(
+            artifact.SourceText,
+            artifact,
+            session);
     }
 }


### PR DESCRIPTION
### Motivation
- Decouple compilation from session creation so compiled outputs can be reused without forcing a prepared session. 
- Make compiled artifacts a first-class result of the pipeline and simplify prepared-execution state. 
- Preserve existing `PrepareToRun`/`Run` surface for backward compatibility while adding explicit `Compile` APIs.

### Description
- Added `PreparedExecutionBuilder.Compile(CompilationInput)` which runs the existing compilation pipeline and returns an `ICompiledArtifact<TCompilationOutput>`, and kept `Build(CompilationInput)` as a thin wrapper that calls `Compile(...)`, creates a session, and returns `PreparedExecution` (changes in `PreparedExecutionBuilder.cs`).
- Simplified `PreparedExecution` to store only `SourceText`, `Artifact`, and `Session` (changed in `PreparedExecution.cs`).
- Added public overloads `Compile(string, OrderedDictionary<string, Type>?)` and `Compile(CompilationInput)` to `BasicCoreImpl`, switched `GetExecutable(...)` to `Compile(...).CompilationOutput`, and changed `RunPrepared()` to invoke `prepared.Session.Run()` (changes in `BasicCoreImpl.cs`).
- Added explicit slot-name building with duplicate-name validation when producing the `CompiledArtifact` so declared-binding slots are validated during `Compile`.

### Testing
- Ran `dotnet restore UniversalToolchain/Wist.sln` and the restore completed successfully. 
- Ran `dotnet build UniversalToolchain/Wist.sln -c Release --no-restore` and the build succeeded with no warnings or errors. 
- Ran `dotnet test UniversalToolchain/Tests/Tests.csproj -c Release --no-build` and the test run passed (29 tests passed). 
- Ran `dotnet test UniversalToolchain/UniversalToolchain.Modules.Tests/UniversalToolchain.Modules.Tests.csproj -c Release --no-build` and the test run passed (117 passed, 7 skipped). 
- Ran `dotnet test UniversalToolchain/UniversalToolchain.Dialects.Tests/UniversalToolchain.Dialects.Tests.csproj -c Release --no-build` and the test run passed (261 tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ccf8fdd83883249cead54644f624c8)