### PR TITLE
Add comments module validation tests for deterministic and semantic behavior

### DIFF
--- a/UniversalToolchain/UniversalToolchain.Modules.Tests/ModuleCoverage/CommentsModuleValidationTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Modules.Tests/ModuleCoverage/CommentsModuleValidationTests.cs
@@ -1,0 +1,45 @@
+namespace UniversalToolchain.Modules.Tests.ModuleCoverage;
+
+[TestFixture]
+public class CommentsModuleValidationTests
+{
+    private static readonly string[] Modules = ModulePipelineTestHelper.FullUniversalModules;
+
+    [Test]
+    public void Comments_UnterminatedBlockComment_ThrowsDeterministicLexerError()
+    {
+        using var helper = new ModulePipelineTestHelper();
+        const string code = "2 /* bad";
+        helper.AssertFails(code, Modules, "comment");
+
+        var compilerError = Assert.Catch(() => helper.ExecuteCompiler(code, Modules));
+        var interpreterError = Assert.Catch(() => helper.ExecuteInterpreter(code, Modules));
+        var compilerMessage = compilerError!.ToString().ToLowerInvariant();
+        var interpreterMessage = interpreterError!.ToString().ToLowerInvariant();
+
+        Assert.That(compilerMessage.Contains("comment") || compilerMessage.Contains("unterminated"), Is.True);
+        Assert.That(interpreterMessage.Contains("comment") || interpreterMessage.Contains("unterminated"), Is.True);
+    }
+
+    [Test]
+    public void Comments_SingleLineComment_StillIgnoredByExecution()
+    {
+        using var helper = new ModulePipelineTestHelper();
+        helper.ExecuteEquivalent("// comment\n2 + 3", "2 + 3", Modules);
+    }
+
+    [Test]
+    public void Comments_BlockCommentOnlyInput_DoesNotCreatePhantomStatement()
+    {
+        using var helper = new ModulePipelineTestHelper();
+        helper.ExecuteEquivalent("let x = 2\n/* comment-only line */\nx + 3", "let x = 2\nx + 3", Modules);
+    }
+
+    [Test]
+    public void Comments_BlockCommentAroundExpression_PreservesExecutionSemantics()
+    {
+        using var helper = new ModulePipelineTestHelper();
+        helper.ExecuteBoth("2 /* comment */ + 3", Modules);
+        helper.ExecuteEquivalent("2 /* comment */ + 3", "2 + 3", Modules);
+    }
+}


### PR DESCRIPTION
### Motivation

- Ensure the `Comments` module is covered by deterministic and semantic validation tests for lexer and execution behavior.
- Verify unterminated block-comment diagnostics are stable and that comments do not change execution semantics or create phantom statements.

### Description

- Added `UniversalToolchain/UniversalToolchain.Modules.Tests/ModuleCoverage/CommentsModuleValidationTests.cs` containing four tests: `Comments_UnterminatedBlockComment_ThrowsDeterministicLexerError`, `Comments_SingleLineComment_StillIgnoredByExecution`, `Comments_BlockCommentOnlyInput_DoesNotCreatePhantomStatement`, and `Comments_BlockCommentAroundExpression_PreservesExecutionSemantics`.
- Tests use the existing helpers `ModulePipelineTestHelper.AssertFails`, `ExecuteEquivalent`, and `ExecuteBoth` to validate lexer failures and runtime parity across `compiler` and `interpreter` modes.
- The unterminated-block-comment test checks for stable message markers such as `comment` or `unterminated` instead of relying on unstable stack formatting.
- No changes to public APIs or modules; tests are additive test-only coverage.

### Testing

- Installed .NET SDK `10.0.103` using the repository-recommended installer script with `dotnet-install.sh` and confirmed `dotnet --version`.
- Ran the focused test filter with `dotnet test UniversalToolchain/UniversalToolchain.Modules.Tests/UniversalToolchain.Modules.Tests.csproj -c Release --filter "FullyQualifiedName~CommentsModuleValidationTests"` and the new test class passed.
- Ran full solution tests with `dotnet test UniversalToolchain/Wist.sln -c Release` and the test suite passed with no failures for the final run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd134cecd88324bc62533f0ad8b7a0)