### PR TITLE
Cache per-assembly component indexes in DefaultRuntimeComponentResolver

### DIFF
--- a/UniversalToolchain/UniversalToolchain.Dialects.Integration/DefaultRuntimeComponentResolver.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Integration/DefaultRuntimeComponentResolver.cs
@@ -9,7 +9,8 @@ namespace UniversalToolchain.Dialects.Integration;
 public sealed class DefaultRuntimeComponentResolver : IRuntimeComponentResolver
 {
     private readonly IRuntimeAssemblyLoadStrategy _assemblyLoadStrategy;
-    private readonly ConcurrentDictionary<string, Lazy<RuntimeComponentDescriptor>> _cache = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, Lazy<Assembly>> _assemblyCache = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, Lazy<IReadOnlyDictionary<RuntimeComponentId, RuntimeComponentDescriptor>>> _assemblyComponentIndexCache = new(StringComparer.Ordinal);
 
     public DefaultRuntimeComponentResolver(IRuntimeAssemblyLoadStrategy assemblyLoadStrategy)
     {
@@ -24,35 +25,66 @@ public sealed class DefaultRuntimeComponentResolver : IRuntimeComponentResolver
         if (entry == null)
             Thrower.ArgumentNull(nameof(entry));
 
-        var key = $"{entry.AssemblySimpleName}|{entry.ComponentId.Value}";
-        var lazy = _cache.GetOrAdd(
-            key,
-            _ => new Lazy<RuntimeComponentDescriptor>(
-                () => ResolveCore(entry),
-                LazyThreadSafetyMode.ExecutionAndPublication));
+        var index = GetAssemblyComponentIndex(entry.AssemblySimpleName);
+        if (index.TryGetValue(entry.ComponentId, out var descriptor))
+            return descriptor;
+
+        return Thrower.InvalidOpEx<RuntimeComponentDescriptor>(
+            $"Runtime component '{entry.ComponentId}' was not found in assembly '{entry.AssemblySimpleName}'.");
+    }
+
+    private IReadOnlyDictionary<RuntimeComponentId, RuntimeComponentDescriptor> GetAssemblyComponentIndex(string assemblySimpleName)
+    {
+        var lazy = _assemblyComponentIndexCache.GetOrAdd(
+            assemblySimpleName,
+            static (name, resolver) => new Lazy<IReadOnlyDictionary<RuntimeComponentId, RuntimeComponentDescriptor>>(
+                () => resolver.BuildAssemblyComponentIndex(name),
+                LazyThreadSafetyMode.ExecutionAndPublication),
+            this);
 
         return lazy.Value;
     }
 
-    private RuntimeComponentDescriptor ResolveCore(RuntimeComponentManifestEntry entry)
+    private IReadOnlyDictionary<RuntimeComponentId, RuntimeComponentDescriptor> BuildAssemblyComponentIndex(string assemblySimpleName)
     {
-        var assembly = _assemblyLoadStrategy.LoadAssembly(entry.AssemblySimpleName);
+        var assembly = GetAssembly(assemblySimpleName);
+        var descriptors = new Dictionary<RuntimeComponentId, RuntimeComponentDescriptor>();
 
-        foreach (var type in assembly.GetTypes())
+        foreach (var type in GetLoadableTypes(assembly))
         {
             if (!TryGetRuntimeExport(type, out var kind, out var canonicalAlias))
                 continue;
 
             var id = RuntimeComponentIdFactory.Create(kind, canonicalAlias);
-            if (id != entry.ComponentId)
-                continue;
-
             var aliases = GetRuntimeAliases(type);
-            return new RuntimeComponentDescriptor(id, kind, canonicalAlias, aliases, type);
+            descriptors[id] = new RuntimeComponentDescriptor(id, kind, canonicalAlias, aliases, type);
         }
 
-        return Thrower.InvalidOpEx<RuntimeComponentDescriptor>(
-            $"Runtime component '{entry.ComponentId}' was not found in assembly '{entry.AssemblySimpleName}'.");
+        return descriptors;
+    }
+
+    private Assembly GetAssembly(string assemblySimpleName)
+    {
+        var lazy = _assemblyCache.GetOrAdd(
+            assemblySimpleName,
+            static (name, resolver) => new Lazy<Assembly>(
+                () => resolver._assemblyLoadStrategy.LoadAssembly(name),
+                LazyThreadSafetyMode.ExecutionAndPublication),
+            this);
+
+        return lazy.Value;
+    }
+
+    private static IEnumerable<Type> GetLoadableTypes(Assembly assembly)
+    {
+        try
+        {
+            return assembly.GetTypes();
+        }
+        catch (ReflectionTypeLoadException exception)
+        {
+            return exception.Types.Where(static type => type != null).Cast<Type>();
+        }
     }
 
     private static bool TryGetRuntimeExport(Type type, out RuntimeComponentKind kind, out string canonicalAlias)

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/RuntimeLoading/DefaultRuntimeComponentResolverTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/RuntimeLoading/DefaultRuntimeComponentResolverTests.cs
@@ -134,7 +134,7 @@ public class DefaultRuntimeComponentResolverTests
         {
             Assert.That(first.ActivationType, Is.Not.EqualTo(second.ActivationType));
             Assert.That(first.Id, Is.Not.EqualTo(second.Id));
-            Assert.That(strategy.GetCalls(TestAssemblyName), Is.EqualTo(2));
+            Assert.That(strategy.GetCalls(TestAssemblyName), Is.EqualTo(1));
         });
     }
 


### PR DESCRIPTION
### Motivation
- Reduce repeated assembly loads and per-component scanning by building and caching a component index per assembly for deterministic and efficient resolution. 
- Separate concerns by caching `Assembly` objects and component indexes independently to simplify concurrency and reuse.
- Keep error behavior simple when a component is missing and avoid introducing complex duplicate/conflict diagnostics in this change.

### Description
- Replaced the single-entry `_cache` with two caches: `_assemblyCache: ConcurrentDictionary<string, Lazy<Assembly>>` and `_assemblyComponentIndexCache: ConcurrentDictionary<string, Lazy<IReadOnlyDictionary<RuntimeComponentId, RuntimeComponentDescriptor>>>` in `DefaultRuntimeComponentResolver`. 
- Updated `Resolve(RuntimeComponentManifestEntry entry)` to load the per-assembly index via `GetAssemblyComponentIndex(entry.AssemblySimpleName)` and return the descriptor by `entry.ComponentId` or throw `Thrower.InvalidOpEx(...)` if not found. 
- Added `BuildAssemblyComponentIndex(string assemblySimpleName)` which obtains the `Assembly` via `GetAssembly(...)`, enumerates loadable types via `GetLoadableTypes(Assembly)`, produces `RuntimeComponentDescriptor` for types marked with `DialectRuntimeExportAttribute`, and returns a `RuntimeComponentId -> RuntimeComponentDescriptor` dictionary. 
- Added `GetAssembly(string assemblySimpleName)` to lazily cache assembly loads and `GetLoadableTypes(Assembly assembly)` which falls back to `ReflectionTypeLoadException.Types` filtering out nulls when `GetTypes()` fails, and updated tests to expect the new assembly-level caching behavior. 

### Testing
- Installed the required SDK and verified `dotnet` with `curl -fsSL https://dot.net/v1/dotnet-install.sh ... --version 10.0.103` which returned `10.0.103`. (succeeded). 
- Ran `dotnet restore UniversalToolchain/Wist.sln` and `dotnet build UniversalToolchain/Wist.sln -c Release --no-restore` (build succeeded). 
- Ran unit tests: `dotnet test UniversalToolchain/Tests/Tests.csproj -c Release --no-build` (Passed: 67, Failed: 0), `dotnet test UniversalToolchain/UniversalToolchain.Modules.Tests/UniversalToolchain.Modules.Tests.csproj -c Release --no-build` (Passed: 154, Skipped: 7, Failed: 0), and `dotnet test UniversalToolchain/UniversalToolchain.Dialects.Tests/UniversalToolchain.Dialects.Tests.csproj -c Release --no-build` (Passed: 271, Failed: 0).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd4d908fa48324b2d266ec222b3c5f)