### PR TITLE
Add cached native delegate invoker API for DynamicMethod artifacts

### DIFF
--- a/UniversalToolchain/DynamicMethodCalling/CompiledArtifactDynamicMethodExtensions.cs
+++ b/UniversalToolchain/DynamicMethodCalling/CompiledArtifactDynamicMethodExtensions.cs
@@ -1,0 +1,62 @@
+namespace DynamicMethodCalling;
+
+/// <summary>
+/// Provides typed delegate access helpers for compiled <see cref="DynamicMethod"/> artifacts.
+/// </summary>
+public static class CompiledArtifactDynamicMethodExtensions
+{
+    private static readonly ConditionalWeakTable<ICompiledArtifact<DynamicMethod>, NativeDelegateInvoker> _invokers = new();
+
+    public static INativeDelegateInvoker GetNativeDelegateInvoker(this ICompiledArtifact<DynamicMethod> artifact)
+    {
+        if (artifact is null)
+            Thrower.ArgumentNull(nameof(artifact));
+
+        return _invokers.GetValue(artifact, CreateInvoker);
+    }
+
+    public static Func<TResult> AsFunc<TResult>(this ICompiledArtifact<DynamicMethod> artifact)
+    {
+        if (artifact is null)
+            Thrower.ArgumentNull(nameof(artifact));
+
+        return artifact.GetNativeDelegateInvoker().AsFunc<TResult>();
+    }
+
+    public static Func<T1, TResult> AsFunc<T1, TResult>(this ICompiledArtifact<DynamicMethod> artifact)
+    {
+        if (artifact is null)
+            Thrower.ArgumentNull(nameof(artifact));
+
+        return artifact.GetNativeDelegateInvoker().AsFunc<T1, TResult>();
+    }
+
+    public static Func<T1, T2, TResult> AsFunc<T1, T2, TResult>(this ICompiledArtifact<DynamicMethod> artifact)
+    {
+        if (artifact is null)
+            Thrower.ArgumentNull(nameof(artifact));
+
+        return artifact.GetNativeDelegateInvoker().AsFunc<T1, T2, TResult>();
+    }
+
+    public static Func<T1, T2, T3, TResult> AsFunc<T1, T2, T3, TResult>(this ICompiledArtifact<DynamicMethod> artifact)
+    {
+        if (artifact is null)
+            Thrower.ArgumentNull(nameof(artifact));
+
+        return artifact.GetNativeDelegateInvoker().AsFunc<T1, T2, T3, TResult>();
+    }
+
+    public static Func<T1, T2, T3, T4, TResult> AsFunc<T1, T2, T3, T4, TResult>(this ICompiledArtifact<DynamicMethod> artifact)
+    {
+        if (artifact is null)
+            Thrower.ArgumentNull(nameof(artifact));
+
+        return artifact.GetNativeDelegateInvoker().AsFunc<T1, T2, T3, T4, TResult>();
+    }
+
+    private static NativeDelegateInvoker CreateInvoker(ICompiledArtifact<DynamicMethod> artifact)
+    {
+        return new NativeDelegateInvoker(artifact.CompilationOutput);
+    }
+}

--- a/UniversalToolchain/DynamicMethodCalling/DynamicMethodCalling.csproj
+++ b/UniversalToolchain/DynamicMethodCalling/DynamicMethodCalling.csproj
@@ -8,6 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <ProjectReference Include="..\BasicCore\BasicCore.csproj"/>
         <ProjectReference Include="..\ExceptionsManager\ExceptionsManager.csproj"/>
         <ProjectReference Include="..\ObjectExtensions\ObjectExtensions.csproj"/>
     </ItemGroup>

--- a/UniversalToolchain/DynamicMethodCalling/GlobalUsings.cs
+++ b/UniversalToolchain/DynamicMethodCalling/GlobalUsings.cs
@@ -3,3 +3,5 @@ global using System.Reflection.Emit;
 global using System.Runtime.CompilerServices;
 global using ExceptionsManager;
 global using ObjectExtensions;
+global using System.Collections.Concurrent;
+global using BasicCore.Compilation;

--- a/UniversalToolchain/DynamicMethodCalling/INativeDelegateInvoker.cs
+++ b/UniversalToolchain/DynamicMethodCalling/INativeDelegateInvoker.cs
@@ -1,0 +1,21 @@
+namespace DynamicMethodCalling;
+
+/// <summary>
+/// Provides cached access to delegates created from a native <see cref="DynamicMethod"/>.
+/// </summary>
+public interface INativeDelegateInvoker
+{
+    /// <summary>
+    /// Gets a cached delegate instance for the requested delegate type.
+    /// </summary>
+    /// <typeparam name="TDelegate">Delegate signature type.</typeparam>
+    /// <returns>Cached delegate instance.</returns>
+    TDelegate GetDelegate<TDelegate>() where TDelegate : Delegate;
+
+    /// <summary>
+    /// Gets a cached delegate instance for the requested delegate type.
+    /// </summary>
+    /// <param name="delegateType">Delegate signature type.</param>
+    /// <returns>Cached delegate instance.</returns>
+    Delegate GetDelegate(Type delegateType);
+}

--- a/UniversalToolchain/DynamicMethodCalling/NativeDelegateInvoker.cs
+++ b/UniversalToolchain/DynamicMethodCalling/NativeDelegateInvoker.cs
@@ -1,0 +1,39 @@
+namespace DynamicMethodCalling;
+
+/// <summary>
+/// Creates and caches native delegates for a single <see cref="DynamicMethod"/>.
+/// </summary>
+public sealed class NativeDelegateInvoker : INativeDelegateInvoker
+{
+    private readonly DynamicMethod _dynamicMethod;
+    private readonly ConcurrentDictionary<Type, Delegate> _delegateCache = new();
+
+    public NativeDelegateInvoker(DynamicMethod dynamicMethod)
+    {
+        if (dynamicMethod is null)
+            Thrower.ArgumentNull(nameof(dynamicMethod));
+
+        _dynamicMethod = dynamicMethod;
+    }
+
+    public TDelegate GetDelegate<TDelegate>() where TDelegate : Delegate
+    {
+        return (TDelegate)GetDelegate(typeof(TDelegate));
+    }
+
+    public Delegate GetDelegate(Type delegateType)
+    {
+        if (delegateType is null)
+            Thrower.ArgumentNull(nameof(delegateType));
+
+        if (!typeof(Delegate).IsAssignableFrom(delegateType))
+            Thrower.Argument(nameof(delegateType), $"Type '{delegateType}' must be a delegate type.");
+
+        return _delegateCache.GetOrAdd(delegateType, CreateDelegate);
+    }
+
+    private Delegate CreateDelegate(Type delegateType)
+    {
+        return _dynamicMethod.CreateDelegate(delegateType);
+    }
+}

--- a/UniversalToolchain/DynamicMethodCalling/NativeDelegateInvokerExtensions.cs
+++ b/UniversalToolchain/DynamicMethodCalling/NativeDelegateInvokerExtensions.cs
@@ -1,0 +1,87 @@
+namespace DynamicMethodCalling;
+
+/// <summary>
+/// Provides typed delegate and invoke helpers for <see cref="INativeDelegateInvoker"/>.
+/// </summary>
+public static class NativeDelegateInvokerExtensions
+{
+    public static Func<TResult> AsFunc<TResult>(this INativeDelegateInvoker invoker)
+    {
+        if (invoker is null)
+            Thrower.ArgumentNull(nameof(invoker));
+
+        return invoker.GetDelegate<Func<TResult>>();
+    }
+
+    public static Func<T1, TResult> AsFunc<T1, TResult>(this INativeDelegateInvoker invoker)
+    {
+        if (invoker is null)
+            Thrower.ArgumentNull(nameof(invoker));
+
+        return invoker.GetDelegate<Func<T1, TResult>>();
+    }
+
+    public static Func<T1, T2, TResult> AsFunc<T1, T2, TResult>(this INativeDelegateInvoker invoker)
+    {
+        if (invoker is null)
+            Thrower.ArgumentNull(nameof(invoker));
+
+        return invoker.GetDelegate<Func<T1, T2, TResult>>();
+    }
+
+    public static Func<T1, T2, T3, TResult> AsFunc<T1, T2, T3, TResult>(this INativeDelegateInvoker invoker)
+    {
+        if (invoker is null)
+            Thrower.ArgumentNull(nameof(invoker));
+
+        return invoker.GetDelegate<Func<T1, T2, T3, TResult>>();
+    }
+
+    public static Func<T1, T2, T3, T4, TResult> AsFunc<T1, T2, T3, T4, TResult>(this INativeDelegateInvoker invoker)
+    {
+        if (invoker is null)
+            Thrower.ArgumentNull(nameof(invoker));
+
+        return invoker.GetDelegate<Func<T1, T2, T3, T4, TResult>>();
+    }
+
+    public static TResult Invoke<TResult>(this INativeDelegateInvoker invoker)
+    {
+        if (invoker is null)
+            Thrower.ArgumentNull(nameof(invoker));
+
+        return invoker.AsFunc<TResult>()();
+    }
+
+    public static TResult Invoke<T1, TResult>(this INativeDelegateInvoker invoker, T1 arg1)
+    {
+        if (invoker is null)
+            Thrower.ArgumentNull(nameof(invoker));
+
+        return invoker.AsFunc<T1, TResult>()(arg1);
+    }
+
+    public static TResult Invoke<T1, T2, TResult>(this INativeDelegateInvoker invoker, T1 arg1, T2 arg2)
+    {
+        if (invoker is null)
+            Thrower.ArgumentNull(nameof(invoker));
+
+        return invoker.AsFunc<T1, T2, TResult>()(arg1, arg2);
+    }
+
+    public static TResult Invoke<T1, T2, T3, TResult>(this INativeDelegateInvoker invoker, T1 arg1, T2 arg2, T3 arg3)
+    {
+        if (invoker is null)
+            Thrower.ArgumentNull(nameof(invoker));
+
+        return invoker.AsFunc<T1, T2, T3, TResult>()(arg1, arg2, arg3);
+    }
+
+    public static TResult Invoke<T1, T2, T3, T4, TResult>(this INativeDelegateInvoker invoker, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
+    {
+        if (invoker is null)
+            Thrower.ArgumentNull(nameof(invoker));
+
+        return invoker.AsFunc<T1, T2, T3, T4, TResult>()(arg1, arg2, arg3, arg4);
+    }
+}


### PR DESCRIPTION
### Motivation

- Provide a low-overhead, thread-safe way to obtain typed delegates from `DynamicMethod` artifacts and avoid reflection/`object[]` overhead on the hot path. 
- Expose a reusable extension point for `ICompiledArtifact<DynamicMethod>` so compiled dynamic methods can supply typed delegates consistently and without leaking implementation details.

### Description

- Added `INativeDelegateInvoker` with `GetDelegate<TDelegate>()` and `GetDelegate(Type)` to represent cached delegate access. 
- Implemented `NativeDelegateInvoker` that holds a `ConcurrentDictionary<Type, Delegate>` cache and creates delegates with `DynamicMethod.CreateDelegate(...)`. 
- Added typed helper extensions `AsFunc<TResult>`, `AsFunc<T1, TResult>`, `AsFunc<T1,T2,TResult>`, `AsFunc<T1,T2,T3,TResult>`, `AsFunc<T1,T2,T3,T4,TResult>` and typed `Invoke` overloads for `INativeDelegateInvoker` to ensure hot-path calls use strongly-typed delegates. 
- Added `CompiledArtifactDynamicMethodExtensions` with `GetNativeDelegateInvoker()` for `ICompiledArtifact<DynamicMethod>` and the same typed `AsFunc` helpers, caching invokers with a `ConditionalWeakTable`. 
- Integrated project references and global usings needed for `ICompiledArtifact` and `ConcurrentDictionary` support by adding a `BasicCore` project reference and required `global using` entries.

### Testing

- Restored and built the solution with `dotnet restore UniversalToolchain/Wist.sln` and `dotnet build UniversalToolchain/Wist.sln -c Release --no-restore`, and the build succeeded. 
- Ran unit tests: `dotnet test UniversalToolchain/Tests/Tests.csproj -c Release` which passed (29 passed), `dotnet test UniversalToolchain/UniversalToolchain.Modules.Tests/UniversalToolchain.Modules.Tests.csproj -c Release` which passed (117 passed, 7 skipped), and `dotnet test UniversalToolchain/UniversalToolchain.Dialects.Tests/UniversalToolchain.Dialects.Tests.csproj -c Release` which passed (261 passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ccff17bd7c83249cb92374f2c7f3a0)