### PR TITLE
Unify backend parity execution infrastructure for tests

### DIFF
--- a/UniversalToolchain/Tests/Infrastructure/BackendParityInfrastructure.cs
+++ b/UniversalToolchain/Tests/Infrastructure/BackendParityInfrastructure.cs
@@ -1,0 +1,141 @@
+using ExceptionsManager;
+using Microsoft.Extensions.DependencyInjection;
+using NumbersModule.Core;
+using UniversalToolchain.Dialects.Wist;
+
+namespace Tests.Infrastructure;
+
+/// <summary>
+/// Unified parity infrastructure for compiler and interpreter backend execution.
+/// </summary>
+public static class BackendParityInfrastructure
+{
+    /// <summary>
+    /// Executes the same code in both backends and captures success/failure outcomes.
+    /// </summary>
+    public static (BackendExecutionResult CompilerResult, BackendExecutionResult InterpreterResult) RunBoth(string dialectText, string code)
+    {
+        using var compilerHost = CreateHost(EnsureSingleBackend(dialectText, "compiler"));
+        using var interpreterHost = CreateHost(EnsureSingleBackend(dialectText, "interpreter"));
+
+        var compilerResult = ExecuteSafely(() => compilerHost.Run(code, "compiler"));
+        var interpreterResult = ExecuteSafely(() => interpreterHost.Run(code, "interpreter"));
+        return (compilerResult, interpreterResult);
+    }
+
+    /// <summary>
+    /// Asserts that two backend outcomes are semantically equivalent.
+    /// </summary>
+    public static void AssertSemanticParity(BackendExecutionResult compilerResult, BackendExecutionResult interpreterResult)
+    {
+        Assert.That(compilerResult.IsSuccess, Is.EqualTo(interpreterResult.IsSuccess), "Backends must either both succeed or both fail.");
+
+        if (compilerResult.IsSuccess)
+        {
+            AssertValuesEqual(compilerResult.Value, interpreterResult.Value);
+            return;
+        }
+
+        var compilerException = compilerResult.Exception ?? Thrower.InvalidOpEx<Exception>("Compiler result must contain exception on failure.");
+        var interpreterException = interpreterResult.Exception ?? Thrower.InvalidOpEx<Exception>("Interpreter result must contain exception on failure.");
+
+        Assert.That(compilerException.GetType().FullName, Is.EqualTo(interpreterException.GetType().FullName));
+        Assert.That(compilerException.Message, Is.EqualTo(interpreterException.Message));
+    }
+
+    /// <summary>
+    /// Converts backend values into a numeric representation.
+    /// </summary>
+    public static double AsNumber(object? value)
+        => value switch
+        {
+            RealNumberImpl n => n.GetValue(),
+            int i => i,
+            long l => l,
+            float f => f,
+            double d => d,
+            decimal m => (double)m,
+            _ => throw new InvalidCastException($"Cannot convert '{value?.GetType().Name ?? "null"}' to number.")
+        };
+
+    /// <summary>
+    /// Converts backend values into a boolean representation.
+    /// </summary>
+    public static bool AsBool(object? value)
+        => value switch
+        {
+            bool b => b,
+            int i => i != 0,
+            RealNumberImpl n => Math.Abs(n.GetValue()) > double.Epsilon,
+            _ => throw new InvalidCastException($"Cannot convert '{value?.GetType().Name ?? "null"}' to bool.")
+        };
+
+    /// <summary>
+    /// Executes a backend function and captures success/failure in <see cref="BackendExecutionResult"/>.
+    /// </summary>
+    public static BackendExecutionResult ExecuteSafely(Func<object?> action)
+    {
+        try
+        {
+            return BackendExecutionResult.Success(action());
+        }
+        catch (Exception ex)
+        {
+            return BackendExecutionResult.Failure(ex);
+        }
+    }
+
+    private static WistDialectExecutionHost CreateHost(string dialectText)
+    {
+        var services = new ServiceCollection();
+        services.AddWistDialectServices();
+        services.AddWistCilBackend();
+        services.AddWistInterpreterBackend();
+
+        using var provider = services.BuildServiceProvider();
+        var workflow = provider.GetRequiredService<WistDialectExecutionWorkflow>();
+        var composition = workflow.ComposeText(dialectText, "backend-parity-inline");
+        if (!composition.IsSuccess)
+            Thrower.InvalidOpEx(composition.ToDeterministicText());
+
+        return workflow.CreateHost(composition);
+    }
+
+    private static string EnsureSingleBackend(string dialectText, string backend)
+    {
+        var lines = dialectText
+            .Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Where(static line => !line.StartsWith("backend ", StringComparison.Ordinal))
+            .ToList();
+
+        lines.Add($"backend {backend}");
+        return string.Join(Environment.NewLine, lines);
+    }
+
+    private static void AssertValuesEqual(object? left, object? right)
+    {
+        if (left is null || right is null)
+        {
+            Assert.That(left, Is.EqualTo(right));
+            return;
+        }
+
+        if (left is bool || right is bool)
+        {
+            Assert.That(AsBool(left), Is.EqualTo(AsBool(right)));
+            return;
+        }
+
+        Assert.That(AsNumber(left), Is.EqualTo(AsNumber(right)).Within(1e-9));
+    }
+}
+
+/// <summary>
+/// Captures backend execution outcome for parity checks in both success and failure scenarios.
+/// </summary>
+public sealed record BackendExecutionResult(bool IsSuccess, object? Value, Exception? Exception)
+{
+    public static BackendExecutionResult Success(object? value) => new(true, value, null);
+
+    public static BackendExecutionResult Failure(Exception exception) => new(false, null, exception);
+}

--- a/UniversalToolchain/Tests/Infrastructure/DialectTestHostInfrastructure.cs
+++ b/UniversalToolchain/Tests/Infrastructure/DialectTestHostInfrastructure.cs
@@ -46,14 +46,9 @@ public static class DialectTestHostInfrastructure
     /// </summary>
     public static object? RunInBothBackends(string dialectText, string code)
     {
-        using var compilerHost = CreateCompilerHost(dialectText);
-        using var interpreterHost = CreateInterpreterHost(dialectText);
-
-        var compilerResult = compilerHost.Run(code, "compiler");
-        var interpreterResult = interpreterHost.Run(code, "interpreter");
-
-        Assert.That(interpreterResult, Is.EqualTo(compilerResult), "Interpreter and compiler results must match.");
-        return compilerResult;
+        var (compilerResult, interpreterResult) = BackendParityInfrastructure.RunBoth(dialectText, code);
+        BackendParityInfrastructure.AssertSemanticParity(compilerResult, interpreterResult);
+        return compilerResult.Value;
     }
 
     private static string EnsureSingleBackend(string dialectText, string backend)

--- a/UniversalToolchain/Tests/Parity/InterpreterBindingsParityTests.cs
+++ b/UniversalToolchain/Tests/Parity/InterpreterBindingsParityTests.cs
@@ -3,6 +3,7 @@ using ExceptionsManager;
 using Microsoft.Extensions.DependencyInjection;
 using NumbersModule.Core;
 using UniversalToolchain.Dialects.Wist;
+using Tests.Infrastructure;
 
 namespace Tests.Integration;
 
@@ -22,7 +23,7 @@ public class InterpreterBindingsParityTests
             ["fee"] = typeof(RealNumberImpl)
         };
 
-        var result = RunInBothBackends(code, declared, [
+        var result = RunWithBindingsInBothBackends(code, declared, [
             new NamedArgument("price", new RealNumberImpl(10.0)),
             new NamedArgument("fee", new RealNumberImpl(2.0))
         ]);
@@ -47,7 +48,7 @@ public class InterpreterBindingsParityTests
             ["fee"] = typeof(RealNumberImpl)
         };
 
-        var result = RunInBothBackends(code, declared, [
+        var result = RunWithBindingsInBothBackends(code, declared, [
             new NamedArgument("price", new RealNumberImpl(100.0)),
             new NamedArgument("fee", new RealNumberImpl(2.5))
         ]);
@@ -73,14 +74,14 @@ public class InterpreterBindingsParityTests
             ["unusedBeta"] = typeof(string)
         };
 
-        var first = RunInBothBackends(code, declared, [
+        var first = RunWithBindingsInBothBackends(code, declared, [
             new NamedArgument("price", new RealNumberImpl(5.0)),
             new NamedArgument("fee", new RealNumberImpl(1.5)),
             new NamedArgument("unusedAlpha", new RealNumberImpl(999.0)),
             new NamedArgument("unusedBeta", "ignored")
         ]);
 
-        var second = RunInBothBackends(code, declared, [
+        var second = RunWithBindingsInBothBackends(code, declared, [
             new NamedArgument("price", new RealNumberImpl(5.0)),
             new NamedArgument("fee", new RealNumberImpl(1.5)),
             new NamedArgument("unusedAlpha", new RealNumberImpl(-321.0)),
@@ -116,12 +117,12 @@ public class InterpreterBindingsParityTests
             ["price"] = typeof(RealNumberImpl)
         };
 
-        var ordered = RunInBothBackends(code, declaredPriceThenFee, [
+        var ordered = RunWithBindingsInBothBackends(code, declaredPriceThenFee, [
             new NamedArgument("price", new RealNumberImpl(7.0)),
             new NamedArgument("fee", new RealNumberImpl(0.75))
         ]);
 
-        var reordered = RunInBothBackends(code, declaredFeeThenPrice, [
+        var reordered = RunWithBindingsInBothBackends(code, declaredFeeThenPrice, [
             new NamedArgument("price", new RealNumberImpl(7.0)),
             new NamedArgument("fee", new RealNumberImpl(0.75))
         ]);
@@ -174,7 +175,7 @@ public class InterpreterBindingsParityTests
                             """;
 
         var declared = new OrderedDictionary<string, Type>();
-        var result = RunInBothBackends(code, declared, []);
+        var result = RunWithBindingsInBothBackends(code, declared, []);
 
         Assert.That(result.CompilerNumeric, Is.EqualTo(result.InterpreterNumeric).Within(1e-9));
         Assert.That(result.CompilerNumeric, Is.EqualTo(2.0).Within(1e-9));
@@ -195,7 +196,7 @@ public class InterpreterBindingsParityTests
             ["fee"] = typeof(RealNumberImpl)
         };
 
-        var result = RunInBothBackends(code, declared, [
+        var result = RunWithBindingsInBothBackends(code, declared, [
             new NamedArgument("price", new RealNumberImpl(100.0)),
             new NamedArgument("fee", new RealNumberImpl(2.5))
         ]);
@@ -214,7 +215,7 @@ public class InterpreterBindingsParityTests
                             """;
 
         var declared = new OrderedDictionary<string, Type>();
-        var result = RunInBothBackends(code, declared, []);
+        var result = RunWithBindingsInBothBackends(code, declared, []);
 
         Assert.That(result.CompilerNumeric, Is.EqualTo(result.InterpreterNumeric).Within(1e-9));
         Assert.That(result.CompilerNumeric, Is.EqualTo(2.0).Within(1e-9));
@@ -246,7 +247,7 @@ public class InterpreterBindingsParityTests
         }
     }
 
-    private static (double CompilerNumeric, double InterpreterNumeric) RunInBothBackends(
+    private static (double CompilerNumeric, double InterpreterNumeric) RunWithBindingsInBothBackends(
         string code,
         OrderedDictionary<string, Type> declared,
         IReadOnlyList<NamedArgument> arguments)
@@ -264,38 +265,36 @@ public class InterpreterBindingsParityTests
             interpreterSession.SetArgument(argument.Name, argument.Value);
         }
 
-        var compilerResult = compilerSession.Run() ?? Thrower.InvalidOpEx<object>("Compiler returned null result.");
-        var interpreterResult = interpreterSession.Run() ?? Thrower.InvalidOpEx<object>("Interpreter returned null result.");
+        var compilerResult = BackendExecutionResult.Success(compilerSession.Run() ?? Thrower.InvalidOpEx<object>("Compiler returned null result."));
+        var interpreterResult = BackendExecutionResult.Success(interpreterSession.Run() ?? Thrower.InvalidOpEx<object>("Interpreter returned null result."));
 
-        return (ToNumeric(compilerResult), ToNumeric(interpreterResult));
+        BackendParityInfrastructure.AssertSemanticParity(compilerResult, interpreterResult);
+        return (BackendParityInfrastructure.AsNumber(compilerResult.Value), BackendParityInfrastructure.AsNumber(interpreterResult.Value));
     }
 
     private static void AssertDeterministicParity(string code, OrderedDictionary<string, Type> declared, IReadOnlyList<NamedArgument> arguments)
     {
-        var first = TryRunInBothBackends(code, declared, arguments);
-        var second = TryRunInBothBackends(code, declared, arguments);
+        var first = TryRunWithBindingsInBothBackends(code, declared, arguments);
+        var second = TryRunWithBindingsInBothBackends(code, declared, arguments);
 
-        Assert.That(first.CompilerOutcome.Kind, Is.EqualTo(first.InterpreterOutcome.Kind));
-        Assert.That(second.CompilerOutcome.Kind, Is.EqualTo(second.InterpreterOutcome.Kind));
-        Assert.That(first.CompilerOutcome.Kind, Is.EqualTo(second.CompilerOutcome.Kind));
+        BackendParityInfrastructure.AssertSemanticParity(first.CompilerOutcome, first.InterpreterOutcome);
+        BackendParityInfrastructure.AssertSemanticParity(second.CompilerOutcome, second.InterpreterOutcome);
 
-        if (first.CompilerOutcome.Kind == OutcomeKind.Success)
+        Assert.That(first.CompilerOutcome.IsSuccess, Is.EqualTo(second.CompilerOutcome.IsSuccess));
+
+        if (first.CompilerOutcome.IsSuccess)
         {
-            Assert.That(first.CompilerOutcome.NumericValue, Is.EqualTo(first.InterpreterOutcome.NumericValue).Within(1e-9));
-            Assert.That(second.CompilerOutcome.NumericValue, Is.EqualTo(second.InterpreterOutcome.NumericValue).Within(1e-9));
-            Assert.That(first.CompilerOutcome.NumericValue, Is.EqualTo(second.CompilerOutcome.NumericValue).Within(1e-9));
+            Assert.That(BackendParityInfrastructure.AsNumber(first.CompilerOutcome.Value),
+                Is.EqualTo(BackendParityInfrastructure.AsNumber(second.CompilerOutcome.Value)).Within(1e-9));
             return;
         }
 
-        Assert.That(first.CompilerOutcome.ExceptionType, Is.EqualTo(first.InterpreterOutcome.ExceptionType));
-        Assert.That(second.CompilerOutcome.ExceptionType, Is.EqualTo(second.InterpreterOutcome.ExceptionType));
-        Assert.That(first.CompilerOutcome.ExceptionType, Is.EqualTo(second.CompilerOutcome.ExceptionType));
-        Assert.That(first.CompilerOutcome.ExceptionMessage, Is.EqualTo(first.InterpreterOutcome.ExceptionMessage));
-        Assert.That(second.CompilerOutcome.ExceptionMessage, Is.EqualTo(second.InterpreterOutcome.ExceptionMessage));
-        Assert.That(first.CompilerOutcome.ExceptionMessage, Is.EqualTo(second.CompilerOutcome.ExceptionMessage));
+        Assert.That(first.CompilerOutcome.Exception?.GetType().FullName,
+            Is.EqualTo(second.CompilerOutcome.Exception?.GetType().FullName));
+        Assert.That(first.CompilerOutcome.Exception?.Message, Is.EqualTo(second.CompilerOutcome.Exception?.Message));
     }
 
-    private static (ExecutionOutcome CompilerOutcome, ExecutionOutcome InterpreterOutcome) TryRunInBothBackends(
+    private static (BackendExecutionResult CompilerOutcome, BackendExecutionResult InterpreterOutcome) TryRunWithBindingsInBothBackends(
         string code,
         OrderedDictionary<string, Type> declared,
         IReadOnlyList<NamedArgument> arguments)
@@ -306,36 +305,20 @@ public class InterpreterBindingsParityTests
         return (compilerOutcome, interpreterOutcome);
     }
 
-    private static ExecutionOutcome TryRunSingleBackend<TCompilationOutput>(
+    private static BackendExecutionResult TryRunSingleBackend<TCompilationOutput>(
         Func<ICompiledArtifact<TCompilationOutput>> artifactFactory,
         IReadOnlyList<NamedArgument> arguments)
     {
-        try
+        return BackendParityInfrastructure.ExecuteSafely(() =>
         {
             var artifact = artifactFactory();
             var session = artifact.CreateSession();
             foreach (var argument in arguments)
                 session.SetArgument(argument.Name, argument.Value);
 
-            var result = session.Run() ?? Thrower.InvalidOpEx<object>("Backend returned null result.");
-            return ExecutionOutcome.Success(ToNumeric(result));
-        }
-        catch (Exception ex)
-        {
-            return ExecutionOutcome.Failure(ex.GetType().FullName ?? ex.GetType().Name, ex.Message);
-        }
+            return session.Run() ?? Thrower.InvalidOpEx<object>("Backend returned null result.");
+        });
     }
-
-    private static double ToNumeric(object value) => value switch
-    {
-        int intValue => intValue,
-        long longValue => longValue,
-        float floatValue => floatValue,
-        double doubleValue => doubleValue,
-        decimal decimalValue => (double)decimalValue,
-        RealNumberImpl realNumber => realNumber.GetValue(),
-        _ => Thrower.InvalidCast<double>($"Cannot convert value of type {value.GetType().FullName} to numeric result.")
-    };
 
     private static WistDialectExecutionHost CreateHost()
     {
@@ -369,18 +352,4 @@ public class InterpreterBindingsParityTests
         ?? Thrower.InvalidOpEx<BasicCoreImpl<IAbstractIR>>("Interpreter core must be BasicCoreImpl<IAbstractIR>.");
 
     private sealed record NamedArgument(string Name, object Value);
-
-    private enum OutcomeKind
-    {
-        Success,
-        Failure
-    }
-
-    private sealed record ExecutionOutcome(OutcomeKind Kind, double? NumericValue, string? ExceptionType, string? ExceptionMessage)
-    {
-        public static ExecutionOutcome Success(double numericValue) => new(OutcomeKind.Success, numericValue, null, null);
-
-        public static ExecutionOutcome Failure(string exceptionType, string exceptionMessage) =>
-            new(OutcomeKind.Failure, null, exceptionType, exceptionMessage);
-    }
 }

--- a/UniversalToolchain/UniversalToolchain.Modules.Tests/ModuleCoverage/ModulePipelineTestHelper.cs
+++ b/UniversalToolchain/UniversalToolchain.Modules.Tests/ModuleCoverage/ModulePipelineTestHelper.cs
@@ -1,8 +1,8 @@
 using System.Text;
 using Microsoft.Extensions.DependencyInjection;
-using NumbersModule.Core;
 using UniversalToolchain.Dialects.Integration;
 using UniversalToolchain.Dialects.Wist;
+using Tests.Infrastructure;
 
 namespace UniversalToolchain.Modules.Tests.ModuleCoverage;
 
@@ -70,43 +70,14 @@ internal sealed class ModulePipelineTestHelper : IDisposable
         return (compiler, interpreter);
     }
 
-    public static double AsNumber(object? value)
-        => value switch
-        {
-            RealNumberImpl n => n.GetValue(),
-            int i => i,
-            long l => l,
-            float f => f,
-            double d => d,
-            decimal m => (double)m,
-            _ => throw new InvalidCastException($"Cannot convert '{value?.GetType().Name ?? "null"}' to number.")
-        };
+    public static double AsNumber(object? value) => BackendParityInfrastructure.AsNumber(value);
 
-    public static bool AsBool(object? value)
-        => value switch
-        {
-            bool b => b,
-            int i => i != 0,
-            RealNumberImpl n => Math.Abs(n.GetValue()) > double.Epsilon,
-            _ => throw new InvalidCastException($"Cannot convert '{value?.GetType().Name ?? "null"}' to bool.")
-        };
+    public static bool AsBool(object? value) => BackendParityInfrastructure.AsBool(value);
 
     public static void AssertParity(object? compiler, object? interpreter)
-    {
-        if (compiler is null || interpreter is null)
-        {
-            Assert.That(compiler, Is.EqualTo(interpreter));
-            return;
-        }
-
-        if (compiler is bool || interpreter is bool)
-        {
-            Assert.That(AsBool(compiler), Is.EqualTo(AsBool(interpreter)));
-            return;
-        }
-
-        Assert.That(AsNumber(compiler), Is.EqualTo(AsNumber(interpreter)).Within(1e-9));
-    }
+        => BackendParityInfrastructure.AssertSemanticParity(
+            BackendExecutionResult.Success(compiler),
+            BackendExecutionResult.Success(interpreter));
 
     private static void AssertSemanticEqual(object? left, object? right)
     {
@@ -164,64 +135,28 @@ internal sealed class ModulePipelineTestHelper : IDisposable
 
     public void AssertFailsContaining(string code, IEnumerable<string> modules, string expectedFragment)
     {
-        Exception? compilerException = null;
-        Exception? interpreterException = null;
+        var dialectText = BuildDialectText("Inline", modules, null, ["compiler", "interpreter"]);
+        var (compilerResult, interpreterResult) = BackendParityInfrastructure.RunBoth(dialectText, code);
 
-        try
-        {
-            _ = ExecuteCompiler(code, modules);
-        }
-        catch (Exception ex)
-        {
-            compilerException = ex;
-        }
+        Assert.That(compilerResult.IsSuccess, Is.False);
+        Assert.That(interpreterResult.IsSuccess, Is.False);
 
-        try
-        {
-            _ = ExecuteInterpreter(code, modules);
-        }
-        catch (Exception ex)
-        {
-            interpreterException = ex;
-        }
-
-        Assert.That(compilerException, Is.Not.Null);
-        Assert.That(interpreterException, Is.Not.Null);
-
-        var comparableCompilerException = GetComparableException(compilerException!);
-        var comparableInterpreterException = GetComparableException(interpreterException!);
-        Assert.That(comparableCompilerException.ToString().Contains(expectedFragment, StringComparison.OrdinalIgnoreCase), Is.True);
-        Assert.That(comparableInterpreterException.ToString().Contains(expectedFragment, StringComparison.OrdinalIgnoreCase), Is.True);
+        var compilerExceptionText = GetComparableException(compilerResult.Exception!).ToString();
+        var interpreterExceptionText = GetComparableException(interpreterResult.Exception!).ToString();
+        Assert.That(compilerExceptionText.Contains(expectedFragment, StringComparison.OrdinalIgnoreCase), Is.True);
+        Assert.That(interpreterExceptionText.Contains(expectedFragment, StringComparison.OrdinalIgnoreCase), Is.True);
     }
 
     public void AssertCompilerAndInterpreterFailSameWay(string code, IEnumerable<string> modules)
     {
-        Exception? compilerException = null;
-        Exception? interpreterException = null;
+        var dialectText = BuildDialectText("Inline", modules, null, ["compiler", "interpreter"]);
+        var (compilerResult, interpreterResult) = BackendParityInfrastructure.RunBoth(dialectText, code);
 
-        try
-        {
-            _ = ExecuteCompiler(code, modules);
-        }
-        catch (Exception ex)
-        {
-            compilerException = ex;
-        }
+        Assert.That(compilerResult.IsSuccess, Is.False);
+        Assert.That(interpreterResult.IsSuccess, Is.False);
 
-        try
-        {
-            _ = ExecuteInterpreter(code, modules);
-        }
-        catch (Exception ex)
-        {
-            interpreterException = ex;
-        }
-
-        Assert.That(compilerException, Is.Not.Null);
-        Assert.That(interpreterException, Is.Not.Null);
-
-        var comparableCompilerException = GetComparableException(compilerException!);
-        var comparableInterpreterException = GetComparableException(interpreterException!);
+        var comparableCompilerException = GetComparableException(compilerResult.Exception!);
+        var comparableInterpreterException = GetComparableException(interpreterResult.Exception!);
         Assert.That(comparableCompilerException.GetType(), Is.EqualTo(comparableInterpreterException.GetType()));
         Assert.That(GetInvariantMessageFragment(comparableCompilerException.Message), Is.EqualTo(GetInvariantMessageFragment(comparableInterpreterException.Message)));
     }

--- a/UniversalToolchain/UniversalToolchain.Modules.Tests/UniversalToolchain.Modules.Tests.csproj
+++ b/UniversalToolchain/UniversalToolchain.Modules.Tests/UniversalToolchain.Modules.Tests.csproj
@@ -26,6 +26,10 @@
     </ItemGroup>
 
     <ItemGroup>
+        <Compile Include="..\Tests\Infrastructure\BackendParityInfrastructure.cs" Link="Infrastructure\BackendParityInfrastructure.cs" />
+    </ItemGroup>
+
+    <ItemGroup>
         <Using Include="NUnit.Framework"/>
     </ItemGroup>
 


### PR DESCRIPTION
### Motivation

- Centralize duplicate parity helpers so all tests share a single, consistent way to execute and compare compiler/interpreter backends.
- Provide a uniform representation of backend outcomes (success vs failure) to simplify parity checks and diagnostic comparisons.
- Remove local ad-hoc conversions and parity assertions to avoid drifting behavior and duplicated logic across tests.

### Description

- Add `BackendParityInfrastructure` at `UniversalToolchain/Tests/Infrastructure/BackendParityInfrastructure.cs` exposing `RunBoth(dialectText, code)`, `AssertSemanticParity(compilerResult, interpreterResult)`, `AsNumber(object?)`, `AsBool(object?)`, and `ExecuteSafely(...)`.
- Introduce `BackendExecutionResult` record to represent success (value) or failure (exception) in a single type.
- Migrate `DialectTestHostInfrastructure.RunInBothBackends` to call `BackendParityInfrastructure.RunBoth` and assert parity via `AssertSemanticParity`.
- Migrate `InterpreterBindingsParityTests` and `ModulePipelineTestHelper` to use `BackendExecutionResult` and `BackendParityInfrastructure` for parity checks, numeric/bool conversions, and failure diagnostics; add the new infrastructure file as a linked compile item into `UniversalToolchain.Modules.Tests`.

### Testing

- Performed `dotnet restore` and `dotnet build` of `UniversalToolchain/Wist.sln` and the build succeeded.
- Ran targeted tests: filtered `InterpreterBindingsParityTests` passed (`dotnet test ... --filter "FullyQualifiedName~InterpreterBindingsParityTests"`).
- Ran `UniversalToolchain.Modules.Tests` and `UniversalToolchain.Dialects.Tests` and both test assemblies passed after the migration.
- Ran the full `UniversalToolchain/Tests/Tests.csproj` which showed pre-existing unrelated failures in native/interop/intrinsic areas that are outside this migration scope, while parity-related tests touched by this change passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4c28c02848324bad0397706e35c0d)