### PR TITLE
Harden VariablesContainer.Get missing-key behavior and add TryGet + tests

### DIFF
--- a/UniversalToolchain/SettableGettableModule/Core/VariablesContainer.cs
+++ b/UniversalToolchain/SettableGettableModule/Core/VariablesContainer.cs
@@ -4,15 +4,31 @@ public static class VariablesContainer<T>
 {
     private static readonly Dictionary<string, T> _variables = [];
 
+    /// <summary>
+    /// Stores value by key, replacing an existing value when key is already present.
+    /// </summary>
     public static void Set(string key, T value)
     {
         CollectionsMarshal.GetValueRefOrAddDefault(_variables, key, out _) = value;
     }
 
+    /// <summary>
+    /// Gets value by key or throws <see cref="KeyNotFoundException"/> when key is missing.
+    /// </summary>
     public static T Get(string key)
     {
-        var value = CollectionsMarshal.GetValueRefOrNullRef(_variables, key);
-        return value;
+        if (TryGet(key, out var value))
+            return value;
+
+        throw new KeyNotFoundException($"Variable with key '{key}' was not found.");
+    }
+
+    /// <summary>
+    /// Tries to get value by key without throwing when key is missing.
+    /// </summary>
+    public static bool TryGet(string key, out T value)
+    {
+        return _variables.TryGetValue(key, out value!);
     }
 
     public static VariableReference<T> GetRef(string key)

--- a/UniversalToolchain/Tests/Infrastructure/BytecodeAndStateIsolationTests.cs
+++ b/UniversalToolchain/Tests/Infrastructure/BytecodeAndStateIsolationTests.cs
@@ -77,6 +77,27 @@ public class BytecodeAndStateIsolationTests : TestBase
     }
 
     [Test]
+    public void VariablesContainer_Get_ShouldThrowClearException_WhenKeyIsMissing()
+    {
+        var missingKey = "missing-" + Guid.NewGuid().ToString("N");
+
+        var exception = Assert.Throws<KeyNotFoundException>(() => VariablesContainer<int>.Get(missingKey));
+
+        Assert.That(exception!.Message, Does.Contain(missingKey));
+    }
+
+    [Test]
+    public void VariablesContainer_Get_ShouldReturnValue_WhenKeyExists()
+    {
+        var key = "existing-" + Guid.NewGuid().ToString("N");
+        VariablesContainer<int>.Set(key, 123);
+
+        var value = VariablesContainer<int>.Get(key);
+
+        Assert.That(value, Is.EqualTo(123));
+    }
+
+    [Test]
     public void Should_BeStableAcrossRepeatedRuns_When_ExecutingSameProgramMultipleTimes()
     {
         const string code = @"


### PR DESCRIPTION
### Motivation

- Make variable lookups explicit by detecting missing keys instead of returning an implicit default value, so callers receive a clear, actionable error when a lookup fails.
- Preserve backward-compatible non-throwing lookup semantics for callers that rely on the old behavior by adding a `TryGet` API.
- Document the intended strict semantics of `Get` and the non-throwing `TryGet` to keep public API contracts explicit.

### Description

- Changed `VariablesContainer<T>.Get(string key)` to explicitly test presence and throw a `KeyNotFoundException` containing the missing key when not found.
- Added `VariablesContainer<T>.TryGet(string key, out T value)` which forwards to `_variables.TryGetValue(...)` for non-throwing lookups.
- Added English XML documentation comments explaining that `Get` throws on missing keys and `TryGet` is the non-throwing alternative.
- Added two infrastructure tests in `BytecodeAndStateIsolationTests`: one asserting `Get` throws with a clear message for a missing key, and one asserting `Get` returns the expected value for an existing key.

### Testing

- Restored and built the solution with `dotnet restore UniversalToolchain/Wist.sln` and `dotnet build UniversalToolchain/Wist.sln -c Release --no-restore`, and the build succeeded.
- Ran unit tests with `dotnet test UniversalToolchain/Tests/Tests.csproj -c Release --no-build` and the test assembly passed (78 passed).
- Ran module and dialect test suites with `dotnet test UniversalToolchain/UniversalToolchain.Modules.Tests/UniversalToolchain.Modules.Tests.csproj -c Release --no-build` and `dotnet test UniversalToolchain/UniversalToolchain.Dialects.Tests/UniversalToolchain.Dialects.Tests.csproj -c Release --no-build`, and both passed (Modules: 194 passed, 7 skipped; Dialects: 302 passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3b797c45c8324b1015cbb95a6ef09)