### PR TITLE
Add contract tests for runtime descriptor validation and normalization

### DIFF
--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/RuntimeLoading/RuntimeIntrinsicDescriptorContractsTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/RuntimeLoading/RuntimeIntrinsicDescriptorContractsTests.cs
@@ -1,0 +1,52 @@
+using UniversalToolchain.Dialects.Abstractions;
+using UniversalToolchain.Dialects.Integration;
+
+namespace UniversalToolchain.Dialects.Tests.RuntimeLoading;
+
+public class RuntimeIntrinsicDescriptorContractsTests
+{
+    [Test]
+    public void Ctor_NullAliases_ProducesEmptyAliasList()
+    {
+        var descriptor = new RuntimeIntrinsicDescriptor("intrinsic.sample", new DialectBackendId("compiler"), null);
+
+        Assert.That(descriptor.Aliases, Is.Empty);
+    }
+
+    [Test]
+    public void Ctor_Aliases_AreSortedAndDeduplicated()
+    {
+        var descriptor = new RuntimeIntrinsicDescriptor(
+            "intrinsic.sample",
+            new DialectBackendId("compiler"),
+            ["beta", "alpha", "beta", "intrinsic.sample"]);
+
+        Assert.That(descriptor.Aliases, Is.EqualTo(new[] { "alpha", "beta" }));
+    }
+
+    [Test]
+    public void Ctor_BlankAlias_ThrowsArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            new RuntimeIntrinsicDescriptor("intrinsic.sample", new DialectBackendId("compiler"), [" "]));
+    }
+
+    [Test]
+    public void Ctor_BlankCanonicalId_ThrowsArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            new RuntimeIntrinsicDescriptor(" ", new DialectBackendId("compiler"), ["alias"]));
+    }
+
+    [Test]
+    public void AppliesTo_ReturnsExpectedResult_ForMatchingAndMismatchingBackends()
+    {
+        var descriptor = new RuntimeIntrinsicDescriptor("intrinsic.sample", new DialectBackendId("compiler"));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(descriptor.AppliesTo(new DialectBackendId("compiler")), Is.True);
+            Assert.That(descriptor.AppliesTo(new DialectBackendId("interpreter")), Is.False);
+        });
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/RuntimeLoading/RuntimeModuleDescriptorContractsTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/RuntimeLoading/RuntimeModuleDescriptorContractsTests.cs
@@ -1,0 +1,64 @@
+using BasicCore.Contracts;
+using UniversalToolchain.Dialects.Integration;
+
+namespace UniversalToolchain.Dialects.Tests.RuntimeLoading;
+
+public class RuntimeModuleDescriptorContractsTests
+{
+    [Test]
+    public void Ctor_RecognizesFrontendAndIrModuleFlags()
+    {
+        var frontendDescriptor = new RuntimeModuleDescriptor("frontend.sample", typeof(TestFrontendModule));
+        var irDescriptor = new RuntimeModuleDescriptor("ir.sample", typeof(TestIrModule));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(frontendDescriptor.IsFrontendModule, Is.True);
+            Assert.That(frontendDescriptor.IsIrProcessingModule, Is.False);
+            Assert.That(irDescriptor.IsFrontendModule, Is.False);
+            Assert.That(irDescriptor.IsIrProcessingModule, Is.True);
+        });
+    }
+
+    [Test]
+    public void Ctor_InvalidImplementationType_ThrowsArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            new RuntimeModuleDescriptor("invalid.sample", typeof(InvalidModuleType)));
+    }
+
+    [Test]
+    public void Ctor_Aliases_AreSortedDeduplicatedAndRejectBlankValues()
+    {
+        var descriptor = new RuntimeModuleDescriptor(
+            "module.sample",
+            typeof(TestFrontendModule),
+            ["beta", "alpha", "beta", "module.sample"]);
+
+        Assert.That(descriptor.Aliases, Is.EqualTo(new[] { "alpha", "beta" }));
+
+        Assert.Throws<ArgumentException>(() =>
+            new RuntimeModuleDescriptor("module.sample", typeof(TestFrontendModule), [""]));
+    }
+
+    [Test]
+    public void Ctor_BlankCanonicalId_ThrowsArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            new RuntimeModuleDescriptor(" ", typeof(TestFrontendModule)));
+    }
+
+    [Test]
+    public void MetadataOwnerType_MatchesImplementationType()
+    {
+        var descriptor = new RuntimeModuleDescriptor("module.sample", typeof(TestFrontendModule));
+
+        Assert.That(descriptor.MetadataOwnerType, Is.SameAs(descriptor.ImplementationType));
+    }
+
+    private sealed class TestFrontendModule : IFrontendCoreModule;
+
+    private sealed class TestIrModule : IIRProcessingModule;
+
+    private sealed class InvalidModuleType;
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/RuntimeLoading/RuntimeOptimizerDescriptorContractsTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/RuntimeLoading/RuntimeOptimizerDescriptorContractsTests.cs
@@ -1,0 +1,47 @@
+using BasicCore.Contracts;
+using UniversalToolchain.Dialects.Integration;
+
+namespace UniversalToolchain.Dialects.Tests.RuntimeLoading;
+
+public class RuntimeOptimizerDescriptorContractsTests
+{
+    [Test]
+    public void Ctor_ValidOptimizerType_IsAccepted()
+    {
+        var descriptor = new RuntimeOptimizerDescriptor("optimizer.sample", typeof(TestOptimizerModule));
+
+        Assert.That(descriptor.ImplementationType, Is.EqualTo(typeof(TestOptimizerModule)));
+    }
+
+    [Test]
+    public void Ctor_InvalidImplementationType_ThrowsArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            new RuntimeOptimizerDescriptor("optimizer.sample", typeof(InvalidOptimizerType)));
+    }
+
+    [Test]
+    public void Ctor_Aliases_AreSortedDeduplicatedAndRejectBlankValues()
+    {
+        var descriptor = new RuntimeOptimizerDescriptor(
+            "optimizer.sample",
+            typeof(TestOptimizerModule),
+            ["beta", "alpha", "beta", "optimizer.sample"]);
+
+        Assert.That(descriptor.Aliases, Is.EqualTo(new[] { "alpha", "beta" }));
+
+        Assert.Throws<ArgumentException>(() =>
+            new RuntimeOptimizerDescriptor("optimizer.sample", typeof(TestOptimizerModule), ["  "]));
+    }
+
+    [Test]
+    public void Ctor_BlankCanonicalId_ThrowsArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            new RuntimeOptimizerDescriptor(" ", typeof(TestOptimizerModule)));
+    }
+
+    private sealed class TestOptimizerModule : IIRProcessingModule;
+
+    private sealed class InvalidOptimizerType;
+}


### PR DESCRIPTION
### Motivation
- Ensure runtime descriptor types enforce canonical identifier and alias invariants and correctly identify applicable backends and module/optimizer capabilities.
- Prevent regressions in alias normalization (null → empty, sort, dedupe, blank guards) and implementation-type validation for runtime modules and optimizers.

### Description
- Add `RuntimeIntrinsicDescriptorContractsTests.cs` with tests for null aliases producing an empty list, alias sorting/deduplication, blank-alias and blank-canonical-id guards, and `AppliesTo` backend matching behavior.
- Add `RuntimeModuleDescriptorContractsTests.cs` with tests for frontend vs IR module recognition, invalid implementation-type guard, alias normalization/blank-guard behavior, blank canonical id guard, and `MetadataOwnerType` invariant.
- Add `RuntimeOptimizerDescriptorContractsTests.cs` with tests for accepted optimizer types, invalid implementation-type guard, alias normalization/blank-guard behavior, and blank canonical id guard.

### Testing
- Ran `dotnet test UniversalToolchain/UniversalToolchain.Dialects.Tests/UniversalToolchain.Dialects.Tests.csproj -c Release` and the test assembly completed with 0 failures (Passed: 286, Skipped: 0, Total: 286).
- Ran `dotnet test UniversalToolchain/Tests/Tests.csproj -c Release` and the test assembly completed with 0 failures (Passed: 69, Skipped: 0, Total: 69).
- Ran `dotnet test UniversalToolchain/UniversalToolchain.Modules.Tests/UniversalToolchain.Modules.Tests.csproj -c Release` and the test assembly completed with 0 failures (Passed: 154, Skipped: 7, Total: 161).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ceb4b3c49c83248ddbd6881afb23a8)