### PR TITLE
Add NativeUnaryMinus pipeline coverage tests

### DIFF
--- a/UniversalToolchain/UniversalToolchain.Modules.Tests/ModuleCoverage/NativeUnaryMinusPipelineTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Modules.Tests/ModuleCoverage/NativeUnaryMinusPipelineTests.cs
@@ -1,0 +1,79 @@
+namespace UniversalToolchain.Modules.Tests.ModuleCoverage;
+
+[TestFixture]
+public class NativeUnaryMinusPipelineTests
+{
+    private static readonly string[] NativeModules =
+        ModulePipelineTestHelper.FullUniversalModules
+            .Where(x => x is not ("Numbers" or "Arithmetic"))
+            .Concat(["NativeTypes"])
+            .ToArray();
+
+    private static readonly string[] UniversalModules = ModulePipelineTestHelper.FullUniversalModules;
+
+    [Test]
+    public void NativeUnaryMinus_LiteralAtExpressionStart_ParsesAndExecutes()
+    {
+        using var h = new ModulePipelineTestHelper();
+        var result = h.ExecuteBoth("-5", NativeModules);
+
+        ModulePipelineTestHelper.AssertParity(result.Compiler, result.Interpreter);
+        Assert.That(ModulePipelineTestHelper.AsNumber(result.Compiler), Is.EqualTo(-5));
+    }
+
+    [Test]
+    public void NativeUnaryMinus_AfterBinaryOperator_ParsesAsUnaryMinus()
+    {
+        using var h = new ModulePipelineTestHelper();
+        var result = h.ExecuteBoth("2 * -3", NativeModules);
+
+        ModulePipelineTestHelper.AssertParity(result.Compiler, result.Interpreter);
+        Assert.That(ModulePipelineTestHelper.AsNumber(result.Compiler), Is.EqualTo(-6));
+    }
+
+    [Test]
+    public void NativeUnaryMinus_BinarySubtraction_IsNotRewrittenAsUnaryMinus()
+    {
+        using var h = new ModulePipelineTestHelper();
+        var result = h.ExecuteBoth("9 - 4", NativeModules);
+
+        ModulePipelineTestHelper.AssertParity(result.Compiler, result.Interpreter);
+        Assert.That(ModulePipelineTestHelper.AsNumber(result.Compiler), Is.EqualTo(5));
+    }
+
+    [Test]
+    public void NativeUnaryMinus_ParenthesizedExpression_ParsesAndExecutes()
+    {
+        using var h = new ModulePipelineTestHelper();
+        var result = h.ExecuteBoth("-(2 + 3)", NativeModules);
+
+        ModulePipelineTestHelper.AssertParity(result.Compiler, result.Interpreter);
+        Assert.That(ModulePipelineTestHelper.AsNumber(result.Compiler), Is.EqualTo(-5));
+    }
+
+    [Test]
+    public void NativeUnaryMinus_CompilerAndInterpreter_ProduceSameResult()
+    {
+        using var h = new ModulePipelineTestHelper();
+        var result = h.ExecuteBoth("-3 * (4 - 7) + 2", NativeModules);
+
+        ModulePipelineTestHelper.AssertParity(result.Compiler, result.Interpreter);
+    }
+
+    [TestCase("-7")]
+    [TestCase("2 * -3")]
+    [TestCase("-(2 + 5) + 9")]
+    [TestCase("10 - -2")]
+    public void NativeUnaryMinus_And_UniversalUnaryMinus_ProduceEquivalentResult_OnSameExpression(string code)
+    {
+        using var h = new ModulePipelineTestHelper();
+
+        var nativeResult = h.ExecuteBoth(code, NativeModules);
+        var universalResult = h.ExecuteBoth(code, UniversalModules);
+
+        ModulePipelineTestHelper.AssertParity(nativeResult.Compiler, nativeResult.Interpreter);
+        ModulePipelineTestHelper.AssertParity(universalResult.Compiler, universalResult.Interpreter);
+        ModulePipelineTestHelper.AssertParity(nativeResult.Compiler, universalResult.Compiler);
+        ModulePipelineTestHelper.AssertParity(nativeResult.Interpreter, universalResult.Interpreter);
+    }
+}


### PR DESCRIPTION
### Motivation
- Add pipeline-level tests to cover native `unary minus` parsing/execution and to assert parity between native and universal module profiles and between compiler/interpreter backends.

### Description
- Create `UniversalToolchain/UniversalToolchain.Modules.Tests/ModuleCoverage/NativeUnaryMinusPipelineTests.cs` that adds six tests (`NativeUnaryMinus_LiteralAtExpressionStart_ParsesAndExecutes`, `NativeUnaryMinus_AfterBinaryOperator_ParsesAsUnaryMinus`, `NativeUnaryMinus_BinarySubtraction_IsNotRewrittenAsUnaryMinus`, `NativeUnaryMinus_ParenthesizedExpression_ParsesAndExecutes`, `NativeUnaryMinus_CompilerAndInterpreter_ProduceSameResult`, and `NativeUnaryMinus_And_UniversalUnaryMinus_ProduceEquivalentResult_OnSameExpression`), using the native profile (``FullUniversalModules`` without ``Numbers``/``Arithmetic`` plus ``NativeTypes``) and the full universal profile, and comparing compiler/interpreter outputs on identical expressions.

### Testing
- Installed .NET SDK 10.0.103 and ran `dotnet test UniversalToolchain/UniversalToolchain.Modules.Tests/UniversalToolchain.Modules.Tests.csproj -c Release`, which executed the suite and reported failures related to existing unary-minus behavior differences (7 failed, 119 passed, 7 skipped, total 133).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd134a47d483248b8ae1c5e730bffd)