### PR TITLE
Add DialectDefinitionSlice parser/executor core tests

### DIFF
--- a/UniversalToolchain/Tests/Core/DialectDefinitionSliceParserTests.cs
+++ b/UniversalToolchain/Tests/Core/DialectDefinitionSliceParserTests.cs
@@ -1,0 +1,97 @@
+using BasicLexer.Core;
+using BasicParser.Core;
+using Microsoft.Extensions.DependencyInjection;
+using UniversalToolchain.Dialects.Frontend;
+
+namespace Tests.Core;
+
+[TestFixture]
+public class DialectDefinitionSliceParserTests
+{
+    [Test]
+    public void Constructor_WithNullRegistry_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => new DialectDefinitionSliceParser(null!));
+    }
+
+    [Test]
+    public void Parse_WithNullAst_ThrowsArgumentNullException()
+    {
+        var parser = new DialectDefinitionSliceParser(CreateRegistry());
+
+        Assert.Throws<ArgumentNullException>(() => parser.Parse(null!));
+    }
+
+    [Test]
+    public void Parse_WithValidAst_ReturnsExpectedNonNullSliceAndBasicInvariants()
+    {
+        var registry = CreateRegistry();
+        var ast = ParseAst("dialect Tiny\nuse Arithmetic,Variables\nsecurity trusted\ncapability sandbox\n");
+        var parser = new DialectDefinitionSliceParser(registry);
+
+        var slice = parser.Parse(ast);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(slice, Is.Not.Null);
+            Assert.That(slice.Name, Is.EqualTo("Tiny"));
+            Assert.That(slice.UseModules, Is.EqualTo(new[] { "Arithmetic", "Variables" }));
+            Assert.That(slice.ExcludeModules, Is.Empty);
+            Assert.That(slice.OrderDirectives, Is.Empty);
+            Assert.That(slice.BackendDirectives, Is.Empty);
+            Assert.That(slice.IntrinsicDirectives, Is.Empty);
+            Assert.That(slice.OptimizerDirectives, Is.Empty);
+            Assert.That(slice.SecurityProfile, Is.EqualTo(DialectSecurityProfile.Trusted));
+            Assert.That(slice.CapabilityDirectives.Select(x => (x.Name, x.Value)), Is.EqualTo(new[] { ("sandbox", true) }));
+        });
+    }
+
+    [Test]
+    public void Execute_WithNullCompilation_ThrowsArgumentNullException()
+    {
+        var executor = new DialectDefinitionSliceExecutor();
+
+        Assert.Throws<ArgumentNullException>(() => executor.Execute(null!, null!));
+    }
+
+    [Test]
+    public void Execute_ReturnsTheSameSliceInstance()
+    {
+        var executor = new DialectDefinitionSliceExecutor();
+        var slice = new DialectDefinitionSlice(
+            "Tiny",
+            [],
+            [],
+            [],
+            [],
+            [],
+            [],
+            null,
+            []);
+
+        var result = executor.Execute(slice, null!);
+
+        Assert.That(ReferenceEquals(slice, result), Is.True);
+    }
+
+    private static DialectDslRegistry CreateRegistry()
+    {
+        var services = new ServiceCollection();
+        services.AddDialectDslDefaultComposition();
+
+        using var provider = services.BuildServiceProvider();
+        return provider.GetRequiredService<DialectDslRegistry>();
+    }
+
+    private static AstNode ParseAst(string source)
+    {
+        var parser = new BasicParserImpl(new ParserConfiguration([]));
+        var lexer = new BasicLexerImpl(new LexerConfiguration([]));
+        var frontend = new DialectDslFrontendModule(CreateRegistry());
+
+        frontend.InitLexer(lexer);
+        frontend.InitParser(parser);
+
+        return parser.Parse(lexer.Lexemize(source));
+    }
+}

--- a/UniversalToolchain/Tests/Tests.csproj
+++ b/UniversalToolchain/Tests/Tests.csproj
@@ -67,6 +67,7 @@
         <Compile Include="Stress/RuntimeStressContractsTests.cs"/>
         <Compile Include="CoreContracts/BasicCoreLifecycleContractsTests.cs"/>
         <Compile Include="Concurrency/BasicCoreConcurrencyTests.cs"/>
+        <Compile Include="Core/DialectDefinitionSliceParserTests.cs"/>
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
### Motivation
- Add unit coverage for `DialectDefinitionSlice` frontend plumbing to ensure null-guards and basic invariants are preserved.
- Verify `DialectDefinitionSliceExecutor` identity behavior so the executor remains a no-op passthrough for the slice instance.

### Description
- Added `UniversalToolchain/Tests/Core/DialectDefinitionSliceParserTests.cs` containing tests for `DialectDefinitionSliceParser` and `DialectDefinitionSliceExecutor` covering constructor null guard, `Parse` null guard, parsing a valid AST and asserting core slice invariants, executor null guard, and executor identity return.
- Included lightweight helpers in the test to create a `DialectDslRegistry` and to parse an AST via the dialect frontend (`CreateRegistry` and `ParseAst`).
- Registered the new test file in `UniversalToolchain/Tests/Tests.csproj` so it is compiled into the test assembly.

### Testing
- Ran `dotnet restore UniversalToolchain/Wist.sln` and `dotnet build UniversalToolchain/Wist.sln -c Release --no-restore` which completed successfully.
- Ran `dotnet test UniversalToolchain/Tests/Tests.csproj -c Release --no-build` and the targeted test group `FullyQualifiedName~DialectDefinitionSliceParserTests` completed with `Passed: 5` tests.
- Ran full test suites where relevant and observed successful results: `Tests.dll` passed (74 tests), `UniversalToolchain.Dialects.Tests.dll` passed (272 tests), and `UniversalToolchain.Modules.Tests.dll` passed (154 tests with 7 skipped).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ceb4b6b9688324ada3ba523d571a0f)