### PR TITLE
Clarify compiled artifact mutability contract in docs

### DIFF
--- a/UniversalToolchain/BasicCore/Compilation/CompiledArtifact.cs
+++ b/UniversalToolchain/BasicCore/Compilation/CompiledArtifact.cs
@@ -1,7 +1,10 @@
 namespace BasicCore.Compilation;
 
 /// <summary>
-/// Default immutable implementation of <see cref="ICompiledArtifact{TCompilationOutput}"/>.
+/// Default implementation of <see cref="ICompiledArtifact{TCompilationOutput}"/> with fixed artifact structure.
+/// Declared bindings and slots mapping are snapshotted at construction time and stay unchanged afterwards.
+/// Binding values are copied by reference; no generic deep clone is performed.
+/// Mutable object graphs referenced by binding values can still be mutated externally.
 /// </summary>
 /// <typeparam name="TCompilationOutput">Compilation backend output type.</typeparam>
 public sealed class CompiledArtifact<TCompilationOutput> : ICompiledArtifact<TCompilationOutput>

--- a/UniversalToolchain/BasicCore/Compilation/ICompiledArtifact.cs
+++ b/UniversalToolchain/BasicCore/Compilation/ICompiledArtifact.cs
@@ -1,7 +1,11 @@
 namespace BasicCore.Compilation;
 
 /// <summary>
-/// Represents an immutable compiled artifact snapshot that can spawn execution sessions.
+/// Represents a compiled artifact snapshot that can spawn execution sessions.
+/// The artifact structure is fixed after creation: <see cref="DeclaredBindings"/> order/content and
+/// <see cref="SlotsByName"/> mapping do not change.
+/// Binding values are copied by reference and are not deep-cloned.
+/// If <see cref="ExternalBinding.Value"/> references a mutable object graph, that graph can still be mutated externally.
 /// </summary>
 /// <typeparam name="TCompilationOutput">Compilation backend output type.</typeparam>
 public interface ICompiledArtifact<out TCompilationOutput>
@@ -13,11 +17,14 @@ public interface ICompiledArtifact<out TCompilationOutput>
 
     /// <summary>
     /// Gets declared external bindings snapshot used at compilation time.
+    /// Binding entries and their order are stable for the lifetime of the artifact.
+    /// <see cref="ExternalBinding.Value"/> references are preserved as-is and are not deep-cloned.
     /// </summary>
     IReadOnlyList<ExternalBinding> DeclaredBindings { get; }
 
     /// <summary>
     /// Gets name-to-slot mapping for external bindings.
+    /// The mapping is created once from declared bindings and is stable for the artifact lifetime.
     /// </summary>
     IReadOnlyDictionary<string, int> SlotsByName { get; }
 

--- a/UniversalToolchain/Tests/Infrastructure/CompiledArtifactTests.cs
+++ b/UniversalToolchain/Tests/Infrastructure/CompiledArtifactTests.cs
@@ -69,6 +69,23 @@ public class CompiledArtifactTests
     }
 
     [Test]
+    public void Constructor_ShouldPreserveReferenceForMutableBindingValue()
+    {
+        var mutableValue = new List<int> { 1 };
+        var bindings = new List<ExternalBinding>
+        {
+            new() { Name = "x", Type = typeof(List<int>), Value = mutableValue, Kind = ExternalBindingKind.Variable }
+        };
+
+        var artifact = new CompiledArtifact<string>("x", bindings, "compiled", new NoOpExecutor<string>());
+        mutableValue.Add(2);
+
+        var valueFromArtifact = artifact.DeclaredBindings[0].Value;
+        Assert.That(valueFromArtifact, Is.SameAs(mutableValue));
+        Assert.That((List<int>)valueFromArtifact!, Is.EqualTo(new[] { 1, 2 }));
+    }
+
+    [Test]
     public void Constructor_WithDuplicateBindingName_ShouldThrow()
     {
         var bindings = new List<ExternalBinding>


### PR DESCRIPTION
### Motivation

- Remove misleading XML wording that promised full deep-immutability for compiled artifacts and clarify the real contract.  
- Explicitly document that artifact structure (`DeclaredBindings` order/content and `SlotsByName`) is fixed after construction while `ExternalBinding.Value` references are copied by reference and not deep-cloned.  
- Add a small contract test to assert current behavior (reference-preserving for mutable binding values) rather than asserting false deep-immutability.

### Description

- Updated XML docs in `ICompiledArtifact<TCompilationOutput>` to state that the artifact structure is stable after construction and that `ExternalBinding.Value` references are preserved as-is.  
- Updated XML docs in `CompiledArtifact<TCompilationOutput>` to match the same contract language and to note that no generic deep clone is performed and mutable object graphs can still be modified externally.  
- Added a unit test `Constructor_ShouldPreserveReferenceForMutableBindingValue` in `UniversalToolchain/Tests/Infrastructure/CompiledArtifactTests.cs` that verifies a mutable `ExternalBinding.Value` remains the same reference and reflects external mutations.  
- Explicitly did not introduce any generic deep-cloning logic as part of this change.

### Testing

- Restored the solution with `dotnet restore UniversalToolchain/Wist.sln` and built with `dotnet build UniversalToolchain/Wist.sln -c Release --no-restore`.  
- Ran unit tests for core suites with `dotnet test` for `UniversalToolchain/Tests/Tests.csproj`, `UniversalToolchain/UniversalToolchain.Modules.Tests/UniversalToolchain.Modules.Tests.csproj`, and `UniversalToolchain/UniversalToolchain.Dialects.Tests/UniversalToolchain.Dialects.Tests.csproj`.  
- All executed test assemblies passed (no failing tests) when run in the described environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd2ece8904832482b9b6ee06439337)