### PR TITLE
Rename ParametersSetterModuleImpl to ParametersSetterModulePlaceholder

### DIFF
--- a/UniversalToolchain/ParametersSetterModule/ParametersSetterModulePlaceholder.cs
+++ b/UniversalToolchain/ParametersSetterModule/ParametersSetterModulePlaceholder.cs
@@ -5,7 +5,7 @@ namespace ParametersSetterModule;
 /// The module is intentionally not exported to dialect composition until
 /// lexer/parser/runtime contracts are finalized.
 /// </summary>
-public sealed class ParametersSetterModuleImpl
+public sealed class ParametersSetterModulePlaceholder
 {
     public const string UnsupportedReason =
         "ParametersSetter is not exported yet: parser contracts and runtime binding semantics are not finalized.";

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/RuntimeLoading/ParametersSetterExportContractsTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/RuntimeLoading/ParametersSetterExportContractsTests.cs
@@ -27,7 +27,7 @@ public class ParametersSetterExportContractsTests
     [Test]
     public void ParametersSetter_PlaceholderUnsupportedReason_IsStable()
     {
-        Assert.That(ParametersSetterModuleImpl.UnsupportedReason, Is.EqualTo(ExpectedUnsupportedReason));
+        Assert.That(ParametersSetterModulePlaceholder.UnsupportedReason, Is.EqualTo(ExpectedUnsupportedReason));
     }
 
     [Test]


### PR DESCRIPTION
### Motivation
- Clarify intent by renaming the placeholder implementation to an explicit placeholder type and filename to match project naming rules and file-per-type conventions. 
- Preserve the module-as-placeholder contract while ensuring tests refer to the canonical symbol name rather than the old implementation name.

### Description
- Renamed file `UniversalToolchain/ParametersSetterModule/ParametersSetterModuleImpl.cs` to `ParametersSetterModulePlaceholder.cs` and renamed type `ParametersSetterModuleImpl` to `ParametersSetterModulePlaceholder` inside the same namespace. 
- Updated test usage in `UniversalToolchain/UniversalToolchain.Dialects.Tests/RuntimeLoading/ParametersSetterExportContractsTests.cs` to reference `ParametersSetterModulePlaceholder.UnsupportedReason`. 
- Preserved the `UnsupportedReason` constant and its exact message text to keep contract stability. 
- Did not add an `[Obsolete]` wrapper because repository-wide references were updated and backward compatibility layer was not required.

### Testing
- Ran `dotnet restore UniversalToolchain/Wist.sln` and the restore completed successfully. 
- Ran `dotnet build UniversalToolchain/Wist.sln -c Release --no-restore` and the build succeeded with zero warnings and zero errors. 
- Ran `dotnet test UniversalToolchain/Tests/Tests.csproj -c Release --no-build` and all tests passed (`Passed: 64, Failed: 0, Skipped: 0`). 
- Ran `dotnet test UniversalToolchain/UniversalToolchain.Modules.Tests/UniversalToolchain.Modules.Tests.csproj -c Release --no-build` and the suite passed (`Passed: 152, Skipped: 7, Failed: 0`). 
- Ran `dotnet test UniversalToolchain/UniversalToolchain.Dialects.Tests/UniversalToolchain.Dialects.Tests.csproj -c Release --no-build` and the suite passed (`Passed: 271, Failed: 0, Skipped: 0`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd2ed27c088324adcef79c6c5af5a3)