### PR TITLE
Refactor native unary minus to dedicated negate method

### DIFF
--- a/UniversalToolchain/NativeMathModule/NativeArithmetic.cs
+++ b/UniversalToolchain/NativeMathModule/NativeArithmetic.cs
@@ -18,6 +18,9 @@ public static class NativeArithmetic
     [UsedImplicitly]
     public static T Divide<T>(T a, T b) where T : INumber<T> => a / b;
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+    [UsedImplicitly]
+    public static T Negate<T>(T value) where T : INumber<T> => -value;
 
     [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
     [UsedImplicitly]
@@ -34,4 +37,8 @@ public static class NativeArithmetic
     [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
     [UsedImplicitly]
     public static decimal DivideDecimal(decimal a, decimal b) => a / b;
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
+    [UsedImplicitly]
+    public static decimal NegateDecimal(decimal value) => -value;
 }

--- a/UniversalToolchain/NativeMathModule/NativeArithmeticAstVisitor.cs
+++ b/UniversalToolchain/NativeMathModule/NativeArithmeticAstVisitor.cs
@@ -22,7 +22,7 @@ public class NativeArithmeticAstVisitor : IAstVisitor
             nodeType != ExtensibleEnum<AstNodeTag>.CreateOrGet("NativeDivision"))
             return;
 
-        // Обрабатываем оба операнда
+        // Process both operands first to keep stack typing deterministic.
         data.AstToBytecodeTranslator.Translate(data.Node.Children[0]);
         data.AstToBytecodeTranslator.Translate(data.Node.Children[1]);
 
@@ -60,5 +60,28 @@ public class NativeArithmeticAstVisitor : IAstVisitor
             .GetMethod(methodName, BindingFlags.Static | BindingFlags.Public)
             .NotNull()
             .MakeGenericMethod(leftType);
+    }
+
+    internal static MethodInfo ResolveNativeUnaryMinusMethod(Type operandType)
+    {
+        if (operandType == typeof(decimal))
+        {
+            return typeof(NativeArithmetic)
+                .GetMethod(nameof(NativeArithmetic.NegateDecimal), BindingFlags.Static | BindingFlags.Public)
+                .NotNull();
+        }
+
+        try
+        {
+            return typeof(NativeArithmetic)
+                .GetMethod(nameof(NativeArithmetic.Negate), BindingFlags.Static | BindingFlags.Public)
+                .NotNull()
+                .MakeGenericMethod(operandType);
+        }
+        catch (Exception)
+        {
+            return Thrower.NotSupported<MethodInfo>(
+                $"Native unary minus does not support operand type '{operandType}'.");
+        }
     }
 }

--- a/UniversalToolchain/NativeMathModule/NativeUnaryMinusAstVisitor.cs
+++ b/UniversalToolchain/NativeMathModule/NativeUnaryMinusAstVisitor.cs
@@ -11,37 +11,16 @@ public class NativeUnaryMinusAstVisitor : IAstVisitor
 
         data.AstToBytecodeTranslator.Translate(data.Node.Children[0]);
 
-        var pushZeroMethod = new AbstractMethodImpl(
-            "NativeUnaryMinus_PushZero",
+        var negateMethod = new AbstractMethodImpl(
+            "NativeUnaryMinus_Negate",
             (il, context) =>
             {
                 var operandType = context.Stack[^1];
-
-                if (operandType == typeof(decimal))
-                    il.Push(0m);
-                else if (operandType == typeof(double))
-                    il.Push(0d);
-                else if (operandType == typeof(float))
-                    il.Push(0f);
-                else if (operandType == typeof(long))
-                    il.Push(0L);
-                else if (operandType == typeof(int))
-                    il.Push(0);
-                else
-                    Thrower.NotSupported<object>($"Unsupported native unary minus operand type '{operandType}'.");
-            }
-        );
-
-        var subtractMethod = new AbstractMethodImpl(
-            "NativeUnaryMinus_Subtract",
-            (il, context) =>
-            {
-                var resolvedMethod = NativeArithmeticAstVisitor.ResolveNativeArithmeticMethod("Subtract", context.Stack[^2], context.Stack[^1]);
+                var resolvedMethod = NativeArithmeticAstVisitor.ResolveNativeUnaryMinusMethod(operandType);
                 il.CallCSharp(resolvedMethod);
             }
         );
 
-        data.Bytecode.Instructions.Add(new BytecodeInstruction(pushZeroMethod));
-        data.Bytecode.Instructions.Add(new BytecodeInstruction(subtractMethod));
+        data.Bytecode.Instructions.Add(new BytecodeInstruction(negateMethod));
     }
 }

--- a/UniversalToolchain/UniversalToolchain.Modules.Tests/ModuleCoverage/NativeUnaryMinusPipelineTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Modules.Tests/ModuleCoverage/NativeUnaryMinusPipelineTests.cs
@@ -60,6 +60,56 @@ public class NativeUnaryMinusPipelineTests
         ModulePipelineTestHelper.AssertParity(result.Compiler, result.Interpreter);
     }
 
+    [Test]
+    public void NativeUnaryMinus_DoubleLiteral_ParsesAndExecutes()
+    {
+        using var h = new ModulePipelineTestHelper();
+        var result = h.ExecuteBoth("-1.5", NativeModules);
+
+        ModulePipelineTestHelper.AssertParity(result.Compiler, result.Interpreter);
+        Assert.That(ModulePipelineTestHelper.AsNumber(result.Compiler), Is.EqualTo(-1.5d));
+    }
+
+    [Test]
+    public void NativeUnaryMinus_FloatLiteral_ParsesAndExecutes()
+    {
+        using var h = new ModulePipelineTestHelper();
+        var result = h.ExecuteBoth("-1f", NativeModules);
+
+        ModulePipelineTestHelper.AssertParity(result.Compiler, result.Interpreter);
+        Assert.That(ModulePipelineTestHelper.AsNumber(result.Compiler), Is.EqualTo(-1f));
+    }
+
+    [Test]
+    public void NativeUnaryMinus_LongLiteral_ParsesAndExecutes()
+    {
+        using var h = new ModulePipelineTestHelper();
+        var result = h.ExecuteBoth("-1L", NativeModules);
+
+        ModulePipelineTestHelper.AssertParity(result.Compiler, result.Interpreter);
+        Assert.That(ModulePipelineTestHelper.AsNumber(result.Compiler), Is.EqualTo(-1L));
+    }
+
+    [Test]
+    public void NativeUnaryMinus_DecimalLiteral_ParsesAndExecutes()
+    {
+        using var h = new ModulePipelineTestHelper();
+        var result = h.ExecuteBoth("-1m", NativeModules);
+
+        ModulePipelineTestHelper.AssertParity(result.Compiler, result.Interpreter);
+        Assert.That(ModulePipelineTestHelper.AsNumber(result.Compiler), Is.EqualTo(-1m));
+    }
+
+    [Test]
+    public void NativeUnaryMinus_DoubleExpression_AfterBinaryOperator_ParsesAndExecutes()
+    {
+        using var h = new ModulePipelineTestHelper();
+        var result = h.ExecuteBoth("2.0 * -3.0", NativeModules);
+
+        ModulePipelineTestHelper.AssertParity(result.Compiler, result.Interpreter);
+        Assert.That(ModulePipelineTestHelper.AsNumber(result.Compiler), Is.EqualTo(-6.0d));
+    }
+
     [TestCase("-7")]
     [TestCase("2 * -3")]
     [TestCase("-(2 + 5) + 9")]


### PR DESCRIPTION
### Motivation

- Remove the artificial `push 0` + `subtract` approach for native unary minus which caused type/zero compatibility issues and late runtime generic failures.
- Provide a single well-typed native negate path that works uniformly for numeric types and gives a clear error for unsupported types.
- Improve test coverage for native unary minus across different numeric literal kinds and expression forms.

### Description

- `NativeUnaryMinusAstVisitor` now translates only the operand and emits a single `NativeUnaryMinus_Negate` abstract method instead of pushing a zero and calling subtract, so the operand is negated directly from the stack (file: `NativeUnaryMinusAstVisitor.cs`).
- `NativeArithmetic` gains `Negate<T>(T value)` for the generic `INumber<T>` path and `NegateDecimal(decimal value)` for the decimal-specialized path (file: `NativeArithmetic.cs`).
- `NativeArithmeticAstVisitor` gains `ResolveNativeUnaryMinusMethod(Type operandType)` which resolves the correct `Negate`/`NegateDecimal` method and returns a clear `Thrower.NotSupported<MethodInfo>(...)` message for unsupported operand types (file: `NativeArithmeticAstVisitor.cs`).
- Added module coverage tests exercising native unary minus with `double`, `float`, `long`, `decimal`, and a double expression after a binary operator, while keeping existing regression cases (file: `NativeUnaryMinusPipelineTests.cs`).

### Testing

- Ran `dotnet restore UniversalToolchain/Wist.sln` and `dotnet build UniversalToolchain/Wist.sln -c Release --no-restore` which completed successfully.
- Ran the focused native unary minus tests via `dotnet test UniversalToolchain/UniversalToolchain.Modules.Tests/UniversalToolchain.Modules.Tests.csproj -c Release --no-build --filter NativeUnaryMinusPipelineTests` and the targeted cases passed (no failures).
- Ran full test suites: `dotnet test` on the modules, dialects and core test projects and they completed successfully (Modules.Tests run: all tests passed with skipped cases as expected; Dialects.Tests and Tests assemblies also passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd20e04e2c8324bbd529ddb7180d64)