### PR TITLE
Fix external binding reads via slot-based lowering

### DIFF
--- a/UniversalToolchain/AbstractIrConverters/AbstractIrToAbstractIrStub.cs
+++ b/UniversalToolchain/AbstractIrConverters/AbstractIrToAbstractIrStub.cs
@@ -5,7 +5,9 @@ public class AbstractIrToAbstractIrStub : IAbstractIrCompiler<IAbstractIR>
     public IReadOnlyList<string> SupportedIntrinsics =>
     [
         "call C#",
-        "call C# ctor"
+        "call C# ctor",
+        "load_external",
+        "store_external"
     ];
 
     public IAbstractIR Compile(IAbstractIR air, CompilationInput input) => air;

--- a/UniversalToolchain/AbstractIrExtensions/AbstractIrExtensions.cs
+++ b/UniversalToolchain/AbstractIrExtensions/AbstractIrExtensions.cs
@@ -42,6 +42,16 @@ public static class AbstractIrExtensions
         );
     }
 
+    public static void LdExternal<TIdentifier>(this IGenericAbstractIR<TIdentifier> air, int slot, Type valueType)
+    {
+        air.Intrinsic("load_external", slot, valueType);
+    }
+
+    public static void StExternal<TIdentifier>(this IGenericAbstractIR<TIdentifier> air, int slot, Type valueType)
+    {
+        air.Intrinsic("store_external", slot, valueType);
+    }
+
     private static void ActWithLoc<TIdentifier>(
         this IGenericAbstractIR<TIdentifier> air,
         Type locType,

--- a/UniversalToolchain/BasicInterpreter/InterpreterImpl.cs
+++ b/UniversalToolchain/BasicInterpreter/InterpreterImpl.cs
@@ -100,8 +100,29 @@ public class InterpreterImpl : IExecutor<IAbstractIR>
             ExecuteCSharpCall(instruction, state);
         else if (intrinsicName == "call C# ctor")
             ExecuteCSharpConstructor(instruction, state);
+        else if (intrinsicName == "load_external")
+            ExecuteLoadExternal(instruction, state);
+        else if (intrinsicName == "store_external")
+            ExecuteStoreExternal(instruction, state);
         else
             Thrower.InvalidOpEx($"Unknown intrinsic call: {intrinsicName}.");
+    }
+
+    private static void ExecuteLoadExternal(Instruction instruction, InterpreterState state)
+    {
+        var slot = instruction.Operands[1].Get<int>();
+        var value = state.ExecutionEnvironment.NotNull().GetExternalValue(slot);
+        state.ValueStack.Push(value!);
+    }
+
+    private static void ExecuteStoreExternal(Instruction instruction, InterpreterState state)
+    {
+        if (state.ValueStack.Count == 0)
+            Thrower.InvalidOpEx("Cannot store external value: stack is empty.");
+
+        var slot = instruction.Operands[1].Get<int>();
+        var value = state.ValueStack.Pop();
+        state.ExecutionEnvironment.NotNull().SetExternalValue(slot, value);
     }
 
 

--- a/UniversalToolchain/BytecodeDynamicMethodsCompiler/Compilers/AbstractMethodsIntrinsicCompiler.cs
+++ b/UniversalToolchain/BytecodeDynamicMethodsCompiler/Compilers/AbstractMethodsIntrinsicCompiler.cs
@@ -13,6 +13,8 @@ internal sealed class AbstractMethodsIntrinsicCompiler
             ["store_local"] = CompileStoreLocal,
             ["load_local"] = CompileLoadLocal,
             ["load_local_ref"] = CompileLoadLocalRef,
+            ["load_external"] = CompileLoadExternal,
+            ["store_external"] = CompileStoreExternal,
             ["load_bool"] = CompileLoadBool,
             ["boolean_and"] = CompileBooleanAnd,
             ["boolean_or"] = CompileBooleanOr,
@@ -29,6 +31,7 @@ internal sealed class AbstractMethodsIntrinsicCompiler
     [
         "call C#", "call C# ctor",
         "store_local", "load_local", "load_local_ref",
+        "load_external", "store_external",
         "load_i32", "load_i64", "load_f32", "load_f64", "load_decimal",
         "boolean_and", "boolean_or", "boolean_not",
         "add_i32", "sub_i32", "mul_i32", "div_i32",
@@ -140,6 +143,21 @@ internal sealed class AbstractMethodsIntrinsicCompiler
 
         context.Il.Ldloca(context.GetOrCreateLocal(varName, varType, true));
         stack.Push(varType.MakeByRefType());
+    }
+
+    private static void CompileLoadExternal(CompilationContext context, Instruction instruction, List<Type> stack)
+    {
+        var slot = instruction.Operands[1].Get<int>();
+        var varType = instruction.Operands[2].Get<Type>();
+        context.Il.Ldarg(slot);
+        stack.Push(varType);
+    }
+
+    private static void CompileStoreExternal(CompilationContext context, Instruction instruction, List<Type> stack)
+    {
+        var slot = instruction.Operands[1].Get<int>();
+        context.Il.Starg(slot);
+        stack.Pop();
     }
 
 

--- a/UniversalToolchain/DotnetAirHelper/AirTypes.cs
+++ b/UniversalToolchain/DotnetAirHelper/AirTypes.cs
@@ -40,6 +40,21 @@ public static class AirTypes
                 stack.Push(ctor.DeclaringType.NotNull());
             }
         );
+        TryRegisterIntrinsic(
+            "load_external",
+            (instruction, stack) =>
+            {
+                var valueType = instruction.Operands[2].Get<Type>();
+                stack.Push(valueType);
+            }
+        );
+        TryRegisterIntrinsic(
+            "store_external",
+            (_, stack) =>
+            {
+                stack.Pop();
+            }
+        );
     }
 
     public static bool TryRegisterIntrinsic(string name, Action<Instruction, List<Type>> processIntrinsic) => _intrinsicsProcessors.TryAdd(name, processIntrinsic);

--- a/UniversalToolchain/Tests/Integration/InterpreterBindingsParityTests.cs
+++ b/UniversalToolchain/Tests/Integration/InterpreterBindingsParityTests.cs
@@ -10,6 +10,28 @@ namespace Tests.Integration;
 public class InterpreterBindingsParityTests
 {
     [Test]
+    public void ExternalBindings_ReadsMustWorkWithoutLocalContainerStorage()
+    {
+        const string code = """
+                            price + fee
+                            """;
+
+        var declared = new OrderedDictionary<string, Type>
+        {
+            ["price"] = typeof(RealNumberImpl),
+            ["fee"] = typeof(RealNumberImpl)
+        };
+
+        var result = RunInBothBackends(code, declared, [
+            new NamedArgument("price", new RealNumberImpl(10.0)),
+            new NamedArgument("fee", new RealNumberImpl(2.0))
+        ]);
+
+        Assert.That(result.CompilerNumeric, Is.EqualTo(result.InterpreterNumeric).Within(1e-9));
+        Assert.That(result.CompilerNumeric, Is.EqualTo(12.0).Within(1e-9));
+    }
+
+    [Test]
     public void Reproducer_WithPriceFeeAndLocalLoopVariable_ShouldMatchCompilerInterpreterAndExpected()
     {
         const string code = """

--- a/UniversalToolchain/VariablesModule/VariablesVisitor.cs
+++ b/UniversalToolchain/VariablesModule/VariablesVisitor.cs
@@ -74,11 +74,26 @@ public class VariablesVisitor : IAstVisitor
 
     private void HandleBoundVariable(BytecodeVisitorData data, Symbol symbol)
     {
+        if (symbol is ExternalVariableSymbol externalVariableSymbol)
+        {
+            HandleBoundExternalVariable(data, externalVariableSymbol.Name, externalVariableSymbol.Slot, externalVariableSymbol.Type, true);
+            return;
+        }
+
+        if (symbol is ExternalConstantSymbol externalConstantSymbol)
+        {
+            HandleBoundExternalVariable(data, externalConstantSymbol.Name, externalConstantSymbol.Slot, externalConstantSymbol.Type, false);
+            return;
+        }
+
+        HandleBoundLocalVariable(data, symbol);
+    }
+
+    private void HandleBoundLocalVariable(BytecodeVisitorData data, Symbol symbol)
+    {
         var variableKey = symbol.StorageKey;
         var displayName = symbol.Name;
         if (IsConcreteType(symbol.Type))
-            _variablesTypes[variableKey] = symbol.Type;
-        else if (symbol is ExternalVariableSymbol or ExternalConstantSymbol && !_variablesTypes.ContainsKey(variableKey))
             _variablesTypes[variableKey] = symbol.Type;
 
         if (data.Node.AllTags.Contains("ExpectingSettableReference"))
@@ -97,16 +112,51 @@ public class VariablesVisitor : IAstVisitor
             return;
         }
 
-        var loadName = symbol is ExternalVariableSymbol or ExternalConstantSymbol
-            ? "LoadValueOfExternalVar"
-            : "LoadValueOfLocalVar";
-
         var loadMethod = new AbstractMethodImpl(
-            $"{loadName}_{displayName}",
+            $"LoadValueOfLocalVar_{displayName}",
             (il, _) =>
             {
                 var storageType = ResolveReadType(symbol, variableKey);
                 il.LdLoc(variableKey, storageType);
+            }
+        );
+
+        data.Bytecode.Instructions.Add(new BytecodeInstruction(loadMethod));
+    }
+
+    private void HandleBoundExternalVariable(
+        BytecodeVisitorData data,
+        string name,
+        int slot,
+        Type symbolType,
+        bool canAssign)
+    {
+        if (data.Node.AllTags.Contains("ExpectingSettableReference"))
+        {
+            if (!canAssign)
+                Thrower.InvalidOpEx($"External constant '{name}' cannot be assigned.");
+
+            var method = new AbstractMethodImpl(
+                $"LoadReferenceToExternalVar_{name}",
+                (il, context) =>
+                {
+                    var inferredType = context.Stack.Last();
+                    var storageType = ResolveWriteType(new ExternalVariableSymbol(name, symbolType, slot), name, inferredType);
+                    il.LdLocRef(name, storageType);
+                }
+            );
+            data.Bytecode.Instructions.Add(new BytecodeInstruction(method));
+            return;
+        }
+
+        var loadMethod = new AbstractMethodImpl(
+            $"LoadValueOfExternalVar_{name}",
+            (il, _) =>
+            {
+                var loadType = _variablesTypes.TryGetValue(name, out var refinedType) && IsConcreteType(refinedType)
+                    ? refinedType
+                    : symbolType;
+                il.LdExternal(slot, loadType);
             }
         );
 


### PR DESCRIPTION
### Motivation
- External declared bindings (e.g. `price`, `fee`) were being lowered into the local `VariablesContainer<T>` path instead of a slot-based external path, causing the compiled backend to call `VariablesContainer<T>.Get("price")` and fail at runtime. 
- The goal is to enforce slot-based semantics for declared externals so the compiled backend reads method arguments by slot and the interpreter reads via `ExecutionEnvironment` by slot, preserving slot layout and parity between backends.

### Description
- Split variable lowering in `VariablesVisitor` into separate local and external paths so external symbols are no longer lowered via `LdLoc`/`VariablesContainer<>`. (modified `UniversalToolchain/VariablesModule/VariablesVisitor.cs`)
- Introduced backend-neutral AIR helpers `LdExternal(int slot, Type)` and `StExternal(int slot, Type)` in `AbstractIrExtensions` and used `Intrinsic("load_external"/"store_external")` as the AIR-level representation. (modified `UniversalToolchain/AbstractIrExtensions/AbstractIrExtensions.cs`)
- Lowered the new `load_external`/`store_external` intrinsics in the compiled backend to method-argument access (`ldarg` / `starg`) by slot in `AbstractMethodsIntrinsicCompiler`. (modified `UniversalToolchain/BytecodeDynamicMethodsCompiler/Compilers/AbstractMethodsIntrinsicCompiler.cs`)
- Implemented interpreter support for the intrinsics so `load_external` uses `ExecutionEnvironment.GetExternalValue(slot)` and `store_external` uses `SetExternalValue(slot, value)`. (modified `UniversalToolchain/BasicInterpreter/InterpreterImpl.cs`)
- Updated AIR type-processing to include `load_external`/`store_external` and extended the stub compiler intrinsic list for compatibility. (modified `UniversalToolchain/DotnetAirHelper/AirTypes.cs` and `UniversalToolchain/AbstractIrConverters/AbstractIrToAbstractIrStub.cs`)
- Preserved the settable-reference lowering semantics: external settable-reference is still exposed when `ExpectingSettableReference` is present (assignment lowering for externals remains restricted/explicit), and external reads now go through slot-based lowering only. (modified `UniversalToolchain/VariablesModule/VariablesVisitor.cs`)
- Added an integration regression test `ExternalBindings_ReadsMustWorkWithoutLocalContainerStorage` to assert compiler/interpreter parity for slot-based external reads. (modified `UniversalToolchain/Tests/Integration/InterpreterBindingsParityTests.cs`)

### Testing
- Ran the targeted parity/regression tests with `dotnet test` and the specific filter for the reported scenarios using: `dotnet test UniversalToolchain/Tests/Tests.csproj -c Release --filter "FullyQualifiedName~InterpreterBindingsParityTests.ExternalBindings_ReadsMustWorkWithoutLocalContainerStorage|FullyQualifiedName~InterpreterBindingsParityTests.Reproducer_WithPriceFeeAndLocalLoopVariable_ShouldMatchCompilerInterpreterAndExpected|FullyQualifiedName~InterpreterBindingsParityTests.ExtraUnusedDeclaredBindings_ShouldKeepStableParityAndResult|FullyQualifiedName~InterpreterBindingsParityTests.ReorderedDeclaredBindings_WithNamedSetArgument_ShouldRemainStable|FullyQualifiedName~InterpreterBindingsParityTests.LocalVariable_WithExternalArithmetic_MustNotSwitchStorageContainer"`, and the filtered tests passed. 
- Ran the full test suites used during validation: `dotnet test UniversalToolchain/Tests/Tests.csproj -c Release` (unit/integration tests) and `dotnet test UniversalToolchain/UniversalToolchain.Modules.Tests/UniversalToolchain.Modules.Tests.csproj -c Release` and `dotnet test UniversalToolchain/UniversalToolchain.Dialects.Tests/UniversalToolchain.Dialects.Tests.csproj -c Release`, and observed the suites pass after the changes (module-level issue found during the first run was fixed and re-run succeeded). 
- Summary: the four originally failing integration tests are now green and full module/dialect test suites used in validation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3ec6ae90c8324a4430cb242986dd8)