### PR TITLE
Add focused BenchmarkDotNet project comparing C#, NCalc lambda, and Wist CIL execution

### DIFF
--- a/UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/ArithmeticExecutionBenchmarks.cs
+++ b/UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/ArithmeticExecutionBenchmarks.cs
@@ -1,0 +1,384 @@
+using System.Collections.Generic;
+using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Order;
+using DynamicMethodCalling.Core;
+using ExceptionsManager;
+using Microsoft.Extensions.DependencyInjection;
+using NCalc;
+using NCalc.LambdaCompilation;
+using UniversalToolchain.Dialects.Wist;
+
+[MemoryDiagnoser]
+[SimpleJob]
+[Orderer(SummaryOrderPolicy.FastestToSlowest)]
+[RankColumn]
+public abstract class ArithmeticExecutionBenchmarks
+{
+    private const int DataSize = 4096;
+
+    private ServiceProvider? _provider;
+    private WistDialectExecutionHost? _host;
+    private Func<BenchContext, double>? _nCalcLambda;
+    private Func<int, double>? _wistInvoker;
+    private BenchContext? _context;
+    private int _index;
+
+    protected double[] A = [];
+    protected double[] B = [];
+    protected double[] C = [];
+    protected double[] D = [];
+    protected double[] E = [];
+    protected double[] F = [];
+    protected double[] G = [];
+    protected double[] H = [];
+    protected double[] I = [];
+    protected double[] J = [];
+    protected double[] K = [];
+
+    protected abstract string WistFormula { get; }
+    protected abstract string NCalcFormula { get; }
+    protected abstract string[] BindingNames { get; }
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        InitializeInputData();
+
+        var services = new ServiceCollection();
+        services.AddWistDialectServices();
+        services.AddWistCilBackend();
+        services.AddWistInterpreterBackend();
+
+        _provider = services.BuildServiceProvider();
+        var workflow = _provider.GetRequiredService<WistDialectExecutionWorkflow>();
+
+        var dialectFile = Path.Combine(AppContext.BaseDirectory, "Dialects", "examples", "wist", "full-default-native", "dialect.wistdialect");
+        var dialect = workflow.ComposeFile(dialectFile);
+
+        if (!dialect.IsSuccess)
+            Thrower.InvalidOpEx($"Failed to compose dialect file: {dialect.ToDeterministicText()}");
+
+        _host = workflow.CreateHost(dialect);
+
+        var compiler = _host.GetArtifactCompiler<DynamicMethod>("compiler");
+        var declaredBindings = CreateDeclaredBindings();
+        var compiledArtifact = compiler.Compile(WistFormula, declaredBindings);
+
+        _wistInvoker = CreateWistInvoker(compiledArtifact.CompilationOutput);
+
+        var nCalcExpression = new Expression(NCalcFormula);
+        _nCalcLambda = nCalcExpression.ToLambda<BenchContext, double>();
+        _context = new BenchContext();
+
+        EnsureResultParity();
+    }
+
+    [GlobalCleanup]
+    public void GlobalCleanup()
+    {
+        _host?.Dispose();
+        _provider?.Dispose();
+    }
+
+    [Benchmark(Baseline = true)]
+    public double CSharp_NoInliningMethod()
+    {
+        var i = NextIndex();
+        return ExecuteCSharp(i);
+    }
+
+    [Benchmark]
+    public double NCalc_Lambda()
+    {
+        Thrower.AssertAlways(_context != null, "Benchmark context must be initialized.");
+        Thrower.AssertAlways(_nCalcLambda != null, "NCalc lambda must be initialized.");
+
+        var i = NextIndex();
+        _context.A = A[i];
+        _context.B = B[i];
+        _context.C = C[i];
+        _context.D = D[i];
+        _context.E = E[i];
+        _context.F = F[i];
+        _context.G = G[i];
+        _context.H = H[i];
+        _context.I = I[i];
+        _context.J = J[i];
+        _context.K = K[i];
+
+        return _nCalcLambda(_context);
+    }
+
+    [Benchmark]
+    public double Wist_Cil_FastInvoker()
+    {
+        Thrower.AssertAlways(_wistInvoker != null, "Wist invoker must be initialized.");
+
+        var i = NextIndex();
+        return _wistInvoker(i);
+    }
+
+    protected abstract double ExecuteCSharp(int index);
+
+    protected virtual OrderedDictionary<string, Type> CreateDeclaredBindings()
+    {
+        var declaredBindings = new OrderedDictionary<string, Type>();
+
+        foreach (var bindingName in BindingNames)
+            declaredBindings[bindingName] = typeof(double);
+
+        return declaredBindings;
+    }
+
+    protected virtual Func<int, double> CreateWistInvoker(DynamicMethod dynamicMethod)
+    {
+        return BindingNames.Length switch
+        {
+            3 => BuildInvoker3(dynamicMethod),
+            5 => BuildInvoker5(dynamicMethod),
+            6 => BuildInvoker6(dynamicMethod),
+            8 => BuildInvoker8(dynamicMethod),
+            11 => BuildInvoker11(dynamicMethod),
+            _ => Thrower.InvalidOpEx<Func<int, double>>($"Unsupported binding count for fast invoker: {BindingNames.Length}.")
+        };
+    }
+
+    private Func<int, double> BuildInvoker3(DynamicMethod dynamicMethod)
+    {
+        var invoker = new DynamicMethodInvoker<double, double, double, double>(dynamicMethod);
+        return i => invoker.Invoke(A[i], B[i], C[i]);
+    }
+
+    private Func<int, double> BuildInvoker5(DynamicMethod dynamicMethod)
+    {
+        var invoker = new DynamicMethodInvoker<double, double, double, double, double, double>(dynamicMethod);
+        return i => invoker.Invoke(A[i], B[i], C[i], D[i], E[i]);
+    }
+
+    private Func<int, double> BuildInvoker6(DynamicMethod dynamicMethod)
+    {
+        var invoker = new DynamicMethodInvoker<double, double, double, double, double, double, double>(dynamicMethod);
+        return i => invoker.Invoke(A[i], B[i], C[i], D[i], E[i], F[i]);
+    }
+
+    private Func<int, double> BuildInvoker8(DynamicMethod dynamicMethod)
+    {
+        var invoker = new DynamicMethodInvoker<double, double, double, double, double, double, double, double, double>(dynamicMethod);
+        return i => invoker.Invoke(A[i], B[i], C[i], D[i], E[i], F[i], G[i], H[i]);
+    }
+
+    private Func<int, double> BuildInvoker11(DynamicMethod dynamicMethod)
+    {
+        var invoker = new DynamicMethodInvoker<double, double, double, double, double, double, double, double, double, double, double, double>(dynamicMethod);
+        return i => invoker.Invoke(A[i], B[i], C[i], D[i], E[i], F[i], G[i], H[i], I[i], J[i], K[i]);
+    }
+
+    private void EnsureResultParity()
+    {
+        Thrower.AssertAlways(_context != null, "Benchmark context must be initialized.");
+        Thrower.AssertAlways(_nCalcLambda != null, "NCalc lambda must be initialized.");
+        Thrower.AssertAlways(_wistInvoker != null, "Wist invoker must be initialized.");
+
+        const int validationIndex = 0;
+
+        _context.A = A[validationIndex];
+        _context.B = B[validationIndex];
+        _context.C = C[validationIndex];
+        _context.D = D[validationIndex];
+        _context.E = E[validationIndex];
+        _context.F = F[validationIndex];
+        _context.G = G[validationIndex];
+        _context.H = H[validationIndex];
+        _context.I = I[validationIndex];
+        _context.J = J[validationIndex];
+        _context.K = K[validationIndex];
+
+        var cSharpResult = ExecuteCSharp(validationIndex);
+        var nCalcResult = _nCalcLambda(_context);
+        var wistResult = _wistInvoker(validationIndex);
+
+        if (!AreEqual(cSharpResult, nCalcResult) || !AreEqual(cSharpResult, wistResult))
+        {
+            Thrower.InvalidOpEx(
+                $"Result mismatch detected. C#: {cSharpResult}, NCalc: {nCalcResult}, Wist: {wistResult}.");
+        }
+    }
+
+    private static bool AreEqual(double left, double right)
+    {
+        return Math.Abs(left - right) <= 1e-9;
+    }
+
+    private void InitializeInputData()
+    {
+        A = new double[DataSize];
+        B = new double[DataSize];
+        C = new double[DataSize];
+        D = new double[DataSize];
+        E = new double[DataSize];
+        F = new double[DataSize];
+        G = new double[DataSize];
+        H = new double[DataSize];
+        I = new double[DataSize];
+        J = new double[DataSize];
+        K = new double[DataSize];
+
+        var random = new Random(42);
+        Fill(random, A);
+        Fill(random, B);
+        Fill(random, C);
+        Fill(random, D);
+        Fill(random, E);
+        Fill(random, F);
+        Fill(random, G);
+        Fill(random, H);
+        Fill(random, I);
+        Fill(random, J);
+        Fill(random, K);
+    }
+
+    private static void Fill(Random random, double[] values)
+    {
+        for (var i = 0; i < values.Length; i++)
+            values[i] = 0.1 + random.NextDouble() * 999.9;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private int NextIndex()
+    {
+        var i = _index;
+        _index = (i + 1) & (DataSize - 1);
+        return i;
+    }
+}
+
+public class Simple3Benchmarks : ArithmeticExecutionBenchmarks
+{
+    protected override string WistFormula => "A + B * C / 5.0";
+    protected override string NCalcFormula => "[A] + [B] * [C] / 5.0";
+    protected override string[] BindingNames => ["A", "B", "C"];
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static double CSharp_NoInliningMethod(double a, double b, double c)
+    {
+        return a + b * c / 5.0;
+    }
+
+    protected override double ExecuteCSharp(int index)
+    {
+        return CSharp_NoInliningMethod(A[index], B[index], C[index]);
+    }
+}
+
+public class Medium8Benchmarks : ArithmeticExecutionBenchmarks
+{
+    protected override string WistFormula => "((A + B) * (C - D) / (E + 1.0)) + F * G - H / 3.0";
+    protected override string NCalcFormula => "(([A] + [B]) * ([C] - [D]) / ([E] + 1.0)) + [F] * [G] - [H] / 3.0";
+    protected override string[] BindingNames => ["A", "B", "C", "D", "E", "F", "G", "H"];
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static double CSharp_NoInliningMethod(double a, double b, double c, double d, double e, double f, double g, double h)
+    {
+        return ((a + b) * (c - d) / (e + 1.0)) + f * g - h / 3.0;
+    }
+
+    protected override double ExecuteCSharp(int index)
+    {
+        return CSharp_NoInliningMethod(A[index], B[index], C[index], D[index], E[index], F[index], G[index], H[index]);
+    }
+}
+
+public class DeepChain6Benchmarks : ArithmeticExecutionBenchmarks
+{
+    protected override string WistFormula => "((((A * 1.1 + B) * 1.2 + C) * 1.3 + D) * 1.4 + E) / (F + 1.0)";
+    protected override string NCalcFormula => "(((([A] * 1.1 + [B]) * 1.2 + [C]) * 1.3 + [D]) * 1.4 + [E]) / ([F] + 1.0)";
+    protected override string[] BindingNames => ["A", "B", "C", "D", "E", "F"];
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static double CSharp_NoInliningMethod(double a, double b, double c, double d, double e, double f)
+    {
+        return ((((a * 1.1 + b) * 1.2 + c) * 1.3 + d) * 1.4 + e) / (f + 1.0);
+    }
+
+    protected override double ExecuteCSharp(int index)
+    {
+        return CSharp_NoInliningMethod(A[index], B[index], C[index], D[index], E[index], F[index]);
+    }
+}
+
+public class RepeatedSubexpressionsBenchmarks : ArithmeticExecutionBenchmarks
+{
+    protected override string WistFormula => "((A * B) + (A * B) + (A * B) + (C * D)) / (E + 1.0)";
+    protected override string NCalcFormula => "(([A] * [B]) + ([A] * [B]) + ([A] * [B]) + ([C] * [D])) / ([E] + 1.0)";
+    protected override string[] BindingNames => ["A", "B", "C", "D", "E"];
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static double CSharp_NoInliningMethod(double a, double b, double c, double d, double e)
+    {
+        return ((a * b) + (a * b) + (a * b) + (c * d)) / (e + 1.0);
+    }
+
+    protected override double ExecuteCSharp(int index)
+    {
+        return CSharp_NoInliningMethod(A[index], B[index], C[index], D[index], E[index]);
+    }
+}
+
+public class WideExpression11Benchmarks : ArithmeticExecutionBenchmarks
+{
+    protected override string WistFormula => "(A + B + C + D) * (E - F + G) / (H + 1.0) + I * J - K / 3.0";
+    protected override string NCalcFormula => "([A] + [B] + [C] + [D]) * ([E] - [F] + [G]) / ([H] + 1.0) + [I] * [J] - [K] / 3.0";
+    protected override string[] BindingNames => ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K"];
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static double CSharp_NoInliningMethod(
+        double a,
+        double b,
+        double c,
+        double d,
+        double e,
+        double f,
+        double g,
+        double h,
+        double i,
+        double j,
+        double k)
+    {
+        return (a + b + c + d) * (e - f + g) / (h + 1.0) + i * j - k / 3.0;
+    }
+
+    protected override double ExecuteCSharp(int index)
+    {
+        return CSharp_NoInliningMethod(
+            A[index],
+            B[index],
+            C[index],
+            D[index],
+            E[index],
+            F[index],
+            G[index],
+            H[index],
+            I[index],
+            J[index],
+            K[index]);
+    }
+}
+
+public sealed class BenchContext
+{
+    public double A { get; set; }
+    public double B { get; set; }
+    public double C { get; set; }
+    public double D { get; set; }
+    public double E { get; set; }
+    public double F { get; set; }
+    public double G { get; set; }
+    public double H { get; set; }
+    public double I { get; set; }
+    public double J { get; set; }
+    public double K { get; set; }
+}

--- a/UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/Program.cs
+++ b/UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/Program.cs
@@ -1,0 +1,7 @@
+using BenchmarkDotNet.Running;
+
+BenchmarkRunner.Run<Simple3Benchmarks>();
+BenchmarkRunner.Run<Medium8Benchmarks>();
+BenchmarkRunner.Run<DeepChain6Benchmarks>();
+BenchmarkRunner.Run<RepeatedSubexpressionsBenchmarks>();
+BenchmarkRunner.Run<WideExpression11Benchmarks>();

--- a/UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/UniversalToolchain.Benchmarks.csproj
+++ b/UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/UniversalToolchain.Benchmarks.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net10.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <LangVersion>14</LangVersion>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\DynamicMethodCalling\DynamicMethodCalling.csproj"/>
+        <ProjectReference Include="..\..\ExceptionsManager\ExceptionsManager.csproj"/>
+        <ProjectReference Include="..\..\UniversalToolchain.Dialects.Wist\UniversalToolchain.Dialects.Wist.csproj"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="BenchmarkDotNet" Version="0.15.6"/>
+        <PackageReference Include="NCalcSync" Version="5.12.0"/>
+        <PackageReference Include="NCalc.LambdaCompilation" Version="5.12.0"/>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.2"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <Content Include="..\..\Dialects\examples\wist\full-default-native\dialect.wistdialect">
+            <Link>Dialects\examples\wist\full-default-native\dialect.wistdialect</Link>
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </Content>
+    </ItemGroup>
+
+</Project>

--- a/UniversalToolchain/Wist.sln
+++ b/UniversalToolchain/Wist.sln
@@ -124,6 +124,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UniversalToolchain.Dialects
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UniversalToolchain.Modules.Tests", "UniversalToolchain.Modules.Tests\UniversalToolchain.Modules.Tests.csproj", "{507806F7-75E5-4A6A-BF23-18992BF44B97}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Benchmarks", "Benchmarks", "{66320409-64EC-F7C5-3DEF-65E7510DAAD1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UniversalToolchain.Benchmarks", "Benchmarks\UniversalToolchain.Benchmarks\UniversalToolchain.Benchmarks.csproj", "{9C4446FE-D9E4-4FD3-9218-7900F5036FF7}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -782,6 +786,18 @@ Global
 		{507806F7-75E5-4A6A-BF23-18992BF44B97}.Release|x64.Build.0 = Release|Any CPU
 		{507806F7-75E5-4A6A-BF23-18992BF44B97}.Release|x86.ActiveCfg = Release|Any CPU
 		{507806F7-75E5-4A6A-BF23-18992BF44B97}.Release|x86.Build.0 = Release|Any CPU
+		{9C4446FE-D9E4-4FD3-9218-7900F5036FF7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9C4446FE-D9E4-4FD3-9218-7900F5036FF7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9C4446FE-D9E4-4FD3-9218-7900F5036FF7}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{9C4446FE-D9E4-4FD3-9218-7900F5036FF7}.Debug|x64.Build.0 = Debug|Any CPU
+		{9C4446FE-D9E4-4FD3-9218-7900F5036FF7}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9C4446FE-D9E4-4FD3-9218-7900F5036FF7}.Debug|x86.Build.0 = Debug|Any CPU
+		{9C4446FE-D9E4-4FD3-9218-7900F5036FF7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9C4446FE-D9E4-4FD3-9218-7900F5036FF7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9C4446FE-D9E4-4FD3-9218-7900F5036FF7}.Release|x64.ActiveCfg = Release|Any CPU
+		{9C4446FE-D9E4-4FD3-9218-7900F5036FF7}.Release|x64.Build.0 = Release|Any CPU
+		{9C4446FE-D9E4-4FD3-9218-7900F5036FF7}.Release|x86.ActiveCfg = Release|Any CPU
+		{9C4446FE-D9E4-4FD3-9218-7900F5036FF7}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -830,5 +846,6 @@ Global
 		{49C4715B-4442-482B-BA44-E9494D02550D} = {88C5710D-F6DC-410E-BEC0-195979447E14}
 		{02D0DAF6-D85C-4B23-B6D3-30557CC7B83C} = {88C5710D-F6DC-410E-BEC0-195979447E14}
 		{A93F4388-5196-41F3-B8DB-4319FBFA9A27} = {88C5710D-F6DC-410E-BEC0-195979447E14}
+		{9C4446FE-D9E4-4FD3-9218-7900F5036FF7} = {66320409-64EC-F7C5-3DEF-65E7510DAAD1}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
### Motivation
- Provide a small, honest benchmark harness that measures only precompiled execution of three paths: `CSharp_NoInliningMethod`, `NCalc_Lambda`, and `Wist_Cil_FastInvoker` for meaningful apples-to-apples comparison. 
- Reuse the existing Wist example initialization and full-default-native dialect so compilation and backend optimizations are identical to the Example flow. 
- Keep heavy work out of per-iteration paths by performing all expensive operations (compose, host creation, compile, `ToLambda`) in `GlobalSetup` and only invoking prepared callables during measured benchmarks. 

### Description
- Added a new console BenchmarkDotNet project `UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks` with `UniversalToolchain.Benchmarks.csproj`, `Program.cs`, and `ArithmeticExecutionBenchmarks.cs` that implements the harness and scenarios. 
- Implemented `ArithmeticExecutionBenchmarks` which performs DI/service registration, loads the `full-default-native` dialect, creates the Wist host, compiles the Wist formula into a `DynamicMethod`, builds typed `DynamicMethodInvoker` wrappers, creates an NCalc lambda via `ToLambda<BenchContext,double>()`, and generates reusable input arrays and a reusable `BenchContext` in `GlobalSetup`. 
- Added five benchmark scenarios (`Simple3`, `Medium8`, `DeepChain6`, `RepeatedSubexpressions`, `WideExpression11`) with three measured methods each (`CSharp_NoInliningMethod` baseline, `NCalc_Lambda`, `Wist_Cil_FastInvoker`) and an `EnsureResultParity()` check to validate outputs before measurement. 
- Mapped invoker builders for supported arities (3,5,6,8,11) using the in-repo `DynamicMethodInvoker<...>` typed wrappers and adjusted the host field type to `WistDialectExecutionHost` to access `GetArtifactCompiler<T>()`. 
- Project file pins required packages and references: `BenchmarkDotNet`, `NCalcSync`/`NCalc.LambdaCompilation` (v5.12.0), and `Microsoft.Extensions.DependencyInjection` (bumped to `10.0.2`) and copies the dialect file into output so the benchmark can compose the dialect at runtime. 

### Testing
- `dotnet build Benchmarks/UniversalToolchain.Benchmarks/UniversalToolchain.Benchmarks.csproj -c Release` succeeded after resolving package/version adjustments. 
- Attempted a dry run of the `Simple3` benchmarks with `dotnet run -c Release --project Benchmarks/UniversalToolchain.Benchmarks/UniversalToolchain.Benchmarks.csproj -- --filter '*Simple3Benchmarks*' --job Dry`, and BenchmarkDotNet’s auto-generated build phase hit the environment timeout during its internal build step (no measurement results produced in this environment). 
- Project and repository unit tests were validated with `dotnet test Tests/Tests.csproj -c Release` and all tests passed (`78 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfff9b3b54832496965885d969cd70)