### PR TITLE
Add interface-based invoke convenience methods for compiled sessions

### DIFF
--- a/UniversalToolchain/BasicCore/Execution/CompiledArtifactSessionExtensions.cs
+++ b/UniversalToolchain/BasicCore/Execution/CompiledArtifactSessionExtensions.cs
@@ -26,8 +26,8 @@ public static class CompiledArtifactSessionExtensions
     /// <summary>
     /// Assigns positional arguments and executes the session.
     /// </summary>
-    public static T Invoke<TCompilationOutput, T>(
-        this CompiledArtifactSession<TCompilationOutput> session,
+    public static T Invoke<T>(
+        this ICompiledArtifactSession session,
         params object?[] arguments)
     {
         if (session == null)
@@ -52,8 +52,8 @@ public static class CompiledArtifactSessionExtensions
     /// <summary>
     /// Assigns named arguments and executes the session.
     /// </summary>
-    public static T InvokeNamed<TCompilationOutput, T>(
-        this CompiledArtifactSession<TCompilationOutput> session,
+    public static T InvokeNamed<T>(
+        this ICompiledArtifactSession session,
         IReadOnlyDictionary<string, object?> arguments)
     {
         if (session == null)
@@ -73,5 +73,25 @@ public static class CompiledArtifactSessionExtensions
             session.SetArgument(argument.Key, argument.Value);
 
         return session.Run<T>();
+    }
+
+    /// <summary>
+    /// Assigns positional arguments and executes the session.
+    /// </summary>
+    public static T Invoke<TCompilationOutput, T>(
+        this CompiledArtifactSession<TCompilationOutput> session,
+        params object?[] arguments)
+    {
+        return Invoke<T>(session, arguments);
+    }
+
+    /// <summary>
+    /// Assigns named arguments and executes the session.
+    /// </summary>
+    public static T InvokeNamed<TCompilationOutput, T>(
+        this CompiledArtifactSession<TCompilationOutput> session,
+        IReadOnlyDictionary<string, object?> arguments)
+    {
+        return InvokeNamed<T>(session, arguments);
     }
 }

--- a/UniversalToolchain/Tests/Infrastructure/CompiledArtifactContractsTests.cs
+++ b/UniversalToolchain/Tests/Infrastructure/CompiledArtifactContractsTests.cs
@@ -134,6 +134,23 @@ public class CompiledArtifactContractsTests
     }
 
     [Test]
+    public void CompiledArtifactSession_Run_CanBeInvokedViaInterface()
+    {
+        var artifact = CreateTwoArgumentArtifact("compiled", 0, string.Empty);
+        ICompiledArtifactSession session = artifact.CreateSession();
+
+        var first = session.Invoke<string>(1, "a");
+        var second = session.InvokeNamed<string>(new Dictionary<string, object?>
+        {
+            ["value"] = 8,
+            ["text"] = "b"
+        });
+
+        Assert.That(first, Is.EqualTo("compiled:1:a"));
+        Assert.That(second, Is.EqualTo("compiled:8:b"));
+    }
+
+    [Test]
     public void CompiledArtifactSession_Run_RejectsNullForNonNullableValueType()
     {
         var artifact = CreateTwoArgumentArtifact("compiled");

--- a/UniversalToolchain/Tests/Infrastructure/CompiledArtifactSessionTests.cs
+++ b/UniversalToolchain/Tests/Infrastructure/CompiledArtifactSessionTests.cs
@@ -75,11 +75,35 @@ public class CompiledArtifactSessionTests
     }
 
     [Test]
+    public void Invoke_ShouldWork_ThroughInterfaceReference()
+    {
+        ICompiledArtifactSession session = CreateSession(out _);
+
+        var result = session.Invoke<string>(3, "n");
+
+        Assert.That(result, Is.EqualTo("compiled:3:n"));
+    }
+
+    [Test]
     public void InvokeNamed_ShouldAssignByNameAndRun()
     {
         var session = CreateSession(out _);
 
         var result = session.InvokeNamed<string, string>(new Dictionary<string, object?>
+        {
+            ["text"] = "q",
+            ["value"] = 9
+        });
+
+        Assert.That(result, Is.EqualTo("compiled:9:q"));
+    }
+
+    [Test]
+    public void InvokeNamed_ShouldWork_ThroughInterfaceReference()
+    {
+        ICompiledArtifactSession session = CreateSession(out _);
+
+        var result = session.InvokeNamed<string>(new Dictionary<string, object?>
         {
             ["text"] = "q",
             ["value"] = 9


### PR DESCRIPTION
### Motivation
- Improve API ergonomics by allowing callers to invoke compiled sessions through an `ICompiledArtifactSession` reference without downcasting. 
- Ensure the convenience helpers operate only via the interface contract (`ArgumentCount`, `SetArgument(...)`, `Run()`) to avoid coupling to concrete session implementations. 
- Preserve existing strongly-typed overloads for backward compatibility while shifting the primary ergonomics to the interface surface.

### Description
- Added `Invoke<T>(this ICompiledArtifactSession session, params object?[] arguments)` and `InvokeNamed<T>(this ICompiledArtifactSession session, IReadOnlyDictionary<string, object?> arguments)` extension methods that validate `ArgumentCount`, call `SetArgument(...)` and execute via `Run()`/`Run<T>()`.
- Modified existing `CompiledArtifactSession<TCompilationOutput>.Invoke<,>` and `InvokeNamed<,>` overloads to delegate to the new interface-based methods to keep compatibility while centralizing behavior.
- Added tests in `UniversalToolchain/Tests/Infrastructure/CompiledArtifactSessionTests.cs` to assert positional and named invocation through an `ICompiledArtifactSession` reference.
- Added a contract-level test in `UniversalToolchain/Tests/Infrastructure/CompiledArtifactContractsTests.cs` to verify interface-based invocation works in the broader compilation/workflow scenario.

### Testing
- Installed .NET SDK `10.0.103` to match repository requirements from `readme.md` and used it for test runs.
- Ran `dotnet test UniversalToolchain/Tests/Tests.csproj -c Release` and the tests passed (`Passed: 66, Failed: 0`).
- Ran `dotnet test UniversalToolchain/UniversalToolchain.Modules.Tests/UniversalToolchain.Modules.Tests.csproj -c Release` and the tests passed (`Passed: 152, Failed: 0, Skipped: 7`).
- Ran `dotnet test UniversalToolchain/UniversalToolchain.Dialects.Tests/UniversalToolchain.Dialects.Tests.csproj -c Release` and the tests passed (`Passed: 271, Failed: 0`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd2ed273e88324a62be494ee948bc4)