### PR TITLE
Add module coverage tests for BooleanNodeCreator and WhileNodeCreator

### DIFF
--- a/UniversalToolchain/UniversalToolchain.Modules.Tests/ModuleCoverage/BooleanNodeCreatorTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Modules.Tests/ModuleCoverage/BooleanNodeCreatorTests.cs
@@ -1,0 +1,104 @@
+using BasicCore.LexerWrapper;
+using BasicCore.ParserWrapper;
+using BasicTypesExtensions;
+using ConditionsModule.Creators;
+
+namespace UniversalToolchain.Modules.Tests.ModuleCoverage;
+
+[TestFixture]
+public class BooleanNodeCreatorTests
+{
+    [Test]
+    public void ConstantPath_WithMatchingNode_ReturnsTrueWithoutRestructuring()
+    {
+        var creator = new BooleanNodeCreator("BooleanLiteral", BooleanNodeCreator.BooleanStatementType.Constant);
+        var scope = CreateScope([
+            Node("BooleanLiteral", "True")
+        ]);
+
+        var result = creator.TryCreateNode(scope, 0);
+
+        Assert.That(result, Is.True);
+        Assert.That(scope.Children, Has.Count.EqualTo(1));
+        Assert.That(scope[0].Children, Is.Empty);
+    }
+
+    [Test]
+    public void UnaryOperation_WithOperand_AttachesOperandAndReturnsTrue()
+    {
+        var creator = new BooleanNodeCreator("Not", BooleanNodeCreator.BooleanStatementType.UnaryOperation);
+        var scope = CreateScope([
+            Node("Not", "Not"),
+            Node("BooleanLiteral", "False")
+        ]);
+
+        var result = creator.TryCreateNode(scope, 0);
+
+        Assert.That(result, Is.True);
+        Assert.That(scope.Children, Has.Count.EqualTo(1));
+        Assert.That(scope[0].Children, Has.Count.EqualTo(1));
+        Assert.That(scope[0].Children[0].Text, Is.EqualTo("False"));
+    }
+
+    [Test]
+    public void UnaryOperation_WithoutOperand_ReturnsFalse()
+    {
+        var creator = new BooleanNodeCreator("Not", BooleanNodeCreator.BooleanStatementType.UnaryOperation);
+        var scope = CreateScope([
+            Node("Not", "Not")
+        ]);
+
+        var result = creator.TryCreateNode(scope, 0);
+
+        Assert.That(result, Is.False);
+        Assert.That(scope.Children, Has.Count.EqualTo(1));
+        Assert.That(scope[0].Children, Is.Empty);
+    }
+
+    [Test]
+    public void BinaryOperation_WithBothOperands_AttachesBothAndReturnsTrue()
+    {
+        var creator = new BooleanNodeCreator("And", BooleanNodeCreator.BooleanStatementType.BinaryOperation);
+        var scope = CreateScope([
+            Node("BooleanLiteral", "True"),
+            Node("And", "And"),
+            Node("BooleanLiteral", "False")
+        ]);
+
+        var result = creator.TryCreateNode(scope, 1);
+
+        Assert.That(result, Is.True);
+        Assert.That(scope.Children, Has.Count.EqualTo(1));
+        Assert.That(scope[0].Text, Is.EqualTo("And"));
+        Assert.That(scope[0].Children, Has.Count.EqualTo(2));
+        Assert.That(scope[0].Children[0].Text, Is.EqualTo("True"));
+        Assert.That(scope[0].Children[1].Text, Is.EqualTo("False"));
+    }
+
+    [Test]
+    [TestCase(0, "Missing left operand must be rejected.")]
+    [TestCase(1, "Missing right operand must be rejected.")]
+    public void BinaryOperation_WithMissingOperand_ReturnsFalse(int operatorIndex, string reason)
+    {
+        var creator = new BooleanNodeCreator("And", BooleanNodeCreator.BooleanStatementType.BinaryOperation);
+        var scope = operatorIndex == 0
+            ? CreateScope([
+                Node("And", "And"),
+                Node("BooleanLiteral", "True")
+            ])
+            : CreateScope([
+                Node("BooleanLiteral", "True"),
+                Node("And", "And")
+            ]);
+
+        var result = creator.TryCreateNode(scope, operatorIndex);
+
+        Assert.That(result, Is.False, reason);
+    }
+
+    private static AstNode CreateScope(List<AstNode> children) =>
+        new(ExtensibleEnum<AstNodeTag>.CreateOrGet("Scope"), null, children);
+
+    private static AstNode Node(string nodeType, string text) =>
+        new(ExtensibleEnum<AstNodeTag>.CreateOrGet(nodeType), new LexemeValue(text, null, -1, null), []);
+}

--- a/UniversalToolchain/UniversalToolchain.Modules.Tests/ModuleCoverage/WhileNodeCreatorTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Modules.Tests/ModuleCoverage/WhileNodeCreatorTests.cs
@@ -1,0 +1,77 @@
+using BasicCore.LexerWrapper;
+using BasicCore.ParserWrapper;
+using BasicTypesExtensions;
+using LoopsModule.Creators;
+
+namespace UniversalToolchain.Modules.Tests.ModuleCoverage;
+
+[TestFixture]
+public class WhileNodeCreatorTests
+{
+    [Test]
+    public void ConditionAndBodyPresent_ReturnsTrueAndAttachesBothChildren()
+    {
+        var creator = new WhileNodeCreator();
+        var scope = CreateScope([
+            Node("While", "while"),
+            Node("Condition", "cond"),
+            Node("Body", "body")
+        ]);
+
+        var result = creator.TryCreateNode(scope, 0);
+
+        Assert.That(result, Is.True);
+        Assert.That(scope.Children, Has.Count.EqualTo(1));
+        Assert.That(scope[0].Children, Has.Count.EqualTo(2));
+        Assert.That(scope[0].Children[0].Text, Is.EqualTo("cond"));
+        Assert.That(scope[0].Children[1].Text, Is.EqualTo("body"));
+    }
+
+    [Test]
+    public void MissingCondition_ReturnsFalse()
+    {
+        var creator = new WhileNodeCreator();
+        var scope = CreateScope([
+            Node("While", "while")
+        ]);
+
+        var result = creator.TryCreateNode(scope, 0);
+
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void MissingBody_ReturnsFalse()
+    {
+        var creator = new WhileNodeCreator();
+        var scope = CreateScope([
+            Node("While", "while"),
+            Node("Condition", "cond")
+        ]);
+
+        var result = creator.TryCreateNode(scope, 0);
+
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void NonWhileNode_ReturnsFalse()
+    {
+        var creator = new WhileNodeCreator();
+        var scope = CreateScope([
+            Node("Identifier", "x"),
+            Node("Condition", "cond"),
+            Node("Body", "body")
+        ]);
+
+        var result = creator.TryCreateNode(scope, 0);
+
+        Assert.That(result, Is.False);
+    }
+
+    private static AstNode CreateScope(List<AstNode> children) =>
+        new(ExtensibleEnum<AstNodeTag>.CreateOrGet("Scope"), null, children);
+
+    private static AstNode Node(string nodeType, string text) =>
+        new(ExtensibleEnum<AstNodeTag>.CreateOrGet(nodeType), new LexemeValue(text, null, -1, null), []);
+}


### PR DESCRIPTION
### Motivation
- Increase parser/creator test coverage by adding focused unit tests for `BooleanNodeCreator` and `WhileNodeCreator` using the repository's minimal synthetic AST pattern.

### Description
- Added `UniversalToolchain/UniversalToolchain.Modules.Tests/ModuleCoverage/BooleanNodeCreatorTests.cs` covering constant path, unary (with/without operand), binary (with both operands), and missing-left/right-operand cases using local `CreateScope`/`Node` helpers.
- Added `UniversalToolchain/UniversalToolchain.Modules.Tests/ModuleCoverage/WhileNodeCreatorTests.cs` covering condition+body success, missing condition, missing body, and non-while-node rejection using the same minimal synthetic AST helpers.

### Testing
- Ran `dotnet restore` and `dotnet build` for the solution and executed `dotnet test` for the relevant test projects; all test runs completed successfully with the following summaries: `Tests` passed 69/69, `UniversalToolchain.Modules.Tests` passed 164/171 (7 skipped), and `UniversalToolchain.Dialects.Tests` passed 272/272.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ceb4b2a44c8324b0cdab65783d296c)