### PR TITLE
Add runtime artifact compiler tests and resolver loadable-types fallback tests

### DIFF
--- a/UniversalToolchain/Tests/Infrastructure/RuntimeCompiledArtifactContractsTests.cs
+++ b/UniversalToolchain/Tests/Infrastructure/RuntimeCompiledArtifactContractsTests.cs
@@ -128,6 +128,30 @@ public class RuntimeCompiledArtifactContractsTests
         Assert.That(delegateResult, Is.EqualTo(29));
     }
 
+    [Test]
+    public void GetArtifactCompiler_WithDynamicMethodOutput_ReturnsWorkingCompilerArtifactPath()
+    {
+        using var host = CreateHost();
+        var compiler = host.GetArtifactCompiler<DynamicMethod>("compiler");
+        var artifact = compiler.Compile("x", new OrderedDictionary<string, Type> { ["x"] = typeof(object) });
+        var session = artifact.CreateSession();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(artifact.CompilationOutput, Is.Not.Null);
+            Assert.That(artifact.SlotsByName.ContainsKey("x"), Is.True);
+            Assert.That(session, Is.Not.Null);
+        });
+    }
+
+    [Test]
+    public void GetArtifactCompiler_WithMismatchedCompilationOutput_ThrowsInvalidOperationException()
+    {
+        using var host = CreateHost();
+
+        Assert.Throws<InvalidOperationException>(() => host.GetArtifactCompiler<IAbstractIR>("compiler"));
+    }
+
     private static ICompiledArtifact<DynamicMethod> CreateUnaryAddOneArtifact()
     {
         var dynamicMethod = new DynamicMethod("AddOne", typeof(int), [typeof(int)]);

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/RuntimeLoading/DefaultRuntimeComponentResolverTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/RuntimeLoading/DefaultRuntimeComponentResolverTests.cs
@@ -117,7 +117,7 @@ public class DefaultRuntimeComponentResolverTests
     }
 
     [Test]
-    public void Resolve_DifferentEntries_DoNotCrossPolluteCache()
+    public void Resolve_DifferentEntriesFromSameAssembly_LoadAssemblyCalledOnce()
     {
         var strategy = new CountingAssemblyLoadStrategy(new Dictionary<string, Assembly>(StringComparer.Ordinal)
         {
@@ -138,6 +138,26 @@ public class DefaultRuntimeComponentResolverTests
         });
     }
 
+    [Test]
+    public void Resolve_WhenAssemblyGetTypesThrowsReflectionTypeLoadException_UsesLoadableTypesFallback()
+    {
+        var fallbackAssembly = new ReflectionTypeLoadExceptionAssembly([typeof(ResolverExportForFallback), null, typeof(ResolverExportForDifferentEntriesA)]);
+        var strategy = new CountingAssemblyLoadStrategy(new Dictionary<string, Assembly>(StringComparer.Ordinal)
+        {
+            [TestAssemblyName] = fallbackAssembly
+        });
+        var resolver = new DefaultRuntimeComponentResolver(strategy);
+        var entry = Entry(RuntimeComponentKind.FrontendModule, ResolverExportForFallbackAlias, TestAssemblyName);
+
+        var descriptor = resolver.Resolve(entry);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(descriptor.ActivationType, Is.EqualTo(typeof(ResolverExportForFallback)));
+            Assert.That(strategy.GetCalls(TestAssemblyName), Is.EqualTo(1));
+        });
+    }
+
     private static RuntimeComponentManifestEntry Entry(RuntimeComponentKind kind, string canonicalAlias, string assemblySimpleName)
         => new(kind, canonicalAlias, [], RuntimeComponentIdFactory.Create(kind, canonicalAlias), assemblySimpleName);
 
@@ -146,6 +166,7 @@ public class DefaultRuntimeComponentResolverTests
     private const string ResolverExportForAliasesAlias = "resolver.aliases.sample";
     private const string ResolverExportForDifferentEntriesAAlias = "resolver.entries.a";
     private const string ResolverExportForDifferentEntriesBAlias = "resolver.entries.b";
+    private const string ResolverExportForFallbackAlias = "resolver.fallback.sample";
 
     [DialectRuntimeExport("FrontendModule", ResolverExportForCachingAlias)]
     private sealed class ResolverExportForCaching;
@@ -162,6 +183,9 @@ public class DefaultRuntimeComponentResolverTests
 
     [DialectRuntimeExport("FrontendModule", ResolverExportForDifferentEntriesBAlias)]
     private sealed class ResolverExportForDifferentEntriesB;
+
+    [DialectRuntimeExport("FrontendModule", ResolverExportForFallbackAlias)]
+    private sealed class ResolverExportForFallback;
 
     private sealed class CountingAssemblyLoadStrategy(IReadOnlyDictionary<string, Assembly> assemblies) : IRuntimeAssemblyLoadStrategy
     {
@@ -186,5 +210,13 @@ public class DefaultRuntimeComponentResolverTests
         private readonly RuntimeComponentDescriptor _descriptor = descriptor;
 
         public RuntimeComponentDescriptor Resolve(RuntimeComponentManifestEntry entry) => _descriptor;
+    }
+
+    private sealed class ReflectionTypeLoadExceptionAssembly(Type?[] loadableTypes) : Assembly
+    {
+        private readonly Type?[] _loadableTypes = loadableTypes;
+
+        public override Type[] GetTypes()
+            => throw new ReflectionTypeLoadException(_loadableTypes, new Exception?[_loadableTypes.Length]!);
     }
 }


### PR DESCRIPTION
### Motivation
- Improve coverage for the public compile-artifact accessor and ensure `WistDialectExecutionHost.GetArtifactCompiler<T>` behaves correctly for a valid `DynamicMethod` output and for a mismatched generic request. 
- Ensure the runtime component resolver caches assembly loads across different manifest entries from the same assembly and correctly falls back to loadable types when `Assembly.GetTypes()` throws `ReflectionTypeLoadException`.

### Description
- Added a positive test `GetArtifactCompiler_WithDynamicMethodOutput_ReturnsWorkingCompilerArtifactPath` in `RuntimeCompiledArtifactContractsTests` that obtains `GetArtifactCompiler<DynamicMethod>("compiler")`, compiles a simple artifact, creates a session, and asserts key artifact/session invariants (`CompilationOutput` non-null, declared slot exists, session is created).
- Added a mismatch test `GetArtifactCompiler_WithMismatchedCompilationOutput_ThrowsInvalidOperationException` that confirms requesting an incompatible `TCompilationOutput` throws `InvalidOperationException` without asserting message text.
- Renamed/updated existing resolver cache test to `Resolve_DifferentEntriesFromSameAssembly_LoadAssemblyCalledOnce` to explicitly verify two different entries from the same assembly cause a single `LoadAssembly` invocation.
- Added `Resolve_WhenAssemblyGetTypesThrowsReflectionTypeLoadException_UsesLoadableTypesFallback` to `DefaultRuntimeComponentResolverTests` which uses a test assembly stub that throws `ReflectionTypeLoadException` from `GetTypes()` and verifies the resolver indexes loadable types and resolves the expected descriptor; added the `ReflectionTypeLoadExceptionAssembly` test double and a fallback test export type.

### Testing
- Installed .NET SDK `10.0.103` to match project requirements and ran project tests.
- Ran `dotnet test UniversalToolchain/Tests/Tests.csproj -c Release` and the modified test suite passed: 69 passed, 0 failed.
- Ran `dotnet test UniversalToolchain/UniversalToolchain.Dialects.Tests/UniversalToolchain.Dialects.Tests.csproj -c Release` and it passed: 272 passed, 0 failed.
- Ran `dotnet test UniversalToolchain/UniversalToolchain.Modules.Tests/UniversalToolchain.Modules.Tests.csproj -c Release` and it passed: 154 passed, 0 failed, 7 skipped.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd4f8b32288324bcb10983c793e6b9)