### PR TITLE
Align website and docs messaging with README positioning

### DIFF
--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -3,22 +3,7 @@
 ## Purpose
 
 UniversalToolchain is a modular .NET framework for embeddable DSLs, expression engines, and rule engines.
-Wist is the reference language in this repository and validates the framework through a working CLI, dialect composition, and dual execution backends.
-
-
-## Current baseline
-
-Current baseline is .NET 10 / SDK 10.0.103 because active runtime and backend work is being validated there first.
-Older target frameworks are not the current compatibility target.
-
-## Published dialect profiles
-
-The repository currently highlights four runnable dialect profiles:
-
-- `full-default`
-- `full-default-native`
-- `minimal-arithmetic`
-- `restricted-sandbox`
+Wist is the reference language in this repository and demonstrates the framework through a working CLI, dialect composition, and two execution backends.
 
 ## Architecture split
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8"/>
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-    <title>UniversalToolchain — Modular .NET framework for embeddable DSLs and rule engines</title>
+    <title>UniversalToolchain — Modular .NET framework for embeddable DSLs, expression engines, and rule engines</title>
     <style>
         :root {
             --bg: #0a1022;
@@ -710,7 +710,8 @@
             <span class="eyebrow">UniversalToolchain</span>
             <h1>Build DSLs on .NET from reusable compiler modules.</h1>
             <p>
-                UniversalToolchain is a modular .NET framework for embeddable DSLs. Wist is the reference language in this repository.
+                UniversalToolchain is a modular .NET framework for embeddable DSLs, expression engines, and rule engines.
+                Wist is the reference language in this repository and demonstrates the framework through a working CLI, dialect composition, and two execution backends.
             </p>
             <div class="badge-row">
                 <span class="badge">Modular pipeline</span>

--- a/readme.md
+++ b/readme.md
@@ -1,17 +1,12 @@
 # UniversalToolchain
 
-UniversalToolchain is a modular .NET framework for embeddable DSLs, expression engines, and rule engines. Wist is the reference language in this repository and validates the framework through a working CLI, dialect composition, and dual execution backends.
+UniversalToolchain is a modular .NET framework for embeddable DSLs, expression engines, and rule engines. Wist is the reference language in this repository and demonstrates the framework through a working CLI, dialect composition, and two execution backends.
 
 It is designed for cases where you want:
 
 - configurable formulas inside a .NET application,
 - a small domain-specific language instead of hardcoded rules,
 - a reusable toolchain pipeline with interpreter and compiler execution modes.
-
-This repository contains:
-
-- **UniversalToolchain** — reusable framework infrastructure.
-- **Wist** — a reference language used to validate and evolve the framework architecture.
 
 ## Where it can be used
 
@@ -40,7 +35,7 @@ Expected output:
 12
 ```
 
-## Programmatic example with parameters
+## Programmatic example
 
 A fuller scenario is available in `UniversalToolchain/Example/Program.cs`.
 
@@ -70,6 +65,11 @@ Many language projects repeatedly rebuild the same layers: parsing, AST/IR trans
 execution.
 UniversalToolchain focuses on reusable composition so capabilities can be assembled from modules instead of hardcoded
 into one implementation path.
+
+This repository contains:
+
+- **UniversalToolchain** — reusable framework infrastructure.
+- **Wist** — a reference language used to validate and evolve the framework architecture.
 
 ## Compared to language platforms focused on their own runtime model
 
@@ -159,8 +159,8 @@ Located under `UniversalToolchain/Dialects/examples/wist`:
 
 ## Why .NET 10 right now?
 
-Current baseline is .NET 10 / SDK 10.0.103 because active runtime and backend work is being validated there first.
-Older target frameworks are not the current compatibility target.
+The current validation baseline is .NET 10 (`net10.0`) with SDK `10.0.103`.
+Active runtime and backend work is being verified there first, so older target frameworks are not the current compatibility target.
 
 ## Requirements
 


### PR DESCRIPTION
## Summary
- updated `docs/index.html` `<title>` to match the README positioning: embeddable DSLs, expression engines, and rule engines
- updated the hero paragraph under `<h1>` to align with README wording and explicitly describe Wist as the in-repo reference language with CLI, dialect composition, and two execution backends
- cleaned `docs/architecture-overview.md` top section by:
  - keeping a single final `Purpose` statement
  - removing duplicated/overlapping baseline/product-listing sections (`Current baseline`, `Published dialect profiles`)
- refined `readme.md` onboarding flow by:
  - keeping the top section order linear (`...Quick start in 30 seconds` -> `Programmatic example` -> `Why this project exists`)
  - renaming `Programmatic example with parameters` to `Programmatic example`
  - tightening the `.NET 10` section to a concise two-sentence baseline statement

## Notes
- This PR intentionally covers repository files only. GitHub About/topics, Releases, and workflow action-version upgrades were not modified here because they are handled via GitHub UI or a separate infra PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfdab76b2c832481dbbec0e8fd8f4c)