### PR TITLE
docs: clarify compile-artifact API and update Unreleased changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,19 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed constant-binding mutation.
+- Fixed false-positive comment validation for `// /*`.
+- Improved runtime component resolver assembly indexing.
+
+### Added
+
+- Introduced a public compile-artifact contract/accessor.
+
 ### Changed
 
+- Renamed `ParametersSetter` placeholder type.
 - Consolidated repository-level documentation around explicit canonical roles (`readme.md`, `PROJECT_RULES.md`,
   `CONTRIBUTING.md`, `AGENTS.md`).
 - Updated root documentation to reinforce framework-first positioning: UniversalToolchain as reusable architecture, Wist

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -28,6 +28,13 @@ Runtime composition paths:
 - **Default composition**: uses built-in/default service registrations.
 - **Dialect-based composition**: uses a `.wistdialect` file to resolve runtime composition before execution.
 
+Compile-artifact surface:
+
+- The framework exposes a public compile-artifact contract for backends that support artifact-oriented workflows
+  (compile once, create one or more execution sessions).
+- Backend-specific helpers/extensions are optional layers on top of that contract and should be treated as
+  convenience/performance paths, not mandatory framework behavior.
+
 ## Dialect workflow
 
 Typical dialect execution flow:

--- a/readme.md
+++ b/readme.md
@@ -137,7 +137,23 @@ Console.WriteLine(result);
 
 See `UniversalToolchain/Example/Program.cs` for a full composition + diagnostics flow.
 
-### Compile artifact API (DynamicMethod backend)
+### Compile artifact API
+
+Generic framework path (through the public compile-artifact contract/accessor):
+
+```csharp
+var compilerArtifacts = /* resolve public compile-artifact accessor from your composition */;
+var artifact = compilerArtifacts.Compile("x + 1", new OrderedDictionary<string, Type>
+{
+    ["x"] = typeof(int)
+});
+
+var session = artifact.CreateSession();
+session.SetArgument("x", 41);
+var fortyTwo = session.Run<int>();
+```
+
+Optional DynamicMethod fast-path (backend-specific extension):
 
 ```csharp
 var compilerCore = host.GetCore("compiler") as BasicCoreImpl<DynamicMethod>


### PR DESCRIPTION
### Motivation

- Remove a canonical example that hardcoded a direct cast to `BasicCoreImpl<DynamicMethod>` and document a generic framework path instead.
- Surface the public compile-artifact contract so callers understand artifact-oriented workflows are a supported framework abstraction.
- Make clear that `DynamicMethod` helpers are backend-specific performance conveniences, not mandatory framework behavior.
- Record recent bugfixes and API/placeholder renames in the `[Unreleased]` changelog section.

### Description

- Updated `readme.md` to split the compile-artifact documentation into a generic framework path (via a public compile-artifact contract/accessor) and an optional `DynamicMethod` fast-path, and replaced the direct-cast canonical example with a generic accessor-based example using `CreateSession`/`SetArgument`/`Run<T>`.
- Added a short `Compile-artifact surface` note to `docs/architecture-overview.md` that documents the public compile-artifact contract and explicitly marks backend-specific helpers/extensions as optional convenience/performance layers.
- Updated `CHANGELOG.md` `[Unreleased]` to add the requested items under `Fixed` and `Added`, and to rename the `ParametersSetter` placeholder type under `Changed`.
- Adjusted wording in the modified docs to avoid promising behavior that only backend-specific extensions provide.

### Testing

- Attempted to detect runtime/tooling by running `dotnet --version`, but `dotnet` is not available in the environment so no `dotnet test` runs were executed.
- This change is documentation-only and no code-paths were modified, so no unit tests were required to validate behavioral changes within this patch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd2ed431848324ac4eae4239f378d4)