### PR TITLE
Gate backend intrinsic rewrites by strict optimizer capabilities

### DIFF
--- a/UniversalToolchain/ConditionsModule/Optimizers/BooleanOptimizer.cs
+++ b/UniversalToolchain/ConditionsModule/Optimizers/BooleanOptimizer.cs
@@ -25,9 +25,11 @@ public class BooleanOptimizerModule : IIRProcessingModule
         var capabilityContext = _capabilityContext
                                 ?? throw new InvalidOperationException("Boolean optimizer requires intrinsic capability context initialization.");
 
-        if (!capabilityContext.Supports(BuiltinIntrinsicSymbols.Boolean.And) ||
-            !capabilityContext.Supports(BuiltinIntrinsicSymbols.Boolean.Or) ||
-            !capabilityContext.Supports(BuiltinIntrinsicSymbols.Boolean.Not))
+        if (!OptimizerCapabilityGuards.SupportsAll(
+                capabilityContext,
+                (BuiltinIntrinsicSymbols.Boolean.And, []),
+                (BuiltinIntrinsicSymbols.Boolean.Or, []),
+                (BuiltinIntrinsicSymbols.Boolean.Not, [])))
             return current;
 
         var optimized = OptimizeNativeLoads(current);

--- a/UniversalToolchain/ConditionsModule/Optimizers/ComparisonIntrinsicOptimizerModule.cs
+++ b/UniversalToolchain/ConditionsModule/Optimizers/ComparisonIntrinsicOptimizerModule.cs
@@ -66,18 +66,17 @@ public class ComparisonIntrinsicOptimizerModule : IIRProcessingModule
 
     private static bool HasRequiredCapabilities(IOptimizerIntrinsicCapabilityContext capabilityContext)
     {
-        foreach (var type in _supportedComparisonTypes)
+        var requirements = _supportedComparisonTypes.SelectMany(type => new (IntrinsicSymbol Symbol, Type[] TypeArguments)[]
         {
-            if (!capabilityContext.Supports(BuiltinIntrinsicSymbols.Comparison.Equal, type) ||
-                !capabilityContext.Supports(BuiltinIntrinsicSymbols.Comparison.NotEqual, type) ||
-                !capabilityContext.Supports(BuiltinIntrinsicSymbols.Comparison.Greater, type) ||
-                !capabilityContext.Supports(BuiltinIntrinsicSymbols.Comparison.GreaterOrEqual, type) ||
-                !capabilityContext.Supports(BuiltinIntrinsicSymbols.Comparison.Less, type) ||
-                !capabilityContext.Supports(BuiltinIntrinsicSymbols.Comparison.LessOrEqual, type))
-                return false;
-        }
+            (BuiltinIntrinsicSymbols.Comparison.Equal, [type]),
+            (BuiltinIntrinsicSymbols.Comparison.NotEqual, [type]),
+            (BuiltinIntrinsicSymbols.Comparison.Greater, [type]),
+            (BuiltinIntrinsicSymbols.Comparison.GreaterOrEqual, [type]),
+            (BuiltinIntrinsicSymbols.Comparison.Less, [type]),
+            (BuiltinIntrinsicSymbols.Comparison.LessOrEqual, [type])
+        });
 
-        return true;
+        return OptimizerCapabilityGuards.SupportsAll(capabilityContext, requirements);
     }
 
 

--- a/UniversalToolchain/Intrinsics/Capabilities/OptimizerCapabilityGuards.cs
+++ b/UniversalToolchain/Intrinsics/Capabilities/OptimizerCapabilityGuards.cs
@@ -1,0 +1,30 @@
+using UniversalToolchain.Intrinsics.Contracts;
+
+namespace UniversalToolchain.Intrinsics.Capabilities;
+
+public static class OptimizerCapabilityGuards
+{
+    public static bool SupportsAll(
+        IOptimizerIntrinsicCapabilityContext capabilityContext,
+        IEnumerable<(IntrinsicSymbol Symbol, Type[] TypeArguments)> requirements)
+    {
+        if (capabilityContext == null)
+            Thrower.ArgumentNull(nameof(capabilityContext));
+
+        if (requirements == null)
+            Thrower.ArgumentNull(nameof(requirements));
+
+        foreach (var requirement in requirements)
+        {
+            if (!capabilityContext.Supports(requirement.Symbol, requirement.TypeArguments))
+                return false;
+        }
+
+        return true;
+    }
+
+    public static bool SupportsAll(
+        IOptimizerIntrinsicCapabilityContext capabilityContext,
+        params (IntrinsicSymbol Symbol, Type[] TypeArguments)[] requirements)
+        => SupportsAll(capabilityContext, (IEnumerable<(IntrinsicSymbol Symbol, Type[] TypeArguments)>)requirements);
+}

--- a/UniversalToolchain/LocalVariablesOptimizerModule/LocalVariablesOptimizer.cs
+++ b/UniversalToolchain/LocalVariablesOptimizerModule/LocalVariablesOptimizer.cs
@@ -24,9 +24,11 @@ public class LocalVariablesOptimizer : IIRProcessingModule
         var capabilityContext = _capabilityContext
                                 ?? throw new InvalidOperationException("Local variables optimizer requires intrinsic capability context initialization.");
 
-        if (!capabilityContext.Supports(BuiltinIntrinsicSymbols.Storage.StoreLocal) ||
-            !capabilityContext.Supports(BuiltinIntrinsicSymbols.Storage.LoadLocal) ||
-            !capabilityContext.Supports(BuiltinIntrinsicSymbols.Storage.LoadLocalRef))
+        if (!OptimizerCapabilityGuards.SupportsAll(
+                capabilityContext,
+                (BuiltinIntrinsicSymbols.Storage.StoreLocal, []),
+                (BuiltinIntrinsicSymbols.Storage.LoadLocal, []),
+                (BuiltinIntrinsicSymbols.Storage.LoadLocalRef, [])))
             return current;
 
         var optimized = OptimizeVariables(current);

--- a/UniversalToolchain/NativeMathModule/ArithmeticOptimizerModule.cs
+++ b/UniversalToolchain/NativeMathModule/ArithmeticOptimizerModule.cs
@@ -15,9 +15,9 @@ public class ArithmeticOptimizerModule : IIRProcessingModule
 {
     // Lightweight e-graph-inspired symbolic simplifier for straight-line postfix IR.
     // This is intentionally not a full equality-saturation e-graph engine.
-    private static readonly IReadOnlyList<Type> _standardArithmeticTypes =
+    private static readonly IReadOnlyList<Type> _supportedArithmeticTypes =
     [
-        typeof(int), typeof(long), typeof(float), typeof(double)
+        typeof(int), typeof(long), typeof(float), typeof(double), typeof(decimal)
     ];
 
     private IOptimizerIntrinsicCapabilityContext? _capabilityContext;
@@ -31,7 +31,7 @@ public class ArithmeticOptimizerModule : IIRProcessingModule
         var capabilityContext = _capabilityContext
                                 ?? throw new InvalidOperationException("Arithmetic optimizer requires intrinsic capability context initialization.");
 
-        if (!HasRequiredCapabilities(capabilityContext, _standardArithmeticTypes))
+        if (!HasRequiredCapabilities(capabilityContext, _supportedArithmeticTypes))
             return current;
 
         current = OptimizeArithmetic(current);
@@ -40,16 +40,15 @@ public class ArithmeticOptimizerModule : IIRProcessingModule
 
     private static bool HasRequiredCapabilities(IOptimizerIntrinsicCapabilityContext capabilityContext, IReadOnlyList<Type> types)
     {
-        foreach (var type in types)
+        var requirements = types.SelectMany(type => new (IntrinsicSymbol Symbol, Type[] TypeArguments)[]
         {
-            if (!capabilityContext.Supports(BuiltinIntrinsicSymbols.Arithmetic.Add, type) ||
-                !capabilityContext.Supports(BuiltinIntrinsicSymbols.Arithmetic.Subtract, type) ||
-                !capabilityContext.Supports(BuiltinIntrinsicSymbols.Arithmetic.Multiply, type) ||
-                !capabilityContext.Supports(BuiltinIntrinsicSymbols.Arithmetic.Divide, type))
-                return false;
-        }
+            (BuiltinIntrinsicSymbols.Arithmetic.Add, [type]),
+            (BuiltinIntrinsicSymbols.Arithmetic.Subtract, [type]),
+            (BuiltinIntrinsicSymbols.Arithmetic.Multiply, [type]),
+            (BuiltinIntrinsicSymbols.Arithmetic.Divide, [type])
+        });
 
-        return true;
+        return OptimizerCapabilityGuards.SupportsAll(capabilityContext, requirements);
     }
 
     private IAbstractIR OptimizeArithmetic(IAbstractIR air)

--- a/UniversalToolchain/NativeMathModule/EGraphOptimizerModule.cs
+++ b/UniversalToolchain/NativeMathModule/EGraphOptimizerModule.cs
@@ -63,16 +63,16 @@ public class EGraphOptimizerModule : IIRProcessingModule
 
     private static bool HasRequiredCapabilities(IOptimizerIntrinsicCapabilityContext capabilityContext)
     {
-        foreach (var type in _supportedArithmeticTypes)
+        var requirements = _supportedArithmeticTypes.SelectMany(type => new (IntrinsicSymbol Symbol, Type[] TypeArguments)[]
         {
-            if (!capabilityContext.Supports(BuiltinIntrinsicSymbols.Arithmetic.Add, type) ||
-                !capabilityContext.Supports(BuiltinIntrinsicSymbols.Arithmetic.Subtract, type) ||
-                !capabilityContext.Supports(BuiltinIntrinsicSymbols.Arithmetic.Multiply, type) ||
-                !capabilityContext.Supports(BuiltinIntrinsicSymbols.Arithmetic.Divide, type))
-                return false;
-        }
+            (BuiltinIntrinsicSymbols.Arithmetic.Add, [type]),
+            (BuiltinIntrinsicSymbols.Arithmetic.Subtract, [type]),
+            (BuiltinIntrinsicSymbols.Arithmetic.Multiply, [type]),
+            (BuiltinIntrinsicSymbols.Arithmetic.Divide, [type]),
+            (BuiltinIntrinsicSymbols.Storage.LoadLocal, [type])
+        });
 
-        return true;
+        return OptimizerCapabilityGuards.SupportsAll(capabilityContext, requirements);
     }
 
     private static bool IsControlFlowTerminator(Instruction instruction) =>

--- a/UniversalToolchain/NativeMathModule/NativeCILOptimizerModule.cs
+++ b/UniversalToolchain/NativeMathModule/NativeCILOptimizerModule.cs
@@ -14,16 +14,7 @@ public class NativeCilOptimizerModule : IIRProcessingModule
     // Maps constants to typed load-constant intrinsics for backends that support them.
     private static readonly Dictionary<Type, Action<Instruction, CompilationContext>> _cilGenerators = new();
 
-    private static readonly IReadOnlyList<Type> _standardLoadTypes =
-    [
-        typeof(int),
-        typeof(long),
-        typeof(float),
-        typeof(double)
-    ];
-
-    // Supported native types for load-constant lowering.
-    private static readonly HashSet<Type> _supportedTypes =
+    private static readonly IReadOnlyList<Type> _supportedLoadTypes =
     [
         typeof(int),
         typeof(long),
@@ -33,8 +24,6 @@ public class NativeCilOptimizerModule : IIRProcessingModule
     ];
 
     private IOptimizerIntrinsicCapabilityContext? _capabilityContext;
-    private bool _isDecimalsSupported;
-
     static NativeCilOptimizerModule()
     {
         InitializeCilGenerators();
@@ -50,10 +39,10 @@ public class NativeCilOptimizerModule : IIRProcessingModule
         var capabilityContext = _capabilityContext
                                 ?? throw new InvalidOperationException("Native CIL optimizer requires intrinsic capability context initialization.");
 
-        if (!_standardLoadTypes.All(type => capabilityContext.Supports(BuiltinIntrinsicSymbols.Core.LoadConst, type)))
+        var requirements = _supportedLoadTypes
+            .Select(type => (BuiltinIntrinsicSymbols.Core.LoadConst, new[] { type }));
+        if (!OptimizerCapabilityGuards.SupportsAll(capabilityContext, requirements))
             return current;
-
-        _isDecimalsSupported = capabilityContext.Supports(BuiltinIntrinsicSymbols.Core.LoadConst, typeof(decimal));
 
         return OptimizeNativeLoads(current);
     }
@@ -120,13 +109,7 @@ public class NativeCilOptimizerModule : IIRProcessingModule
                 var value = instruction.Operands[0];
                 var valueType = value.GetType();
 
-                if (valueType == typeof(decimal) && !_isDecimalsSupported)
-                {
-                    context.NewInstructions.Add(instruction);
-                    continue;
-                }
-
-                if (_supportedTypes.Contains(valueType) && _cilGenerators.TryGetValue(valueType, out var generator))
+                if (_cilGenerators.TryGetValue(valueType, out var generator))
                 {
                     generator(instruction, context);
                     continue;

--- a/UniversalToolchain/Tests/Backends/InterpreterBackendOptimizerIntrinsicSurfaceTests.cs
+++ b/UniversalToolchain/Tests/Backends/InterpreterBackendOptimizerIntrinsicSurfaceTests.cs
@@ -1,0 +1,56 @@
+using Tests.Infrastructure;
+using UniversalToolchain.Intrinsics.Legacy;
+
+namespace Tests.Backends;
+
+[TestFixture]
+public sealed class InterpreterBackendOptimizerIntrinsicSurfaceTests
+{
+    private static readonly HashSet<string> SupportedInterpreterIntrinsics =
+    [
+        "call C#",
+        "call C# ctor",
+        "load_external",
+        "store_external"
+    ];
+
+    [Test]
+    public void InterpreterBackend_WithOptimizersEnabled_DoesNotContainBackendSpecificIntrinsics()
+    {
+        var dialect = """
+                      dialect Tiny
+                      use NativeTypes, BooleanConditions, ComparisonConditions, Conditions, Numbers, Scopes, Variables, Whitespaces
+                      backend interpreter
+                      enable ArithmeticOptimization
+                      enable BooleanOptimization
+                      enable ComparisonIntrinsicOptimization
+                      enable NativeCilOptimization
+                      enable LocalVariablesOptimization
+                      enable EGraphOptimization
+                      """;
+
+        using var host = DialectTestHostInfrastructure.CreateInterpreterHost(dialect);
+        var compiler = host.GetArtifactCompiler<IAbstractIR>("interpreter");
+        var artifact = compiler.Compile("(1 + 2) > 0 && true");
+
+        var intrinsicNames = CollectIntrinsicNames(artifact.CompilationOutput).ToArray();
+
+        Assert.That(intrinsicNames, Is.Not.Empty);
+        Assert.That(intrinsicNames.All(SupportedInterpreterIntrinsics.Contains), Is.True,
+            $"Interpreter IR contains unsupported intrinsic names: {string.Join(", ", intrinsicNames.Where(x => !SupportedInterpreterIntrinsics.Contains(x)).Distinct(StringComparer.Ordinal))}");
+    }
+
+    private static IEnumerable<string> CollectIntrinsicNames(IAbstractIR air)
+    {
+        foreach (var instruction in air.Instructions)
+        {
+            if (instruction.UOpCode != UOpCode.Intrinsic)
+                continue;
+
+            if (!IntrinsicInstructionLegacyProjector.TryProject(instruction, out var projectedInstruction))
+                Assert.Fail($"Failed to project intrinsic instruction to legacy form: {instruction}");
+
+            yield return (string)projectedInstruction.Operands[0];
+        }
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Modules.Tests/ModuleCoverage/TypedIntrinsicEmitterOptimizerTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Modules.Tests/ModuleCoverage/TypedIntrinsicEmitterOptimizerTests.cs
@@ -7,6 +7,7 @@ using ConditionsModule.Visitors;
 using IntermediateRepresentationAbstractions;
 using LocalVariablesOptimizerModule;
 using NativeMathModule;
+using SettableGettableModule.Core;
 using UniversalIntermediateRepresentation;
 using UniversalToolchain.Intrinsics.Builtins;
 using UniversalToolchain.Intrinsics.Capabilities;
@@ -19,46 +20,30 @@ namespace UniversalToolchain.Modules.Tests.ModuleCoverage;
 public sealed class TypedIntrinsicEmitterOptimizerTests
 {
     [Test]
-    public void BooleanOptimizer_EmitsTypedBooleanIntrinsic()
+    public void ArithmeticOptimizer_WhenCapabilityMissingDecimal_ReturnsInputUnchanged()
     {
         var optimizer = CreateOptimizer(
-            new BooleanOptimizerModule(),
-            (BuiltinIntrinsicSymbols.Boolean.And, null),
-            (BuiltinIntrinsicSymbols.Boolean.Or, null),
-            (BuiltinIntrinsicSymbols.Boolean.Not, null));
-        var method = typeof(BooleanVisitor.BooleanOperations).GetMethod(nameof(BooleanVisitor.BooleanOperations.Not), BindingFlags.Public | BindingFlags.Static);
+            new ArithmeticOptimizerModule(),
+            CreateArithmeticCapabilities(includeDecimal: false).ToArray());
+        var method = typeof(NativeArithmetic).GetMethod(nameof(NativeArithmetic.Add), BindingFlags.Public | BindingFlags.Static)?.MakeGenericMethod(typeof(int));
         Assert.That(method, Is.Not.Null);
 
         var input = CreateIr(
-            new Instruction(UOpCode.Intrinsic, ["load_local", "flag", typeof(bool)]),
+            new Instruction(UOpCode.Push, [2]),
+            new Instruction(UOpCode.Push, [3]),
             new Instruction(UOpCode.Intrinsic, ["call C#", method!]));
 
         var result = optimizer.ProcessIr(input, new FakeCompiler());
 
-        AssertTypedIntrinsic(result.Instructions[^1], BuiltinIntrinsicSymbols.Boolean.Not);
+        Assert.That(result, Is.SameAs(input));
     }
 
     [Test]
-    public void ArithmeticOptimizer_EmitsTypedArithmeticIntrinsic()
+    public void ArithmeticOptimizer_WhenCapabilitySupportsAllTypes_RewritesToTypedIntrinsic()
     {
         var optimizer = CreateOptimizer(
             new ArithmeticOptimizerModule(),
-            (BuiltinIntrinsicSymbols.Arithmetic.Add, typeof(int)),
-            (BuiltinIntrinsicSymbols.Arithmetic.Subtract, typeof(int)),
-            (BuiltinIntrinsicSymbols.Arithmetic.Multiply, typeof(int)),
-            (BuiltinIntrinsicSymbols.Arithmetic.Divide, typeof(int)),
-            (BuiltinIntrinsicSymbols.Arithmetic.Add, typeof(long)),
-            (BuiltinIntrinsicSymbols.Arithmetic.Subtract, typeof(long)),
-            (BuiltinIntrinsicSymbols.Arithmetic.Multiply, typeof(long)),
-            (BuiltinIntrinsicSymbols.Arithmetic.Divide, typeof(long)),
-            (BuiltinIntrinsicSymbols.Arithmetic.Add, typeof(float)),
-            (BuiltinIntrinsicSymbols.Arithmetic.Subtract, typeof(float)),
-            (BuiltinIntrinsicSymbols.Arithmetic.Multiply, typeof(float)),
-            (BuiltinIntrinsicSymbols.Arithmetic.Divide, typeof(float)),
-            (BuiltinIntrinsicSymbols.Arithmetic.Add, typeof(double)),
-            (BuiltinIntrinsicSymbols.Arithmetic.Subtract, typeof(double)),
-            (BuiltinIntrinsicSymbols.Arithmetic.Multiply, typeof(double)),
-            (BuiltinIntrinsicSymbols.Arithmetic.Divide, typeof(double)));
+            CreateArithmeticCapabilities(includeDecimal: true).ToArray());
         var method = typeof(NativeArithmetic).GetMethod(nameof(NativeArithmetic.Add), BindingFlags.Public | BindingFlags.Static)?.MakeGenericMethod(typeof(int));
         Assert.That(method, Is.Not.Null);
 
@@ -73,34 +58,68 @@ public sealed class TypedIntrinsicEmitterOptimizerTests
     }
 
     [Test]
-    public void ComparisonOptimizer_EmitsTypedComparisonIntrinsic()
+    public void BooleanOptimizer_WhenCapabilityIncomplete_ReturnsInputUnchanged()
     {
         var optimizer = CreateOptimizer(
-            new ComparisonIntrinsicOptimizerModule(),
-            (BuiltinIntrinsicSymbols.Comparison.Equal, typeof(int)),
-            (BuiltinIntrinsicSymbols.Comparison.NotEqual, typeof(int)),
-            (BuiltinIntrinsicSymbols.Comparison.Greater, typeof(int)),
-            (BuiltinIntrinsicSymbols.Comparison.GreaterOrEqual, typeof(int)),
-            (BuiltinIntrinsicSymbols.Comparison.Less, typeof(int)),
-            (BuiltinIntrinsicSymbols.Comparison.LessOrEqual, typeof(int)),
-            (BuiltinIntrinsicSymbols.Comparison.Equal, typeof(long)),
-            (BuiltinIntrinsicSymbols.Comparison.NotEqual, typeof(long)),
-            (BuiltinIntrinsicSymbols.Comparison.Greater, typeof(long)),
-            (BuiltinIntrinsicSymbols.Comparison.GreaterOrEqual, typeof(long)),
-            (BuiltinIntrinsicSymbols.Comparison.Less, typeof(long)),
-            (BuiltinIntrinsicSymbols.Comparison.LessOrEqual, typeof(long)),
-            (BuiltinIntrinsicSymbols.Comparison.Equal, typeof(float)),
-            (BuiltinIntrinsicSymbols.Comparison.NotEqual, typeof(float)),
-            (BuiltinIntrinsicSymbols.Comparison.Greater, typeof(float)),
-            (BuiltinIntrinsicSymbols.Comparison.GreaterOrEqual, typeof(float)),
-            (BuiltinIntrinsicSymbols.Comparison.Less, typeof(float)),
-            (BuiltinIntrinsicSymbols.Comparison.LessOrEqual, typeof(float)),
-            (BuiltinIntrinsicSymbols.Comparison.Equal, typeof(double)),
-            (BuiltinIntrinsicSymbols.Comparison.NotEqual, typeof(double)),
-            (BuiltinIntrinsicSymbols.Comparison.Greater, typeof(double)),
-            (BuiltinIntrinsicSymbols.Comparison.GreaterOrEqual, typeof(double)),
-            (BuiltinIntrinsicSymbols.Comparison.Less, typeof(double)),
-            (BuiltinIntrinsicSymbols.Comparison.LessOrEqual, typeof(double)));
+            new BooleanOptimizerModule(),
+            (BuiltinIntrinsicSymbols.Boolean.And, null),
+            (BuiltinIntrinsicSymbols.Boolean.Or, null));
+        var method = typeof(BooleanVisitor.BooleanOperations).GetMethod(nameof(BooleanVisitor.BooleanOperations.Not), BindingFlags.Public | BindingFlags.Static);
+        Assert.That(method, Is.Not.Null);
+
+        var input = CreateIr(
+            new Instruction(UOpCode.Intrinsic, ["load_local", "flag", typeof(bool)]),
+            new Instruction(UOpCode.Intrinsic, ["call C#", method!]));
+
+        var result = optimizer.ProcessIr(input, new FakeCompiler());
+
+        Assert.That(result, Is.SameAs(input));
+    }
+
+    [Test]
+    public void BooleanOptimizer_WhenCapabilitySupportsFamily_RewritesToTypedIntrinsic()
+    {
+        var optimizer = CreateOptimizer(
+            new BooleanOptimizerModule(),
+            (BuiltinIntrinsicSymbols.Boolean.And, null),
+            (BuiltinIntrinsicSymbols.Boolean.Or, null),
+            (BuiltinIntrinsicSymbols.Boolean.Not, null));
+        var method = typeof(BooleanVisitor.BooleanOperations).GetMethod(nameof(BooleanVisitor.BooleanOperations.Not), BindingFlags.Public | BindingFlags.Static);
+        Assert.That(method, Is.Not.Null);
+
+        var input = CreateIr(
+            new Instruction(UOpCode.Push, [true]),
+            new Instruction(UOpCode.Intrinsic, ["call C#", method!]));
+
+        var result = optimizer.ProcessIr(input, new FakeCompiler());
+
+        Assert.That(BuiltinIntrinsicInstruction.Is(result.Instructions[^1], BuiltinIntrinsicSymbols.Boolean.Not), Is.True);
+    }
+
+    [Test]
+    public void ComparisonOptimizer_WhenCapabilityIncomplete_ReturnsInputUnchanged()
+    {
+        var capability = CreateComparisonCapabilities();
+        capability.Remove((BuiltinIntrinsicSymbols.Comparison.Less, typeof(double)));
+
+        var optimizer = CreateOptimizer(new ComparisonIntrinsicOptimizerModule(), capability.ToArray());
+        var method = typeof(Comparisons).GetMethod(nameof(Comparisons.Less), BindingFlags.Public | BindingFlags.Static)?.MakeGenericMethod(typeof(int));
+        Assert.That(method, Is.Not.Null);
+
+        var input = CreateIr(
+            new Instruction(UOpCode.Push, [1]),
+            new Instruction(UOpCode.Push, [2]),
+            new Instruction(UOpCode.Intrinsic, ["call C#", method!]));
+
+        var result = optimizer.ProcessIr(input, new FakeCompiler());
+
+        Assert.That(result, Is.SameAs(input));
+    }
+
+    [Test]
+    public void ComparisonOptimizer_WhenCapabilitySupportsFamily_RewritesToTypedIntrinsic()
+    {
+        var optimizer = CreateOptimizer(new ComparisonIntrinsicOptimizerModule(), CreateComparisonCapabilities().ToArray());
         var method = typeof(Comparisons).GetMethod(nameof(Comparisons.Less), BindingFlags.Public | BindingFlags.Static)?.MakeGenericMethod(typeof(int));
         Assert.That(method, Is.Not.Null);
 
@@ -115,7 +134,7 @@ public sealed class TypedIntrinsicEmitterOptimizerTests
     }
 
     [Test]
-    public void NativeCilOptimizer_EmitsTypedLoadConstIntrinsic()
+    public void NativeCilOptimizer_WhenCapabilityMissingDecimal_ReturnsInputUnchanged()
     {
         var optimizer = CreateOptimizer(
             new NativeCilOptimizerModule(),
@@ -123,15 +142,70 @@ public sealed class TypedIntrinsicEmitterOptimizerTests
             (BuiltinIntrinsicSymbols.Core.LoadConst, typeof(long)),
             (BuiltinIntrinsicSymbols.Core.LoadConst, typeof(float)),
             (BuiltinIntrinsicSymbols.Core.LoadConst, typeof(double)));
+
         var input = CreateIr(new Instruction(UOpCode.Push, [1.5d]));
 
         var result = optimizer.ProcessIr(input, new FakeCompiler());
 
-        AssertTypedIntrinsic(
-            result.Instructions[0],
-            BuiltinIntrinsicSymbols.Core.LoadConst,
-            typeof(double),
-            1.5d);
+        Assert.That(result, Is.SameAs(input));
+    }
+
+    [Test]
+    public void NativeCilOptimizer_WhenCapabilitySupportsAllLoadConstTypes_RewritesToTypedIntrinsic()
+    {
+        var optimizer = CreateOptimizer(
+            new NativeCilOptimizerModule(),
+            (BuiltinIntrinsicSymbols.Core.LoadConst, typeof(int)),
+            (BuiltinIntrinsicSymbols.Core.LoadConst, typeof(long)),
+            (BuiltinIntrinsicSymbols.Core.LoadConst, typeof(float)),
+            (BuiltinIntrinsicSymbols.Core.LoadConst, typeof(double)),
+            (BuiltinIntrinsicSymbols.Core.LoadConst, typeof(decimal)));
+
+        var input = CreateIr(new Instruction(UOpCode.Push, [1.5d]));
+
+        var result = optimizer.ProcessIr(input, new FakeCompiler());
+
+        AssertTypedIntrinsic(result.Instructions[0], BuiltinIntrinsicSymbols.Core.LoadConst, typeof(double), 1.5d);
+    }
+
+    [Test]
+    public void LocalVariablesOptimizer_WhenCapabilityMissingLoadLocalRef_ReturnsInputUnchanged()
+    {
+        var optimizer = CreateOptimizer(
+            new LocalVariablesOptimizer(),
+            (BuiltinIntrinsicSymbols.Storage.LoadLocal, null),
+            (BuiltinIntrinsicSymbols.Storage.StoreLocal, null));
+        var method = typeof(VariablesContainer<int>)
+            .GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static)
+            .FirstOrDefault(x => x.Name == nameof(VariablesContainer<int>.Get) &&
+                                 x.GetParameters().Length == 1 &&
+                                 x.GetParameters()[0].ParameterType == typeof(string));
+        Assert.That(method, Is.Not.Null);
+
+        var input = CreateIr(
+            new Instruction(UOpCode.Push, ["x"]),
+            new Instruction(UOpCode.Intrinsic, ["call C#", method!]));
+
+        var result = optimizer.ProcessIr(input, new FakeCompiler());
+
+        Assert.That(result, Is.SameAs(input));
+    }
+
+    [Test]
+    public void EGraphOptimizer_WhenCapabilityMissingLoadLocal_ReturnsInputUnchanged()
+    {
+        var optimizer = CreateOptimizer(
+            new EGraphOptimizerModule(),
+            CreateArithmeticCapabilities(includeDecimal: false).ToArray());
+
+        var input = CreateIr(
+            BuiltinIntrinsicInstruction.Create(BuiltinIntrinsicSymbols.Storage.LoadLocal, typeof(int), ["x", typeof(int)]),
+            new Instruction(UOpCode.Push, [0]),
+            BuiltinIntrinsicInstruction.Create(BuiltinIntrinsicSymbols.Arithmetic.Add, typeof(int)));
+
+        var result = optimizer.ProcessIr(input, new FakeCompiler());
+
+        Assert.That(result, Is.SameAs(input));
     }
 
     private static TOptimizer CreateOptimizer<TOptimizer>(
@@ -141,6 +215,51 @@ public sealed class TypedIntrinsicEmitterOptimizerTests
     {
         optimizer.InitIntrinsicCapabilityContext(new OptimizerIntrinsicCapabilityContext(new FakeCapabilitySet(supportedIntrinsics)));
         return optimizer;
+    }
+
+    private static HashSet<(IntrinsicSymbol Symbol, Type? RuntimeType)> CreateArithmeticCapabilities(bool includeDecimal)
+    {
+        var supported = new HashSet<(IntrinsicSymbol Symbol, Type? RuntimeType)>();
+        var types = new[] { typeof(int), typeof(long), typeof(float), typeof(double) };
+
+        foreach (var type in types)
+        {
+            supported.Add((BuiltinIntrinsicSymbols.Arithmetic.Add, type));
+            supported.Add((BuiltinIntrinsicSymbols.Arithmetic.Subtract, type));
+            supported.Add((BuiltinIntrinsicSymbols.Arithmetic.Multiply, type));
+            supported.Add((BuiltinIntrinsicSymbols.Arithmetic.Divide, type));
+        }
+
+        if (includeDecimal)
+        {
+            supported.Add((BuiltinIntrinsicSymbols.Arithmetic.Add, typeof(decimal)));
+            supported.Add((BuiltinIntrinsicSymbols.Arithmetic.Subtract, typeof(decimal)));
+            supported.Add((BuiltinIntrinsicSymbols.Arithmetic.Multiply, typeof(decimal)));
+            supported.Add((BuiltinIntrinsicSymbols.Arithmetic.Divide, typeof(decimal)));
+        }
+
+        return supported;
+    }
+
+    private static HashSet<(IntrinsicSymbol Symbol, Type? RuntimeType)> CreateComparisonCapabilities()
+    {
+        var supported = new HashSet<(IntrinsicSymbol Symbol, Type? RuntimeType)>();
+        var symbols = new[]
+        {
+            BuiltinIntrinsicSymbols.Comparison.Equal,
+            BuiltinIntrinsicSymbols.Comparison.NotEqual,
+            BuiltinIntrinsicSymbols.Comparison.Greater,
+            BuiltinIntrinsicSymbols.Comparison.GreaterOrEqual,
+            BuiltinIntrinsicSymbols.Comparison.Less,
+            BuiltinIntrinsicSymbols.Comparison.LessOrEqual
+        };
+        var types = new[] { typeof(int), typeof(long), typeof(float), typeof(double) };
+
+        foreach (var type in types)
+        foreach (var symbol in symbols)
+            supported.Add((symbol, type));
+
+        return supported;
     }
 
     private static void AssertTypedIntrinsic(


### PR DESCRIPTION
### Motivation

- Prevent backend-specific typed intrinsics from reaching the interpreter path by enforcing strict capability gating inside optimizers rather than adding interpreter support. 
- Centralize the capability-checking logic to avoid copy-paste and ensure deterministic behavior: if a backend does not fully support every intrinsic an optimizer could emit, the optimizer must leave IR unchanged. 
- Preserve existing compiler/projector bridges for typed -> legacy projection in compiler and dialect policy, while keeping the interpreter runtime narrow (only the 4 allowed core intrinsics). 

### Description

- Added a small, explicit helper `OptimizerCapabilityGuards.SupportsAll(...)` for optimizer gating (new file `UniversalToolchain/Intrinsics/Capabilities/OptimizerCapabilityGuards.cs`).
- Reworked optimizer capability checks to use the helper and made gates strict in the following modules so they return the unmodified IR unless the backend supports the entire emitted family:
  - `ArithmeticOptimizerModule` now requires Add/Subtract/Multiply/Divide for all supported types (including `decimal`). (`UniversalToolchain/NativeMathModule/ArithmeticOptimizerModule.cs`) 
  - `BooleanOptimizerModule` requires And/Or/Not together. (`UniversalToolchain/ConditionsModule/Optimizers/BooleanOptimizer.cs`) 
  - `ComparisonIntrinsicOptimizerModule` requires all comparison symbols for all supported numeric types. (`UniversalToolchain/ConditionsModule/Optimizers/ComparisonIntrinsicOptimizerModule.cs`) 
  - `NativeCILOptimizerModule` gates load-constant lowering on `Core.LoadConst<T>` for every concrete type the module can emit (including decimal) and no longer does partial/best-effort lowering. (`UniversalToolchain/NativeMathModule/NativeCILOptimizerModule.cs`) 
  - `LocalVariablesOptimizer` requires support for `StoreLocal`, `LoadLocal`, and `LoadLocalRef` before rewriting. (`UniversalToolchain/LocalVariablesOptimizerModule/LocalVariablesOptimizer.cs`) 
  - `EGraphOptimizerModule` gating expanded to require arithmetic family plus `Storage.LoadLocal<T>` for relevant types. (`UniversalToolchain/NativeMathModule/EGraphOptimizerModule.cs`) 
- Tests: updated and added tests that assert optimizer gating semantics and interpreter-surface regression:
  - Expanded/updated `TypedIntrinsicEmitterOptimizerTests` to include negative cases (when capability is missing the optimizer must return input unchanged) and positive cases (when capability is complete the rewrite happens). (`UniversalToolchain/UniversalToolchain.Modules.Tests/ModuleCoverage/TypedIntrinsicEmitterOptimizerTests.cs`) 
  - Added an interpreter-path regression test `InterpreterBackendOptimizerIntrinsicSurfaceTests` that composes a dialect with many optimizers enabled, compiles for the interpreter backend and asserts the final IR contains only interpreter-supported legacy intrinsics (`call C#`, `call C# ctor`, `load_external`, `store_external`) after projection. (`UniversalToolchain/Tests/Backends/InterpreterBackendOptimizerIntrinsicSurfaceTests.cs`) 
- Did not add any interpreter execution support for arithmetic/comparison/boolean/storage/load_const intrinsics; interpreter dispatch logic in `BasicInterpreter/InterpreterImpl.cs` remains deterministic and still supports only the four allowed intrinsics (projector remains as a normalization step). 

### Testing

- Ran `dotnet restore UniversalToolchain/Wist.sln` successfully to restore packages and projects. 
- Ran focused module tests and fixes iteratively: executed and iterated on `TypedIntrinsicEmitterOptimizerTests` and related module coverage tests under `UniversalToolchain.Modules.Tests` and adjusted tests/fixes until the optimizer gating scenarios (both negative and positive) behaved as expected (focused test runs exercised the new guards and passed after fixes). 
- Ran broader suites (`dotnet test` for `UniversalToolchain/Tests`, `UniversalToolchain/UniversalToolchain.Dialects.Tests`, and `UniversalToolchain/UniversalToolchain.Modules.Tests`) in this environment; those runs exposed pre-existing unrelated failures (dialect startup/duplicate annotations and other baseline instability) so full suites are not all green here and the failing tests appear to be outside the scope of the optimizer-gating changes.

Notes: the change intentionally preserves existing typed->legacy projection in the compiler/policy paths and keeps the interpreter runtime narrow and deterministic; the PR concentrates on preventing backend-specific intrinsics from being emitted on backends that do not advertise full support for them.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7661ddfd08324960949fd08dab324)