### PR TITLE
docs: align compile-artifact API and resolver behavior docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,14 +12,18 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - Fixed constant-binding mutation.
 - Fixed false-positive comment validation for `// /*`.
 - Improved runtime component resolver assembly indexing.
+- Prevented silent duplicate runtime component id overwrite during assembly component indexing.
 
 ### Added
 
-- Introduced a public compile-artifact contract/accessor.
+- Introduced host-level compile-artifact access via `WistDialectExecutionHost.GetArtifactCompiler<TCompilationOutput>(mode)`.
+- Added interface-based invoke helpers for `ICompiledArtifactSession`.
 
 ### Changed
 
 - Renamed `ParametersSetter` placeholder type.
+- Clarified compiled artifact mutability contract in XML documentation.
+- Refactored native unary minus in native arithmetic path to use a dedicated negate method.
 - Consolidated repository-level documentation around explicit canonical roles (`readme.md`, `PROJECT_RULES.md`,
   `CONTRIBUTING.md`, `AGENTS.md`).
 - Updated root documentation to reinforce framework-first positioning: UniversalToolchain as reusable architecture, Wist

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -30,10 +30,12 @@ Runtime composition paths:
 
 Compile-artifact surface:
 
-- The framework exposes a public compile-artifact contract for backends that support artifact-oriented workflows
-  (compile once, create one or more execution sessions).
-- Backend-specific helpers/extensions are optional layers on top of that contract and should be treated as
-  convenience/performance paths, not mandatory framework behavior.
+- Host-level artifact compilation is exposed through
+  `WistDialectExecutionHost.GetArtifactCompiler<TCompilationOutput>(mode)`.
+- Backends that support artifact-oriented execution return `IArtifactCompiler<TCompilationOutput>` and produce
+  `ICompiledArtifact<TCompilationOutput>`.
+- Backend-specific helpers/extensions (for example, `DynamicMethod` convenience APIs) are optional layers and should
+  be treated as convenience/performance paths, not mandatory framework behavior.
 
 ## Dialect workflow
 
@@ -44,6 +46,9 @@ Typical dialect execution flow:
 3. Resolve runtime composition descriptors.
 4. Create execution host.
 5. Run code.
+
+Runtime component resolution builds cached per-assembly component indexes and uses a loadable-types fallback when
+reflection encounters partial type-load failures.
 
 ## Repository entry points
 

--- a/readme.md
+++ b/readme.md
@@ -139,11 +139,11 @@ See `UniversalToolchain/Example/Program.cs` for a full composition + diagnostics
 
 ### Compile artifact API
 
-Generic framework path (through the public compile-artifact contract/accessor):
+Generic framework path (through the host-level accessor):
 
 ```csharp
-var compilerArtifacts = /* resolve public compile-artifact accessor from your composition */;
-var artifact = compilerArtifacts.Compile("x + 1", new OrderedDictionary<string, Type>
+var compiler = host.GetArtifactCompiler<DynamicMethod>("compiler");
+var artifact = compiler.Compile("x + 1", new OrderedDictionary<string, Type>
 {
     ["x"] = typeof(int)
 });
@@ -156,10 +156,8 @@ var fortyTwo = session.Run<int>();
 Optional DynamicMethod fast-path (backend-specific extension):
 
 ```csharp
-var compilerCore = host.GetCore("compiler") as BasicCoreImpl<DynamicMethod>
-                   ?? throw new InvalidOperationException();
-
-var artifact = compilerCore.Compile("x + 1", new OrderedDictionary<string, Type>
+var compiler = host.GetArtifactCompiler<DynamicMethod>("compiler");
+var artifact = compiler.Compile("x + 1", new OrderedDictionary<string, Type>
 {
     ["x"] = typeof(int)
 });


### PR DESCRIPTION
## Summary
- Updated `readme.md` compile-artifact section to use the host-level accessor (`GetArtifactCompiler<TCompilationOutput>(...)`) in both canonical and optional fast-path snippets.
- Updated `docs/architecture-overview.md` with concrete compile-artifact surface details and a short note on resolver behavior (cached per-assembly indexing + loadable types fallback).
- Updated `CHANGELOG.md` to reflect additional branch-surface changes:
  - duplicate runtime component id overwrite prevention,
  - interface-based `ICompiledArtifactSession` invoke helpers,
  - compiled artifact mutability contract documentation clarification,
  - dedicated negate path for native unary minus.

## Validation
- Performed targeted text search for stale phrasing in updated docs.
- Confirmed removal of old README placeholder/cast patterns and old contract/accessor wording in the touched documents.

## Notes
- Left unrelated code/test usages of `host.GetCore("compiler") as BasicCoreImpl<DynamicMethod>` intact because this task requested documentation/changelog alignment only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd5cc1db688324b176c2b712a0667c)