### PR TITLE
Fix native unary minus bytecode order and add regression tests

### DIFF
--- a/UniversalToolchain/NativeMathModule/NativeUnaryMinusAstVisitor.cs
+++ b/UniversalToolchain/NativeMathModule/NativeUnaryMinusAstVisitor.cs
@@ -9,26 +9,11 @@ public class NativeUnaryMinusAstVisitor : IAstVisitor
         if (data.Node.NodeType != NativeUnaryMinus)
             return;
 
-        data.AstToBytecodeTranslator.Translate(data.Node.Children[0]);
-
         var pushZeroMethod = new AbstractMethodImpl(
             "NativeUnaryMinus_PushZero",
-            (il, context) =>
+            (il, _) =>
             {
-                var operandType = context.Stack[^1];
-
-                if (operandType == typeof(decimal))
-                    il.Push(0m);
-                else if (operandType == typeof(double))
-                    il.Push(0d);
-                else if (operandType == typeof(float))
-                    il.Push(0f);
-                else if (operandType == typeof(long))
-                    il.Push(0L);
-                else if (operandType == typeof(int))
-                    il.Push(0);
-                else
-                    Thrower.NotSupported<object>($"Unsupported native unary minus operand type '{operandType}'.");
+                il.Push(0);
             }
         );
 
@@ -42,6 +27,7 @@ public class NativeUnaryMinusAstVisitor : IAstVisitor
         );
 
         data.Bytecode.Instructions.Add(new BytecodeInstruction(pushZeroMethod));
+        data.AstToBytecodeTranslator.Translate(data.Node.Children[0]);
         data.Bytecode.Instructions.Add(new BytecodeInstruction(subtractMethod));
     }
 }

--- a/UniversalToolchain/UniversalToolchain.Modules.Tests/ModuleCoverage/NativeUnaryMinusPipelineTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Modules.Tests/ModuleCoverage/NativeUnaryMinusPipelineTests.cs
@@ -76,4 +76,19 @@ public class NativeUnaryMinusPipelineTests
         ModulePipelineTestHelper.AssertParity(nativeResult.Compiler, universalResult.Compiler);
         ModulePipelineTestHelper.AssertParity(nativeResult.Interpreter, universalResult.Interpreter);
     }
+
+    [TestCase("10 - -2")]
+    [TestCase("-(2 + 5) + 9")]
+    public void NativeUnaryMinus_RegressionCases_MatchUniversalUnaryMinus(string code)
+    {
+        using var h = new ModulePipelineTestHelper();
+
+        var nativeResult = h.ExecuteBoth(code, NativeModules);
+        var universalResult = h.ExecuteBoth(code, UniversalModules);
+
+        ModulePipelineTestHelper.AssertParity(nativeResult.Compiler, nativeResult.Interpreter);
+        ModulePipelineTestHelper.AssertParity(universalResult.Compiler, universalResult.Interpreter);
+        ModulePipelineTestHelper.AssertParity(nativeResult.Compiler, universalResult.Compiler);
+        ModulePipelineTestHelper.AssertParity(nativeResult.Interpreter, universalResult.Interpreter);
+    }
 }


### PR DESCRIPTION
### Motivation

- Native unary minus emitted instructions in the wrong order producing `operand - 0` semantics instead of `0 - operand`, which broke expressions like `10 - -2` and `-(2 + 5) + 9`.
- The intent is to keep the native path behavior consistent with the universal arithmetic path while making the minimal localized change.

### Description

- Reordered the bytecode emission in `NativeUnaryMinusAstVisitor` so it now emits `push zero`, `translate operand`, then `subtract` to implement `0 - operand` semantics. (`UniversalToolchain/NativeMathModule/NativeUnaryMinusAstVisitor.cs`)
- Simplified the zero push implementation to emit a literal zero via the `pushZero` abstract method and removed reliance on `context.Stack` in that method. (`NativeUnaryMinusAstVisitor.cs`)
- Added explicit regression tests to ensure parity between native and universal unary minus for known failure cases `10 - -2` and `-(2 + 5) + 9` by extending `NativeUnaryMinusPipelineTests`. (`UniversalToolchain/UniversalToolchain.Modules.Tests/ModuleCoverage/NativeUnaryMinusPipelineTests.cs`)

### Testing

- Ran `dotnet test UniversalToolchain/UniversalToolchain.Modules.Tests/UniversalToolchain.Modules.Tests.csproj -c Release`. 
- Test run succeeded with the test project reporting `Passed: 149, Skipped: 7, Failed: 0`, and the added regression tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd1c90be508324bbfef7afcbfea425)