### PR TITLE
Introduce generic artifact compiler contract and runtime accessor

### DIFF
--- a/UniversalToolchain/BasicCore/Contracts/IArtifactCompiler.cs
+++ b/UniversalToolchain/BasicCore/Contracts/IArtifactCompiler.cs
@@ -1,0 +1,7 @@
+namespace BasicCore.Contracts;
+
+public interface IArtifactCompiler<TCompilationOutput>
+{
+    ICompiledArtifact<TCompilationOutput> Compile(string code, OrderedDictionary<string, Type>? parameters = null);
+    ICompiledArtifact<TCompilationOutput> Compile(CompilationInput input);
+}

--- a/UniversalToolchain/BasicCore/Core/BasicCoreImpl.cs
+++ b/UniversalToolchain/BasicCore/Core/BasicCoreImpl.cs
@@ -10,7 +10,7 @@ public class BasicCoreImpl<TCompilationOutput>(
     IReadOnlyList<IFrontendCoreModule> modules,
     IReadOnlyList<IIRProcessingModule> optimizers,
     IReadOnlyList<IMiddleEndCoreModule<TCompilationOutput>> middleEndModules
-) : ICoreRunnable, ICoreOptimizedRunnable, IExecutableGiver<TCompilationOutput>
+) : ICoreRunnable, ICoreOptimizedRunnable, IExecutableGiver<TCompilationOutput>, IArtifactCompiler<TCompilationOutput>
 {
     private readonly CompilationInputNormalizer _inputNormalizer = new();
 

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistDialectExecutionHost.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistDialectExecutionHost.cs
@@ -32,6 +32,20 @@ public sealed class WistDialectExecutionHost : IDisposable
     }
 
     public ICoreRunnable GetCore(string mode)
+        => ResolveRuntime(mode).Core;
+
+    public IArtifactCompiler<TCompilationOutput> GetArtifactCompiler<TCompilationOutput>(string mode)
+    {
+        var runtime = ResolveRuntime(mode);
+
+        if (runtime.Core is IArtifactCompiler<TCompilationOutput> artifactCompiler)
+            return artifactCompiler;
+
+        return Thrower.InvalidOpEx<IArtifactCompiler<TCompilationOutput>>(
+            "Selected backend does not expose a compatible artifact compiler.");
+    }
+
+    private WistDialectBackendRuntime ResolveRuntime(string mode)
     {
         if (string.IsNullOrWhiteSpace(mode))
             Thrower.Argument(nameof(mode), "Execution mode must not be empty.");
@@ -48,9 +62,9 @@ public sealed class WistDialectExecutionHost : IDisposable
         var runtime = _serviceProvider.GetServices<WistDialectBackendRuntime>()
             .FirstOrDefault(x => x.Descriptor.BackendId == backendConfiguration.BackendDescriptor.BackendId);
         if (runtime == null)
-            Thrower.InvalidOpEx<ICoreRunnable>($"Backend core '{backendConfiguration.BackendDescriptor.CanonicalId}' was not registered.");
+            Thrower.InvalidOpEx<WistDialectBackendRuntime>($"Backend core '{backendConfiguration.BackendDescriptor.CanonicalId}' was not registered.");
 
-        return runtime.Core;
+        return runtime;
     }
 
     public object? Run(string code, string mode) => GetCore(mode).Run(code);


### PR DESCRIPTION
### Motivation
- Expose a generic compile-artifact contract so backends can provide a typed artifact-compiler surface independent of concrete core types.
- Make Wist host runtime resolution reusable so callers can access the runtime core and a typed artifact compiler accessor without duplicating resolution logic.
- Keep existing backend-specific fast-paths (e.g. `AsFunc(...)`, `GetNativeDelegateInvoker()`) unchanged and optional.

### Description
- Added `BasicCore.Contracts.IArtifactCompiler<TCompilationOutput>` with two overloads: `Compile(string, OrderedDictionary<string, Type>?)` and `Compile(CompilationInput)` in `UniversalToolchain/BasicCore/Contracts/IArtifactCompiler.cs`.
- Updated `BasicCore.Core.BasicCoreImpl<TCompilationOutput>` to explicitly implement `IArtifactCompiler<TCompilationOutput>` so existing compile methods remain the public contract implementation.
- Refactored `UniversalToolchain.Dialects.Wist.WistDialectExecutionHost` by extracting runtime lookup into `ResolveRuntime(string mode)`, making `GetCore(string mode)` a thin wrapper over `ResolveRuntime(mode).Core`, and adding a typed accessor `GetArtifactCompiler<TCompilationOutput>(string mode)` that returns the runtime core as `IArtifactCompiler<TCompilationOutput>` when compatible and throws `Thrower.InvalidOpEx<T>(...)` when not.

### Testing
- Installed .NET SDK `10.0.103` and ran `dotnet restore UniversalToolchain/Wist.sln` which completed successfully.
- Built the solution with `dotnet build UniversalToolchain/Wist.sln -c Release --no-restore` and the build succeeded with `0 Error(s)` and `0 Warning(s)`.
- Ran unit tests: `dotnet test UniversalToolchain/Tests/Tests.csproj -c Release --no-build` (Passed: 67/67), `dotnet test UniversalToolchain/UniversalToolchain.Modules.Tests/UniversalToolchain.Modules.Tests.csproj -c Release --no-build` (Passed: 154, Skipped: 7, Total: 161), and `dotnet test UniversalToolchain/UniversalToolchain.Dialects.Tests/UniversalToolchain.Dialects.Tests.csproj -c Release --no-build` (Passed: 271/271), all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd4d8eaa988324a0bd3721f3bd0d02)