### PR TITLE
Extract ValidateAssignment and reject constant external bindings in CompiledArtifactSession

### DIFF
--- a/UniversalToolchain/BasicCore/Execution/CompiledArtifactSession.cs
+++ b/UniversalToolchain/BasicCore/Execution/CompiledArtifactSession.cs
@@ -32,11 +32,7 @@ public sealed class CompiledArtifactSession<TCompilationOutput> : ICompiledArtif
 
     public void SetArgument(int slot, object? value)
     {
-        if (slot < 0 || slot >= _artifact.DeclaredBindings.Count)
-            Thrower.ArgumentOutOfRange<object>(nameof(slot), $"Argument slot '{slot}' is out of range [0, {_artifact.DeclaredBindings.Count - 1}].");
-
-        var binding = _artifact.DeclaredBindings[slot];
-        EnsureAssignable(binding, value, slot, binding.Name);
+        ValidateAssignment(slot, value);
         _executionEnvironment.SetExternalValue(slot, value);
     }
 
@@ -52,6 +48,21 @@ public sealed class CompiledArtifactSession<TCompilationOutput> : ICompiledArtif
     }
 
     public object? Run() => _executor.Execute(_artifact.CompilationOutput, _executionEnvironment);
+
+    private void ValidateAssignment(int slot, object? value)
+    {
+        if (slot < 0 || slot >= _artifact.DeclaredBindings.Count)
+            Thrower.ArgumentOutOfRange<object>(nameof(slot), $"Argument slot '{slot}' is out of range [0, {_artifact.DeclaredBindings.Count - 1}].");
+
+        var binding = _artifact.DeclaredBindings[slot];
+        if (binding.Kind == ExternalBindingKind.Constant)
+        {
+            Thrower.InvalidOpEx(
+                $"Binding '{binding.Name}' at slot {slot} is constant and cannot be reassigned.");
+        }
+
+        EnsureAssignable(binding, value, slot, binding.Name);
+    }
 
     private static void EnsureAssignable(ExternalBinding binding, object? value, int slot, string name)
     {

--- a/UniversalToolchain/Tests/Infrastructure/CompiledArtifactContractsTests.cs
+++ b/UniversalToolchain/Tests/Infrastructure/CompiledArtifactContractsTests.cs
@@ -110,6 +110,39 @@ public class CompiledArtifactContractsTests
     }
 
     [Test]
+    public void CompiledArtifactSession_SetArgument_RejectsConstantBindingBySlot()
+    {
+        var artifact = CreateArtifactWithConstantBinding("compiled");
+        var session = artifact.CreateSession();
+
+        var ex = Assert.Throws<InvalidOperationException>(() => session.SetArgument(0, 99));
+
+        Assert.That(ex!.Message, Is.EqualTo("Binding 'value' at slot 0 is constant and cannot be reassigned."));
+    }
+
+    [Test]
+    public void CompiledArtifactSession_SetArgument_RejectsConstantBindingByName()
+    {
+        var artifact = CreateArtifactWithConstantBinding("compiled");
+        var session = artifact.CreateSession();
+
+        var ex = Assert.Throws<InvalidOperationException>(() => session.SetArgument("value", 99));
+
+        Assert.That(ex!.Message, Is.EqualTo("Binding 'value' at slot 0 is constant and cannot be reassigned."));
+    }
+
+    [Test]
+    public void CompiledArtifactSession_SetArgument_AllowsVariableBindingMutation()
+    {
+        var artifact = CreateTwoArgumentArtifact("compiled", 1, "seed");
+        var session = artifact.CreateSession();
+
+        session.SetArgument(0, 10);
+
+        Assert.That(session.Run(), Is.EqualTo("compiled:10:seed"));
+    }
+
+    [Test]
     public void CompiledArtifactSession_Run_UsesArtifactCompilationOutput()
     {
         var artifact = CreateTwoArgumentArtifact("expected-output", 3, "x");
@@ -180,6 +213,18 @@ public class CompiledArtifactContractsTests
             [
                 new ExternalBinding { Name = "value", Type = typeof(int), Value = defaultValue, Kind = ExternalBindingKind.Variable },
                 new ExternalBinding { Name = "text", Type = typeof(string), Value = defaultText, Kind = ExternalBindingKind.Variable }
+            ],
+            compilationOutput,
+            new PairFormattingExecutor());
+    }
+
+    private static CompiledArtifact<string> CreateArtifactWithConstantBinding(string compilationOutput)
+    {
+        return new CompiledArtifact<string>(
+            "value + text",
+            [
+                new ExternalBinding { Name = "value", Type = typeof(int), Value = 1, Kind = ExternalBindingKind.Constant },
+                new ExternalBinding { Name = "text", Type = typeof(string), Value = "seed", Kind = ExternalBindingKind.Variable }
             ],
             compilationOutput,
             new PairFormattingExecutor());


### PR DESCRIPTION
### Motivation

- Consolidate pre-validation for argument assignment to avoid duplicated checks and ensure a deterministic rejection for attempts to reassign constant bindings.
- Ensure both overloads of `SetArgument` follow the same validation path and preserve existing type-assignability checks.

### Description

- Extracted a private `ValidateAssignment(int slot, object? value)` helper in `CompiledArtifactSession<TCompilationOutput>` that checks `slot` range, reads `binding = _artifact.DeclaredBindings[slot]`, rejects `ExternalBindingKind.Constant` with a deterministic `Thrower.InvalidOpEx(...)` message, and then delegates to the existing `EnsureAssignable(...)` method.
- Updated `SetArgument(int, object?)` to call `ValidateAssignment(...)` and retained the actual write via `_executionEnvironment.SetExternalValue(...)`.
- Kept `SetArgument(string, object?)` resolving the slot by name and delegating to the slot-based overload to avoid copy-paste.
- Added tests to `CompiledArtifactContractsTests.cs`: `CompiledArtifactSession_SetArgument_RejectsConstantBindingBySlot`, `CompiledArtifactSession_SetArgument_RejectsConstantBindingByName`, and `CompiledArtifactSession_SetArgument_AllowsVariableBindingMutation`, and a helper `CreateArtifactWithConstantBinding(...)` used by the new tests; tests assert the exact deterministic error text.

### Testing

- Restored the solution with `dotnet restore UniversalToolchain/Wist.sln`, which completed successfully.
- Ran the focused tests with `dotnet test UniversalToolchain/Tests/Tests.csproj -c Release --no-build --filter "FullyQualifiedName~CompiledArtifactContractsTests"` and the focused suite passed (Passed: 9, Failed: 0).
- Ran the full test projects and they passed: `dotnet test UniversalToolchain/Tests/Tests.csproj -c Release --no-build` (Passed: 64, Failed: 0), `dotnet test UniversalToolchain/UniversalToolchain.Modules.Tests/UniversalToolchain.Modules.Tests.csproj -c Release` (Passed: 152, Failed: 0), and `dotnet test UniversalToolchain/UniversalToolchain.Dialects.Tests/UniversalToolchain.Dialects.Tests.csproj -c Release` (Passed: 271, Failed: 0).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd2ecae6b08324bc93f680cbac4a17)