### PR TITLE
Add execution-focused BenchmarkDotNet suite for Wist

### DIFF
--- a/UniversalToolchain/UniversalToolchain.Benchmarks/Benchmarks/ArithmeticExecutionBenchmarks.cs
+++ b/UniversalToolchain/UniversalToolchain.Benchmarks/Benchmarks/ArithmeticExecutionBenchmarks.cs
@@ -1,0 +1,150 @@
+using System.Collections.Specialized;
+using System.Reflection.Emit;
+using BenchmarkDotNet.Attributes;
+using DynamicMethodCalling;
+using ExceptionsManager;
+using UniversalToolchain.Benchmarks.Infrastructure;
+
+namespace UniversalToolchain.Benchmarks.Benchmarks;
+
+[MemoryDiagnoser]
+[CsvMeasurementsExporter]
+[JsonExporterAttribute.Full]
+public class ArithmeticExecutionBenchmarks
+{
+    [Params(ExpressionCatalog.IntUnary, ExpressionCatalog.IntBinary, ExpressionCatalog.IntQuad)]
+    public string CaseName { get; set; } = ExpressionCatalog.IntUnary;
+
+    private Func<int, int>? _funcUnary;
+    private Func<int, int, int>? _funcBinary;
+    private Func<int, int, int, int, int>? _funcQuad;
+
+    private INativeDelegateInvoker? _invoker;
+    private dynamic? _artifact;
+    private dynamic? _reusedSession;
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        using var host = BenchmarkHostFactory.CreateWistHost();
+        var compiler = host.GetArtifactCompiler<DynamicMethod>("compiler");
+
+        switch (CaseName)
+        {
+            case ExpressionCatalog.IntUnary:
+                _artifact = compiler.Compile(ExpressionCatalog.IntUnary, new OrderedDictionary<string, Type>
+                {
+                    ["x"] = typeof(int)
+                });
+                _funcUnary = _artifact.AsFunc<int, int>();
+                break;
+            case ExpressionCatalog.IntBinary:
+                _artifact = compiler.Compile(ExpressionCatalog.IntBinary, new OrderedDictionary<string, Type>
+                {
+                    ["x"] = typeof(int),
+                    ["y"] = typeof(int)
+                });
+                _funcBinary = _artifact.AsFunc<int, int, int>();
+                break;
+            case ExpressionCatalog.IntQuad:
+                _artifact = compiler.Compile(ExpressionCatalog.IntQuad, new OrderedDictionary<string, Type>
+                {
+                    ["a"] = typeof(int),
+                    ["b"] = typeof(int),
+                    ["c"] = typeof(int),
+                    ["d"] = typeof(int)
+                });
+                _funcQuad = _artifact.AsFunc<int, int, int, int, int>();
+                break;
+            default:
+                Thrower.Argument(nameof(CaseName), $"Unsupported arithmetic case '{CaseName}'.");
+                break;
+        }
+
+        _invoker = _artifact.GetNativeDelegateInvoker();
+        _reusedSession = _artifact.CreateSession();
+    }
+
+    [Benchmark(Baseline = true)]
+    public int CSharpBaseline() => CaseName switch
+    {
+        ExpressionCatalog.IntUnary => InputData.X * 2 + 3,
+        ExpressionCatalog.IntBinary => InputData.X * InputData.Y + 7,
+        ExpressionCatalog.IntQuad => InputData.A * InputData.B + InputData.C * InputData.D - InputData.A + 3,
+        _ => Thrower.ArgumentOutOfRange<int>(nameof(CaseName), $"Unknown case '{CaseName}'.")
+    };
+
+    [Benchmark]
+    public int WistAsFunc() => CaseName switch
+    {
+        ExpressionCatalog.IntUnary => _funcUnary.NotNull()(InputData.X),
+        ExpressionCatalog.IntBinary => _funcBinary.NotNull()(InputData.X, InputData.Y),
+        ExpressionCatalog.IntQuad => _funcQuad.NotNull()(InputData.A, InputData.B, InputData.C, InputData.D),
+        _ => Thrower.ArgumentOutOfRange<int>(nameof(CaseName), $"Unknown case '{CaseName}'.")
+    };
+
+    [Benchmark]
+    public int WistNativeInvoker() => CaseName switch
+    {
+        ExpressionCatalog.IntUnary => _invoker.NotNull().Invoke<int, int>(InputData.X),
+        ExpressionCatalog.IntBinary => _invoker.NotNull().Invoke<int, int, int>(InputData.X, InputData.Y),
+        ExpressionCatalog.IntQuad => _invoker.NotNull().Invoke<int, int, int, int, int>(InputData.A, InputData.B, InputData.C, InputData.D),
+        _ => Thrower.ArgumentOutOfRange<int>(nameof(CaseName), $"Unknown case '{CaseName}'.")
+    };
+
+    [Benchmark]
+    public int WistSessionReused()
+    {
+        var session = _reusedSession.NotNull();
+
+        switch (CaseName)
+        {
+            case ExpressionCatalog.IntUnary:
+                session.SetArgument("x", InputData.X);
+                break;
+            case ExpressionCatalog.IntBinary:
+                session.SetArgument("x", InputData.X);
+                session.SetArgument("y", InputData.Y);
+                break;
+            case ExpressionCatalog.IntQuad:
+                session.SetArgument("a", InputData.A);
+                session.SetArgument("b", InputData.B);
+                session.SetArgument("c", InputData.C);
+                session.SetArgument("d", InputData.D);
+                break;
+            default:
+                Thrower.Argument(nameof(CaseName), $"Unknown case '{CaseName}'.");
+                break;
+        }
+
+        return session.Run<int>();
+    }
+
+    [Benchmark]
+    public int WistSessionNew()
+    {
+        var session = _artifact.NotNull().CreateSession();
+
+        switch (CaseName)
+        {
+            case ExpressionCatalog.IntUnary:
+                session.SetArgument("x", InputData.X);
+                break;
+            case ExpressionCatalog.IntBinary:
+                session.SetArgument("x", InputData.X);
+                session.SetArgument("y", InputData.Y);
+                break;
+            case ExpressionCatalog.IntQuad:
+                session.SetArgument("a", InputData.A);
+                session.SetArgument("b", InputData.B);
+                session.SetArgument("c", InputData.C);
+                session.SetArgument("d", InputData.D);
+                break;
+            default:
+                Thrower.Argument(nameof(CaseName), $"Unknown case '{CaseName}'.");
+                break;
+        }
+
+        return session.Run<int>();
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Benchmarks/Benchmarks/BooleanExecutionBenchmarks.cs
+++ b/UniversalToolchain/UniversalToolchain.Benchmarks/Benchmarks/BooleanExecutionBenchmarks.cs
@@ -1,0 +1,143 @@
+using System.Collections.Specialized;
+using System.Reflection.Emit;
+using BenchmarkDotNet.Attributes;
+using DynamicMethodCalling;
+using ExceptionsManager;
+using UniversalToolchain.Benchmarks.Infrastructure;
+
+namespace UniversalToolchain.Benchmarks.Benchmarks;
+
+[MemoryDiagnoser]
+[CsvMeasurementsExporter]
+[JsonExporterAttribute.Full]
+public class BooleanExecutionBenchmarks
+{
+    [Params(ExpressionCatalog.TernaryClamp, ExpressionCatalog.ShortCircuit)]
+    public string CaseName { get; set; } = ExpressionCatalog.TernaryClamp;
+
+    [Params(true, false)]
+    public bool UsePredictableData { get; set; }
+
+    private Func<int, int>? _ternaryFunc;
+    private Func<int, int, int, bool>? _shortCircuitFunc;
+    private INativeDelegateInvoker? _invoker;
+    private dynamic? _artifact;
+    private dynamic? _reusedSession;
+
+    private int _index;
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        using var host = BenchmarkHostFactory.CreateWistHost();
+        var compiler = host.GetArtifactCompiler<DynamicMethod>("compiler");
+
+        switch (CaseName)
+        {
+            case ExpressionCatalog.TernaryClamp:
+                _artifact = compiler.Compile(ExpressionCatalog.TernaryClamp, new OrderedDictionary<string, Type>
+                {
+                    ["x"] = typeof(int)
+                });
+                _ternaryFunc = _artifact.AsFunc<int, int>();
+                break;
+            case ExpressionCatalog.ShortCircuit:
+                _artifact = compiler.Compile(ExpressionCatalog.ShortCircuit, new OrderedDictionary<string, Type>
+                {
+                    ["a"] = typeof(int),
+                    ["b"] = typeof(int),
+                    ["c"] = typeof(int)
+                });
+                _shortCircuitFunc = _artifact.AsFunc<int, int, int, bool>();
+                break;
+            default:
+                Thrower.Argument(nameof(CaseName), $"Unsupported boolean case '{CaseName}'.");
+                break;
+        }
+
+        _invoker = _artifact.GetNativeDelegateInvoker();
+        _reusedSession = _artifact.CreateSession();
+    }
+
+    [Benchmark(Baseline = true)]
+    public int CSharpBaseline()
+    {
+        return CaseName == ExpressionCatalog.TernaryClamp
+            ? TernaryBaseline(NextTernary())
+            : ShortCircuitBaseline(NextShortCircuit()) ? 1 : 0;
+    }
+
+    [Benchmark]
+    public int WistAsFunc()
+    {
+        if (CaseName == ExpressionCatalog.TernaryClamp)
+            return _ternaryFunc.NotNull()(NextTernary());
+
+        var args = NextShortCircuit();
+        return _shortCircuitFunc.NotNull()(args.a, args.b, args.c) ? 1 : 0;
+    }
+
+    [Benchmark]
+    public int WistNativeInvoker()
+    {
+        if (CaseName == ExpressionCatalog.TernaryClamp)
+            return _invoker.NotNull().Invoke<int, int>(NextTernary());
+
+        var args = NextShortCircuit();
+        return _invoker.NotNull().Invoke<int, int, int, bool>(args.a, args.b, args.c) ? 1 : 0;
+    }
+
+    [Benchmark]
+    public int WistSessionReused()
+    {
+        var session = _reusedSession.NotNull();
+        if (CaseName == ExpressionCatalog.TernaryClamp)
+        {
+            session.SetArgument("x", NextTernary());
+            return session.Run<int>();
+        }
+
+        var args = NextShortCircuit();
+        session.SetArgument("a", args.a);
+        session.SetArgument("b", args.b);
+        session.SetArgument("c", args.c);
+        return session.Run<bool>() ? 1 : 0;
+    }
+
+    [Benchmark]
+    public int WistSessionNew()
+    {
+        var session = _artifact.NotNull().CreateSession();
+        if (CaseName == ExpressionCatalog.TernaryClamp)
+        {
+            session.SetArgument("x", NextTernary());
+            return session.Run<int>();
+        }
+
+        var args = NextShortCircuit();
+        session.SetArgument("a", args.a);
+        session.SetArgument("b", args.b);
+        session.SetArgument("c", args.c);
+        return session.Run<bool>() ? 1 : 0;
+    }
+
+    private int NextTernary()
+    {
+        var data = UsePredictableData ? InputData.PredictableBranchInputs : InputData.RandomLikeBranchInputs;
+        var value = data[_index % data.Length];
+        _index++;
+        return value;
+    }
+
+    private (int a, int b, int c) NextShortCircuit()
+    {
+        var data = UsePredictableData ? InputData.PredictableShortCircuitInputs : InputData.RandomLikeShortCircuitInputs;
+        var value = data[_index % data.Length];
+        _index++;
+        return value;
+    }
+
+    private static int TernaryBaseline(int x) => x > 10 ? x : 0;
+
+    private static bool ShortCircuitBaseline((int a, int b, int c) x) => (x.a > 0 && x.b > 0) || x.c > 0;
+}

--- a/UniversalToolchain/UniversalToolchain.Benchmarks/Benchmarks/DecimalExecutionBenchmarks.cs
+++ b/UniversalToolchain/UniversalToolchain.Benchmarks/Benchmarks/DecimalExecutionBenchmarks.cs
@@ -1,0 +1,112 @@
+using System.Collections.Specialized;
+using System.Reflection.Emit;
+using BenchmarkDotNet.Attributes;
+using DynamicMethodCalling;
+using ExceptionsManager;
+using UniversalToolchain.Benchmarks.Infrastructure;
+
+namespace UniversalToolchain.Benchmarks.Benchmarks;
+
+[MemoryDiagnoser]
+[CsvMeasurementsExporter]
+[JsonExporterAttribute.Full]
+public class DecimalExecutionBenchmarks
+{
+    [Params("double", "decimal")]
+    public string NumericMode { get; set; } = "double";
+
+    private Func<double, double, double>? _doubleFunc;
+    private Func<decimal, decimal, decimal>? _decimalFunc;
+    private INativeDelegateInvoker? _invoker;
+    private dynamic? _artifact;
+    private dynamic? _reusedSession;
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        using var host = BenchmarkHostFactory.CreateWistHost();
+        var compiler = host.GetArtifactCompiler<DynamicMethod>("compiler");
+
+        if (NumericMode == "double")
+        {
+            _artifact = compiler.Compile(ExpressionCatalog.DoublePricing, new OrderedDictionary<string, Type>
+            {
+                ["price"] = typeof(double),
+                ["fee"] = typeof(double)
+            });
+            _doubleFunc = _artifact.AsFunc<double, double, double>();
+        }
+        else if (NumericMode == "decimal")
+        {
+            _artifact = compiler.Compile(ExpressionCatalog.DecimalPricing, new OrderedDictionary<string, Type>
+            {
+                ["price"] = typeof(decimal),
+                ["fee"] = typeof(decimal)
+            });
+            _decimalFunc = _artifact.AsFunc<decimal, decimal, decimal>();
+        }
+        else
+        {
+            Thrower.Argument(nameof(NumericMode), $"Unknown numeric mode '{NumericMode}'.");
+        }
+
+        _invoker = _artifact.GetNativeDelegateInvoker();
+        _reusedSession = _artifact.CreateSession();
+    }
+
+    [Benchmark(Baseline = true)]
+    public decimal CSharpBaseline()
+    {
+        return NumericMode == "double"
+            ? (decimal)(InputData.Price * 0.9 + InputData.Fee)
+            : InputData.DecimalPrice * 0.9m + InputData.DecimalFee;
+    }
+
+    [Benchmark]
+    public decimal WistAsFunc()
+    {
+        return NumericMode == "double"
+            ? (decimal)_doubleFunc.NotNull()(InputData.Price, InputData.Fee)
+            : _decimalFunc.NotNull()(InputData.DecimalPrice, InputData.DecimalFee);
+    }
+
+    [Benchmark]
+    public decimal WistNativeInvoker()
+    {
+        return NumericMode == "double"
+            ? (decimal)_invoker.NotNull().Invoke<double, double, double>(InputData.Price, InputData.Fee)
+            : _invoker.NotNull().Invoke<decimal, decimal, decimal>(InputData.DecimalPrice, InputData.DecimalFee);
+    }
+
+    [Benchmark]
+    public decimal WistSessionReused()
+    {
+        var session = _reusedSession.NotNull();
+        if (NumericMode == "double")
+        {
+            session.SetArgument("price", InputData.Price);
+            session.SetArgument("fee", InputData.Fee);
+            return (decimal)session.Run<double>();
+        }
+
+        session.SetArgument("price", InputData.DecimalPrice);
+        session.SetArgument("fee", InputData.DecimalFee);
+        return session.Run<decimal>();
+    }
+
+    [Benchmark]
+    public decimal WistSessionNew()
+    {
+        var session = _artifact.NotNull().CreateSession();
+        if (NumericMode == "double")
+        {
+            session.SetArgument("price", InputData.Price);
+            session.SetArgument("fee", InputData.Fee);
+            return (decimal)session.Run<double>();
+        }
+
+        session.SetArgument("price", InputData.DecimalPrice);
+        session.SetArgument("fee", InputData.DecimalFee);
+        return session.Run<decimal>();
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Benchmarks/Benchmarks/ScaleExecutionBenchmarks.cs
+++ b/UniversalToolchain/UniversalToolchain.Benchmarks/Benchmarks/ScaleExecutionBenchmarks.cs
@@ -1,0 +1,85 @@
+using System.Collections.Specialized;
+using System.Reflection.Emit;
+using BenchmarkDotNet.Attributes;
+using DynamicMethodCalling;
+using ExceptionsManager;
+using UniversalToolchain.Benchmarks.Infrastructure;
+
+namespace UniversalToolchain.Benchmarks.Benchmarks;
+
+[MemoryDiagnoser]
+[CsvMeasurementsExporter]
+[JsonExporterAttribute.Full]
+public class ScaleExecutionBenchmarks
+{
+    [Params(8, 32, 128, 512)]
+    public int NodeCount { get; set; }
+
+    private Func<int, int>? _wistFunc;
+    private INativeDelegateInvoker? _invoker;
+    private dynamic? _artifact;
+    private dynamic? _reusedSession;
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        using var host = BenchmarkHostFactory.CreateWistHost();
+        var compiler = host.GetArtifactCompiler<DynamicMethod>("compiler");
+
+        var expression = BuildGrowthExpression(NodeCount);
+        _artifact = compiler.Compile(expression, new OrderedDictionary<string, Type>
+        {
+            ["x"] = typeof(int)
+        });
+
+        _wistFunc = _artifact.AsFunc<int, int>();
+        _invoker = _artifact.GetNativeDelegateInvoker();
+        _reusedSession = _artifact.CreateSession();
+    }
+
+    [Benchmark(Baseline = true)]
+    public int CSharpBaseline() => EvaluateGrowthBaseline(InputData.X, NodeCount);
+
+    [Benchmark]
+    public int WistAsFunc() => _wistFunc.NotNull()(InputData.X);
+
+    [Benchmark]
+    public int WistNativeInvoker() => _invoker.NotNull().Invoke<int, int>(InputData.X);
+
+    [Benchmark]
+    public int WistSessionReused()
+    {
+        var session = _reusedSession.NotNull();
+        session.SetArgument("x", InputData.X);
+        return session.Run<int>();
+    }
+
+    [Benchmark]
+    public int WistSessionNew()
+    {
+        var session = _artifact.NotNull().CreateSession();
+        session.SetArgument("x", InputData.X);
+        return session.Run<int>();
+    }
+
+    private static string BuildGrowthExpression(int nodeCount)
+    {
+        if (nodeCount < 2)
+            Thrower.ArgumentOutOfRange<string>(nameof(nodeCount), "Node count must be at least 2.");
+
+        var terms = new List<string>(nodeCount);
+        for (var i = 1; i <= nodeCount; i++)
+            terms.Add($"x * {i}");
+
+        return string.Join(" + ", terms);
+    }
+
+    private static int EvaluateGrowthBaseline(int x, int nodeCount)
+    {
+        var sum = 0;
+        for (var i = 1; i <= nodeCount; i++)
+            sum += x * i;
+
+        return sum;
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Benchmarks/Infrastructure/BenchmarkHostFactory.cs
+++ b/UniversalToolchain/UniversalToolchain.Benchmarks/Infrastructure/BenchmarkHostFactory.cs
@@ -1,0 +1,29 @@
+using ExceptionsManager;
+using Microsoft.Extensions.DependencyInjection;
+using UniversalToolchain.Dialects.Wist;
+
+namespace UniversalToolchain.Benchmarks.Infrastructure;
+
+public static class BenchmarkHostFactory
+{
+    private const string DialectText = """
+                                      dialect Benchmarks
+                                      use Arithmetic,Numbers,Variables,Conditions
+                                      backend compiler
+                                      """;
+
+    public static WistDialectExecutionHost CreateWistHost()
+    {
+        var services = new ServiceCollection();
+        services.AddWistDialectServices();
+        services.AddWistCilBackend();
+
+        using var provider = services.BuildServiceProvider();
+        var workflow = provider.GetRequiredService<WistDialectExecutionWorkflow>();
+        var composition = workflow.ComposeText(DialectText, "benchmarks-inline");
+        if (!composition.IsSuccess)
+            Thrower.InvalidOpEx(composition.ToDeterministicText());
+
+        return workflow.CreateHost(composition);
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Benchmarks/Infrastructure/ExpressionCatalog.cs
+++ b/UniversalToolchain/UniversalToolchain.Benchmarks/Infrastructure/ExpressionCatalog.cs
@@ -1,0 +1,14 @@
+namespace UniversalToolchain.Benchmarks.Infrastructure;
+
+public static class ExpressionCatalog
+{
+    public const string IntUnary = "x * 2 + 3";
+    public const string IntBinary = "x * y + 7";
+    public const string IntQuad = "a * b + c * d - a + 3";
+
+    public const string DoublePricing = "price * 0.9 + fee";
+    public const string DecimalPricing = "price * 0.9m + fee";
+
+    public const string TernaryClamp = "x > 10 ? x : 0";
+    public const string ShortCircuit = "(a > 0 && b > 0) || c > 0";
+}

--- a/UniversalToolchain/UniversalToolchain.Benchmarks/Infrastructure/InputData.cs
+++ b/UniversalToolchain/UniversalToolchain.Benchmarks/Infrastructure/InputData.cs
@@ -1,0 +1,41 @@
+namespace UniversalToolchain.Benchmarks.Infrastructure;
+
+public static class InputData
+{
+    public static readonly int X = 123;
+    public static readonly int Y = 17;
+
+    public static readonly int A = 5;
+    public static readonly int B = 8;
+    public static readonly int C = 11;
+    public static readonly int D = 3;
+
+    public static readonly double Price = 100.0;
+    public static readonly double Fee = 5.0;
+
+    public static readonly decimal DecimalPrice = 100.0m;
+    public static readonly decimal DecimalFee = 5.0m;
+
+    public static readonly int[] PredictableBranchInputs = [11, 12, 16, 30, 41, 9, 12, 33, 18, 15, 13, 7];
+    public static readonly int[] RandomLikeBranchInputs = [5, -3, 9, 14, -11, 22, -1, 4, 17, 0, -8, 31];
+
+    public static readonly (int a, int b, int c)[] PredictableShortCircuitInputs =
+    [
+        (3, 1, -9),
+        (4, 2, -4),
+        (1, 5, -7),
+        (5, 2, -3),
+        (2, 2, -1),
+        (-5, 1, 7)
+    ];
+
+    public static readonly (int a, int b, int c)[] RandomLikeShortCircuitInputs =
+    [
+        (-3, -4, -1),
+        (8, -2, -5),
+        (-1, 6, 4),
+        (9, 1, -6),
+        (2, 4, -9),
+        (-7, 5, 2)
+    ];
+}

--- a/UniversalToolchain/UniversalToolchain.Benchmarks/Program.cs
+++ b/UniversalToolchain/UniversalToolchain.Benchmarks/Program.cs
@@ -1,0 +1,7 @@
+using BenchmarkDotNet.Running;
+using UniversalToolchain.Benchmarks.Benchmarks;
+
+BenchmarkRunner.Run<ArithmeticExecutionBenchmarks>();
+BenchmarkRunner.Run<DecimalExecutionBenchmarks>();
+BenchmarkRunner.Run<BooleanExecutionBenchmarks>();
+BenchmarkRunner.Run<ScaleExecutionBenchmarks>();

--- a/UniversalToolchain/UniversalToolchain.Benchmarks/UniversalToolchain.Benchmarks.csproj
+++ b/UniversalToolchain/UniversalToolchain.Benchmarks/UniversalToolchain.Benchmarks.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <Optimize>true</Optimize>
+    <LangVersion>preview</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.6" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\DynamicMethodCalling\DynamicMethodCalling.csproj" />
+    <ProjectReference Include="..\ExceptionsManager\ExceptionsManager.csproj" />
+    <ProjectReference Include="..\UniversalToolchain.Dialects.Wist\UniversalToolchain.Dialects.Wist.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/UniversalToolchain/Wist.sln
+++ b/UniversalToolchain/Wist.sln
@@ -124,6 +124,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UniversalToolchain.Dialects
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UniversalToolchain.Modules.Tests", "UniversalToolchain.Modules.Tests\UniversalToolchain.Modules.Tests.csproj", "{507806F7-75E5-4A6A-BF23-18992BF44B97}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UniversalToolchain.Benchmarks", "UniversalToolchain.Benchmarks\UniversalToolchain.Benchmarks.csproj", "{18782C5E-D825-4823-ADF3-29AEE3AE6FF4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -782,6 +784,18 @@ Global
 		{507806F7-75E5-4A6A-BF23-18992BF44B97}.Release|x64.Build.0 = Release|Any CPU
 		{507806F7-75E5-4A6A-BF23-18992BF44B97}.Release|x86.ActiveCfg = Release|Any CPU
 		{507806F7-75E5-4A6A-BF23-18992BF44B97}.Release|x86.Build.0 = Release|Any CPU
+		{18782C5E-D825-4823-ADF3-29AEE3AE6FF4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{18782C5E-D825-4823-ADF3-29AEE3AE6FF4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{18782C5E-D825-4823-ADF3-29AEE3AE6FF4}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{18782C5E-D825-4823-ADF3-29AEE3AE6FF4}.Debug|x64.Build.0 = Debug|Any CPU
+		{18782C5E-D825-4823-ADF3-29AEE3AE6FF4}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{18782C5E-D825-4823-ADF3-29AEE3AE6FF4}.Debug|x86.Build.0 = Debug|Any CPU
+		{18782C5E-D825-4823-ADF3-29AEE3AE6FF4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{18782C5E-D825-4823-ADF3-29AEE3AE6FF4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{18782C5E-D825-4823-ADF3-29AEE3AE6FF4}.Release|x64.ActiveCfg = Release|Any CPU
+		{18782C5E-D825-4823-ADF3-29AEE3AE6FF4}.Release|x64.Build.0 = Release|Any CPU
+		{18782C5E-D825-4823-ADF3-29AEE3AE6FF4}.Release|x86.ActiveCfg = Release|Any CPU
+		{18782C5E-D825-4823-ADF3-29AEE3AE6FF4}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
### Motivation

- Provide a standalone, execution-focused BenchmarkDotNet project to measure Wist execution paths (not parsing/compilation/host setup) across identical formulas and inputs. 
- Compare the same workload across four execution paths: handwritten C# baseline, compiled delegate (`AsFunc`), native delegate invoker, and generic session (new and reused).
- Keep benchmarks deterministic and setup-heavy so measured benchmark methods only exercise the steady-state execution path.

### Description

- Add a new console project `UniversalToolchain.Benchmarks` targeting `net10.0` and referencing `BenchmarkDotNet`, DI, and required UniversalToolchain projects, and register it in the solution `Wist.sln`. Files added include `UniversalToolchain.Benchmarks.csproj` and `Program.cs`. 
- Provide reusable infrastructure under `Infrastructure/`: `BenchmarkHostFactory.cs` (inline dialect composition and host creation), `ExpressionCatalog.cs` (fixed formulas), and `InputData.cs` (fixed inputs including predictable/random branch inputs). 
- Add four benchmark classes under `Benchmarks/` implementing the execution suite and comparison methods: `ArithmeticExecutionBenchmarks`, `DecimalExecutionBenchmarks`, `BooleanExecutionBenchmarks`, and `ScaleExecutionBenchmarks`; each measures `CSharpBaseline`, `WistAsFunc`, `WistNativeInvoker`, `WistSessionReused`, and `WistSessionNew` where applicable. 
- Configure measurement helpers on each benchmark class: `MemoryDiagnoser` plus JSON/CSV exporters via class-level attributes so benchmark outputs can be exported in desired formats, and ensure heavy work (host creation, compilation, delegates, session creation) is performed in `[GlobalSetup]` only.

### Testing

- Installed the required SDK via `bash /tmp/dotnet-install.sh --version 10.0.103 --install-dir $HOME/.dotnet` and verified `dotnet --info`; the SDK install succeeded. (success)
- Restored packages with `dotnet restore UniversalToolchain/Wist.sln`; restore completed successfully. (success)
- Built the new benchmark project with `dotnet build UniversalToolchain/UniversalToolchain.Benchmarks/UniversalToolchain.Benchmarks.csproj -c Release --no-restore`; build completed successfully (warnings only from nullable/dynamic interop). (success)
- Launched a filtered benchmark run with `dotnet run -c Release --project UniversalToolchain/UniversalToolchain.Benchmarks/UniversalToolchain.Benchmarks.csproj -- --filter '*ArithmeticExecutionBenchmarks*' --job short`; the benchmark process started but the full run was not captured to completion in this session. (attempted)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd7f50496883248296804c775f9dda)