### PR TITLE
Add unary minus module pipeline coverage tests

### DIFF
--- a/UniversalToolchain/UniversalToolchain.Modules.Tests/ModuleCoverage/ArithmeticUnaryMinusPipelineTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Modules.Tests/ModuleCoverage/ArithmeticUnaryMinusPipelineTests.cs
@@ -1,0 +1,73 @@
+namespace UniversalToolchain.Modules.Tests.ModuleCoverage;
+
+[TestFixture]
+public class ArithmeticUnaryMinusPipelineTests
+{
+    private static readonly string[] Modules = ModulePipelineTestHelper.FullUniversalModules;
+
+    [Test]
+    public void UnaryMinus_LiteralAtExpressionStart_ParsesAndExecutes()
+    {
+        using var h = new ModulePipelineTestHelper();
+        var result = h.ExecuteBoth("-2+3", Modules);
+
+        ModulePipelineTestHelper.AssertParity(result.Compiler, result.Interpreter);
+        Assert.That(ModulePipelineTestHelper.AsNumber(result.Compiler), Is.EqualTo(1));
+    }
+
+    [Test]
+    public void UnaryMinus_DoubleUnaryMinus_ParsesAndExecutes()
+    {
+        using var h = new ModulePipelineTestHelper();
+        var result = h.ExecuteBoth("--2", Modules);
+
+        ModulePipelineTestHelper.AssertParity(result.Compiler, result.Interpreter);
+        Assert.That(ModulePipelineTestHelper.AsNumber(result.Compiler), Is.EqualTo(2));
+    }
+
+    [Test]
+    public void UnaryMinus_AfterBinaryOperator_ParsesAsUnaryMinus()
+    {
+        using var h = new ModulePipelineTestHelper();
+        var result = h.ExecuteBoth("2*-3", Modules);
+
+        ModulePipelineTestHelper.AssertParity(result.Compiler, result.Interpreter);
+        Assert.That(ModulePipelineTestHelper.AsNumber(result.Compiler), Is.EqualTo(-6));
+    }
+
+    [Test]
+    public void UnaryMinus_AfterOpenParenthesis_ParsesAsUnaryMinus()
+    {
+        using var h = new ModulePipelineTestHelper();
+        var result = h.ExecuteBoth("(-3)+1", Modules);
+
+        ModulePipelineTestHelper.AssertParity(result.Compiler, result.Interpreter);
+        Assert.That(ModulePipelineTestHelper.AsNumber(result.Compiler), Is.EqualTo(-2));
+    }
+
+    [Test]
+    public void UnaryMinus_BinarySubtraction_IsNotRewrittenAsUnaryMinus()
+    {
+        using var h = new ModulePipelineTestHelper();
+        h.ExecuteEquivalent("5-3", "2", Modules);
+    }
+
+    [Test]
+    public void UnaryMinus_InAssignmentContext_ParsesAndExecutes()
+    {
+        using var h = new ModulePipelineTestHelper();
+        var result = h.ExecuteBoth("let x=-2; x+5", Modules);
+
+        ModulePipelineTestHelper.AssertParity(result.Compiler, result.Interpreter);
+        Assert.That(ModulePipelineTestHelper.AsNumber(result.Compiler), Is.EqualTo(3));
+    }
+
+    [Test]
+    public void UnaryMinus_CompilerAndInterpreter_ProduceSameResult()
+    {
+        using var h = new ModulePipelineTestHelper();
+        var result = h.ExecuteBoth("let x=-2; x+5", Modules);
+
+        ModulePipelineTestHelper.AssertParity(result.Compiler, result.Interpreter);
+    }
+}


### PR DESCRIPTION
### Motivation
- Add targeted coverage for unary minus parsing and execution across compiler and interpreter backends to prevent regressions in operator parsing and context sensitivity.

### Description
- Added `UniversalToolchain/UniversalToolchain.Modules.Tests/ModuleCoverage/ArithmeticUnaryMinusPipelineTests.cs` containing seven tests that cover `UnaryMinus_LiteralAtExpressionStart_ParsesAndExecutes`, `UnaryMinus_DoubleUnaryMinus_ParsesAndExecutes`, `UnaryMinus_AfterBinaryOperator_ParsesAsUnaryMinus`, `UnaryMinus_AfterOpenParenthesis_ParsesAsUnaryMinus`, `UnaryMinus_BinarySubtraction_IsNotRewrittenAsUnaryMinus`, `UnaryMinus_InAssignmentContext_ParsesAndExecutes`, and `UnaryMinus_CompilerAndInterpreter_ProduceSameResult`.
- Tests use `ModulePipelineTestHelper.FullUniversalModules` and the helper methods `ExecuteBoth` and `ExecuteEquivalent` with expressions `-2+3`, `--2`, `2*-3`, `(-3)+1`, `5-3`, and `let x=-2; x+5`, asserting both backend parity and numeric expectations where appropriate.

### Testing
- Ran `dotnet restore UniversalToolchain/Wist.sln` which completed successfully.
- Ran `dotnet test UniversalToolchain/UniversalToolchain.Modules.Tests/UniversalToolchain.Modules.Tests.csproj -c Release` which passed with `Passed: 124, Skipped: 7, Total: 131`.
- Ran `dotnet test UniversalToolchain/Tests/Tests.csproj -c Release` which passed with `Passed: 51, Total: 51`.
- Ran `dotnet test UniversalToolchain/UniversalToolchain.Dialects.Tests/UniversalToolchain.Dialects.Tests.csproj -c Release` which passed with `Passed: 261, Total: 261`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd13492e888324a6081ab8dc37ed0c)