### PR TITLE
Add deterministic WistDialectExecutionHost contract tests

### DIFF
--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/WistDialectExecutionHostContractTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/WistDialectExecutionHostContractTests.cs
@@ -1,0 +1,135 @@
+using System.Reflection.Emit;
+using Microsoft.Extensions.DependencyInjection;
+using UniversalToolchain.Dialects.Wist;
+
+namespace UniversalToolchain.Dialects.Tests;
+
+public class WistDialectExecutionHostContractTests
+{
+    [Test]
+    public void ComposeFile_WithEmptyPath_ThrowsArgumentException()
+    {
+        using var provider = CreateWorkflowProvider();
+        var workflow = provider.GetRequiredService<WistDialectExecutionWorkflow>();
+
+        AssertThrowsWithMessageFragment<ArgumentException>(
+            () => workflow.ComposeFile(string.Empty),
+            "Dialect file path must not be empty");
+    }
+
+    [Test]
+    public void ComposeFile_WithMissingFile_ThrowsFileNotFoundException()
+    {
+        using var provider = CreateWorkflowProvider();
+        var workflow = provider.GetRequiredService<WistDialectExecutionWorkflow>();
+        var missingPath = Path.Combine(Path.GetTempPath(), $"wist-missing-{Guid.NewGuid():N}.wistdialect");
+
+        AssertThrowsWithMessageFragment<FileNotFoundException>(
+            () => workflow.ComposeFile(missingPath),
+            missingPath);
+    }
+
+    [Test]
+    public void ComposeText_WithNullSourceText_ThrowsArgumentNullException()
+    {
+        using var provider = CreateWorkflowProvider();
+        var workflow = provider.GetRequiredService<WistDialectExecutionWorkflow>();
+
+        AssertThrowsWithMessageFragment<ArgumentNullException>(
+            () => workflow.ComposeText(null!, "inline"),
+            "sourceText");
+    }
+
+    [Test]
+    public void ComposeText_WithEmptySourceName_ThrowsArgumentException()
+    {
+        using var provider = CreateWorkflowProvider();
+        var workflow = provider.GetRequiredService<WistDialectExecutionWorkflow>();
+
+        AssertThrowsWithMessageFragment<ArgumentException>(
+            () => workflow.ComposeText("dialect Demo\nuse Arithmetic\nbackend interpreter", string.Empty),
+            "Source name must not be empty");
+    }
+
+    [Test]
+    public void CreateHost_WithFailedComposition_ThrowsArgumentException()
+    {
+        using var provider = CreateWorkflowProvider();
+        var workflow = provider.GetRequiredService<WistDialectExecutionWorkflow>();
+        var composition = workflow.ComposeText("dialect Broken\nuse MissingModule\nbackend interpreter", "broken-inline");
+
+        Assert.That(composition.IsSuccess, Is.False);
+
+        AssertThrowsWithMessageFragment<ArgumentException>(
+            () => workflow.CreateHost(composition),
+            "must be successful");
+    }
+
+    [Test]
+    public void GetCore_WithUnknownMode_ThrowsInvalidOperationException_WithSupportedModesList()
+    {
+        using var host = ComposeAndCreateHost("dialect Demo\nuse Arithmetic,Numbers\nbackend compiler,interpreter");
+
+        AssertThrowsWithMessageFragment<InvalidOperationException>(
+            () => host.GetCore("unknown-mode"),
+            "Supported modes:");
+    }
+
+    [Test]
+    public void GetArtifactCompiler_WithWrongCompilationOutputType_ThrowsInvalidOperationException()
+    {
+        using var host = ComposeAndCreateHost("dialect Demo\nuse Arithmetic,Numbers\nbackend interpreter");
+
+        AssertThrowsWithMessageFragment<InvalidOperationException>(
+            () => host.GetArtifactCompiler<DynamicMethod>("interpreter"),
+            "compatible artifact compiler");
+    }
+
+    [Test]
+    public void GetCore_WithDisabledBackend_ThrowsInvalidOperationException()
+    {
+        using var host = ComposeAndCreateHost("dialect Demo\nuse Arithmetic,Numbers\nbackend interpreter");
+
+        AssertThrowsWithMessageFragment<InvalidOperationException>(
+            () => host.GetCore("compiler"),
+            "does not enable the 'compiler' backend");
+    }
+
+    [Test]
+    public void Run_WithUnknownMode_ThrowsInvalidOperationException()
+    {
+        using var host = ComposeAndCreateHost("dialect Demo\nuse Arithmetic,Numbers\nbackend interpreter");
+
+        AssertThrowsWithMessageFragment<InvalidOperationException>(
+            () => host.Run("2 + 2", "unknown-mode"),
+            "Unknown execution mode 'unknown-mode'");
+    }
+
+    private static WistDialectExecutionHost ComposeAndCreateHost(string dialect)
+    {
+        using var provider = CreateWorkflowProvider();
+        var workflow = provider.GetRequiredService<WistDialectExecutionWorkflow>();
+        var composition = workflow.ComposeText(dialect, "inline");
+        if (!composition.IsSuccess)
+            throw new InvalidOperationException(composition.ToDeterministicText());
+
+        return workflow.CreateHost(composition);
+    }
+
+    private static ServiceProvider CreateWorkflowProvider()
+    {
+        var services = new ServiceCollection();
+        services.AddWistDialectServices();
+        services.AddWistCilBackend();
+        services.AddWistInterpreterBackend();
+        return services.BuildServiceProvider();
+    }
+
+    private static void AssertThrowsWithMessageFragment<TException>(TestDelegate action, string expectedMessageFragment)
+        where TException : Exception
+    {
+        var ex = Assert.Throws<TException>(action);
+
+        Assert.That(ex!.Message, Does.Contain(expectedMessageFragment));
+    }
+}


### PR DESCRIPTION
### Motivation
- Ensure Wist runtime composition and host surface clearly reject invalid inputs and modes with deterministic exception types and message fragments.
- Capture a small, focused regression suite that codifies expected error contracts for `WistDialectExecutionWorkflow` and `WistDialectExecutionHost` so future changes remain safe and deterministic.

### Description
- Add new test file `UniversalToolchain/UniversalToolchain.Dialects.Tests/WistDialectExecutionHostContractTests.cs` containing contract tests for composition and host usage.
- Cover eight scenarios: `ComposeFile` empty path, `ComposeFile` missing file, `ComposeText` null `sourceText`, `ComposeText` empty `sourceName`, `CreateHost` with failed composition, `GetCore` unknown mode (checks supported modes text), `GetArtifactCompiler<T>` wrong output type, `GetCore` disabled backend, and `Run` unknown mode.
- Introduce reusable helpers `ComposeAndCreateHost`, `CreateWorkflowProvider`, and `AssertThrowsWithMessageFragment<TException>` to centralize provider setup and deterministic exception assertions.
- Tests exercise realistic provider configuration by registering both CIL and interpreter backends and use a deterministic message-fragment check rather than relying on full message text.

### Testing
- Ran `dotnet test UniversalToolchain/UniversalToolchain.Dialects.Tests/UniversalToolchain.Dialects.Tests.csproj -c Release` and the Dialects test assembly passed (all tests in that project succeeded).
- Ran `dotnet test UniversalToolchain/Wist.sln -c Release` to validate the change across the solution and observed a green test run for the solution's test suites.
- All executed automated tests passed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ceb4b5188c83249f5d8b79858291c2)