### PR TITLE
Add Wist backend matrix tests and testing-guidelines

### DIFF
--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/Wist/WistDialectBackendMatrixTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/Wist/WistDialectBackendMatrixTests.cs
@@ -1,0 +1,151 @@
+using System.Globalization;
+using ExceptionsManager;
+using Microsoft.Extensions.DependencyInjection;
+using NumbersModule.Core;
+using UniversalToolchain.Dialects.Wist;
+
+namespace UniversalToolchain.Dialects.Tests.Wist;
+
+public sealed class WistDialectBackendMatrixTests
+{
+    [TestCaseSource(nameof(GetExamplePrograms))]
+    public void ExampleProgram_BackendMatrix_ShouldMatchExpectedOutcomes(BackendMatrixCase @case)
+    {
+        using var provider = CreateProvider();
+        var workflow = provider.GetRequiredService<WistDialectExecutionWorkflow>();
+
+        var composition = workflow.ComposeFile(Path.Combine(@case.ExampleDirectory, "dialect.wistdialect"));
+        Assert.That(composition.IsSuccess, Is.True, composition.ToDeterministicText());
+
+        using var host = workflow.CreateHost(composition);
+        var code = File.ReadAllText(Path.Combine(@case.ExampleDirectory, "program.wist"));
+
+        var interpreter = Execute(host, code, "interpreter");
+        var compiler = Execute(host, code, "compiler");
+
+        AssertBackendOutcome(interpreter, @case.InterpreterExpected, "interpreter");
+        AssertBackendOutcome(compiler, @case.CompilerExpected, "compiler");
+
+        if (@case.InterpreterExpected.IsSuccess && @case.CompilerExpected.IsSuccess)
+            Assert.That(interpreter.ValueText, Is.EqualTo(compiler.ValueText), "Backend result parity failed.");
+
+        if (@case.InterpreterExpected.IsFailure && @case.CompilerExpected.IsFailure)
+            Assert.That(interpreter.ErrorMarker, Is.EqualTo(compiler.ErrorMarker), "Backend diagnostics parity failed.");
+    }
+
+    public static IEnumerable<TestCaseData> GetExamplePrograms()
+    {
+        yield return BuildCase(
+            "minimal-arithmetic",
+            ExpectedOutcome.Success("14"),
+            ExpectedOutcome.Failure("does not enable the 'compiler' backend"));
+
+        yield return BuildCase(
+            "full-default",
+            ExpectedOutcome.Success("15"),
+            ExpectedOutcome.Success("15"));
+
+        yield return BuildCase(
+            "full-default-native",
+            ExpectedOutcome.Success("15"),
+            ExpectedOutcome.Success("15"));
+    }
+
+    private static TestCaseData BuildCase(
+        string exampleName,
+        ExpectedOutcome interpreterExpected,
+        ExpectedOutcome compilerExpected)
+    {
+        var directory = ResolveExampleDirectory(exampleName);
+        return new TestCaseData(new BackendMatrixCase(directory, interpreterExpected, compilerExpected))
+            .SetName($"Wist example matrix: {exampleName}");
+    }
+
+    private static ExecutionOutcome Execute(WistDialectExecutionHost host, string code, string backend)
+    {
+        try
+        {
+            var result = host.Run(code, backend);
+            return ExecutionOutcome.Success(Normalize(result));
+        }
+        catch (Exception ex)
+        {
+            var marker = ex.Message;
+            return ExecutionOutcome.Failure(marker);
+        }
+    }
+
+    private static void AssertBackendOutcome(ExecutionOutcome actual, ExpectedOutcome expected, string backend)
+    {
+        if (expected.IsSuccess)
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(actual.IsSuccess, Is.True, $"Expected backend '{backend}' success, but it failed with: {actual.ErrorMarker}");
+                Assert.That(actual.ValueText, Is.EqualTo(expected.ExpectedValueText), $"Unexpected value for backend '{backend}'.");
+            });
+
+            return;
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(actual.IsSuccess, Is.False, $"Expected backend '{backend}' failure, but it succeeded with: {actual.ValueText}");
+            Assert.That(actual.ErrorMarker, Does.Contain(expected.ExpectedDiagnosticMarker!), $"Unexpected diagnostics for backend '{backend}'.");
+        });
+    }
+
+    private static string ResolveExampleDirectory(string name)
+    {
+        var path = Path.GetFullPath(Path.Combine(TestContext.CurrentContext.TestDirectory, "..", "..", "..", "..", "Dialects", "examples", "wist", name));
+        if (!Directory.Exists(path))
+            Thrower.FileNotFound(path);
+
+        return path;
+    }
+
+    private static ServiceProvider CreateProvider()
+    {
+        var services = new ServiceCollection();
+        services.AddWistDialectServices();
+        services.AddWistCilBackend();
+        services.AddWistInterpreterBackend();
+        return services.BuildServiceProvider();
+    }
+
+    private static string Normalize(object? value)
+    {
+        return value switch
+        {
+            RealNumberImpl number => number.GetValue().ToString(CultureInfo.InvariantCulture),
+            int intValue => intValue.ToString(CultureInfo.InvariantCulture),
+            long longValue => longValue.ToString(CultureInfo.InvariantCulture),
+            double doubleValue => doubleValue.ToString("G17", CultureInfo.InvariantCulture),
+            float floatValue => floatValue.ToString("G9", CultureInfo.InvariantCulture),
+            decimal decimalValue => decimalValue.ToString(CultureInfo.InvariantCulture),
+            null => "<null>",
+            _ => Convert.ToString(value, CultureInfo.InvariantCulture) ?? value.ToString() ?? "<unknown>"
+        };
+    }
+
+    public sealed record BackendMatrixCase(
+        string ExampleDirectory,
+        ExpectedOutcome InterpreterExpected,
+        ExpectedOutcome CompilerExpected);
+
+    public sealed record ExpectedOutcome(bool IsSuccess, string? ExpectedValueText, string? ExpectedDiagnosticMarker)
+    {
+        public bool IsFailure => !IsSuccess;
+
+        public static ExpectedOutcome Success(string expectedValueText) => new(true, expectedValueText, null);
+
+        public static ExpectedOutcome Failure(string expectedDiagnosticMarker) => new(false, null, expectedDiagnosticMarker);
+    }
+
+    private sealed record ExecutionOutcome(bool IsSuccess, string? ValueText, string? ErrorMarker)
+    {
+        public static ExecutionOutcome Success(string valueText) => new(true, valueText, null);
+
+        public static ExecutionOutcome Failure(string errorMarker) => new(false, null, errorMarker);
+    }
+}

--- a/docs/testing-guidelines.md
+++ b/docs/testing-guidelines.md
@@ -1,0 +1,17 @@
+# Testing Guidelines by Layer
+
+This matrix defines expected testing boundaries for UniversalToolchain and dialect-level test suites.
+
+| Layer | May know internal types? | May use reflection to private members? | Must compare backend behavior? |
+|---|---|---|---|
+| Contract | No. Use only public contracts and observable behavior. | No. | Yes, when the contract is backend-agnostic and promises parity. |
+| Parity | No for framework internals; only public surface and deterministic outputs/diagnostics. | No. | Yes. Parity tests exist specifically to compare enabled backends. |
+| Backend-specific | Yes, but only for that backend's own internal implementation boundaries. | Rarely, and only with explicit justification in test intent. | No cross-backend parity requirement; validate backend-local guarantees. |
+| Internal | Yes. Internal collaborators and implementation details are test scope. | Allowed when no stable extension point exists and intent is explicitly documented. | Optional. Compare backends only if the internal change affects backend selection/execution semantics. |
+
+## Additional Rules
+
+- Prefer extension-point-level assertions before internal implementation assertions.
+- Avoid brittle reflection-based assertions when deterministic public outcomes can be asserted.
+- If behavior changes by backend are intentional, assert the difference explicitly instead of masking it as parity.
+- Keep diagnostics assertions deterministic (code/message fragment), not environment-dependent full text.


### PR DESCRIPTION
### Motivation

- Provide a concise, documented testing policy that clarifies what tests at different layers may rely on (Contract / Parity / Backend-specific / Internal). 
- Add a deterministic matrix-style test that exercises real example dialects across interpreter and compiler backends to catch parity and expected backend-specific failures. 
- Make it easier to validate example programs (`minimal-arithmetic`, `full-default`, `full-default-native`) end-to-end through composition, host creation, execution, and parity checks. 

### Description

- Added `docs/testing-guidelines.md` containing a layer-based testing matrix and additional rules governing internal-type visibility and use of reflection in tests. 
- Added `UniversalToolchain/UniversalToolchain.Dialects.Tests/Wist/WistDialectBackendMatrixTests.cs` which provides a `TestCaseSource`-driven matrix over the three example dialects and asserts composition success, host creation, and backend outcomes for both `interpreter` and `compiler`. 
- The new test normalizes runtime results (`Normalize`) and represents expected outcomes using `ExpectedOutcome` and `ExecutionOutcome` records, asserting value parity when both backends succeed and diagnostics parity when both fail. 
- The test constructs a service provider via `services.AddWistDialectServices()`, `services.AddWistCilBackend()` and `services.AddWistInterpreterBackend()` to exercise real backend wiring. 

### Testing

- Ran `dotnet restore UniversalToolchain/Wist.sln` which completed successfully. 
- Ran `dotnet test UniversalToolchain/UniversalToolchain.Dialects.Tests/UniversalToolchain.Dialects.Tests.csproj -c Release --no-restore` and the test suite passed (305 passed). 
- Ran `dotnet test UniversalToolchain/UniversalToolchain.Modules.Tests/UniversalToolchain.Modules.Tests.csproj -c Release --no-restore` and the suite passed (194 passed, 7 skipped). 
- Ran `dotnet test UniversalToolchain/Tests/Tests.csproj -c Release --no-restore` which failed due to existing native/intrinsic-related failures (examples include unknown intrinsic errors and an unregistered `NativeMath` descriptor), which are pre-existing and outside the scope of these additions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4be7f442083248ee0d8e97410f35f)