### PR TITLE
Fail fast on duplicate runtime component ids in resolver index

### DIFF
--- a/UniversalToolchain/UniversalToolchain.Dialects.Integration/DefaultRuntimeComponentResolver.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Integration/DefaultRuntimeComponentResolver.cs
@@ -57,7 +57,9 @@ public sealed class DefaultRuntimeComponentResolver : IRuntimeComponentResolver
 
             var id = RuntimeComponentIdFactory.Create(kind, canonicalAlias);
             var aliases = GetRuntimeAliases(type);
-            descriptors[id] = new RuntimeComponentDescriptor(id, kind, canonicalAlias, aliases, type);
+            var descriptor = new RuntimeComponentDescriptor(id, kind, canonicalAlias, aliases, type);
+            if (!descriptors.TryAdd(id, descriptor))
+                Thrower.InvalidOpEx("Duplicate runtime component id detected during assembly component indexing.");
         }
 
         return descriptors;

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/RuntimeLoading/DefaultRuntimeComponentResolverTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/RuntimeLoading/DefaultRuntimeComponentResolverTests.cs
@@ -12,7 +12,7 @@ public class DefaultRuntimeComponentResolverTests
     {
         var strategy = new CountingAssemblyLoadStrategy(new Dictionary<string, Assembly>(StringComparer.Ordinal)
         {
-            [TestAssemblyName] = typeof(ResolverExportForCaching).Assembly
+            [TestAssemblyName] = CreateTestAssembly(typeof(ResolverExportForCaching))
         });
         var resolver = new DefaultRuntimeComponentResolver(strategy);
         var entry = Entry(RuntimeComponentKind.FrontendModule, ResolverExportForCachingAlias, TestAssemblyName);
@@ -32,7 +32,7 @@ public class DefaultRuntimeComponentResolverTests
     {
         var strategy = new CountingAssemblyLoadStrategy(new Dictionary<string, Assembly>(StringComparer.Ordinal)
         {
-            [TestAssemblyName] = typeof(ResolverExportForCaching).Assembly
+            [TestAssemblyName] = CreateTestAssembly(typeof(ResolverExportForCaching))
         });
         var resolver = new DefaultRuntimeComponentResolver(strategy);
         var entry = Entry(RuntimeComponentKind.FrontendModule, ResolverExportForCachingAlias, TestAssemblyName);
@@ -52,7 +52,7 @@ public class DefaultRuntimeComponentResolverTests
     {
         var strategy = new CountingAssemblyLoadStrategy(new Dictionary<string, Assembly>(StringComparer.Ordinal)
         {
-            [TestAssemblyName] = typeof(ResolverExportForCaching).Assembly
+            [TestAssemblyName] = CreateTestAssembly(typeof(ResolverExportForCaching))
         });
         var resolver = new DefaultRuntimeComponentResolver(strategy);
         var entry = Entry(RuntimeComponentKind.FrontendModule, "resolver.missing.component", TestAssemblyName);
@@ -69,7 +69,7 @@ public class DefaultRuntimeComponentResolverTests
     {
         var strategy = new CountingAssemblyLoadStrategy(new Dictionary<string, Assembly>(StringComparer.Ordinal)
         {
-            [TestAssemblyName] = typeof(ResolverExportForAliases).Assembly
+            [TestAssemblyName] = CreateTestAssembly(typeof(ResolverExportForAliases))
         });
         var resolver = new DefaultRuntimeComponentResolver(strategy);
         var entry = Entry(RuntimeComponentKind.FrontendModule, ResolverExportForAliasesAlias, TestAssemblyName);
@@ -80,11 +80,24 @@ public class DefaultRuntimeComponentResolverTests
     }
 
     [Test]
+    public void Resolve_WhenAssemblyContainsDuplicateRuntimeComponentIds_ThrowsInvalidOperationException()
+    {
+        var strategy = new CountingAssemblyLoadStrategy(new Dictionary<string, Assembly>(StringComparer.Ordinal)
+        {
+            [TestAssemblyName] = CreateTestAssembly(typeof(ResolverExportDuplicateA), typeof(ResolverExportDuplicateB))
+        });
+        var resolver = new DefaultRuntimeComponentResolver(strategy);
+        var entry = Entry(RuntimeComponentKind.FrontendModule, ResolverExportDuplicateAlias, TestAssemblyName);
+
+        Assert.Throws<InvalidOperationException>(() => resolver.Resolve(entry));
+    }
+
+    [Test]
     public async Task Resolve_ParallelCalls_ForSameEntry_AreConsistent()
     {
         var strategy = new CountingAssemblyLoadStrategy(new Dictionary<string, Assembly>(StringComparer.Ordinal)
         {
-            [TestAssemblyName] = typeof(ResolverExportForCaching).Assembly
+            [TestAssemblyName] = CreateTestAssembly(typeof(ResolverExportForCaching))
         });
         var resolver = new DefaultRuntimeComponentResolver(strategy);
         var entry = Entry(RuntimeComponentKind.FrontendModule, ResolverExportForCachingAlias, TestAssemblyName);
@@ -121,7 +134,7 @@ public class DefaultRuntimeComponentResolverTests
     {
         var strategy = new CountingAssemblyLoadStrategy(new Dictionary<string, Assembly>(StringComparer.Ordinal)
         {
-            [TestAssemblyName] = typeof(ResolverExportForCaching).Assembly
+            [TestAssemblyName] = CreateTestAssembly(typeof(ResolverExportForDifferentEntriesA), typeof(ResolverExportForDifferentEntriesB))
         });
         var resolver = new DefaultRuntimeComponentResolver(strategy);
         var firstEntry = Entry(RuntimeComponentKind.FrontendModule, ResolverExportForDifferentEntriesAAlias, TestAssemblyName);
@@ -161,12 +174,15 @@ public class DefaultRuntimeComponentResolverTests
     private static RuntimeComponentManifestEntry Entry(RuntimeComponentKind kind, string canonicalAlias, string assemblySimpleName)
         => new(kind, canonicalAlias, [], RuntimeComponentIdFactory.Create(kind, canonicalAlias), assemblySimpleName);
 
+    private static Assembly CreateTestAssembly(params Type[] loadableTypes) => new ReflectionTypeLoadExceptionAssembly(loadableTypes.Cast<Type?>().ToArray());
+
     private const string TestAssemblyName = "ResolverTestsAssembly";
     private const string ResolverExportForCachingAlias = "resolver.cache.sample";
     private const string ResolverExportForAliasesAlias = "resolver.aliases.sample";
     private const string ResolverExportForDifferentEntriesAAlias = "resolver.entries.a";
     private const string ResolverExportForDifferentEntriesBAlias = "resolver.entries.b";
     private const string ResolverExportForFallbackAlias = "resolver.fallback.sample";
+    private const string ResolverExportDuplicateAlias = "resolver.duplicate.sample";
 
     [DialectRuntimeExport("FrontendModule", ResolverExportForCachingAlias)]
     private sealed class ResolverExportForCaching;
@@ -186,6 +202,12 @@ public class DefaultRuntimeComponentResolverTests
 
     [DialectRuntimeExport("FrontendModule", ResolverExportForFallbackAlias)]
     private sealed class ResolverExportForFallback;
+
+    [DialectRuntimeExport("FrontendModule", ResolverExportDuplicateAlias)]
+    private sealed class ResolverExportDuplicateA;
+
+    [DialectRuntimeExport("FrontendModule", ResolverExportDuplicateAlias)]
+    private sealed class ResolverExportDuplicateB;
 
     private sealed class CountingAssemblyLoadStrategy(IReadOnlyDictionary<string, Assembly> assemblies) : IRuntimeAssemblyLoadStrategy
     {


### PR DESCRIPTION
### Motivation
- Prevent silent overwrites when multiple types produce the same `RuntimeComponentId` during assembly indexing by failing early and deterministically.
- Keep the `BuildAssemblyComponentIndex` contract and overall resolver behavior unchanged, but make index construction deterministic and order-independent by removing silent last-write-wins behavior.

### Description
- Replaced the silent dictionary overwrite in `DefaultRuntimeComponentResolver.BuildAssemblyComponentIndex` with a two-step insert using `TryAdd` and `Thrower.InvalidOpEx(...)` on conflict, preserving the existing method signature and dictionary creation.
- Added a regression test `Resolve_WhenAssemblyContainsDuplicateRuntimeComponentIds_ThrowsInvalidOperationException` that verifies an assembly with two exports that resolve to the same id causes `Resolve(...)` to throw `InvalidOperationException`.
- Adjusted resolver tests to use a controlled test assembly via `CreateTestAssembly(...)` / `ReflectionTypeLoadExceptionAssembly` so each test indexes only the intended types and remains deterministic.

### Testing
- Ran `dotnet restore` and `dotnet build` for the solution and then ran tests for the relevant projects. All automated test runs completed successfully.
- `dotnet test UniversalToolchain/Tests/Tests.csproj` — Passed (69 tests).
- `dotnet test UniversalToolchain/UniversalToolchain.Modules.Tests/UniversalToolchain.Modules.Tests.csproj` — Passed (154 passed, 7 skipped).
- `dotnet test UniversalToolchain/UniversalToolchain.Dialects.Tests/UniversalToolchain.Dialects.Tests.csproj` — Passed (273 tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd571d738883248d6c5998371fea10)