### PR TITLE
Stabilize variable storage typing and introduce per-local StorageKey

### DIFF
--- a/UniversalToolchain/BasicCore/Binding/Symbols/LocalVariableSymbol.cs
+++ b/UniversalToolchain/BasicCore/Binding/Symbols/LocalVariableSymbol.cs
@@ -1,3 +1,14 @@
 namespace BasicCore.Binding.Symbols;
 
-public sealed class LocalVariableSymbol(string name, Type type) : Symbol(name, type);
+public sealed class LocalVariableSymbol : Symbol
+{
+    private readonly string _storageKey;
+
+    public LocalVariableSymbol(string name, Type type)
+        : base(name, type)
+    {
+        _storageKey = $"local:{Guid.NewGuid():N}:{name}";
+    }
+
+    public override string StorageKey => _storageKey;
+}

--- a/UniversalToolchain/BasicCore/Binding/Symbols/Symbol.cs
+++ b/UniversalToolchain/BasicCore/Binding/Symbols/Symbol.cs
@@ -4,4 +4,6 @@ public abstract class Symbol(string name, Type type)
 {
     public string Name { get; } = name;
     public Type Type { get; } = type;
+
+    public virtual string StorageKey => Name;
 }

--- a/UniversalToolchain/SettableGettableModule/Core/VariablesContainer.cs
+++ b/UniversalToolchain/SettableGettableModule/Core/VariablesContainer.cs
@@ -20,7 +20,9 @@ public static class VariablesContainer<T>
         if (TryGet(key, out var value))
             return value;
 
-        throw new KeyNotFoundException($"Variable with key '{key}' was not found.");
+        throw new KeyNotFoundException(
+            $"Variable with key '{key}' was not found in {typeof(VariablesContainer<T>).FullName}. " +
+            $"Value type: {typeof(T).FullName}.");
     }
 
     /// <summary>

--- a/UniversalToolchain/Tests/Integration/InterpreterBindingsParityTests.cs
+++ b/UniversalToolchain/Tests/Integration/InterpreterBindingsParityTests.cs
@@ -140,6 +140,64 @@ public class InterpreterBindingsParityTests
         AssertDeterministicParity(nestedScopeCode, declared, arguments);
     }
 
+
+    [Test]
+    public void LocalVariable_TypeMustStayStableAcrossRepeatedReadWrite()
+    {
+        const string code = """
+                            let i = 0
+                            i = i + 1
+                            i = i + 1
+                            i
+                            """;
+
+        var declared = new OrderedDictionary<string, Type>();
+        var result = RunInBothBackends(code, declared, []);
+
+        Assert.That(result.CompilerNumeric, Is.EqualTo(result.InterpreterNumeric).Within(1e-9));
+        Assert.That(result.CompilerNumeric, Is.EqualTo(2.0).Within(1e-9));
+    }
+
+    [Test]
+    public void LocalVariable_WithExternalArithmetic_MustNotSwitchStorageContainer()
+    {
+        const string code = """
+                            let i = 0
+                            i = i + 1
+                            price + fee * i
+                            """;
+
+        var declared = new OrderedDictionary<string, Type>
+        {
+            ["price"] = typeof(object),
+            ["fee"] = typeof(object)
+        };
+
+        var result = RunInBothBackends(code, declared, [
+            new NamedArgument("price", 100.0),
+            new NamedArgument("fee", 2.5)
+        ]);
+
+        Assert.That(result.CompilerNumeric, Is.EqualTo(result.InterpreterNumeric).Within(1e-9));
+        Assert.That(result.CompilerNumeric, Is.EqualTo(102.5).Within(1e-9));
+    }
+
+    [Test]
+    public void LocalShadowing_MustUseIndependentStorageKeys()
+    {
+        const string code = """
+                            let fee = 1
+                            let total = fee
+                            total + fee
+                            """;
+
+        var declared = new OrderedDictionary<string, Type>();
+        var result = RunInBothBackends(code, declared, []);
+
+        Assert.That(result.CompilerNumeric, Is.EqualTo(result.InterpreterNumeric).Within(1e-9));
+        Assert.That(result.CompilerNumeric, Is.EqualTo(2.0).Within(1e-9));
+    }
+
     [Test]
     public void UnknownVariableAccess_WhenStrictFailureExists_ShouldExposeMeaningfulError()
     {

--- a/UniversalToolchain/VariablesModule/VariablesVisitor.cs
+++ b/UniversalToolchain/VariablesModule/VariablesVisitor.cs
@@ -1,3 +1,5 @@
+using ExceptionsManager;
+
 namespace VariablesModule;
 
 public class VariablesVisitor : IAstVisitor
@@ -21,39 +23,101 @@ public class VariablesVisitor : IAstVisitor
             HandleVariable(data);
     }
 
+    private static bool IsConcreteType(Type type)
+    {
+        return type != typeof(object);
+    }
+
+    private Type ResolveReadType(Symbol symbol, string variableKey)
+    {
+        if (_variablesTypes.TryGetValue(variableKey, out var existing))
+        {
+            if (IsConcreteType(existing))
+                return existing;
+
+            if (symbol is ExternalVariableSymbol or ExternalConstantSymbol)
+                return existing;
+        }
+
+        if (IsConcreteType(symbol.Type))
+        {
+            _variablesTypes[variableKey] = symbol.Type;
+            return symbol.Type;
+        }
+
+        Thrower.InvalidOpEx(
+            $"Storage type for variable '{symbol.Name}' is not fixed before read. " +
+            $"Current symbol type: '{symbol.Type.FullName}'.");
+        return null!;
+    }
+
+    private Type ResolveWriteType(Symbol symbol, string variableKey, Type inferredType)
+    {
+        if (_variablesTypes.TryGetValue(variableKey, out var existing) && IsConcreteType(existing))
+            return existing;
+
+        if (IsConcreteType(symbol.Type))
+        {
+            _variablesTypes[variableKey] = symbol.Type;
+            return symbol.Type;
+        }
+
+        if (IsConcreteType(inferredType))
+        {
+            _variablesTypes[variableKey] = inferredType;
+            return inferredType;
+        }
+
+        _variablesTypes[variableKey] = typeof(object);
+        return typeof(object);
+    }
+
     private void HandleBoundVariable(BytecodeVisitorData data, Symbol symbol)
     {
-        var varName = symbol.Name;
-        if (symbol.Type != typeof(object) || !_variablesTypes.ContainsKey(varName))
-            _variablesTypes[varName] = symbol.Type;
+        var variableKey = symbol.StorageKey;
+        var displayName = symbol.Name;
+        if (IsConcreteType(symbol.Type))
+            _variablesTypes[variableKey] = symbol.Type;
+        else if (symbol is ExternalVariableSymbol or ExternalConstantSymbol && !_variablesTypes.ContainsKey(variableKey))
+            _variablesTypes[variableKey] = symbol.Type;
 
         if (data.Node.AllTags.Contains("ExpectingSettableReference"))
         {
             var method = new AbstractMethodImpl(
-                $"LoadReferenceToVar_{varName}",
+                $"LoadReferenceToVar_{displayName}",
                 (il, context) =>
                 {
-                    var type = symbol.Type != typeof(object) ? symbol.Type : context.Stack.Last();
-                    _variablesTypes[varName] = type;
-                    il.LdLocRef(varName, type);
+                    var inferredType = context.Stack.Last();
+                    var storageType = ResolveWriteType(symbol, variableKey, inferredType);
+                    il.LdLocRef(variableKey, storageType);
                 }
             );
+
             data.Bytecode.Instructions.Add(new BytecodeInstruction(method));
             return;
         }
 
-        var loadName = symbol is ExternalVariableSymbol or ExternalConstantSymbol ? "LoadValueOfExternalVar" : "LoadValueOfLocalVar";
+        var loadName = symbol is ExternalVariableSymbol or ExternalConstantSymbol
+            ? "LoadValueOfExternalVar"
+            : "LoadValueOfLocalVar";
+
         var loadMethod = new AbstractMethodImpl(
-            $"{loadName}_{varName}",
-            (il, _) => il.LdLoc(varName, _variablesTypes[varName])
+            $"{loadName}_{displayName}",
+            (il, _) =>
+            {
+                var storageType = ResolveReadType(symbol, variableKey);
+                il.LdLoc(variableKey, storageType);
+            }
         );
+
         data.Bytecode.Instructions.Add(new BytecodeInstruction(loadMethod));
     }
 
     private void HandlePreprocessorLexeme(BytecodeVisitorData data)
     {
         var text = data.Node.Text[3..^1].Split();
-        if (text is not ["define", _, "as", _]) return;
+        if (text is not ["define", _, "as", _])
+            return;
 
         var paramName = text[1];
         var type = TypesFinder.GetType(text[3]);
@@ -67,27 +131,43 @@ public class VariablesVisitor : IAstVisitor
 
     private void HandleVariable(BytecodeVisitorData data)
     {
-        var varName = data.Node.Text;
+        var variableKey = data.Node.Text;
 
         if (data.Node.AllTags.Contains("ExpectingSettableReference"))
         {
             var method = new AbstractMethodImpl(
-                $"LoadReferenceToLocalVar_{varName}",
+                $"LoadReferenceToLocalVar_{data.Node.Text}",
                 (il, context) =>
                 {
-                    var type = _variablesTypes[varName] = context.Stack.Last();
-                    il.LdLocRef(varName, type);
+                    var inferredType = context.Stack.Last();
+
+                    var storageType =
+                        _variablesTypes.TryGetValue(variableKey, out var existing) && IsConcreteType(existing)
+                            ? existing
+                            : IsConcreteType(inferredType)
+                                ? (_variablesTypes[variableKey] = inferredType)
+                                : typeof(object);
+
+                    il.LdLocRef(variableKey, storageType);
                 }
             );
+
             data.Bytecode.Instructions.Add(new BytecodeInstruction(method));
+            return;
         }
-        else
-        {
-            var method = new AbstractMethodImpl(
-                $"LoadValueOfLocalVar_{varName}",
-                (il, _) => il.LdLoc(varName, _variablesTypes[varName])
-            );
-            data.Bytecode.Instructions.Add(new BytecodeInstruction(method));
-        }
+
+        var loadMethod = new AbstractMethodImpl(
+            $"LoadValueOfLocalVar_{data.Node.Text}",
+            (il, _) =>
+            {
+                var storageType = _variablesTypes.TryGetValue(variableKey, out var existingType)
+                    ? existingType
+                    : Thrower.InvalidOpEx<Type>($"Storage type for variable '{data.Node.Text}' is not fixed before read.");
+
+                il.LdLoc(variableKey, storageType);
+            }
+        );
+
+        data.Bytecode.Instructions.Add(new BytecodeInstruction(loadMethod));
     }
 }


### PR DESCRIPTION
### Motivation
- Fix confusing "Variable with key '...' was not found" failures and make diagnostics show which generic `VariablesContainer<T>` is involved. 
- Prevent storage-type drift where the same textual variable name could be written into one `VariablesContainer<T>` and read from another, causing spurious not-found / mismatch errors. 
- Isolate local storage for shadowed locals so different local symbols with the same name do not share the same runtime storage slot.

### Description
- Improved the not-found diagnostic in `VariablesContainer<T>.Get` to include the concrete `VariablesContainer<T>` type and `T` value type for faster root-cause identification. 
- Added stable storage-type resolution helpers `IsConcreteType`, `ResolveReadType`, and `ResolveWriteType` and updated `VariablesVisitor` to fix a variable's storage type after the first concrete type is known. 
- Reworked `HandleBoundVariable` and `HandleVariable` in `UniversalToolchain/VariablesModule/VariablesVisitor.cs` to use the new resolvers and to avoid letting unbound/fallback reads/writes freely change a variable's storage-type. 
- Introduced a `StorageKey` property on `Symbol` and gave `LocalVariableSymbol` a unique GUID-based `StorageKey` so each local symbol uses its own storage key while preserving readable instruction names. 
- Added three integration regression tests to `InterpreterBindingsParityTests` covering repeated local read/write stability, local+external arithmetic storage behavior, and local shadowing isolation.

### Testing
- Ran the local setup and build commands: `dotnet clean UniversalToolchain/Wist.sln` and full solution build, which succeeded. 
- Executed the parity-focused test command `dotnet test UniversalToolchain/Wist.sln -c Release --filter "FullyQualifiedName~InterpreterBindingsParityTests"`, and observed failures concentrated in the parity tests where compiler backend attempts produced `Cannot cast System.Object to NumbersModule.Core.RealNumberImpl`. 
- Ran the full test sweep `dotnet test UniversalToolchain/Wist.sln -c Release`, where most test projects passed (for example `UniversalToolchain.Dialects.Tests` and `UniversalToolchain.Modules.Tests` passed), but `Tests.dll` contained 4 failing parity tests (same casting issue), indicating the storage-type stabilization logic is active but additional handling is required for arithmetic involving declared `typeof(object)` externals.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3dbf9ac34832485292ee9ffffa463)