### PR TITLE
Refactor parity tests to use unified host-level backend execution adapter

### DIFF
--- a/UniversalToolchain/Tests/Infrastructure/ParityBackendExecutionAdapter.cs
+++ b/UniversalToolchain/Tests/Infrastructure/ParityBackendExecutionAdapter.cs
@@ -1,0 +1,71 @@
+using System.Collections.Specialized;
+using UniversalToolchain.Dialects.Wist;
+using System.Reflection.Emit;
+using ExceptionsManager;
+
+namespace Tests.Infrastructure;
+
+internal static class ParityBackendExecutionAdapter
+{
+    public static BackendArtifactSnapshot CompileSnapshot(
+        WistDialectExecutionHost host,
+        string backendName,
+        string code,
+        OrderedDictionary<string, Type> declared)
+    {
+        var artifact = CompileArtifact(host, backendName, code, declared);
+        return new BackendArtifactSnapshot(
+            artifact.DeclaredBindings.Select(static binding => binding.Name).ToArray(),
+            new Dictionary<string, int>(artifact.SlotsByName, StringComparer.Ordinal));
+    }
+
+    public static object RunCompiled(
+        WistDialectExecutionHost host,
+        string backendName,
+        string code,
+        OrderedDictionary<string, Type> declared,
+        IReadOnlyList<KeyValuePair<string, object>> arguments)
+    {
+        var artifact = CompileArtifact(host, backendName, code, declared);
+        var session = artifact.CreateSession();
+
+        foreach (var argument in arguments)
+            session.SetArgument(argument.Key, argument.Value);
+
+        return session.Run() ?? Thrower.InvalidOpEx<object>($"Backend '{backendName}' returned null result.");
+    }
+
+    private static ICompiledArtifact<object> CompileArtifact(
+        WistDialectExecutionHost host,
+        string backendName,
+        string code,
+        OrderedDictionary<string, Type> declared)
+    {
+        return backendName switch
+        {
+            "compiler" => Wrap(host.GetArtifactCompiler<DynamicMethod>(backendName).Compile(code, declared)),
+            "interpreter" => Wrap(host.GetArtifactCompiler<IAbstractIR>(backendName).Compile(code, declared)),
+            _ => Thrower.InvalidOpEx<ICompiledArtifact<object>>($"Unsupported backend '{backendName}'.")
+        };
+    }
+
+    private static ICompiledArtifact<object> Wrap<TCompilationOutput>(ICompiledArtifact<TCompilationOutput> artifact)
+        => new ArtifactAdapter<TCompilationOutput>(artifact);
+
+    internal sealed record BackendArtifactSnapshot(
+        IReadOnlyList<string> DeclaredBindingNames,
+        IReadOnlyDictionary<string, int> SlotsByName);
+
+    private sealed class ArtifactAdapter<TCompilationOutput>(ICompiledArtifact<TCompilationOutput> inner) : ICompiledArtifact<object>
+    {
+        public string SourceText => inner.SourceText;
+
+        public IReadOnlyList<ExternalBinding> DeclaredBindings => inner.DeclaredBindings;
+
+        public IReadOnlyDictionary<string, int> SlotsByName => inner.SlotsByName;
+
+        public object CompilationOutput => inner.CompilationOutput!;
+
+        public ICompiledArtifactSession CreateSession() => inner.CreateSession();
+    }
+}

--- a/UniversalToolchain/Tests/Parity/InterpreterBindingsParityTests.cs
+++ b/UniversalToolchain/Tests/Parity/InterpreterBindingsParityTests.cs
@@ -1,8 +1,7 @@
-using System.Reflection.Emit;
-using ExceptionsManager;
-using Microsoft.Extensions.DependencyInjection;
-using NumbersModule.Core;
+using System.Collections.Generic;
+using System.Collections.Specialized;
 using UniversalToolchain.Dialects.Wist;
+using NumbersModule.Core;
 using Tests.Infrastructure;
 
 namespace Tests.Integration;
@@ -225,18 +224,18 @@ public class InterpreterBindingsParityTests
     public void UnknownVariableAccess_WhenStrictFailureExists_ShouldExposeMeaningfulError()
     {
         using var host = CreateHost();
-        var compilerCore = GetCompilerCore(host);
         var declared = new OrderedDictionary<string, Type>
         {
             ["price"] = typeof(RealNumberImpl)
         };
 
+        var arguments = new List<KeyValuePair<string, object>>
+        {
+            new("price", new RealNumberImpl(2.0))
+        };
         try
         {
-            var artifact = compilerCore.Compile("unknown + price", declared);
-            var session = artifact.CreateSession();
-            session.SetArgument("price", new RealNumberImpl(2.0));
-            _ = session.Run();
+            _ = ParityBackendExecutionAdapter.RunCompiled(host, "compiler", "unknown + price", declared, arguments);
             Assert.Pass("Current runtime allows the scenario without strict unknown-variable failure.");
         }
         catch (Exception ex)
@@ -253,20 +252,12 @@ public class InterpreterBindingsParityTests
         IReadOnlyList<NamedArgument> arguments)
     {
         using var host = CreateHost();
-        var compilerArtifact = GetCompilerCore(host).Compile(code, declared);
-        var interpreterArtifact = GetInterpreterCore(host).Compile(code, declared);
+        var mappedArguments = arguments
+            .Select(static argument => new KeyValuePair<string, object>(argument.Name, argument.Value))
+            .ToArray();
 
-        var compilerSession = compilerArtifact.CreateSession();
-        var interpreterSession = interpreterArtifact.CreateSession();
-
-        foreach (var argument in arguments)
-        {
-            compilerSession.SetArgument(argument.Name, argument.Value);
-            interpreterSession.SetArgument(argument.Name, argument.Value);
-        }
-
-        var compilerResult = BackendExecutionResult.Success(compilerSession.Run() ?? Thrower.InvalidOpEx<object>("Compiler returned null result."));
-        var interpreterResult = BackendExecutionResult.Success(interpreterSession.Run() ?? Thrower.InvalidOpEx<object>("Interpreter returned null result."));
+        var compilerResult = BackendExecutionResult.Success(ParityBackendExecutionAdapter.RunCompiled(host, "compiler", code, declared, mappedArguments));
+        var interpreterResult = BackendExecutionResult.Success(ParityBackendExecutionAdapter.RunCompiled(host, "interpreter", code, declared, mappedArguments));
 
         BackendParityInfrastructure.AssertSemanticParity(compilerResult, interpreterResult);
         return (BackendParityInfrastructure.AsNumber(compilerResult.Value), BackendParityInfrastructure.AsNumber(interpreterResult.Value));
@@ -300,56 +291,21 @@ public class InterpreterBindingsParityTests
         IReadOnlyList<NamedArgument> arguments)
     {
         using var host = CreateHost();
-        var compilerOutcome = TryRunSingleBackend(() => GetCompilerCore(host).Compile(code, declared), arguments);
-        var interpreterOutcome = TryRunSingleBackend(() => GetInterpreterCore(host).Compile(code, declared), arguments);
+        var mappedArguments = arguments
+            .Select(static argument => new KeyValuePair<string, object>(argument.Name, argument.Value))
+            .ToArray();
+
+        var compilerOutcome = TryRunSingleBackend(() => ParityBackendExecutionAdapter.RunCompiled(host, "compiler", code, declared, mappedArguments));
+        var interpreterOutcome = TryRunSingleBackend(() => ParityBackendExecutionAdapter.RunCompiled(host, "interpreter", code, declared, mappedArguments));
         return (compilerOutcome, interpreterOutcome);
     }
 
-    private static BackendExecutionResult TryRunSingleBackend<TCompilationOutput>(
-        Func<ICompiledArtifact<TCompilationOutput>> artifactFactory,
-        IReadOnlyList<NamedArgument> arguments)
+    private static BackendExecutionResult TryRunSingleBackend(Func<object> backendRunner)
     {
-        return BackendParityInfrastructure.ExecuteSafely(() =>
-        {
-            var artifact = artifactFactory();
-            var session = artifact.CreateSession();
-            foreach (var argument in arguments)
-                session.SetArgument(argument.Name, argument.Value);
-
-            return session.Run() ?? Thrower.InvalidOpEx<object>("Backend returned null result.");
-        });
+        return BackendParityInfrastructure.ExecuteSafely(backendRunner);
     }
 
-    private static WistDialectExecutionHost CreateHost()
-    {
-        var services = new ServiceCollection();
-        services.AddWistDialectServices();
-        services.AddWistCilBackend();
-        services.AddWistInterpreterBackend();
-
-        using var provider = services.BuildServiceProvider();
-        var workflow = provider.GetRequiredService<WistDialectExecutionWorkflow>();
-        var composition = workflow.ComposeText(
-            """
-            dialect InterpreterBindingsParity
-            use Whitespaces,SemicolonAsNewLine,Comments,Numbers,Identifier,Arithmetic,Equality,Conditions,Loops,Variables,Scopes,Labels,InternalPreprocessorLexemes,CSharpInterop
-            backend compiler,interpreter
-            """,
-            "interpreter-bindings-parity-inline");
-
-        if (!composition.IsSuccess)
-            Thrower.InvalidOpEx(composition.ToDeterministicText());
-
-        return workflow.CreateHost(composition);
-    }
-
-    private static BasicCoreImpl<DynamicMethod> GetCompilerCore(WistDialectExecutionHost host) =>
-        host.GetCore("compiler") as BasicCoreImpl<DynamicMethod>
-        ?? Thrower.InvalidOpEx<BasicCoreImpl<DynamicMethod>>("Compiler core must be BasicCoreImpl<DynamicMethod>.");
-
-    private static BasicCoreImpl<IAbstractIR> GetInterpreterCore(WistDialectExecutionHost host) =>
-        host.GetCore("interpreter") as BasicCoreImpl<IAbstractIR>
-        ?? Thrower.InvalidOpEx<BasicCoreImpl<IAbstractIR>>("Interpreter core must be BasicCoreImpl<IAbstractIR>.");
+    private static WistDialectExecutionHost CreateHost() => RuntimeCompiledArtifactTestFactory.CreateHost();
 
     private sealed record NamedArgument(string Name, object Value);
 }

--- a/UniversalToolchain/Tests/Parity/RuntimeCompiledArtifactParityTests.cs
+++ b/UniversalToolchain/Tests/Parity/RuntimeCompiledArtifactParityTests.cs
@@ -1,5 +1,4 @@
 using System.Collections.Specialized;
-using System.Reflection.Emit;
 using Tests.Infrastructure;
 
 namespace Tests.Parity;
@@ -17,11 +16,11 @@ public class RuntimeCompiledArtifactParityTests
             ["y"] = typeof(object)
         };
 
-        ICompiledArtifact<DynamicMethod> compilerArtifact = RuntimeCompiledArtifactTestFactory.GetCompilerCore(host).Compile("x", declared);
-        ICompiledArtifact<IAbstractIR> interpreterArtifact = RuntimeCompiledArtifactTestFactory.GetInterpreterCore(host).Compile("x", declared);
+        var compilerArtifact = ParityBackendExecutionAdapter.CompileSnapshot(host, "compiler", "x", declared);
+        var interpreterArtifact = ParityBackendExecutionAdapter.CompileSnapshot(host, "interpreter", "x", declared);
 
-        Assert.That(compilerArtifact.DeclaredBindings.Select(static b => b.Name),
-            Is.EqualTo(interpreterArtifact.DeclaredBindings.Select(static b => b.Name)));
+        Assert.That(compilerArtifact.DeclaredBindingNames,
+            Is.EqualTo(interpreterArtifact.DeclaredBindingNames));
         Assert.That(compilerArtifact.SlotsByName, Is.EqualTo(interpreterArtifact.SlotsByName));
     }
 }


### PR DESCRIPTION
### Motivation
- Parity tests must not access backend implementation types (`BasicCoreImpl<...>`, `DynamicMethod`, `InterpreterImpl`, `AbstractMethodsCompilerImpl`) directly and should use a single public execution surface. 
- Provide a common, backend-agnostic execution/compile path so both backends are exercised through the same abstraction. 
- Keep backend-specific helpers in backend-focused tests only, avoiding leakage of implementation details into parity checks.

### Description
- Added `ParityBackendExecutionAdapter` (tests infrastructure) which exposes `CompileSnapshot` and `RunCompiled` and wraps backend artifact compilation/session execution behind a uniform API. 
- Updated `RuntimeCompiledArtifactParityTests` to use `ParityBackendExecutionAdapter.CompileSnapshot(...)` instead of direct `GetCompilerCore/GetInterpreterCore` and removed direct `DynamicMethod`/`IAbstractIR` usage from the parity test. 
- Updated `InterpreterBindingsParityTests` to run both backends through the adapter/session abstraction, removed `GetCompilerCore/GetInterpreterCore` usage and centralized host construction to the `RuntimeCompiledArtifactTestFactory`. 
- The change keeps backend-specific core access (helper getters) only in backend infrastructure tests (e.g., `RuntimeCompiledArtifactTestFactory` / backends tests) and prevents parity tests from depending on concrete backend impls.

### Testing
- Restored and built solution with `dotnet restore` and `dotnet build` in `Release` configuration successfully. 
- Ran parity-focused tests with `dotnet test UniversalToolchain/Tests/Tests.csproj -c Release --no-build --filter "FullyQualifiedName~Parity"` and the parity test subset passed. 
- Ran `dotnet test` for `UniversalToolchain.Modules.Tests` and `UniversalToolchain.Dialects.Tests` with `--no-build` and those suites passed. 
- A full `dotnet test` run of `UniversalToolchain/Tests/Tests.csproj` (no build) exhibits unrelated pre-existing backend/native failures not introduced by these changes, so parity-specific runs were used for validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4c79b77e883248377f42fe36baa6c)