### PR TITLE
Bridge typed intrinsic payloads to legacy shape in backend pipeline

### DIFF
--- a/UniversalToolchain/BasicCore/AssemblyInternals.cs
+++ b/UniversalToolchain/BasicCore/AssemblyInternals.cs
@@ -1,0 +1,6 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("BytecodeDynamicMethodsCompiler")]
+[assembly: InternalsVisibleTo("BasicInterpreter")]
+[assembly: InternalsVisibleTo("UniversalToolchain.Dialects.Wist")]
+[assembly: InternalsVisibleTo("Tests")]

--- a/UniversalToolchain/BasicInterpreter/InterpreterImpl.cs
+++ b/UniversalToolchain/BasicInterpreter/InterpreterImpl.cs
@@ -1,3 +1,5 @@
+using UniversalToolchain.Intrinsics.Legacy;
+
 namespace BasicInterpreter;
 
 public class InterpreterImpl : IExecutor<IAbstractIR>
@@ -95,15 +97,18 @@ public class InterpreterImpl : IExecutor<IAbstractIR>
 
     private void ExecuteIntrinsic(Instruction instruction, InterpreterState state)
     {
-        var intrinsicName = instruction.Operands[0].Get<string>();
+        if (!IntrinsicInstructionLegacyProjector.TryProject(instruction, out var projectedInstruction))
+            Thrower.InvalidOpEx($"Unknown intrinsic call payload: {instruction}.");
+
+        var intrinsicName = projectedInstruction.Operands[0].Get<string>();
         if (intrinsicName == "call C#")
-            ExecuteCSharpCall(instruction, state);
+            ExecuteCSharpCall(projectedInstruction, state);
         else if (intrinsicName == "call C# ctor")
-            ExecuteCSharpConstructor(instruction, state);
+            ExecuteCSharpConstructor(projectedInstruction, state);
         else if (intrinsicName == "load_external")
-            ExecuteLoadExternal(instruction, state);
+            ExecuteLoadExternal(projectedInstruction, state);
         else if (intrinsicName == "store_external")
-            ExecuteStoreExternal(instruction, state);
+            ExecuteStoreExternal(projectedInstruction, state);
         else
             Thrower.InvalidOpEx($"Unknown intrinsic call: {intrinsicName}.");
     }

--- a/UniversalToolchain/BytecodeDynamicMethodsCompiler/Compilers/AbstractMethodsIntrinsicCompiler.cs
+++ b/UniversalToolchain/BytecodeDynamicMethodsCompiler/Compilers/AbstractMethodsIntrinsicCompiler.cs
@@ -1,3 +1,5 @@
+using UniversalToolchain.Intrinsics.Legacy;
+
 namespace BytecodeDynamicMethodsCompiler.Compilers;
 
 internal sealed class AbstractMethodsIntrinsicCompiler
@@ -18,22 +20,22 @@ internal sealed class AbstractMethodsIntrinsicCompiler
 
     public void Compile(CompilationContext context, Instruction instruction, List<Type> stack)
     {
-        Thrower.AssertAlways(instruction.UOpCode == UOpCode.Intrinsic);
-        Thrower.AssertAlways(instruction.Operands[0] is string);
+        if (!IntrinsicInstructionLegacyProjector.TryProject(instruction, out var projectedInstruction))
+            Thrower.InvalidOpEx($"Unsupported intrinsic instruction payload: {instruction}");
 
-        var name = instruction.Operands[0].Get<string>();
+        var name = projectedInstruction.Operands[0].Get<string>();
         var descriptor = _registry.GetRequired(name);
-        descriptor.Compile(context, instruction, stack);
+        descriptor.Compile(context, projectedInstruction, stack);
     }
 
     public void ProcessTypes(Instruction instruction, List<Type> stack)
     {
-        Thrower.AssertAlways(instruction.UOpCode == UOpCode.Intrinsic);
-        Thrower.AssertAlways(instruction.Operands[0] is string);
+        if (!IntrinsicInstructionLegacyProjector.TryProject(instruction, out var projectedInstruction))
+            Thrower.InvalidOpEx($"Unsupported intrinsic instruction payload: {instruction}");
 
-        var name = instruction.Operands[0].Get<string>();
+        var name = projectedInstruction.Operands[0].Get<string>();
         var descriptor = _registry.GetRequired(name);
-        descriptor.ProcessTypes(instruction, stack);
+        descriptor.ProcessTypes(projectedInstruction, stack);
     }
 
     internal static void CompileCallCSharp(CompilationContext context, Instruction instruction, List<Type> stack)

--- a/UniversalToolchain/Intrinsics/Legacy/IntrinsicInstructionLegacyProjector.cs
+++ b/UniversalToolchain/Intrinsics/Legacy/IntrinsicInstructionLegacyProjector.cs
@@ -1,0 +1,139 @@
+using IntermediateRepresentationAbstractions;
+using ObjectExtensions;
+using UniversalToolchain.Intrinsics.Builtins;
+using UniversalToolchain.Intrinsics.Capabilities;
+using UniversalToolchain.Intrinsics.Contracts;
+
+namespace UniversalToolchain.Intrinsics.Legacy;
+
+internal static class IntrinsicInstructionLegacyProjector
+{
+    public static bool TryProject(Instruction instruction, out Instruction projectedInstruction)
+    {
+        if (instruction == null)
+            Thrower.ArgumentNull(nameof(instruction));
+
+        projectedInstruction = default!;
+
+        if (instruction.UOpCode != UOpCode.Intrinsic)
+            return false;
+
+        if (instruction.Operands.Count == 0)
+            return false;
+
+        if (instruction.Operands[0] is string)
+        {
+            projectedInstruction = instruction;
+            return true;
+        }
+
+        if (instruction.Operands.Count != 1 || instruction.Operands[0] is not IntrinsicInvocation invocation)
+            return false;
+
+        if (!LegacyCapabilityNameEncoder.TryEncode(invocation.Symbol, invocation.TypeArguments, out var intrinsicName))
+            return false;
+
+        if (invocation.Symbol == BuiltinIntrinsicSymbols.Core.CallCSharp
+            || invocation.Symbol == BuiltinIntrinsicSymbols.Core.CallCSharpCtor)
+        {
+            if (!TryGetDataOperand(invocation.DataOperands, 0, out var dataOperand))
+                return false;
+
+            projectedInstruction = new Instruction(UOpCode.Intrinsic, [intrinsicName, dataOperand]);
+            return true;
+        }
+
+        if (invocation.Symbol == BuiltinIntrinsicSymbols.Core.LoadExternal)
+        {
+            if (!TryGetDataOperand(invocation.DataOperands, 0, out var dataOperand)
+                || !TryGetSingleRuntimeType(invocation.TypeArguments, out var runtimeType))
+                return false;
+
+            projectedInstruction = new Instruction(UOpCode.Intrinsic, [intrinsicName, dataOperand, runtimeType]);
+            return true;
+        }
+
+        if (invocation.Symbol == BuiltinIntrinsicSymbols.Core.StoreExternal
+            || invocation.Symbol == BuiltinIntrinsicSymbols.Core.LoadConst)
+        {
+            if (!TryGetDataOperand(invocation.DataOperands, 0, out var dataOperand))
+                return false;
+
+            projectedInstruction = new Instruction(UOpCode.Intrinsic, [intrinsicName, dataOperand]);
+            return true;
+        }
+
+        if (invocation.Symbol == BuiltinIntrinsicSymbols.Storage.LoadLocal
+            || invocation.Symbol == BuiltinIntrinsicSymbols.Storage.LoadLocalRef)
+        {
+            if (!TryGetDataOperand(invocation.DataOperands, 0, out var dataOperand)
+                || !TryGetSingleRuntimeType(invocation.TypeArguments, out var runtimeType))
+                return false;
+
+            projectedInstruction = new Instruction(UOpCode.Intrinsic, [intrinsicName, dataOperand, runtimeType]);
+            return true;
+        }
+
+        if (invocation.Symbol == BuiltinIntrinsicSymbols.Storage.StoreLocal)
+        {
+            if (!TryGetDataOperand(invocation.DataOperands, 0, out var dataOperand))
+                return false;
+
+            if (TryGetSingleRuntimeType(invocation.TypeArguments, out var runtimeTypeFromTypeArguments))
+            {
+                projectedInstruction = new Instruction(UOpCode.Intrinsic, [intrinsicName, dataOperand, runtimeTypeFromTypeArguments]);
+                return true;
+            }
+
+            if (invocation.TypeArguments.Count == 0
+                && invocation.DataOperands.Count >= 2
+                && invocation.DataOperands[1] is Type runtimeTypeFromData)
+            {
+                projectedInstruction = new Instruction(UOpCode.Intrinsic, [intrinsicName, dataOperand, runtimeTypeFromData]);
+                return true;
+            }
+
+            return false;
+        }
+
+        if (invocation.Symbol == BuiltinIntrinsicSymbols.Boolean.And
+            || invocation.Symbol == BuiltinIntrinsicSymbols.Boolean.Or
+            || invocation.Symbol == BuiltinIntrinsicSymbols.Boolean.Not)
+        {
+            projectedInstruction = new Instruction(UOpCode.Intrinsic, [intrinsicName]);
+            return true;
+        }
+
+        if (invocation.Symbol.Namespace == BuiltinIntrinsicSymbols.Arithmetic.Add.Namespace
+            || invocation.Symbol.Namespace == BuiltinIntrinsicSymbols.Comparison.Equal.Namespace)
+        {
+            projectedInstruction = new Instruction(UOpCode.Intrinsic, [intrinsicName]);
+            return true;
+        }
+
+        return false;
+    }
+
+
+    private static bool TryGetDataOperand(IReadOnlyList<object?> dataOperands, int index, out object operand)
+    {
+        operand = default!;
+
+        if (dataOperands.Count <= index || dataOperands[index] == null)
+            return false;
+
+        operand = dataOperands[index]!;
+        return true;
+    }
+
+    private static bool TryGetSingleRuntimeType(IReadOnlyList<IntrinsicTypeArgument> typeArguments, out Type runtimeType)
+    {
+        runtimeType = default!;
+
+        if (typeArguments.Count != 1)
+            return false;
+
+        runtimeType = typeArguments[0].RuntimeType;
+        return true;
+    }
+}

--- a/UniversalToolchain/Tests/Backends/CilBackendAbstractIrCompilationTests.cs
+++ b/UniversalToolchain/Tests/Backends/CilBackendAbstractIrCompilationTests.cs
@@ -1,3 +1,5 @@
+using UniversalToolchain.Intrinsics.Builtins;
+using UniversalToolchain.Intrinsics.Contracts;
 using System.Reflection.Emit;
 
 namespace Tests.Backends;
@@ -363,6 +365,34 @@ public class CilBackendAbstractIrCompilationTests
         Assert.That(result, Is.EqualTo(1056));
     }
 
+
+    [Test]
+    public void TypedArithmeticIntrinsicI32_ProducesCorrectResult()
+    {
+        var ir = BuildIr(
+            new Instruction(UOpCode.Push, [19]),
+            new Instruction(UOpCode.Push, [23]),
+            CreateTypedIntrinsic(BuiltinIntrinsicSymbols.Arithmetic.Add, [IntrinsicTypeArgument.From(typeof(int))])
+        );
+
+        var result = CompileAndExecute(ir);
+
+        Assert.That(result, Is.EqualTo(42));
+    }
+
+    [Test]
+    public void TypedBooleanNotIntrinsic_ProducesCorrectResult()
+    {
+        var ir = BuildIr(
+            new Instruction(UOpCode.Push, [true]),
+            CreateTypedIntrinsic(BuiltinIntrinsicSymbols.Boolean.Not)
+        );
+
+        var result = CompileAndExecute(ir);
+
+        Assert.That(result, Is.EqualTo(false));
+    }
+
     private static int AddOne(int value) => value + 1;
 
     private static int IncrementRef(ref int value)
@@ -374,6 +404,20 @@ public class CilBackendAbstractIrCompilationTests
     private static int CombineDigits(int acc, int nextDigit) => acc * 10 + nextDigit;
 
     private static T Echo<T>(T value) => value;
+
+
+    private static Instruction CreateTypedIntrinsic(
+        IntrinsicSymbol symbol,
+        IReadOnlyList<IntrinsicTypeArgument>? typeArguments = null,
+        IReadOnlyList<object?>? dataOperands = null)
+    {
+        var invocation = new IntrinsicInvocation(
+            symbol,
+            typeArguments ?? [],
+            dataOperands ?? []);
+
+        return new Instruction(UOpCode.Intrinsic, [invocation]);
+    }
 
     private static IAbstractIR BuildIr(params Instruction[] instructions)
     {

--- a/UniversalToolchain/Tests/Backends/InterpreterBackendIrExecutionTests.cs
+++ b/UniversalToolchain/Tests/Backends/InterpreterBackendIrExecutionTests.cs
@@ -1,3 +1,5 @@
+using UniversalToolchain.Intrinsics.Builtins;
+using UniversalToolchain.Intrinsics.Contracts;
 using SettableGettableModule.Core;
 using Tests.Infrastructure;
 
@@ -194,9 +196,51 @@ public class InterpreterBackendIrExecutionTests
         Assert.That(result, Is.EqualTo(123));
     }
 
+
+    [Test]
+    public void TypedArithmeticIntrinsicI32_OnCoreInterpreterPath_RemainsUnsupported()
+    {
+        var ir = BuildIr(
+            new Instruction(UOpCode.Push, [20]),
+            new Instruction(UOpCode.Push, [22]),
+            CreateTypedIntrinsic(BuiltinIntrinsicSymbols.Arithmetic.Add, [IntrinsicTypeArgument.From(typeof(int))])
+        );
+
+        var exception = Assert.Throws<RuntimeExecutionException>(() => ExecuteInInterpreter(ir));
+
+        Assert.That(exception!.Message, Does.Contain("Unknown intrinsic call: add_i32."));
+    }
+
+    [Test]
+    public void TypedBooleanNotIntrinsic_OnCoreInterpreterPath_RemainsUnsupported()
+    {
+        var ir = BuildIr(
+            new Instruction(UOpCode.Push, [true]),
+            CreateTypedIntrinsic(BuiltinIntrinsicSymbols.Boolean.Not)
+        );
+
+        var exception = Assert.Throws<RuntimeExecutionException>(() => ExecuteInInterpreter(ir));
+
+        Assert.That(exception!.Message, Does.Contain("Unknown intrinsic call: boolean_not."));
+    }
+
     private static int CombineDigits(int acc, int nextDigit) => acc * 10 + nextDigit;
 
     private static T Echo<T>(T value) => value;
+
+
+    private static Instruction CreateTypedIntrinsic(
+        IntrinsicSymbol symbol,
+        IReadOnlyList<IntrinsicTypeArgument>? typeArguments = null,
+        IReadOnlyList<object?>? dataOperands = null)
+    {
+        var invocation = new IntrinsicInvocation(
+            symbol,
+            typeArguments ?? [],
+            dataOperands ?? []);
+
+        return new Instruction(UOpCode.Intrinsic, [invocation]);
+    }
 
     private static object? ExecuteInInterpreter(IAbstractIR ir)
     {

--- a/UniversalToolchain/Tests/Intrinsics/IntrinsicInstructionLegacyProjectorTests.cs
+++ b/UniversalToolchain/Tests/Intrinsics/IntrinsicInstructionLegacyProjectorTests.cs
@@ -1,0 +1,138 @@
+using System.Reflection;
+using UniversalToolchain.Intrinsics.Builtins;
+using UniversalToolchain.Intrinsics.Contracts;
+
+namespace Tests.Intrinsics;
+
+[TestFixture]
+public class IntrinsicInstructionLegacyProjectorTests
+{
+    [Test]
+    public void TryProject_TypedBooleanIntrinsic_ProjectsToLegacyName()
+    {
+        var instruction = CreateTypedInstruction(BuiltinIntrinsicSymbols.Boolean.Not);
+
+        var success = TryProject(instruction, out var projectedInstruction);
+
+        Assert.That(success, Is.True);
+        Assert.That(projectedInstruction.Operands, Is.EqualTo(new object?[] { "boolean_not" }));
+    }
+
+    [Test]
+    public void TryProject_TypedArithmeticIntrinsic_ProjectsToTypedLegacyName()
+    {
+        var instruction = CreateTypedInstruction(
+            BuiltinIntrinsicSymbols.Arithmetic.Add,
+            [IntrinsicTypeArgument.From(typeof(double))]);
+
+        var success = TryProject(instruction, out var projectedInstruction);
+
+        Assert.That(success, Is.True);
+        Assert.That(projectedInstruction.Operands, Is.EqualTo(new object?[] { "add_f64" }));
+    }
+
+    [Test]
+    public void TryProject_TypedComparisonIntrinsic_ProjectsToTypedLegacyName()
+    {
+        var instruction = CreateTypedInstruction(
+            BuiltinIntrinsicSymbols.Comparison.LessOrEqual,
+            [IntrinsicTypeArgument.From(typeof(double))]);
+
+        var success = TryProject(instruction, out var projectedInstruction);
+
+        Assert.That(success, Is.True);
+        Assert.That(projectedInstruction.Operands, Is.EqualTo(new object?[] { "cmp_le_f64" }));
+    }
+
+    [Test]
+    public void TryProject_TypedLoadConst_ProjectsToLegacyNameAndDataOperand()
+    {
+        var instruction = CreateTypedInstruction(
+            BuiltinIntrinsicSymbols.Core.LoadConst,
+            [IntrinsicTypeArgument.From(typeof(double))],
+            [12.5d]);
+
+        var success = TryProject(instruction, out var projectedInstruction);
+
+        Assert.That(success, Is.True);
+        Assert.That(projectedInstruction.Operands, Is.EqualTo(new object?[] { "load_f64", 12.5d }));
+    }
+
+    [Test]
+    public void TryProject_TypedLoadLocal_ProjectsToLegacyShape()
+    {
+        var instruction = CreateTypedInstruction(
+            BuiltinIntrinsicSymbols.Storage.LoadLocal,
+            [IntrinsicTypeArgument.From(typeof(int))],
+            ["value"]);
+
+        var success = TryProject(instruction, out var projectedInstruction);
+
+        Assert.That(success, Is.True);
+        Assert.That(projectedInstruction.Operands, Is.EqualTo(new object?[] { "load_local", "value", typeof(int) }));
+    }
+
+    [Test]
+    public void TryProject_TypedLoadLocalRef_ProjectsToLegacyShape()
+    {
+        var instruction = CreateTypedInstruction(
+            BuiltinIntrinsicSymbols.Storage.LoadLocalRef,
+            [IntrinsicTypeArgument.From(typeof(int))],
+            ["value"]);
+
+        var success = TryProject(instruction, out var projectedInstruction);
+
+        Assert.That(success, Is.True);
+        Assert.That(projectedInstruction.Operands, Is.EqualTo(new object?[] { "load_local_ref", "value", typeof(int) }));
+    }
+
+    [Test]
+    public void TryProject_TypedCallCSharp_ProjectsToLegacyShape()
+    {
+        var method = typeof(Math).GetMethod(nameof(Math.Abs), [typeof(int)]);
+        var instruction = CreateTypedInstruction(
+            BuiltinIntrinsicSymbols.Core.CallCSharp,
+            dataOperands: [method]);
+
+        var success = TryProject(instruction, out var projectedInstruction);
+
+        Assert.That(success, Is.True);
+        Assert.That(projectedInstruction.Operands, Is.EqualTo(new object?[] { "call C#", method }));
+    }
+
+    [Test]
+    public void TryProject_MalformedTypedPayload_ReturnsFalse()
+    {
+        var instruction = CreateTypedInstruction(BuiltinIntrinsicSymbols.Core.LoadExternal);
+
+        var success = TryProject(instruction, out _);
+
+        Assert.That(success, Is.False);
+    }
+
+
+    private static bool TryProject(Instruction instruction, out Instruction projectedInstruction)
+    {
+        var projectorType = typeof(IntrinsicInvocation).Assembly
+            .GetType("UniversalToolchain.Intrinsics.Legacy.IntrinsicInstructionLegacyProjector", throwOnError: true)!;
+        var method = projectorType.GetMethod("TryProject", BindingFlags.Public | BindingFlags.Static)!;
+
+        var args = new object?[] { instruction, null };
+        var success = (bool)(method.Invoke(null, args) ?? false);
+        projectedInstruction = args[1] is Instruction projected ? projected : default!;
+        return success;
+    }
+
+    private static Instruction CreateTypedInstruction(
+        IntrinsicSymbol symbol,
+        IReadOnlyList<IntrinsicTypeArgument>? typeArguments = null,
+        IReadOnlyList<object?>? dataOperands = null)
+    {
+        var invocation = new IntrinsicInvocation(
+            symbol,
+            typeArguments ?? [],
+            dataOperands ?? []);
+
+        return new Instruction(UOpCode.Intrinsic, [invocation]);
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/DialectDslTestSupport.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/DialectDslTestSupport.cs
@@ -3,6 +3,7 @@ using BasicCodeTranslator;
 using BasicCore.LexerWrapper;
 using BasicCore.ParserWrapper;
 using BasicCore.Registration;
+using BasicCore.Contracts;
 using BasicCore.TranslatorWrapper;
 using BasicLexer.Core;
 using BasicParser.Core;

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/DialectIntrinsicPolicyCompilerTypedCompatibilityTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/DialectIntrinsicPolicyCompilerTypedCompatibilityTests.cs
@@ -1,0 +1,66 @@
+using BasicCore.Compilation;
+using BasicCore.Contracts;
+using IntermediateRepresentationAbstractions;
+using UniversalToolchain.Dialects.Wist;
+using UniversalToolchain.Intrinsics.Builtins;
+using UniversalToolchain.Intrinsics.Contracts;
+using UniversalIntermediateRepresentation;
+
+namespace UniversalToolchain.Dialects.Tests;
+
+public class DialectIntrinsicPolicyCompilerTypedCompatibilityTests
+{
+    [Test]
+    public void Compile_ForbidsTypedIntrinsic_SameWayAsLegacyStringIntrinsic()
+    {
+        var compiler = CreatePolicyCompiler(forbiddenIntrinsics: ["boolean_not"]);
+        var typedIr = BuildIr(CreateTypedIntrinsic(BuiltinIntrinsicSymbols.Boolean.Not));
+        var legacyIr = BuildIr(new Instruction(UOpCode.Intrinsic, ["boolean_not"]));
+        var input = new CompilationInput { SourceText = string.Empty };
+
+        var typedException = Assert.Throws<InvalidOperationException>(() => compiler.Compile(typedIr, input));
+        var legacyException = Assert.Throws<InvalidOperationException>(() => compiler.Compile(legacyIr, input));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(typedException!.Message, Does.Contain("forbidden by the selected dialect"));
+            Assert.That(legacyException!.Message, Does.Contain("forbidden by the selected dialect"));
+        });
+    }
+
+    private static DialectIntrinsicPolicyCompiler<IAbstractIR> CreatePolicyCompiler(IReadOnlyList<string> forbiddenIntrinsics)
+    {
+        return new DialectIntrinsicPolicyCompiler<IAbstractIR>(
+            new PassthroughCompiler(),
+            allowedIntrinsics: [],
+            forbiddenIntrinsics: forbiddenIntrinsics,
+            hasExplicitAllowList: false);
+    }
+
+    private static Instruction CreateTypedIntrinsic(
+        IntrinsicSymbol symbol,
+        IReadOnlyList<IntrinsicTypeArgument>? typeArguments = null,
+        IReadOnlyList<object?>? dataOperands = null)
+    {
+        var invocation = new IntrinsicInvocation(
+            symbol,
+            typeArguments ?? [],
+            dataOperands ?? []);
+
+        return new Instruction(UOpCode.Intrinsic, [invocation]);
+    }
+
+    private static IAbstractIR BuildIr(params Instruction[] instructions)
+    {
+        var air = new AbstractIR();
+        air.AppendInstructions(instructions);
+        return air;
+    }
+
+    private sealed class PassthroughCompiler : IAbstractIrCompiler<IAbstractIR>
+    {
+        public IReadOnlyList<string> SupportedIntrinsics => ["boolean_not"];
+
+        public IAbstractIR Compile(IAbstractIR air, CompilationInput input) => air;
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/DialectIntrinsicPolicyCompiler.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/DialectIntrinsicPolicyCompiler.cs
@@ -2,6 +2,8 @@ using BasicCore.Compilation;
 using BasicCore.Contracts;
 using ExceptionsManager;
 using IntermediateRepresentationAbstractions;
+using ObjectExtensions;
+using UniversalToolchain.Intrinsics.Legacy;
 
 namespace UniversalToolchain.Dialects.Wist;
 
@@ -52,8 +54,10 @@ internal sealed class DialectIntrinsicPolicyCompiler<TCompilationOutput> : IAbst
             if (instruction.UOpCode != UOpCode.Intrinsic)
                 continue;
 
-            if (instruction.Operands.Count == 0 || instruction.Operands[0] is not string intrinsicName)
-                continue;
+            if (!IntrinsicInstructionLegacyProjector.TryProject(instruction, out var projectedInstruction))
+                Thrower.InvalidOpEx($"Intrinsic payload cannot be validated against dialect policy: {instruction}");
+
+            var intrinsicName = projectedInstruction.Operands[0].Get<string>();
 
             if (_forbiddenIntrinsics.Contains(intrinsicName))
                 Thrower.InvalidOpEx($"Intrinsic '{intrinsicName}' is forbidden by the selected dialect.");


### PR DESCRIPTION
### Motivation
- Optimizers and earlier converters emit typed intrinsics as `IntrinsicInvocation`, but several backend and policy stages expected legacy string-shaped operands and failed on typed payloads.  
- Provide a minimal, architectural adapter so both legacy (`string`) and typed (`IntrinsicInvocation`) intrinsic instructions are accepted without rolling back optimizer changes or removing legacy decoder/encoder layers.  
- Keep change small, reuse existing legacy handlers, and avoid touching `BytecodeToAbstractIrConverterImpl`, capability layer, or public contracts beyond what is necessary.  

### Description
- Added a single adapter `IntrinsicInstructionLegacyProjector` (internal static) with `public static bool TryProject(Instruction instruction, out Instruction projectedInstruction)` that projects typed `IntrinsicInvocation` payloads into legacy-shaped `Instruction` instances or returns false for unsupported/malformed shapes.  
- Wired the projector into the compiler backend by projecting intrinsics first inside `AbstractMethodsIntrinsicCompiler.Compile` and `ProcessTypes`, then invoking existing legacy descriptors on the projected instruction.  
- Wired the projector into the interpreter by projecting in `InterpreterImpl.ExecuteIntrinsic` and dispatching to existing `ExecuteCSharpCall`/`ExecuteLoadExternal`/... using the projected instruction.  
- Wired the projector into dialect validation in `DialectIntrinsicPolicyCompiler.ValidateIntrinsics` so typed intrinsics are validated against the same allow/forbid lists as legacy names.  
- Kept legacy behavior intact: if an instruction is already legacy-shaped, the projector passes it through unchanged; malformed typed payloads return `false` so callers can surface errors appropriately.  
- Added unit tests covering projector behavior and backend compatibility, plus a small `InternalsVisibleTo` addition so the internal projector can be used by backend/test assemblies without exposing internals publicly.  

### Testing
- Ran targeted unit tests for intrinsics and backends: `dotnet test UniversalToolchain/Tests/Tests.csproj -c Release --filter "FullyQualifiedName~Tests.Intrinsics"` and `--filter "FullyQualifiedName~CilBackendAbstractIrCompilationTests|FullyQualifiedName~InterpreterBackendIrExecutionTests"`, both succeeded for the filtered suites.  
- Ran dialect policy typed-compat test: `dotnet test UniversalToolchain/UniversalToolchain.Dialects.Tests/UniversalToolchain.Dialects.Tests.csproj -c Release --no-build --filter "FullyQualifiedName~DialectIntrinsicPolicyCompilerTypedCompatibilityTests"` which passed.  
- Ran a set of legacy/optimizer-related test groups (`ArithmeticOptimizer`, `Boolean`, `NativeMath`, `LocalVariablesOptimizer`) which passed for the filtered runs.  
- Broader suite runs surfaced pre-existing unrelated issues: `WistDialectBackendMatrixTests` failed with a duplicate intrinsic descriptor error and some legacy test projects had unrelated compile-time infra problems; these failures are not caused by this adapter and were observed when running broader test selections.  

All changes are localized to the new projector and three integration points (compiler, interpreter, dialect policy) plus tests and `InternalsVisibleTo` entries; no changes were made to optimizer emitters, legacy decoders/encoders, or core registry descriptors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6a8a915388324ad28ee262b1f92a2)