### PR TITLE
Add ParametersSetter runtime export contract tests

### DIFF
--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/RuntimeLoading/ParametersSetterExportContractsTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/RuntimeLoading/ParametersSetterExportContractsTests.cs
@@ -1,0 +1,70 @@
+using ParametersSetterModule;
+using UniversalToolchain.Dialects.Abstractions;
+using UniversalToolchain.Dialects.Integration;
+
+namespace UniversalToolchain.Dialects.Tests.RuntimeLoading;
+
+public class ParametersSetterExportContractsTests
+{
+    private const string ExpectedUnsupportedReason =
+        "ParametersSetter is not exported yet: parser contracts and runtime binding semantics are not finalized.";
+
+    [Test]
+    public void ParametersSetter_IsNotExported_ToDialectRuntimeComposition()
+    {
+        var resolver = CreateResolverFromStandardCatalog();
+        var plan = BuildPlan(["ParametersSetter"]);
+
+        var selected = resolver.Resolve(plan);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(selected.OrderedModules, Is.Empty);
+            Assert.That(selected.Diagnostics.Any(static x => x.Code == "R001" && x.Message.Contains("ParametersSetter", StringComparison.Ordinal)), Is.True);
+        });
+    }
+
+    [Test]
+    public void ParametersSetter_PlaceholderUnsupportedReason_IsStable()
+    {
+        Assert.That(ParametersSetterModuleImpl.UnsupportedReason, Is.EqualTo(ExpectedUnsupportedReason));
+    }
+
+    [Test]
+    public void ParametersSetter_DoesNotAccidentallyAppearInResolvedRuntimeCatalog()
+    {
+        var catalog = CreateStandardCatalog();
+
+        var foundByAlias = catalog.TryResolveModule("ParametersSetter", out _);
+        var appearsInDeterministicOrder = catalog
+            .GetModulesInDeterministicOrder()
+            .Any(static x => string.Equals(x.CanonicalAlias, "ParametersSetter", StringComparison.Ordinal)
+                             || x.Aliases.Contains("ParametersSetter", StringComparer.Ordinal));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(foundByAlias, Is.False);
+            Assert.That(appearsInDeterministicOrder, Is.False);
+        });
+    }
+
+    private static DialectBuildPlan BuildPlan(IReadOnlyList<string> modules) =>
+        new(
+            "ContractDialect",
+            null,
+            modules,
+            [],
+            [],
+            [],
+            [],
+            null,
+            [],
+            new DialectValidationResult([]));
+
+    private static SelectedRuntimePlanResolver CreateResolverFromStandardCatalog() => new(CreateStandardCatalog());
+
+    private static IRuntimeComponentCatalog CreateStandardCatalog() =>
+        new FileBasedRuntimeComponentCatalog(
+            new DefaultRuntimeManifestFileLocator(new RuntimeArtifactLocatorOptions()),
+            new RuntimeManifestJsonSerializer());
+}


### PR DESCRIPTION
### Motivation
- Ensure the placeholder `ParametersSetter` module remains non-exported to runtime composition and that its placeholder message is deterministic and stable.
- Protect against accidental inclusion of `ParametersSetter` in runtime catalogs or resolution flows while its parser/runtime contracts are not implemented.

### Description
- Added `UniversalToolchain/UniversalToolchain.Dialects.Tests/RuntimeLoading/ParametersSetterExportContractsTests.cs` containing three tests: `ParametersSetter_IsNotExported_ToDialectRuntimeComposition`, `ParametersSetter_PlaceholderUnsupportedReason_IsStable`, and `ParametersSetter_DoesNotAccidentallyAppearInResolvedRuntimeCatalog`.
- The tests exercise `SelectedRuntimePlanResolver` and the `IRuntimeComponentCatalog` (`FileBasedRuntimeComponentCatalog`) to assert `ParametersSetter` is not resolved as a runtime module and does not appear in deterministic module listings.
- The tests assert the placeholder string `ParametersSetterModuleImpl.UnsupportedReason` remains the exact, deterministic message used as the unsupported reason.

### Testing
- Restored and built the solution with `dotnet restore UniversalToolchain/Wist.sln` and `dotnet build UniversalToolchain/Wist.sln -c Release --no-restore`, both succeeded.
- Ran `dotnet test UniversalToolchain/Tests/Tests.csproj -c Release --no-build` which passed (51 passed, 0 failed).
- Ran `dotnet test UniversalToolchain/UniversalToolchain.Modules.Tests/UniversalToolchain.Modules.Tests.csproj -c Release --no-build` which passed (117 passed, 7 skipped) and observed the existing ParametersSetter module pipeline tests remain skipped as intended.
- Ran `dotnet test UniversalToolchain/UniversalToolchain.Dialects.Tests/UniversalToolchain.Dialects.Tests.csproj -c Release --no-build` which passed (264 passed, 0 failed), including the newly added `ParametersSetterExportContractsTests`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd134f36a88324b03863067c1b8a66)