### PR TITLE
Cache per-assembly component indexes in DefaultRuntimeComponentResolver

### DIFF
--- a/UniversalToolchain/UniversalToolchain.Dialects.Integration/DefaultRuntimeComponentResolver.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Integration/DefaultRuntimeComponentResolver.cs
@@ -9,7 +9,9 @@ namespace UniversalToolchain.Dialects.Integration;
 public sealed class DefaultRuntimeComponentResolver : IRuntimeComponentResolver
 {
     private readonly IRuntimeAssemblyLoadStrategy _assemblyLoadStrategy;
-    private readonly ConcurrentDictionary<string, Lazy<RuntimeComponentDescriptor>> _cache = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, Lazy<Assembly>> _assemblyCache = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, Lazy<IReadOnlyDictionary<RuntimeComponentId, RuntimeComponentDescriptor>>> _assemblyComponentIndexCache =
+        new(StringComparer.Ordinal);
 
     public DefaultRuntimeComponentResolver(IRuntimeAssemblyLoadStrategy assemblyLoadStrategy)
     {
@@ -24,35 +26,64 @@ public sealed class DefaultRuntimeComponentResolver : IRuntimeComponentResolver
         if (entry == null)
             Thrower.ArgumentNull(nameof(entry));
 
-        var key = $"{entry.AssemblySimpleName}|{entry.ComponentId.Value}";
-        var lazy = _cache.GetOrAdd(
-            key,
-            _ => new Lazy<RuntimeComponentDescriptor>(
-                () => ResolveCore(entry),
-                LazyThreadSafetyMode.ExecutionAndPublication));
+        var componentIndex = GetAssemblyComponentIndex(entry.AssemblySimpleName);
+        if (componentIndex.TryGetValue(entry.ComponentId, out var descriptor))
+            return descriptor;
 
-        return lazy.Value;
+        return Thrower.InvalidOpEx<RuntimeComponentDescriptor>(
+            $"Runtime component '{entry.ComponentId}' was not found in assembly '{entry.AssemblySimpleName}'.");
     }
 
-    private RuntimeComponentDescriptor ResolveCore(RuntimeComponentManifestEntry entry)
+    private IReadOnlyDictionary<RuntimeComponentId, RuntimeComponentDescriptor> GetAssemblyComponentIndex(string assemblySimpleName)
     {
-        var assembly = _assemblyLoadStrategy.LoadAssembly(entry.AssemblySimpleName);
+        var lazyIndex = _assemblyComponentIndexCache.GetOrAdd(
+            assemblySimpleName,
+            _ => new Lazy<IReadOnlyDictionary<RuntimeComponentId, RuntimeComponentDescriptor>>(
+                () => BuildAssemblyComponentIndex(assemblySimpleName),
+                LazyThreadSafetyMode.ExecutionAndPublication));
 
-        foreach (var type in assembly.GetTypes())
+        return lazyIndex.Value;
+    }
+
+    private IReadOnlyDictionary<RuntimeComponentId, RuntimeComponentDescriptor> BuildAssemblyComponentIndex(string assemblySimpleName)
+    {
+        var assembly = GetAssembly(assemblySimpleName);
+        var index = new Dictionary<RuntimeComponentId, RuntimeComponentDescriptor>();
+
+        foreach (var type in GetLoadableTypes(assembly))
         {
             if (!TryGetRuntimeExport(type, out var kind, out var canonicalAlias))
                 continue;
 
             var id = RuntimeComponentIdFactory.Create(kind, canonicalAlias);
-            if (id != entry.ComponentId)
-                continue;
-
             var aliases = GetRuntimeAliases(type);
-            return new RuntimeComponentDescriptor(id, kind, canonicalAlias, aliases, type);
+            index[id] = new RuntimeComponentDescriptor(id, kind, canonicalAlias, aliases, type);
         }
 
-        return Thrower.InvalidOpEx<RuntimeComponentDescriptor>(
-            $"Runtime component '{entry.ComponentId}' was not found in assembly '{entry.AssemblySimpleName}'.");
+        return index;
+    }
+
+    private Assembly GetAssembly(string assemblySimpleName)
+    {
+        var lazyAssembly = _assemblyCache.GetOrAdd(
+            assemblySimpleName,
+            _ => new Lazy<Assembly>(
+                () => _assemblyLoadStrategy.LoadAssembly(assemblySimpleName),
+                LazyThreadSafetyMode.ExecutionAndPublication));
+
+        return lazyAssembly.Value;
+    }
+
+    private static IEnumerable<Type> GetLoadableTypes(Assembly assembly)
+    {
+        try
+        {
+            return assembly.GetTypes();
+        }
+        catch (ReflectionTypeLoadException exception)
+        {
+            return exception.Types.Where(static type => type != null).Cast<Type>();
+        }
     }
 
     private static bool TryGetRuntimeExport(Type type, out RuntimeComponentKind kind, out string canonicalAlias)

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/RuntimeLoading/DefaultRuntimeComponentResolverTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/RuntimeLoading/DefaultRuntimeComponentResolverTests.cs
@@ -134,7 +134,49 @@ public class DefaultRuntimeComponentResolverTests
         {
             Assert.That(first.ActivationType, Is.Not.EqualTo(second.ActivationType));
             Assert.That(first.Id, Is.Not.EqualTo(second.Id));
-            Assert.That(strategy.GetCalls(TestAssemblyName), Is.EqualTo(2));
+            Assert.That(strategy.GetCalls(TestAssemblyName), Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public void Resolve_DifferentEntries_FromSameAssembly_UsesSingleAssemblyIndexBuild()
+    {
+        var strategy = new CountingAssemblyLoadStrategy(new Dictionary<string, Assembly>(StringComparer.Ordinal)
+        {
+            [TestAssemblyName] = typeof(ResolverExportForCaching).Assembly
+        });
+        var resolver = new DefaultRuntimeComponentResolver(strategy);
+        var firstEntry = Entry(RuntimeComponentKind.FrontendModule, ResolverExportForDifferentEntriesAAlias, TestAssemblyName);
+        var secondEntry = Entry(RuntimeComponentKind.FrontendModule, ResolverExportForDifferentEntriesBAlias, TestAssemblyName);
+
+        _ = resolver.Resolve(firstEntry);
+        _ = resolver.Resolve(secondEntry);
+
+        Assert.That(strategy.GetCalls(TestAssemblyName), Is.EqualTo(1));
+    }
+
+    [Test]
+    public void Resolve_AssemblyTypeLoadFailure_StillUsesLoadableTypes()
+    {
+        var loadableType = typeof(ResolverExportForDifferentEntriesA);
+        var failingAssembly = new ReflectionTypeLoadExceptionAssembly(
+            [loadableType, null],
+            [new TypeLoadException("Simulated type load failure")]);
+
+        var strategy = new CountingAssemblyLoadStrategy(new Dictionary<string, Assembly>(StringComparer.Ordinal)
+        {
+            [TestAssemblyName] = failingAssembly
+        });
+        var resolver = new DefaultRuntimeComponentResolver(strategy);
+        var entry = Entry(RuntimeComponentKind.FrontendModule, ResolverExportForDifferentEntriesAAlias, TestAssemblyName);
+
+        var descriptor = resolver.Resolve(entry);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(descriptor.Id, Is.EqualTo(entry.ComponentId));
+            Assert.That(descriptor.ActivationType, Is.EqualTo(loadableType));
+            Assert.That(strategy.GetCalls(TestAssemblyName), Is.EqualTo(1));
         });
     }
 
@@ -186,5 +228,13 @@ public class DefaultRuntimeComponentResolverTests
         private readonly RuntimeComponentDescriptor _descriptor = descriptor;
 
         public RuntimeComponentDescriptor Resolve(RuntimeComponentManifestEntry entry) => _descriptor;
+    }
+
+    private sealed class ReflectionTypeLoadExceptionAssembly(Type?[] types, Exception[] loaderExceptions) : Assembly
+    {
+        private readonly Type?[] _types = types;
+        private readonly Exception[] _loaderExceptions = loaderExceptions;
+
+        public override Type[] GetTypes() => throw new ReflectionTypeLoadException(_types, _loaderExceptions);
     }
 }


### PR DESCRIPTION
### Motivation
- Reduce redundant assembly loads and avoid per-component cache cross-pollution by indexing components per assembly instead of per-entry. 
- Make indexing robust to partial type load failures by continuing with types available when `ReflectionTypeLoadException` occurs. 
- Preserve existing public contract `Resolve(RuntimeComponentManifestEntry entry)` and deterministic error/alias semantics while improving concurrency behavior.

### Description
- Added an assembly load cache `ConcurrentDictionary<string, Lazy<Assembly>>` and an assembly component index cache `ConcurrentDictionary<string, Lazy<IReadOnlyDictionary<RuntimeComponentId, RuntimeComponentDescriptor>>>` and kept the `Resolve(...)` signature unchanged. 
- Reworked `Resolve(...)` to obtain the per-assembly index from the cache and perform a dictionary lookup by `entry.ComponentId`, returning the same deterministic error message when missing. 
- Implemented `BuildAssemblyComponentIndex(...)` which loads the assembly via `IRuntimeAssemblyLoadStrategy`, enumerates loadable types via `GetLoadableTypes(...)` (handling `ReflectionTypeLoadException` with `exception.Types.Where(t != null)`), and indexes only types annotated with `DialectRuntimeExportAttribute` into a `Dictionary<RuntimeComponentId, RuntimeComponentDescriptor>`. 
- Preserved deterministic alias deduplication and ordering using `Distinct(StringComparer.Ordinal).OrderBy(StringComparer.Ordinal)` and added a `ReflectionTypeLoadException` test assembly helper for tests. 

### Testing
- Restored and ran tests with `dotnet restore UniversalToolchain/Wist.sln` and `dotnet test` for the affected test projects. 
- Ran `dotnet test UniversalToolchain/UniversalToolchain.Dialects.Tests/UniversalToolchain.Dialects.Tests.csproj -c Release` which passed (Passed: 273, Failed: 0). 
- Ran `dotnet test UniversalToolchain/Tests/Tests.csproj -c Release` which passed (Passed: 64, Failed: 0). 
- Ran `dotnet test UniversalToolchain/UniversalToolchain.Modules.Tests/UniversalToolchain.Modules.Tests.csproj -c Release` which passed (Passed: 152, Skipped: 7, Failed: 0).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd2ecf5eb083248fc64402b39956ab)