### PR TITLE
Add ExternalBindingsLayout and stabilize interpreter external binding resolution

### DIFF
--- a/UniversalToolchain/BasicCore/Compilation/CompiledArtifact.cs
+++ b/UniversalToolchain/BasicCore/Compilation/CompiledArtifact.cs
@@ -11,6 +11,7 @@ public sealed class CompiledArtifact<TCompilationOutput> : ICompiledArtifact<TCo
 {
     private readonly ExternalBinding[] _declaredBindings;
     private readonly IExecutor<TCompilationOutput> _executor;
+    private readonly ExternalBindingsLayout _externalBindingsLayout;
 
     public CompiledArtifact(
         string sourceText,
@@ -28,7 +29,8 @@ public sealed class CompiledArtifact<TCompilationOutput> : ICompiledArtifact<TCo
             Thrower.ArgumentNull(nameof(executor));
 
         _declaredBindings = SnapshotBindings(declaredBindings);
-        SlotsByName = BuildSlots(_declaredBindings);
+        _externalBindingsLayout = ExternalBindingsLayout.FromDeclaredBindings(_declaredBindings);
+        SlotsByName = _externalBindingsLayout.SlotsByName;
         _executor = executor;
 
         SourceText = sourceText;
@@ -43,7 +45,7 @@ public sealed class CompiledArtifact<TCompilationOutput> : ICompiledArtifact<TCo
 
     public TCompilationOutput CompilationOutput { get; }
 
-    public ICompiledArtifactSession CreateSession() => new CompiledArtifactSession<TCompilationOutput>(this, _executor, new ExecutionEnvironment(_declaredBindings));
+    public ICompiledArtifactSession CreateSession() => new CompiledArtifactSession<TCompilationOutput>(this, _executor, new ExecutionEnvironment(_declaredBindings, _externalBindingsLayout));
 
     private static ExternalBinding[] SnapshotBindings(IReadOnlyList<ExternalBinding> declaredBindings)
     {
@@ -73,17 +75,4 @@ public sealed class CompiledArtifact<TCompilationOutput> : ICompiledArtifact<TCo
         return snapshot;
     }
 
-    private static IReadOnlyDictionary<string, int> BuildSlots(IReadOnlyList<ExternalBinding> declaredBindings)
-    {
-        var slots = new Dictionary<string, int>(declaredBindings.Count, StringComparer.Ordinal);
-
-        for (var i = 0; i < declaredBindings.Count; i++)
-        {
-            var name = declaredBindings[i].Name;
-            if (!slots.TryAdd(name, i))
-                Thrower.Argument(nameof(declaredBindings), $"Declared binding '{name}' is duplicated.");
-        }
-
-        return slots;
-    }
 }

--- a/UniversalToolchain/BasicCore/Execution/ExecutionEnvironment.cs
+++ b/UniversalToolchain/BasicCore/Execution/ExecutionEnvironment.cs
@@ -1,15 +1,22 @@
 namespace BasicCore.Execution;
 
-public sealed class ExecutionEnvironment : IExecutionEnvironment
+public sealed class ExecutionEnvironment : IExecutionEnvironment, IExternalBindingsLayoutProvider
 {
     private readonly object?[] _values;
 
-    public ExecutionEnvironment(IReadOnlyList<ExternalBinding> bindings)
+    public ExecutionEnvironment(IReadOnlyList<ExternalBinding> bindings, ExternalBindingsLayout? externalBindingsLayout = null)
     {
+        if (bindings is null)
+            Thrower.ArgumentNull(nameof(bindings));
+
         _values = new object?[bindings.Count];
         for (var i = 0; i < bindings.Count; i++)
             _values[i] = bindings[i].Value;
+
+        ExternalBindingsLayout = externalBindingsLayout ?? ExternalBindingsLayout.FromDeclaredBindings(bindings);
     }
+
+    public ExternalBindingsLayout ExternalBindingsLayout { get; }
 
     public object? GetExternalValue(int slot) => _values[slot];
 

--- a/UniversalToolchain/BasicCore/Execution/ExternalBindingsLayout.cs
+++ b/UniversalToolchain/BasicCore/Execution/ExternalBindingsLayout.cs
@@ -1,0 +1,39 @@
+namespace BasicCore.Execution;
+
+/// <summary>
+///     Immutable name-to-slot layout for declared external bindings.
+/// </summary>
+public sealed class ExternalBindingsLayout
+{
+    private ExternalBindingsLayout(IReadOnlyDictionary<string, int> slotsByName)
+    {
+        if (slotsByName is null)
+            Thrower.ArgumentNull(nameof(slotsByName));
+
+        SlotsByName = slotsByName;
+    }
+
+    /// <summary>
+    ///     Gets external binding slots keyed by binding name.
+    /// </summary>
+    public IReadOnlyDictionary<string, int> SlotsByName { get; }
+
+    /// <summary>
+    ///     Builds immutable layout from declared bindings in their compile-time order.
+    /// </summary>
+    public static ExternalBindingsLayout FromDeclaredBindings(IReadOnlyList<ExternalBinding> declaredBindings)
+    {
+        if (declaredBindings is null)
+            Thrower.ArgumentNull(nameof(declaredBindings));
+
+        var slots = new Dictionary<string, int>(declaredBindings.Count, StringComparer.Ordinal);
+        for (var i = 0; i < declaredBindings.Count; i++)
+        {
+            var name = declaredBindings[i].Name;
+            if (!slots.TryAdd(name, i))
+                Thrower.Argument(nameof(declaredBindings), $"Declared binding '{name}' is duplicated.");
+        }
+
+        return new ExternalBindingsLayout(new System.Collections.ObjectModel.ReadOnlyDictionary<string, int>(slots));
+    }
+}

--- a/UniversalToolchain/BasicCore/Execution/IExternalBindingsLayoutProvider.cs
+++ b/UniversalToolchain/BasicCore/Execution/IExternalBindingsLayoutProvider.cs
@@ -1,0 +1,12 @@
+namespace BasicCore.Execution;
+
+/// <summary>
+///     Provides compile-time external bindings layout for runtime execution environments.
+/// </summary>
+public interface IExternalBindingsLayoutProvider
+{
+    /// <summary>
+    ///     Gets immutable external bindings layout.
+    /// </summary>
+    ExternalBindingsLayout ExternalBindingsLayout { get; }
+}

--- a/UniversalToolchain/BasicInterpreter/InterpreterImpl.cs
+++ b/UniversalToolchain/BasicInterpreter/InterpreterImpl.cs
@@ -4,7 +4,11 @@ public class InterpreterImpl : IExecutor<IAbstractIR>
 {
     public object? Execute(IAbstractIR air, IExecutionEnvironment environment)
     {
-        var state = new InterpreterState { ExecutionEnvironment = environment };
+        var state = new InterpreterState
+        {
+            ExecutionEnvironment = environment,
+            ExternalBindingsLayout = (environment as IExternalBindingsLayoutProvider)?.ExternalBindingsLayout
+        };
         state.BuildLabelPositions(air.Instructions);
         return ExecuteInstructions(air.Instructions, state);
     }
@@ -112,44 +116,14 @@ public class InterpreterImpl : IExecutor<IAbstractIR>
                && method.GetParameters()[0].ParameterType == typeof(string);
     }
 
-    private static object? ResolveVariableValue(string key, InterpreterState state)
-    {
-        if (state.ExternalSlotsByName.TryGetValue(key, out var existingSlot))
-            return state.ExecutionEnvironment?.GetExternalValue(existingSlot);
-
-        if (state.LocalVariables.Contains(key))
-            return null;
-
-        if (state.ExecutionEnvironment == null)
-            return null;
-
-        var slot = state.ExternalSlotsByName.Count;
-        try
-        {
-            var value = state.ExecutionEnvironment.GetExternalValue(slot);
-            state.ExternalSlotsByName[key] = slot;
-            return value;
-        }
-        catch (IndexOutOfRangeException)
-        {
-            return null;
-        }
-        catch (ArgumentOutOfRangeException)
-        {
-            return null;
-        }
-    }
-
     private void ExecuteCSharpCall(Instruction instruction, InterpreterState state)
     {
         var method = instruction.Operands[1].Get<MethodInfo>();
 
-        // Получаем типы аргументов из стека
         var parameters = method.GetParameters();
         var args = new object?[parameters.Length];
         var argsTypes = new Type[parameters.Length];
 
-        // Собираем аргументы в обратном порядке (последний аргумент первым в стеке)
         for (var i = parameters.Length - 1; i >= 0; i--)
         {
             if (state.ValueStack.Count == 0)
@@ -160,24 +134,19 @@ public class InterpreterImpl : IExecutor<IAbstractIR>
             argsTypes[i] = value?.GetType() ?? typeof(object);
         }
 
-        if (IsVariablesContainerGet(method) && args[0] is string key)
+        if (IsVariablesContainerGet(method)
+            && args[0] is string key
+            && state.ExternalBindingsLayout?.SlotsByName.TryGetValue(key, out var slot) == true)
         {
-            var value = ResolveVariableValue(key, state);
-            if (value != null || state.ExternalSlotsByName.ContainsKey(key))
-            {
-                state.ValueStack.Push(value!);
-                return;
-            }
+            var value = state.ExecutionEnvironment.NotNull().GetExternalValue(slot);
+            state.ValueStack.Push(value!);
+            return;
         }
 
-        if (method.Name == "Set" && method.GetParameters().Length == 2 && args[0] is string localVariable)
-            state.LocalVariables.Add(localVariable);
-
-        // Use the same logic as in compiler
+        // Use the same logic as in compiler.
         var stackTypes = argsTypes.AsReadOnly().ToList();
         var targetTypes = GenericTypeResolver.GetParameterTypes(method, stackTypes).ToList();
 
-        // Приводим аргументы к нужным типам, если необходимо
         for (var i = 0; i < args.Length; i++)
         {
             if (args[i]?.GetType() == targetTypes[i])
@@ -189,15 +158,14 @@ public class InterpreterImpl : IExecutor<IAbstractIR>
             }
             catch
             {
-                // Если не удалось преобразовать, оставляем как есть
-                // Это может привести к исключению при вызове, что корректно
+                // If conversion fails, keep the original value.
+                // Method invocation will raise a meaningful exception if needed.
             }
         }
 
-        // Создаем конкретный generic-метод, если нужно (используем ту же логику, что и в компиляторе)
+        // Create closed generic method when needed, using the same logic as compiler backend.
         method = GenericTypeResolver.MakeGenericMethod(method, targetTypes.ToArray());
 
-        // Вызов метода
         object result;
         if (method.IsStatic)
         {
@@ -205,7 +173,7 @@ public class InterpreterImpl : IExecutor<IAbstractIR>
         }
         else
         {
-            // Для нестатических методов, экземпляр должен быть в стеке перед аргументами
+            // For instance methods the target instance must be on stack before arguments.
             if (state.ValueStack.Count == 0)
                 Thrower.InvalidOpEx("Cannot call instance method: object instance is missing on the interpreter stack.");
 
@@ -213,7 +181,6 @@ public class InterpreterImpl : IExecutor<IAbstractIR>
             result = method.Invoke(instance, args) ?? new object();
         }
 
-        // Если метод возвращает значение, кладем его в стек
         if (method.ReturnType != typeof(void))
             state.ValueStack.Push(result);
     }
@@ -223,7 +190,6 @@ public class InterpreterImpl : IExecutor<IAbstractIR>
         var ctor = instruction.Operands[1].Get<ConstructorInfo>();
         var parameters = ctor.GetParameters();
 
-        // Собираем аргументы в обратном порядке
         var args = new object[parameters.Length];
 
         for (var i = parameters.Length - 1; i >= 0; i--)
@@ -234,10 +200,8 @@ public class InterpreterImpl : IExecutor<IAbstractIR>
             args[i] = state.ValueStack.Pop();
         }
 
-        // Создаем экземпляр
         var instance = ctor.Invoke(args);
 
-        // Кладем экземпляр в стек
         state.ValueStack.Push(instance);
     }
 }

--- a/UniversalToolchain/BasicInterpreter/InterpreterState.cs
+++ b/UniversalToolchain/BasicInterpreter/InterpreterState.cs
@@ -5,8 +5,7 @@ public class InterpreterState
     private readonly Dictionary<Guid, int> _labelPositions = new();
     private bool _labelsBuilt;
     public Stack<object> ValueStack { get; } = new();
-    public Dictionary<string, int> ExternalSlotsByName { get; } = new();
-    public HashSet<string> LocalVariables { get; } = [];
+    public ExternalBindingsLayout? ExternalBindingsLayout { get; set; }
 
     public int InstructionPointer { get; set; }
     public IExecutionEnvironment? ExecutionEnvironment { get; set; }

--- a/UniversalToolchain/Tests/Infrastructure/CompilerAndInterpreterResilienceTests.cs
+++ b/UniversalToolchain/Tests/Infrastructure/CompilerAndInterpreterResilienceTests.cs
@@ -1,3 +1,5 @@
+using SettableGettableModule.Core;
+
 namespace Tests.Infrastructure;
 
 [TestFixture]
@@ -116,6 +118,50 @@ public class CompilerAndInterpreterResilienceTests
         var exception = Assert.Throws<RuntimeExecutionException>(() => ExecuteInInterpreter(ir));
 
         Assert.That(exception!.Message, Does.Contain("unknown intrinsic"));
+    }
+
+    [Test]
+    public void Interpreter_VariablesContainerGet_UsesDeclaredExternalBindingLayoutSlot()
+    {
+        var getMethod = typeof(VariablesContainer<int>).GetMethod(nameof(VariablesContainer<int>.Get), [typeof(string)]);
+        Assert.That(getMethod, Is.Not.Null);
+
+        var ir = BuildIr(
+            new Instruction(UOpCode.Push, ["target"]),
+            new Instruction(UOpCode.Intrinsic, ["call C#", getMethod!]));
+
+        var environment = new ExecutionEnvironment(
+        [
+            new ExternalBinding { Name = "other", Type = typeof(int), Value = 11, Kind = ExternalBindingKind.Variable },
+            new ExternalBinding { Name = "target", Type = typeof(int), Value = 42, Kind = ExternalBindingKind.Variable }
+        ]);
+
+        var result = ExecuteInInterpreter(ir, environment);
+
+        Assert.That(result, Is.EqualTo(42));
+    }
+
+    [Test]
+    public void Interpreter_VariablesContainerGet_NameMissingInLayout_IsTreatedAsLocalVariable()
+    {
+        var key = $"local_only_{Guid.NewGuid():N}";
+        VariablesContainer<int>.Set(key, 7);
+
+        var getMethod = typeof(VariablesContainer<int>).GetMethod(nameof(VariablesContainer<int>.Get), [typeof(string)]);
+        Assert.That(getMethod, Is.Not.Null);
+
+        var ir = BuildIr(
+            new Instruction(UOpCode.Push, [key]),
+            new Instruction(UOpCode.Intrinsic, ["call C#", getMethod!]));
+
+        var environment = new ExecutionEnvironment(
+        [
+            new ExternalBinding { Name = "declared", Type = typeof(int), Value = 999, Kind = ExternalBindingKind.Variable }
+        ]);
+
+        var result = ExecuteInInterpreter(ir, environment);
+
+        Assert.That(result, Is.EqualTo(7));
     }
 
     [Test]
@@ -358,6 +404,12 @@ public class CompilerAndInterpreterResilienceTests
     {
         var interpreter = new InterpreterImpl();
         return interpreter.Execute(ir, new ExecutionEnvironment([]));
+    }
+
+    private static object? ExecuteInInterpreter(IAbstractIR ir, IExecutionEnvironment environment)
+    {
+        var interpreter = new InterpreterImpl();
+        return interpreter.Execute(ir, environment);
     }
 
     private static IAbstractIR BuildIr(params Instruction[] instructions)


### PR DESCRIPTION
### Motivation
- Make external binding name→slot mapping deterministic and immutable by building it once at compile time rather than allocating slots at runtime. 
- Remove exception-driven probing and implicit slot creation in the interpreter to avoid hidden mutations of artifact/session structure. 
- Propagate compile-time binding layout into runtime state so interpreter and compiled sessions share the same contract for external access. 

### Description
- Added `ExternalBindingsLayout` (immutable name→slot snapshot) and `IExternalBindingsLayoutProvider` to the execution infrastructure. 
- `CompiledArtifact` now constructs the layout from declared `ExternalBinding`s and uses `ExternalBindingsLayout.SlotsByName` as `SlotsByName`, and session creation injects the layout into `ExecutionEnvironment`. 
- `ExecutionEnvironment` now implements `IExternalBindingsLayoutProvider` and holds an `ExternalBindingsLayout` instance while preserving declared binding values. 
- Interpreter changes: removed dynamic `ResolveVariableValue` and removed runtime slot allocation/probing, added `InterpreterState.ExternalBindingsLayout`, and updated `ExecuteCSharpCall` so `VariablesContainer<T>.Get(string)` resolves only via `ExternalBindingsLayout.SlotsByName.TryGetValue(name, out slot)` and reads with `ExecutionEnvironment.GetExternalValue(slot)`, treating missing names as non-external. 
- Added regression tests validating declared-layout slot resolution and that names missing from the layout are treated as local variables. 

### Testing
- Installed the SDK and verified with `dotnet --version` after running the official installer script `curl .../dotnet-install.sh && bash /tmp/dotnet-install.sh --version 10.0.103`. 
- Restored packages with `dotnet restore UniversalToolchain/Wist.sln` which completed successfully. 
- Running `dotnet build UniversalToolchain/Wist.sln -c Release --no-restore` encountered an intermittent file-lock error in the manifest-emitter step (runtimeconfig generation) and did not complete in this session. 
- Executed unit tests: `dotnet test UniversalToolchain/Tests/Tests.csproj -c Release --no-restore` passed (78 tests), `dotnet test UniversalToolchain/UniversalToolchain.Modules.Tests/UniversalToolchain.Modules.Tests.csproj -c Release --no-restore` passed (194 passed, 7 skipped), and `dotnet test UniversalToolchain/UniversalToolchain.Dialects.Tests/UniversalToolchain.Dialects.Tests.csproj -c Release --no-restore` passed (302 tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3a868e970832486e810b328518863)