### PR TITLE
Clarify interpreter external symbol resolution contracts

### DIFF
--- a/UniversalToolchain/BasicInterpreter/InterpreterImpl.cs
+++ b/UniversalToolchain/BasicInterpreter/InterpreterImpl.cs
@@ -116,6 +116,20 @@ public class InterpreterImpl : IExecutor<IAbstractIR>
                && method.GetParameters()[0].ParameterType == typeof(string);
     }
 
+    private static bool TryResolveDeclaredExternalSlot(
+        InterpreterState state,
+        object?[] args,
+        out int slot)
+    {
+        slot = default;
+        if (args.Length != 1 || args[0] is not string key)
+            return false;
+
+        // Only declared layout metadata can mark a symbol as external.
+        // Runtime call observation must not infer local/external symbol class.
+        return state.ExternalBindingsLayout?.SlotsByName.TryGetValue(key, out slot) == true;
+    }
+
     private void ExecuteCSharpCall(Instruction instruction, InterpreterState state)
     {
         var method = instruction.Operands[1].Get<MethodInfo>();
@@ -135,8 +149,7 @@ public class InterpreterImpl : IExecutor<IAbstractIR>
         }
 
         if (IsVariablesContainerGet(method)
-            && args[0] is string key
-            && state.ExternalBindingsLayout?.SlotsByName.TryGetValue(key, out var slot) == true)
+            && TryResolveDeclaredExternalSlot(state, args, out var slot))
         {
             var value = state.ExecutionEnvironment.NotNull().GetExternalValue(slot);
             state.ValueStack.Push(value!);

--- a/UniversalToolchain/BasicInterpreter/InterpreterState.cs
+++ b/UniversalToolchain/BasicInterpreter/InterpreterState.cs
@@ -5,6 +5,12 @@ public class InterpreterState
     private readonly Dictionary<Guid, int> _labelPositions = new();
     private bool _labelsBuilt;
     public Stack<object> ValueStack { get; } = new();
+
+    /// <summary>
+    /// Compile-time binding layout used to resolve declared external symbols at runtime.
+    /// Symbol class (local vs external) must be determined before interpreter execution.
+    /// Runtime state is not allowed to infer or redefine symbol class from observed calls.
+    /// </summary>
     public ExternalBindingsLayout? ExternalBindingsLayout { get; set; }
 
     public int InstructionPointer { get; set; }


### PR DESCRIPTION
### Motivation
- Prevent interpreter runtime behavior from inferring whether a symbol is local or external by observing calls, and ensure that symbol class is provided by compile-time metadata.
- Make interpreter state and call execution contracts explicit for future maintenance and to avoid subtle semantic leaks between optimizer/compiler and runtime.

### Description
- Added XML documentation to `InterpreterState.ExternalBindingsLayout` clarifying that the external binding layout is compile-time metadata and that symbol class (local vs external) must be resolved before interpreter execution (`UniversalToolchain/BasicInterpreter/InterpreterState.cs`).
- Introduced `TryResolveDeclaredExternalSlot(InterpreterState, object?[], out int)` to centralize metadata-based external-slot resolution and to explicitly forbid runtime inference of symbol class (`UniversalToolchain/BasicInterpreter/InterpreterImpl.cs`).
- Updated `ExecuteCSharpCall` to use the new resolver when intercepting `VariablesContainer<T>.Get` and added guard comments noting that runtime call observation must not classify symbols as local/external (`UniversalToolchain/BasicInterpreter/InterpreterImpl.cs`).

### Testing
- Ran `dotnet restore UniversalToolchain/Wist.sln` which completed successfully.
- Built the solution with `dotnet build UniversalToolchain/Wist.sln -c Release --no-restore` and the build succeeded with zero errors.
- Executed unit test suites with `dotnet test` and the relevant projects passed: `Tests` passed (78 passed), `UniversalToolchain.Modules.Tests` passed (194 passed, 7 skipped), and `UniversalToolchain.Dialects.Tests` passed (302 passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3ad8fbc6c8324a6676d401b9c5605)