### PR TITLE
Rewrite comment unterminated check to single-pass state scanner

### DIFF
--- a/UniversalToolchain/CommentsModule/CommentsModuleImpl.cs
+++ b/UniversalToolchain/CommentsModule/CommentsModuleImpl.cs
@@ -28,25 +28,60 @@ public class CommentsModuleImpl : IFrontendCoreModule
 
     private static void ValidateNoUnterminatedBlockComment(string code)
     {
-        var searchIndex = 0;
+        var state = CommentScanState.Normal;
+        var blockCommentStartIndex = -1;
 
-        while (searchIndex < code.Length)
+        for (var index = 0; index < code.Length; index++)
         {
-            var openingIndex = code.IndexOf("/*", searchIndex, StringComparison.Ordinal);
-            if (openingIndex < 0)
-                return;
+            var currentChar = code[index];
+            var nextChar = index + 1 < code.Length ? code[index + 1] : '\0';
 
-            var closingIndex = code.IndexOf("*/", openingIndex + 2, StringComparison.Ordinal);
-            if (closingIndex < 0)
+            switch (state)
             {
-                var location = new LexemeValue("/*", null, openingIndex, code);
-                WistThrower.Lexer(
-                    "Unterminated block comment (comment).",
-                    new SourceLocation { Line = location.LineNumber, Column = location.CharNumber }
-                );
-            }
+                case CommentScanState.Normal:
+                    if (currentChar == '/' && nextChar == '/')
+                    {
+                        state = CommentScanState.SingleLineComment;
+                        index++;
+                    }
+                    else if (currentChar == '/' && nextChar == '*')
+                    {
+                        state = CommentScanState.BlockComment;
+                        blockCommentStartIndex = index;
+                        index++;
+                    }
+                    break;
 
-            searchIndex = closingIndex + 2;
+                case CommentScanState.SingleLineComment:
+                    if (currentChar is '\n' or '\r')
+                        state = CommentScanState.Normal;
+                    break;
+
+                case CommentScanState.BlockComment:
+                    if (currentChar == '*' && nextChar == '/')
+                    {
+                        state = CommentScanState.Normal;
+                        blockCommentStartIndex = -1;
+                        index++;
+                    }
+                    break;
+            }
         }
+
+        if (state == CommentScanState.BlockComment)
+        {
+            var location = new LexemeValue("/*", null, blockCommentStartIndex, code);
+            WistThrower.Lexer(
+                "Unterminated block comment (comment).",
+                new SourceLocation { Line = location.LineNumber, Column = location.CharNumber }
+            );
+        }
+    }
+
+    private enum CommentScanState
+    {
+        Normal,
+        SingleLineComment,
+        BlockComment
     }
 }

--- a/UniversalToolchain/UniversalToolchain.Modules.Tests/ModuleCoverage/CommentsModuleValidationTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Modules.Tests/ModuleCoverage/CommentsModuleValidationTests.cs
@@ -29,6 +29,20 @@ public class CommentsModuleValidationTests
     }
 
     [Test]
+    public void Comments_SingleLineCommentContainingBlockOpen_DoesNotThrow()
+    {
+        using var helper = new ModulePipelineTestHelper();
+        helper.ExecuteEquivalent("// /*\n2 + 3", "2 + 3", Modules);
+    }
+
+    [Test]
+    public void Comments_BlockCommentOpenedInsideSingleLineComment_DoesNotAffectNextLine()
+    {
+        using var helper = new ModulePipelineTestHelper();
+        helper.ExecuteEquivalent("// before /*\n2 + 3", "2 + 3", Modules);
+    }
+
+    [Test]
     public void Comments_BlockCommentOnlyInput_DoesNotCreatePhantomStatement()
     {
         using var helper = new ModulePipelineTestHelper();


### PR DESCRIPTION
### Motivation

- The existing `ValidateNoUnterminatedBlockComment` used repeated `IndexOf` searches and was fragile for mixed comment cases, so a single-pass scanner simplifies logic and fixes false positives when `/*` appears inside a single-line comment. 

### Description

- Replaced `ValidateNoUnterminatedBlockComment(string code)` with a one-pass character scanner implementing explicit states `Normal`, `SingleLineComment`, and `BlockComment` in `UniversalToolchain/CommentsModule/CommentsModuleImpl.cs`. 
- In `Normal` the scanner now transitions on `//` to `SingleLineComment` and on `/*` to `BlockComment` while remembering the block start index. 
- In `SingleLineComment` the scanner returns to `Normal` on `\n` or `\r`, and in `BlockComment` it returns to `Normal` on `*/`, with no nested block comment handling introduced. 
- On EOF while in `BlockComment` the existing lexer error is thrown using the original opening position via `LexemeValue` to preserve diagnostic behavior. 
- Added `CommentScanState` enum and updated tests in `UniversalToolchain/UniversalToolchain.Modules.Tests/ModuleCoverage/CommentsModuleValidationTests.cs` to include `Comments_SingleLineCommentContainingBlockOpen_DoesNotThrow` and `Comments_BlockCommentOpenedInsideSingleLineComment_DoesNotAffectNextLine` while preserving the negative case `Comments_UnterminatedBlockComment_ThrowsDeterministicLexerError` for `2 /* bad`.

### Testing

- Installed the required SDK with `bash /tmp/dotnet-install.sh --version 10.0.103 --install-dir $HOME/.dotnet` and verified `dotnet --version` succeeded. 
- Ran `dotnet test UniversalToolchain/UniversalToolchain.Modules.Tests/UniversalToolchain.Modules.Tests.csproj -c Release` and the test assembly completed with `Passed! - Failed: 0, Passed: 154, Skipped: 7, Total: 161`. 
- Ran `dotnet test` for `UniversalToolchain/Tests/Tests.csproj` and `UniversalToolchain/UniversalToolchain.Dialects.Tests/UniversalToolchain.Dialects.Tests.csproj` with `--no-build` and both commands exited successfully with no failures reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd2eccad888324817331538eb23de9)