### PR TITLE
Add IArtifactCompiler<T> contract and typed host accessor

### DIFF
--- a/UniversalToolchain/BasicCore/Contracts/IArtifactCompiler.cs
+++ b/UniversalToolchain/BasicCore/Contracts/IArtifactCompiler.cs
@@ -1,0 +1,18 @@
+namespace BasicCore.Contracts;
+
+/// <summary>
+/// Provides a reusable public contract for compiling source text into immutable artifacts.
+/// </summary>
+/// <typeparam name="TCompilationOutput">Compilation backend output type.</typeparam>
+public interface IArtifactCompiler<out TCompilationOutput>
+{
+    /// <summary>
+    /// Compiles source text with optional declared external bindings.
+    /// </summary>
+    ICompiledArtifact<TCompilationOutput> Compile(string code, OrderedDictionary<string, Type>? parameters = null);
+
+    /// <summary>
+    /// Compiles an explicit compilation input.
+    /// </summary>
+    ICompiledArtifact<TCompilationOutput> Compile(CompilationInput input);
+}

--- a/UniversalToolchain/BasicCore/Core/BasicCoreImpl.cs
+++ b/UniversalToolchain/BasicCore/Core/BasicCoreImpl.cs
@@ -11,6 +11,7 @@ public class BasicCoreImpl<TCompilationOutput>(
     IReadOnlyList<IIRProcessingModule> optimizers,
     IReadOnlyList<IMiddleEndCoreModule<TCompilationOutput>> middleEndModules
 ) : ICoreRunnable, ICoreOptimizedRunnable, IExecutableGiver<TCompilationOutput>
+    , IArtifactCompiler<TCompilationOutput>
 {
     private readonly CompilationInputNormalizer _inputNormalizer = new();
 

--- a/UniversalToolchain/Tests/Infrastructure/RuntimeCompiledArtifactContractsTests.cs
+++ b/UniversalToolchain/Tests/Infrastructure/RuntimeCompiledArtifactContractsTests.cs
@@ -49,6 +49,22 @@ public class RuntimeCompiledArtifactContractsTests
     }
 
     [Test]
+    public void HostArtifactCompilerAccessor_ShouldReturnTypedCompiler_AndRejectUnsupportedOutput()
+    {
+        using var host = CreateHost();
+
+        var compiler = host.GetArtifactCompiler<DynamicMethod>("compiler");
+        var artifact = compiler.Compile("41 + 1");
+        var value = artifact.CreateSession().Run();
+
+        var ex = Assert.Throws<InvalidOperationException>(() => host.GetArtifactCompiler<DynamicMethod>("interpreter"));
+
+        Assert.That(value, Is.Not.Null);
+        Assert.That(ex!.Message, Does.Contain("does not support compilation output"));
+        Assert.That(ex.Message, Does.Contain(typeof(DynamicMethod).FullName));
+    }
+
+    [Test]
     public void DynamicMethodArtifact_AsFunc_SingleArgument_ReturnsExpectedValue()
     {
         var artifact = CreateUnaryAddOneArtifact();

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistDialectExecutionHost.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistDialectExecutionHost.cs
@@ -33,6 +33,24 @@ public sealed class WistDialectExecutionHost : IDisposable
 
     public ICoreRunnable GetCore(string mode)
     {
+        return ResolveRuntime(mode).Core;
+    }
+
+    public object? Run(string code, string mode) => GetCore(mode).Run(code);
+
+    public IArtifactCompiler<TCompilationOutput> GetArtifactCompiler<TCompilationOutput>(string mode)
+    {
+        var runtime = ResolveRuntime(mode);
+        if (runtime.Core is IArtifactCompiler<TCompilationOutput> compiler)
+            return compiler;
+
+        Thrower.InvalidOpEx<IArtifactCompiler<TCompilationOutput>>(
+            $"Backend '{runtime.Descriptor.CanonicalId}' does not support compilation output '{typeof(TCompilationOutput).FullName}'.");
+        return null!;
+    }
+
+    private WistDialectBackendRuntime ResolveRuntime(string mode)
+    {
         if (string.IsNullOrWhiteSpace(mode))
             Thrower.Argument(nameof(mode), "Execution mode must not be empty.");
 
@@ -48,10 +66,8 @@ public sealed class WistDialectExecutionHost : IDisposable
         var runtime = _serviceProvider.GetServices<WistDialectBackendRuntime>()
             .FirstOrDefault(x => x.Descriptor.BackendId == backendConfiguration.BackendDescriptor.BackendId);
         if (runtime == null)
-            Thrower.InvalidOpEx<ICoreRunnable>($"Backend core '{backendConfiguration.BackendDescriptor.CanonicalId}' was not registered.");
+            Thrower.InvalidOpEx<WistDialectBackendRuntime>($"Backend core '{backendConfiguration.BackendDescriptor.CanonicalId}' was not registered.");
 
-        return runtime.Core;
+        return runtime;
     }
-
-    public object? Run(string code, string mode) => GetCore(mode).Run(code);
 }

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -28,6 +28,10 @@ Runtime composition paths:
 - **Default composition**: uses built-in/default service registrations.
 - **Dialect-based composition**: uses a `.wistdialect` file to resolve runtime composition before execution.
 
+Public compile-artifact access is exposed through a host-level contract:
+
+- `IArtifactCompiler<TCompilationOutput>` for deterministic artifact compilation (`Compile(...)`) and session creation via `ICompiledArtifact<TCompilationOutput>`.
+
 ## Dialect workflow
 
 Typical dialect execution flow:

--- a/readme.md
+++ b/readme.md
@@ -131,19 +131,38 @@ var dialect = workflow.ComposeFile("./Dialects/examples/wist/full-default/dialec
 if (!dialect.IsSuccess) return;
 
 using var host = workflow.CreateHost(dialect);
-var result = host.Run("(2 + 2) * 3", "compiler");
-Console.WriteLine(result);
+
+var artifactCompiler = host.GetArtifactCompiler<DynamicMethod>("compiler");
+var artifact = artifactCompiler.Compile("(2 + 2) * 3");
+var result = artifact.CreateSession().Run();
+Console.WriteLine(result); // 12
 ```
 
 See `UniversalToolchain/Example/Program.cs` for a full composition + diagnostics flow.
 
-### Compile artifact API (DynamicMethod backend)
+### Compile artifact API (canonical contract)
+
+`GetArtifactCompiler<TCompilationOutput>(mode)` is the canonical compile-artifact access path from the host layer:
 
 ```csharp
-var compilerCore = host.GetCore("compiler") as BasicCoreImpl<DynamicMethod>
-                   ?? throw new InvalidOperationException();
+var compiler = host.GetArtifactCompiler<DynamicMethod>("compiler");
+var artifact = compiler.Compile("x + 1", new OrderedDictionary<string, Type>
+{
+    ["x"] = typeof(int)
+});
 
-var artifact = compilerCore.Compile("x + 1", new OrderedDictionary<string, Type>
+var session = artifact.CreateSession();
+session.SetArgument("x", 41);
+var fortyTwo = session.Run<int>();
+```
+
+### DynamicMethod fast-path (optional)
+
+For `DynamicMethod` artifacts, extension methods remain available as an optional fast-path API:
+
+```csharp
+var compiler = host.GetArtifactCompiler<DynamicMethod>("compiler");
+var artifact = compiler.Compile("x + 1", new OrderedDictionary<string, Type>
 {
     ["x"] = typeof(int)
 });


### PR DESCRIPTION
### Motivation

- Provide a canonical, public compile-to-artifact contract to decouple host-level usage from concrete core types and to make compile semantics deterministic across backends.
- Expose a typed host accessor so callers can request an artifact compiler for a specific `TCompilationOutput` and get a deterministic error when the backend cannot produce that output.
- Preserve the existing `DynamicMethod` extension API as an optional fast-path without changing current public extension behavior.

### Description

- Added a new public contract `IArtifactCompiler<TCompilationOutput>` with `Compile(string, OrderedDictionary<string, Type>?)` and `Compile(CompilationInput)` overloads in `UniversalToolchain/BasicCore/Contracts/IArtifactCompiler.cs`.
- Implemented the contract in `BasicCoreImpl<TCompilationOutput>` without breaking existing interfaces by adding `IArtifactCompiler<TCompilationOutput>` to the implemented interfaces and forwarding to existing compilation logic.
- Added a typed accessor `GetArtifactCompiler<TCompilationOutput>(string mode)` to `UniversalToolchain.Dialects.Wist/WistDialectExecutionHost.cs` and centralized backend resolution into `ResolveRuntime(...)`; the accessor throws a deterministic `InvalidOperationException` when the backend does not support the requested `TCompilationOutput`.
- Kept `DynamicMethod` extension helpers as an optional fast-path and updated `readme.md` and `docs/architecture-overview.md` to document the canonical `GetArtifactCompiler<TCompilationOutput>` flow and the `DynamicMethod` fast-path.
- Added an infrastructure contract test `HostArtifactCompilerAccessor_ShouldReturnTypedCompiler_AndRejectUnsupportedOutput` in `UniversalToolchain/Tests/Infrastructure/RuntimeCompiledArtifactContractsTests.cs` that verifies successful typed access and deterministic failure for unsupported output types.

### Testing

- Ran `dotnet restore UniversalToolchain/Wist.sln` and `dotnet build UniversalToolchain/Wist.sln -c Release --no-restore` which succeeded.
- Ran `dotnet test UniversalToolchain/Tests/Tests.csproj -c Release` and the updated `RuntimeCompiledArtifactContractsTests` (including the new accessor test) passed.
- Ran `dotnet test` for `UniversalToolchain.Modules.Tests` and `UniversalToolchain.Dialects.Tests` and both test suites passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd2ed109b48324b854d08e40598dfc)