### PR TITLE
Add runtime compiled-artifact contract tests and tighten session invoke validation

### DIFF
--- a/UniversalToolchain/BasicCore/Execution/CompiledArtifactSessionExtensions.cs
+++ b/UniversalToolchain/BasicCore/Execution/CompiledArtifactSessionExtensions.cs
@@ -62,6 +62,13 @@ public static class CompiledArtifactSessionExtensions
         if (arguments == null)
             Thrower.ArgumentNull(nameof(arguments));
 
+        if (arguments.Count != session.ArgumentCount)
+        {
+            Thrower.Argument(
+                nameof(arguments),
+                $"Expected {session.ArgumentCount} named arguments, but got {arguments.Count}.");
+        }
+
         foreach (var argument in arguments)
             session.SetArgument(argument.Key, argument.Value);
 

--- a/UniversalToolchain/Tests/Infrastructure/CompiledArtifactSessionTests.cs
+++ b/UniversalToolchain/Tests/Infrastructure/CompiledArtifactSessionTests.cs
@@ -6,7 +6,7 @@ public class CompiledArtifactSessionTests
     [Test]
     public void SetArgument_ShouldThrow_WhenSlotIsOutOfRange()
     {
-        var session = CreateSession();
+        var session = CreateSession(out _);
 
         Assert.Throws<ArgumentOutOfRangeException>(() => session.SetArgument(-1, 1));
         Assert.Throws<ArgumentOutOfRangeException>(() => session.SetArgument(2, 1));
@@ -15,7 +15,7 @@ public class CompiledArtifactSessionTests
     [Test]
     public void SetArgument_ShouldThrow_WhenValueIsNotAssignable()
     {
-        var session = CreateSession();
+        var session = CreateSession(out _);
 
         Assert.Throws<ArgumentException>(() => session.SetArgument(0, "bad"));
     }
@@ -23,7 +23,7 @@ public class CompiledArtifactSessionTests
     [Test]
     public void SetArgument_ShouldThrow_WhenNullAssignedToNonNullableValueType()
     {
-        var session = CreateSession();
+        var session = CreateSession(out _);
 
         Assert.Throws<ArgumentException>(() => session.SetArgument(0, null));
     }
@@ -31,17 +31,17 @@ public class CompiledArtifactSessionTests
     [Test]
     public void SetArgument_ByName_ShouldAssignValueToCorrespondingSlot()
     {
-        var session = CreateSession();
+        var session = CreateSession(out var environment);
 
         session.SetArgument("value", 7);
 
-        Assert.That(session.Environment.GetExternalValue(0), Is.EqualTo(7));
+        Assert.That(environment.GetExternalValue(0), Is.EqualTo(7));
     }
 
     [Test]
     public void Run_ShouldExecuteViaExecutor()
     {
-        var session = CreateSession();
+        var session = CreateSession(out _);
 
         session.SetArgument(0, 11);
         session.SetArgument(1, "abc");
@@ -54,7 +54,7 @@ public class CompiledArtifactSessionTests
     [Test]
     public void RunGeneric_ShouldReturnTypedResult()
     {
-        var session = CreateSession();
+        var session = CreateSession(out _);
 
         session.SetArgument(0, 5);
         session.SetArgument(1, "x");
@@ -67,7 +67,7 @@ public class CompiledArtifactSessionTests
     [Test]
     public void Invoke_ShouldAssignByPositionAndRun()
     {
-        var session = CreateSession();
+        var session = CreateSession(out _);
 
         var result = session.Invoke<string, string>(3, "n");
 
@@ -77,7 +77,7 @@ public class CompiledArtifactSessionTests
     [Test]
     public void InvokeNamed_ShouldAssignByNameAndRun()
     {
-        var session = CreateSession();
+        var session = CreateSession(out _);
 
         var result = session.InvokeNamed<string, string>(new Dictionary<string, object?>
         {
@@ -88,7 +88,59 @@ public class CompiledArtifactSessionTests
         Assert.That(result, Is.EqualTo("compiled:9:q"));
     }
 
-    private static SessionContext CreateSession()
+    [Test]
+    public void Invoke_ShouldThrow_WhenArgumentCountIsWrong()
+    {
+        var session = CreateSession(out _);
+
+        Assert.Throws<ArgumentException>(() => session.Invoke<string, string>(1));
+    }
+
+    [Test]
+    public void Invoke_ShouldThrow_WhenArgumentTypeIsWrong()
+    {
+        var session = CreateSession(out _);
+
+        Assert.Throws<ArgumentException>(() => session.Invoke<string, string>("bad", "ok"));
+    }
+
+    [Test]
+    public void InvokeNamed_ShouldThrow_WhenMissingRequiredArgument()
+    {
+        var session = CreateSession(out _);
+
+        Assert.Throws<ArgumentException>(() => session.InvokeNamed<string, string>(new Dictionary<string, object?>
+        {
+            ["value"] = 9
+        }));
+    }
+
+    [Test]
+    public void InvokeNamed_ShouldThrow_WhenExtraArgumentIsProvided()
+    {
+        var session = CreateSession(out _);
+
+        Assert.Throws<ArgumentException>(() => session.InvokeNamed<string, string>(new Dictionary<string, object?>
+        {
+            ["value"] = 9,
+            ["text"] = "q",
+            ["extra"] = 42
+        }));
+    }
+
+    [Test]
+    public void Session_ShouldBeReusable_WithDifferentArgumentsAcrossRuns()
+    {
+        var session = CreateSession(out _);
+
+        var first = session.Invoke<string, string>(3, "a");
+        var second = session.Invoke<string, string>(8, "b");
+
+        Assert.That(first, Is.EqualTo("compiled:3:a"));
+        Assert.That(second, Is.EqualTo("compiled:8:b"));
+    }
+
+    private static CompiledArtifactSession<string> CreateSession(out ExecutionEnvironment environment)
     {
         var bindings = new List<ExternalBinding>
         {
@@ -96,22 +148,9 @@ public class CompiledArtifactSessionTests
             new() { Name = "text", Type = typeof(string) }
         };
 
-        var environment = new ExecutionEnvironment(bindings);
+        environment = new ExecutionEnvironment(bindings);
         var executor = new FakeExecutor();
-        var session = new CompiledArtifactSession<string>("compiled", executor, environment, bindings);
-
-        return new SessionContext(session, environment);
-    }
-
-    private sealed class SessionContext(
-        CompiledArtifactSession<string> session,
-        ExecutionEnvironment environment)
-    {
-        public CompiledArtifactSession<string> Session { get; } = session;
-
-        public ExecutionEnvironment Environment { get; } = environment;
-
-        public static implicit operator CompiledArtifactSession<string>(SessionContext context) => context.Session;
+        return new CompiledArtifactSession<string>("compiled", executor, environment, bindings);
     }
 
     private sealed class FakeExecutor : IExecutor<string>

--- a/UniversalToolchain/Tests/Infrastructure/RuntimeCompiledArtifactContractsTests.cs
+++ b/UniversalToolchain/Tests/Infrastructure/RuntimeCompiledArtifactContractsTests.cs
@@ -1,0 +1,120 @@
+using System.Collections.Specialized;
+using System.Reflection.Emit;
+using DynamicMethodCalling;
+using ExceptionsManager;
+using Microsoft.Extensions.DependencyInjection;
+using UniversalToolchain.Dialects.Wist;
+
+namespace Tests.Infrastructure;
+
+[TestFixture]
+public class RuntimeCompiledArtifactContractsTests
+{
+    [Test]
+    public void Compile_WithDeclaredBindings_ShouldPreserveBindingOrderInSlotsByName()
+    {
+        using var host = CreateHost();
+        var compilerCore = GetCompilerCore(host);
+        var declared = new OrderedDictionary<string, Type>
+        {
+            ["beta"] = typeof(object),
+            ["alpha"] = typeof(object),
+            ["gamma"] = typeof(object)
+        };
+
+        var artifact = compilerCore.Compile("alpha", declared);
+
+        Assert.That(artifact.DeclaredBindings.Select(static b => b.Name), Is.EqualTo(new[] { "beta", "alpha", "gamma" }));
+        Assert.That(artifact.SlotsByName["beta"], Is.EqualTo(0));
+        Assert.That(artifact.SlotsByName["alpha"], Is.EqualTo(1));
+        Assert.That(artifact.SlotsByName["gamma"], Is.EqualTo(2));
+    }
+
+    [Test]
+    public void CompilerAndInterpreter_ShouldKeepDeclaredBindingsParity()
+    {
+        using var host = CreateHost();
+        var declared = new OrderedDictionary<string, Type>
+        {
+            ["x"] = typeof(object),
+            ["y"] = typeof(object)
+        };
+
+        var compilerArtifact = GetCompilerCore(host).Compile("x", declared);
+        var interpreterArtifact = GetInterpreterCore(host).Compile("x", declared);
+
+        Assert.That(compilerArtifact.DeclaredBindings.Select(static b => b.Name),
+            Is.EqualTo(interpreterArtifact.DeclaredBindings.Select(static b => b.Name)));
+        Assert.That(compilerArtifact.SlotsByName, Is.EqualTo(interpreterArtifact.SlotsByName));
+    }
+
+    [Test]
+    public void CompiledArtifact_AsFuncAndNativeInvoker_ShouldExecuteHappyPath()
+    {
+        var artifact = CreateUnaryAddOneArtifact();
+
+        Assert.That(artifact.AsFunc<int, int>()(41), Is.EqualTo(42));
+        Assert.That(artifact.GetNativeDelegateInvoker().Invoke<int, int>(9), Is.EqualTo(10));
+    }
+
+    [Test]
+    public void NativeDelegateInvoker_ShouldCacheDelegateInstancePerDelegateType()
+    {
+        var invoker = CreateUnaryAddOneArtifact().GetNativeDelegateInvoker();
+
+        var first = invoker.AsFunc<int, int>();
+        var second = invoker.AsFunc<int, int>();
+
+        Assert.That(second, Is.SameAs(first));
+    }
+
+    private static ICompiledArtifact<DynamicMethod> CreateUnaryAddOneArtifact()
+    {
+        var dynamicMethod = new DynamicMethod("AddOne", typeof(int), [typeof(int)]);
+        var il = dynamicMethod.GetILGenerator();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Ret);
+
+        return new CompiledArtifact<DynamicMethod>(
+            "x + 1",
+            [new ExternalBinding { Name = "x", Type = typeof(int), Kind = ExternalBindingKind.Variable }],
+            dynamicMethod);
+    }
+
+    private static WistDialectExecutionHost CreateHost()
+    {
+        var services = new ServiceCollection();
+        services.AddWistDialectServices();
+        services.AddWistCilBackend();
+        services.AddWistInterpreterBackend();
+
+        using var provider = services.BuildServiceProvider();
+        var workflow = provider.GetRequiredService<WistDialectExecutionWorkflow>();
+        var composition = workflow.ComposeText(
+            """
+            dialect RuntimeContracts
+            use Whitespaces,SemicolonAsNewLine,Comments,Numbers,Identifier,Arithmetic,Equality,Conditions,Loops,Variables,Scopes,Labels,InternalPreprocessorLexemes,CSharpInterop
+            backend compiler,interpreter
+            """,
+            "runtime-contracts-inline");
+
+        if (!composition.IsSuccess)
+            Thrower.InvalidOpEx(composition.ToDeterministicText());
+
+        return workflow.CreateHost(composition);
+    }
+
+    private static BasicCoreImpl<DynamicMethod> GetCompilerCore(WistDialectExecutionHost host)
+    {
+        return host.GetCore("compiler") as BasicCoreImpl<DynamicMethod>
+               ?? Thrower.InvalidOpEx<BasicCoreImpl<DynamicMethod>>("Compiler core must be BasicCoreImpl<DynamicMethod>.");
+    }
+
+    private static BasicCoreImpl<IAbstractIR> GetInterpreterCore(WistDialectExecutionHost host)
+    {
+        return host.GetCore("interpreter") as BasicCoreImpl<IAbstractIR>
+               ?? Thrower.InvalidOpEx<BasicCoreImpl<IAbstractIR>>("Interpreter core must be BasicCoreImpl<IAbstractIR>.");
+    }
+}

--- a/UniversalToolchain/Tests/Tests.csproj
+++ b/UniversalToolchain/Tests/Tests.csproj
@@ -60,6 +60,9 @@
         <Compile Include="Cli/WistcCliEndToEndTests.cs"/>
         <Compile Include="Architecture/DeletedLegacySurfaceTests.cs"/>
         <Compile Include="Infrastructure/DialectTestHostInfrastructure.cs"/>
+        <Compile Include="Infrastructure/CompiledArtifactSessionTests.cs"/>
+        <Compile Include="Infrastructure/CompiledArtifactTests.cs"/>
+        <Compile Include="Infrastructure/RuntimeCompiledArtifactContractsTests.cs"/>
         <Compile Include="Stress/RuntimeStressContractsTests.cs"/>
         <Compile Include="CoreContracts/BasicCoreLifecycleContractsTests.cs"/>
         <Compile Include="Concurrency/BasicCoreConcurrencyTests.cs"/>


### PR DESCRIPTION
### Motivation
- Increase coverage of core/runtime compiled-artifact behavior (not module-specific) by exercising real `BasicCore` / backend composition paths. 
- Verify declared binding ordering and `SlotsByName` semantics, typed/native delegate helpers, session argument semantics, positional/named invoke error conditions, compiler/interpreter parity, and native-delegate reuse. 
- Avoid Wist-specific test shortcuts and ensure tests reflect framework-level contracts. 

### Description
- Added `RuntimeCompiledArtifactContractsTests` to `UniversalToolchain/Tests/Infrastructure` to assert declared binding order, artifact metadata parity between compiler and interpreter, `AsFunc<int,int>()`/`GetNativeDelegateInvoker().Invoke<int,int>(...)` happy paths, and `NativeDelegateInvoker` delegate-cache reuse. 
- Extended `CompiledArtifactSessionTests` with additional cases for `SetArgument(name)` + `Run`, positional invoke success and argument-count/type failures, named invoke success and missing/extra argument failures, and session reuse across runs. 
- Tightened `CompiledArtifactSessionExtensions.InvokeNamed(...)` to validate exact named-argument count before applying arguments. 
- Added the new test file to the test project by updating `UniversalToolchain/Tests/Tests.csproj` and adjusted helper/test scaffolding to use real `ExecutionEnvironment`/`CompiledArtifactSession` where appropriate. 

### Testing
- Installed .NET SDK and verified with `dotnet --version` (installed `10.0.103`).
- Ran the targeted tests with `dotnet test UniversalToolchain/Tests/Tests.csproj -c Release --filter "FullyQualifiedName~CompiledArtifactSessionTests|FullyQualifiedName~CompiledArtifactTests|FullyQualifiedName~RuntimeCompiledArtifactContractsTests"` and iteratively fixed issues revealed by failures. 
- Ran the full test suite with `dotnet test UniversalToolchain/Tests/Tests.csproj -c Release` and confirmed all tests in the `Tests` project passed (final run: all tests green).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ccf509966c8324b4b7a71240bb2e80)