### PR TITLE
Unify intrinsic normalization path and route interpreter intrinsics through shared executor

### DIFF
--- a/UniversalToolchain/BasicInterpreter/InterpreterImpl.cs
+++ b/UniversalToolchain/BasicInterpreter/InterpreterImpl.cs
@@ -1,9 +1,9 @@
-using UniversalToolchain.Intrinsics.Legacy;
-
 namespace BasicInterpreter;
 
 public class InterpreterImpl : IExecutor<IAbstractIR>
 {
+    private readonly InterpreterIntrinsicExecutor _intrinsicExecutor = new();
+
     public object? Execute(IAbstractIR air, IExecutionEnvironment environment)
     {
         var state = new InterpreterState
@@ -37,8 +37,10 @@ public class InterpreterImpl : IExecutor<IAbstractIR>
             }
         }
 
-        if (state.ValueStack.Count == 0) return null!;
-        return state.ValueStack.Count != 0 ? state.ValueStack.Peek() : null;
+        if (state.ValueStack.Count == 0)
+            return null;
+
+        return state.ValueStack.Peek();
     }
 
     private void ExecuteInstruction(Instruction instruction, InterpreterState state)
@@ -81,10 +83,8 @@ public class InterpreterImpl : IExecutor<IAbstractIR>
                 }
                 break;
             case UOpCode.Label:
-                // Label - do nothing, just skip
                 break;
             case UOpCode.Annotate:
-                // Annotation - do nothing
                 break;
             case UOpCode.Intrinsic:
                 ExecuteIntrinsic(instruction, state);
@@ -97,150 +97,6 @@ public class InterpreterImpl : IExecutor<IAbstractIR>
 
     private void ExecuteIntrinsic(Instruction instruction, InterpreterState state)
     {
-        if (!IntrinsicInstructionLegacyProjector.TryProject(instruction, out var projectedInstruction))
-            Thrower.InvalidOpEx($"Unknown intrinsic call payload: {instruction}.");
-
-        var intrinsicName = projectedInstruction.Operands[0].Get<string>();
-        if (intrinsicName == "call C#")
-            ExecuteCSharpCall(projectedInstruction, state);
-        else if (intrinsicName == "call C# ctor")
-            ExecuteCSharpConstructor(projectedInstruction, state);
-        else if (intrinsicName == "load_external")
-            ExecuteLoadExternal(projectedInstruction, state);
-        else if (intrinsicName == "store_external")
-            ExecuteStoreExternal(projectedInstruction, state);
-        else
-            Thrower.InvalidOpEx($"Unknown intrinsic call: {intrinsicName}.");
-    }
-
-    private static void ExecuteLoadExternal(Instruction instruction, InterpreterState state)
-    {
-        var slot = instruction.Operands[1].Get<int>();
-        var value = state.ExecutionEnvironment.NotNull().GetExternalValue(slot);
-        state.ValueStack.Push(value!);
-    }
-
-    private static void ExecuteStoreExternal(Instruction instruction, InterpreterState state)
-    {
-        if (state.ValueStack.Count == 0)
-            Thrower.InvalidOpEx("Cannot store external value: stack is empty.");
-
-        var slot = instruction.Operands[1].Get<int>();
-        var value = state.ValueStack.Pop();
-        state.ExecutionEnvironment.NotNull().SetExternalValue(slot, value);
-    }
-
-
-    private static bool IsVariablesContainerGet(MethodInfo method)
-    {
-        var declaringType = method.DeclaringType;
-        return declaringType != null
-               && declaringType.IsGenericType
-               && declaringType.GetGenericTypeDefinition().FullName == "SettableGettableModule.Core.VariablesContainer`1"
-               && method.Name == "Get"
-               && method.GetParameters().Length == 1
-               && method.GetParameters()[0].ParameterType == typeof(string);
-    }
-
-    private static bool TryResolveDeclaredExternalSlot(
-        InterpreterState state,
-        object?[] args,
-        out int slot)
-    {
-        slot = default;
-        if (args.Length != 1 || args[0] is not string key)
-            return false;
-
-        // Only declared layout metadata can mark a symbol as external.
-        // Runtime call observation must not infer local/external symbol class.
-        return state.ExternalBindingsLayout?.SlotsByName.TryGetValue(key, out slot) == true;
-    }
-
-    private void ExecuteCSharpCall(Instruction instruction, InterpreterState state)
-    {
-        var method = instruction.Operands[1].Get<MethodInfo>();
-
-        var parameters = method.GetParameters();
-        var args = new object?[parameters.Length];
-        var argsTypes = new Type[parameters.Length];
-
-        for (var i = parameters.Length - 1; i >= 0; i--)
-        {
-            if (state.ValueStack.Count == 0)
-                Thrower.InvalidOpEx("Cannot call method: not enough arguments on the interpreter stack.");
-
-            var value = state.ValueStack.Pop();
-            args[i] = value;
-            argsTypes[i] = value?.GetType() ?? typeof(object);
-        }
-
-        if (IsVariablesContainerGet(method)
-            && TryResolveDeclaredExternalSlot(state, args, out var slot))
-        {
-            var value = state.ExecutionEnvironment.NotNull().GetExternalValue(slot);
-            state.ValueStack.Push(value!);
-            return;
-        }
-
-        // Use the same logic as in compiler.
-        var stackTypes = argsTypes.AsReadOnly().ToList();
-        var targetTypes = GenericTypeResolver.GetParameterTypes(method, stackTypes).ToList();
-
-        for (var i = 0; i < args.Length; i++)
-        {
-            if (args[i]?.GetType() == targetTypes[i])
-                continue;
-
-            try
-            {
-                args[i] = Convert.ChangeType(args[i], targetTypes[i]);
-            }
-            catch
-            {
-                // If conversion fails, keep the original value.
-                // Method invocation will raise a meaningful exception if needed.
-            }
-        }
-
-        // Create closed generic method when needed, using the same logic as compiler backend.
-        method = GenericTypeResolver.MakeGenericMethod(method, targetTypes.ToArray());
-
-        object result;
-        if (method.IsStatic)
-        {
-            result = method.Invoke(null, args) ?? new object();
-        }
-        else
-        {
-            // For instance methods the target instance must be on stack before arguments.
-            if (state.ValueStack.Count == 0)
-                Thrower.InvalidOpEx("Cannot call instance method: object instance is missing on the interpreter stack.");
-
-            var instance = state.ValueStack.Pop();
-            result = method.Invoke(instance, args) ?? new object();
-        }
-
-        if (method.ReturnType != typeof(void))
-            state.ValueStack.Push(result);
-    }
-
-    private void ExecuteCSharpConstructor(Instruction instruction, InterpreterState state)
-    {
-        var ctor = instruction.Operands[1].Get<ConstructorInfo>();
-        var parameters = ctor.GetParameters();
-
-        var args = new object[parameters.Length];
-
-        for (var i = parameters.Length - 1; i >= 0; i--)
-        {
-            if (state.ValueStack.Count == 0)
-                Thrower.InvalidOpEx("Cannot call constructor: not enough arguments on the interpreter stack.");
-
-            args[i] = state.ValueStack.Pop();
-        }
-
-        var instance = ctor.Invoke(args);
-
-        state.ValueStack.Push(instance);
+        _intrinsicExecutor.Execute(instruction, state);
     }
 }

--- a/UniversalToolchain/BasicInterpreter/InterpreterIntrinsicExecutor.cs
+++ b/UniversalToolchain/BasicInterpreter/InterpreterIntrinsicExecutor.cs
@@ -1,0 +1,388 @@
+using UniversalToolchain.Intrinsics.Core;
+
+namespace BasicInterpreter;
+
+internal sealed class InterpreterIntrinsicExecutor
+{
+    private sealed class LocalReference(string name, Type type)
+    {
+        public string Name { get; } = name;
+        public Type Type { get; } = type;
+    }
+
+    public void Execute(Instruction instruction, InterpreterState state)
+    {
+        var normalizedInstruction = IntrinsicInstructionNormalizer.NormalizeOrThrow(instruction);
+        var intrinsicName = normalizedInstruction.Operands[0].Get<string>();
+
+        if (intrinsicName == "call C#")
+        {
+            ExecuteCallCSharp(normalizedInstruction, state);
+            return;
+        }
+
+        if (intrinsicName == "call C# ctor")
+        {
+            ExecuteCallCSharpCtor(normalizedInstruction, state);
+            return;
+        }
+
+        if (intrinsicName == "load_bool")
+        {
+            ExecuteLoadBool(normalizedInstruction, state);
+            return;
+        }
+
+        if (intrinsicName == "boolean_and")
+        {
+            ExecuteBooleanAnd(state);
+            return;
+        }
+
+        if (intrinsicName == "boolean_or")
+        {
+            ExecuteBooleanOr(state);
+            return;
+        }
+
+        if (intrinsicName == "boolean_not")
+        {
+            ExecuteBooleanNot(state);
+            return;
+        }
+
+        if (intrinsicName == "load_external")
+        {
+            ExecuteLoadExternal(normalizedInstruction, state);
+            return;
+        }
+
+        if (intrinsicName == "store_external")
+        {
+            ExecuteStoreExternal(normalizedInstruction, state);
+            return;
+        }
+
+        if (intrinsicName == "load_local")
+        {
+            ExecuteLoadLocal(normalizedInstruction, state);
+            return;
+        }
+
+        if (intrinsicName == "store_local")
+        {
+            ExecuteStoreLocal(normalizedInstruction, state);
+            return;
+        }
+
+        if (intrinsicName == "load_local_ref")
+        {
+            ExecuteLoadLocalRef(normalizedInstruction, state);
+            return;
+        }
+
+        if (intrinsicName.StartsWith("load_", StringComparison.Ordinal))
+        {
+            ExecuteLoadNativeNumber(normalizedInstruction, state);
+            return;
+        }
+
+        if (intrinsicName.StartsWith("add_", StringComparison.Ordinal)
+            || intrinsicName.StartsWith("sub_", StringComparison.Ordinal)
+            || intrinsicName.StartsWith("mul_", StringComparison.Ordinal)
+            || intrinsicName.StartsWith("div_", StringComparison.Ordinal))
+        {
+            ExecuteArithmeticIntrinsic(normalizedInstruction, state);
+            return;
+        }
+
+        if (intrinsicName.StartsWith("cmp_", StringComparison.Ordinal))
+        {
+            ExecuteComparisonIntrinsic(normalizedInstruction, state);
+            return;
+        }
+
+        Thrower.InvalidOpEx($"Unknown intrinsic call: {intrinsicName}.");
+    }
+
+    private void ExecuteCallCSharp(Instruction instruction, InterpreterState state)
+    {
+        var method = instruction.Operands[1].Get<MethodInfo>();
+        var parameters = method.GetParameters();
+        var args = new object?[parameters.Length];
+        var argTypes = new Type[parameters.Length];
+        var byRefTargets = new Dictionary<int, LocalReference>();
+
+        for (var i = parameters.Length - 1; i >= 0; i--)
+        {
+            if (state.ValueStack.Count == 0)
+                Thrower.InvalidOpEx("Cannot call method: not enough arguments on the interpreter stack.");
+
+            var value = state.ValueStack.Pop();
+            if (parameters[i].ParameterType.IsByRef)
+            {
+                if (value is not LocalReference localReference)
+                {
+                    Thrower.InvalidOpEx("By-ref call requires local reference operand.");
+                    return;
+                }
+
+                var byRefType = parameters[i].ParameterType.GetElementType().NotNull();
+                args[i] = state.GetLocalValue(localReference.Name, byRefType);
+                argTypes[i] = byRefType;
+                byRefTargets[i] = localReference;
+                continue;
+            }
+
+            args[i] = value;
+            argTypes[i] = value?.GetType() ?? typeof(object);
+        }
+
+        if (IsVariablesContainerGet(method)
+            && TryResolveDeclaredExternalSlot(state, args, out var externalSlot))
+        {
+            var externalValue = state.ExecutionEnvironment.NotNull().GetExternalValue(externalSlot);
+            state.ValueStack.Push(externalValue.NotNull());
+            return;
+        }
+
+        var stackTypes = argTypes.AsReadOnly().ToList();
+        var targetTypes = GenericTypeResolver.GetParameterTypes(method, stackTypes).ToList();
+
+        for (var i = 0; i < args.Length; i++)
+        {
+            if (args[i] == null || targetTypes[i] == args[i]!.GetType() || targetTypes[i].IsByRef)
+                continue;
+
+            args[i] = ConvertValue(args[i]!, targetTypes[i]);
+        }
+
+        method = GenericTypeResolver.MakeGenericMethod(method, targetTypes.ToArray());
+
+        object? result;
+        if (method.IsStatic)
+        {
+            result = method.Invoke(null, args);
+        }
+        else
+        {
+            if (state.ValueStack.Count == 0)
+                Thrower.InvalidOpEx("Cannot call instance method: object instance is missing on the interpreter stack.");
+
+            var instance = state.ValueStack.Pop();
+            result = method.Invoke(instance, args);
+        }
+
+        foreach (var (index, localReference) in byRefTargets)
+            state.SetLocalValue(localReference.Name, args[index]);
+
+        if (method.ReturnType != typeof(void))
+            state.ValueStack.Push(result.NotNull());
+    }
+
+    private static bool IsVariablesContainerGet(MethodInfo method)
+    {
+        var declaringType = method.DeclaringType;
+        return declaringType != null
+               && declaringType.IsGenericType
+               && declaringType.GetGenericTypeDefinition().FullName == "SettableGettableModule.Core.VariablesContainer`1"
+               && method.Name == "Get"
+               && method.GetParameters().Length == 1
+               && method.GetParameters()[0].ParameterType == typeof(string);
+    }
+
+    private static bool TryResolveDeclaredExternalSlot(
+        InterpreterState state,
+        object?[] args,
+        out int slot)
+    {
+        slot = default;
+
+        if (args.Length != 1 || args[0] is not string key)
+            return false;
+
+        return state.ExternalBindingsLayout?.SlotsByName.TryGetValue(key, out slot) == true;
+    }
+
+    private static object? ConvertValue(object value, Type targetType)
+    {
+        try
+        {
+            return Convert.ChangeType(value, targetType);
+        }
+        catch
+        {
+            return value;
+        }
+    }
+
+    private void ExecuteCallCSharpCtor(Instruction instruction, InterpreterState state)
+    {
+        var ctor = instruction.Operands[1].Get<ConstructorInfo>();
+        var parameters = ctor.GetParameters();
+        var args = new object[parameters.Length];
+
+        for (var i = parameters.Length - 1; i >= 0; i--)
+        {
+            if (state.ValueStack.Count == 0)
+                Thrower.InvalidOpEx("Cannot call constructor: not enough arguments on the interpreter stack.");
+
+            args[i] = state.ValueStack.Pop();
+        }
+
+        var instance = ctor.Invoke(args);
+        state.ValueStack.Push(instance.NotNull());
+    }
+
+    private static void ExecuteLoadBool(Instruction instruction, InterpreterState state)
+    {
+        state.ValueStack.Push(instruction.Operands[1].Get<bool>());
+    }
+
+    private static void ExecuteLoadNativeNumber(Instruction instruction, InterpreterState state)
+    {
+        state.ValueStack.Push(instruction.Operands[1]);
+    }
+
+    private static void ExecuteBooleanAnd(InterpreterState state)
+    {
+        var right = Pop<bool>(state);
+        var left = Pop<bool>(state);
+        state.ValueStack.Push(left && right);
+    }
+
+    private static void ExecuteBooleanOr(InterpreterState state)
+    {
+        var right = Pop<bool>(state);
+        var left = Pop<bool>(state);
+        state.ValueStack.Push(left || right);
+    }
+
+    private static void ExecuteBooleanNot(InterpreterState state)
+    {
+        state.ValueStack.Push(!Pop<bool>(state));
+    }
+
+    private static void ExecuteArithmeticIntrinsic(Instruction instruction, InterpreterState state)
+    {
+        var name = instruction.Operands[0].Get<string>();
+        var operation = name.Split('_')[0];
+
+        if (name.EndsWith("_decimal", StringComparison.Ordinal))
+        {
+            var rightDecimal = Pop<decimal>(state);
+            var leftDecimal = Pop<decimal>(state);
+            var decimalResult = operation switch
+            {
+                "add" => decimal.Add(leftDecimal, rightDecimal),
+                "sub" => decimal.Subtract(leftDecimal, rightDecimal),
+                "mul" => decimal.Multiply(leftDecimal, rightDecimal),
+                "div" => decimal.Divide(leftDecimal, rightDecimal),
+                _ => Thrower.InvalidOpEx<decimal>($"Unknown arithmetic intrinsic '{name}'.")
+            };
+            state.ValueStack.Push(decimalResult);
+            return;
+        }
+
+        var numericType = GetNumericType(name);
+        var rightValue = Convert.ChangeType(state.ValueStack.Pop(), numericType);
+        var leftValue = Convert.ChangeType(state.ValueStack.Pop(), numericType);
+
+        dynamic right = rightValue.NotNull();
+        dynamic left = leftValue.NotNull();
+
+        object result = operation switch
+        {
+            "add" => left + right,
+            "sub" => left - right,
+            "mul" => left * right,
+            "div" => left / right,
+            _ => Thrower.InvalidOpEx<object>($"Unknown arithmetic intrinsic '{name}'.")
+        };
+
+        state.ValueStack.Push(result);
+    }
+
+    private static void ExecuteComparisonIntrinsic(Instruction instruction, InterpreterState state)
+    {
+        var name = instruction.Operands[0].Get<string>();
+        var operation = name.Split('_')[1];
+
+        var operandType = GetNumericType(name);
+        dynamic right = Convert.ChangeType(state.ValueStack.Pop(), operandType).NotNull();
+        dynamic left = Convert.ChangeType(state.ValueStack.Pop(), operandType).NotNull();
+
+        var result = operation switch
+        {
+            "eq" => left == right,
+            "ne" => left != right,
+            "gt" => left > right,
+            "ge" => left >= right,
+            "lt" => left < right,
+            "le" => left <= right,
+            _ => Thrower.InvalidOpEx<bool>($"Unknown comparison intrinsic '{name}'.")
+        };
+
+        state.ValueStack.Push(result);
+    }
+
+    private static Type GetNumericType(string intrinsicName)
+    {
+        if (intrinsicName.EndsWith("_i32", StringComparison.Ordinal))
+            return typeof(int);
+        if (intrinsicName.EndsWith("_i64", StringComparison.Ordinal))
+            return typeof(long);
+        if (intrinsicName.EndsWith("_f32", StringComparison.Ordinal))
+            return typeof(float);
+        if (intrinsicName.EndsWith("_f64", StringComparison.Ordinal))
+            return typeof(double);
+        if (intrinsicName.EndsWith("_decimal", StringComparison.Ordinal))
+            return typeof(decimal);
+
+        return Thrower.InvalidOpEx<Type>($"Unknown intrinsic numeric type in '{intrinsicName}'.");
+    }
+
+    private static void ExecuteLoadExternal(Instruction instruction, InterpreterState state)
+    {
+        var slot = instruction.Operands[1].Get<int>();
+        var value = state.ExecutionEnvironment.NotNull().GetExternalValue(slot);
+        state.ValueStack.Push(value.NotNull());
+    }
+
+    private static void ExecuteStoreExternal(Instruction instruction, InterpreterState state)
+    {
+        var slot = instruction.Operands[1].Get<int>();
+        var value = state.ValueStack.Pop();
+        state.ExecutionEnvironment.NotNull().SetExternalValue(slot, value);
+    }
+
+    private static void ExecuteLoadLocal(Instruction instruction, InterpreterState state)
+    {
+        var name = instruction.Operands[1].Get<string>();
+        var type = instruction.Operands[2].Get<Type>();
+        state.ValueStack.Push(state.GetLocalValue(name, type));
+    }
+
+    private static void ExecuteStoreLocal(Instruction instruction, InterpreterState state)
+    {
+        var name = instruction.Operands[1].Get<string>();
+        var value = state.ValueStack.Pop();
+        state.SetLocalValue(name, value);
+    }
+
+    private static void ExecuteLoadLocalRef(Instruction instruction, InterpreterState state)
+    {
+        var name = instruction.Operands[1].Get<string>();
+        var type = instruction.Operands[2].Get<Type>();
+        state.GetLocalValue(name, type);
+        state.ValueStack.Push(new LocalReference(name, type));
+    }
+
+    private static T Pop<T>(InterpreterState state)
+    {
+        if (state.ValueStack.Count == 0)
+            Thrower.InvalidOpEx("Interpreter stack is empty.");
+
+        return state.ValueStack.Pop().Get<T>();
+    }
+}

--- a/UniversalToolchain/BasicInterpreter/InterpreterState.cs
+++ b/UniversalToolchain/BasicInterpreter/InterpreterState.cs
@@ -3,6 +3,7 @@ namespace BasicInterpreter;
 public class InterpreterState
 {
     private readonly Dictionary<Guid, int> _labelPositions = new();
+    private readonly Dictionary<string, object?> _locals = new(StringComparer.Ordinal);
     private bool _labelsBuilt;
     public Stack<object> ValueStack { get; } = new();
 
@@ -18,7 +19,8 @@ public class InterpreterState
 
     public void BuildLabelPositions(IReadOnlyList<Instruction> instructions)
     {
-        if (_labelsBuilt) return;
+        if (_labelsBuilt)
+            return;
 
         _labelPositions.Clear();
         for (var i = 0; i < instructions.Count; i++)
@@ -39,5 +41,27 @@ public class InterpreterState
             Thrower.InvalidOpEx($"Label with id '{labelId}' was not found in the instruction stream.");
 
         return position;
+    }
+
+    public object GetLocalValue(string name, Type runtimeType)
+    {
+        if (_locals.TryGetValue(name, out var value) && value != null)
+            return value;
+
+        var defaultValue = runtimeType.IsValueType
+            ? Activator.CreateInstance(runtimeType)
+            : null;
+
+        _locals[name] = defaultValue;
+
+        if (defaultValue == null)
+            Thrower.InvalidOpEx($"Local '{name}' is null and cannot be loaded.");
+
+        return defaultValue;
+    }
+
+    public void SetLocalValue(string name, object? value)
+    {
+        _locals[name] = value;
     }
 }

--- a/UniversalToolchain/BytecodeDynamicMethodsCompiler/Compilers/AbstractMethodsIntrinsicCompiler.cs
+++ b/UniversalToolchain/BytecodeDynamicMethodsCompiler/Compilers/AbstractMethodsIntrinsicCompiler.cs
@@ -1,5 +1,4 @@
 using UniversalToolchain.Intrinsics.Core;
-using UniversalToolchain.Intrinsics.Legacy;
 
 namespace BytecodeDynamicMethodsCompiler.Compilers;
 
@@ -21,12 +20,11 @@ internal sealed class AbstractMethodsIntrinsicCompiler
 
     public void Compile(CompilationContext context, Instruction instruction, List<Type> stack)
     {
-        if (!IntrinsicInstructionLegacyProjector.TryProject(instruction, out var projectedInstruction))
-            Thrower.InvalidOpEx($"Unsupported intrinsic instruction payload: {instruction}");
+        var normalizedInstruction = IntrinsicInstructionNormalizer.NormalizeOrThrow(instruction);
 
-        var name = projectedInstruction.Operands[0].Get<string>();
+        var name = normalizedInstruction.Operands[0].Get<string>();
         var descriptor = _registry.GetRequired(name);
-        descriptor.Compile(context, projectedInstruction, stack);
+        descriptor.Compile(context, normalizedInstruction, stack);
     }
 
     public void ProcessTypes(Instruction instruction, List<Type> stack)

--- a/UniversalToolchain/Intrinsics/Core/IntrinsicInstructionNormalizer.cs
+++ b/UniversalToolchain/Intrinsics/Core/IntrinsicInstructionNormalizer.cs
@@ -29,8 +29,11 @@ internal static class IntrinsicInstructionNormalizer
         if (instruction.Operands.Count == 0)
             return false;
 
-        if (instruction.Operands[0] is string)
+        if (instruction.Operands[0] is string intrinsicName)
         {
+            if (!IsSupportedIntrinsicName(intrinsicName))
+                return false;
+
             normalizedInstruction = instruction;
             return true;
         }
@@ -38,7 +41,7 @@ internal static class IntrinsicInstructionNormalizer
         if (instruction.Operands.Count != 1 || instruction.Operands[0] is not IntrinsicInvocation invocation)
             return false;
 
-        if (!LegacyCapabilityNameEncoder.TryEncode(invocation.Symbol, invocation.TypeArguments, out var intrinsicName))
+        if (!LegacyCapabilityNameEncoder.TryEncode(invocation.Symbol, invocation.TypeArguments, out var encodedName))
             return false;
 
         if (invocation.Symbol == BuiltinIntrinsicSymbols.Core.CallCSharp
@@ -47,7 +50,7 @@ internal static class IntrinsicInstructionNormalizer
             if (!TryGetDataOperand(invocation.DataOperands, 0, out var dataOperand))
                 return false;
 
-            normalizedInstruction = new Instruction(UOpCode.Intrinsic, [intrinsicName, dataOperand]);
+            normalizedInstruction = new Instruction(UOpCode.Intrinsic, [encodedName, dataOperand]);
             return true;
         }
 
@@ -57,7 +60,7 @@ internal static class IntrinsicInstructionNormalizer
                 || !TryGetSingleRuntimeType(invocation.TypeArguments, out var runtimeType))
                 return false;
 
-            normalizedInstruction = new Instruction(UOpCode.Intrinsic, [intrinsicName, dataOperand, runtimeType]);
+            normalizedInstruction = new Instruction(UOpCode.Intrinsic, [encodedName, dataOperand, runtimeType]);
             return true;
         }
 
@@ -67,7 +70,7 @@ internal static class IntrinsicInstructionNormalizer
             if (!TryGetDataOperand(invocation.DataOperands, 0, out var dataOperand))
                 return false;
 
-            normalizedInstruction = new Instruction(UOpCode.Intrinsic, [intrinsicName, dataOperand]);
+            normalizedInstruction = new Instruction(UOpCode.Intrinsic, [encodedName, dataOperand]);
             return true;
         }
 
@@ -78,7 +81,7 @@ internal static class IntrinsicInstructionNormalizer
                 || !TryGetSingleRuntimeType(invocation.TypeArguments, out var runtimeType))
                 return false;
 
-            normalizedInstruction = new Instruction(UOpCode.Intrinsic, [intrinsicName, dataOperand, runtimeType]);
+            normalizedInstruction = new Instruction(UOpCode.Intrinsic, [encodedName, dataOperand, runtimeType]);
             return true;
         }
 
@@ -89,7 +92,7 @@ internal static class IntrinsicInstructionNormalizer
 
             if (TryGetSingleRuntimeType(invocation.TypeArguments, out var runtimeTypeFromTypeArguments))
             {
-                normalizedInstruction = new Instruction(UOpCode.Intrinsic, [intrinsicName, dataOperand, runtimeTypeFromTypeArguments]);
+                normalizedInstruction = new Instruction(UOpCode.Intrinsic, [encodedName, dataOperand, runtimeTypeFromTypeArguments]);
                 return true;
             }
 
@@ -97,7 +100,7 @@ internal static class IntrinsicInstructionNormalizer
                 && invocation.DataOperands.Count >= 2
                 && invocation.DataOperands[1] is Type runtimeTypeFromData)
             {
-                normalizedInstruction = new Instruction(UOpCode.Intrinsic, [intrinsicName, dataOperand, runtimeTypeFromData]);
+                normalizedInstruction = new Instruction(UOpCode.Intrinsic, [encodedName, dataOperand, runtimeTypeFromData]);
                 return true;
             }
 
@@ -108,14 +111,14 @@ internal static class IntrinsicInstructionNormalizer
             || invocation.Symbol == BuiltinIntrinsicSymbols.Boolean.Or
             || invocation.Symbol == BuiltinIntrinsicSymbols.Boolean.Not)
         {
-            normalizedInstruction = new Instruction(UOpCode.Intrinsic, [intrinsicName]);
+            normalizedInstruction = new Instruction(UOpCode.Intrinsic, [encodedName]);
             return true;
         }
 
         if (invocation.Symbol.Namespace == BuiltinIntrinsicSymbols.Arithmetic.Add.Namespace
             || invocation.Symbol.Namespace == BuiltinIntrinsicSymbols.Comparison.Equal.Namespace)
         {
-            normalizedInstruction = new Instruction(UOpCode.Intrinsic, [intrinsicName]);
+            normalizedInstruction = new Instruction(UOpCode.Intrinsic, [encodedName]);
             return true;
         }
 
@@ -142,5 +145,28 @@ internal static class IntrinsicInstructionNormalizer
 
         runtimeType = typeArguments[0].RuntimeType;
         return true;
+    }
+
+    private static bool IsSupportedIntrinsicName(string intrinsicName)
+    {
+        if (intrinsicName == "call C#"
+            || intrinsicName == "call C# ctor"
+            || intrinsicName == "store_local"
+            || intrinsicName == "load_local"
+            || intrinsicName == "load_local_ref"
+            || intrinsicName == "load_external"
+            || intrinsicName == "store_external"
+            || intrinsicName == "load_bool"
+            || intrinsicName == "boolean_and"
+            || intrinsicName == "boolean_or"
+            || intrinsicName == "boolean_not")
+            return true;
+
+        return intrinsicName.StartsWith("load_", StringComparison.Ordinal)
+               || intrinsicName.StartsWith("add_", StringComparison.Ordinal)
+               || intrinsicName.StartsWith("sub_", StringComparison.Ordinal)
+               || intrinsicName.StartsWith("mul_", StringComparison.Ordinal)
+               || intrinsicName.StartsWith("div_", StringComparison.Ordinal)
+               || intrinsicName.StartsWith("cmp_", StringComparison.Ordinal);
     }
 }

--- a/UniversalToolchain/Intrinsics/Core/IntrinsicInstructionNormalizer.cs
+++ b/UniversalToolchain/Intrinsics/Core/IntrinsicInstructionNormalizer.cs
@@ -4,16 +4,24 @@ using UniversalToolchain.Intrinsics.Builtins;
 using UniversalToolchain.Intrinsics.Capabilities;
 using UniversalToolchain.Intrinsics.Contracts;
 
-namespace UniversalToolchain.Intrinsics.Legacy;
+namespace UniversalToolchain.Intrinsics.Core;
 
-internal static class IntrinsicInstructionLegacyProjector
+internal static class IntrinsicInstructionNormalizer
 {
-    public static bool TryProject(Instruction instruction, out Instruction projectedInstruction)
+    public static Instruction NormalizeOrThrow(Instruction instruction)
+    {
+        if (!TryNormalize(instruction, out var normalizedInstruction))
+            return Thrower.InvalidOpEx<Instruction>($"Unsupported intrinsic instruction payload: {instruction}");
+
+        return normalizedInstruction;
+    }
+
+    public static bool TryNormalize(Instruction instruction, out Instruction normalizedInstruction)
     {
         if (instruction == null)
             Thrower.ArgumentNull(nameof(instruction));
 
-        projectedInstruction = default!;
+        normalizedInstruction = default!;
 
         if (instruction.UOpCode != UOpCode.Intrinsic)
             return false;
@@ -23,7 +31,7 @@ internal static class IntrinsicInstructionLegacyProjector
 
         if (instruction.Operands[0] is string)
         {
-            projectedInstruction = instruction;
+            normalizedInstruction = instruction;
             return true;
         }
 
@@ -39,7 +47,7 @@ internal static class IntrinsicInstructionLegacyProjector
             if (!TryGetDataOperand(invocation.DataOperands, 0, out var dataOperand))
                 return false;
 
-            projectedInstruction = new Instruction(UOpCode.Intrinsic, [intrinsicName, dataOperand]);
+            normalizedInstruction = new Instruction(UOpCode.Intrinsic, [intrinsicName, dataOperand]);
             return true;
         }
 
@@ -49,7 +57,7 @@ internal static class IntrinsicInstructionLegacyProjector
                 || !TryGetSingleRuntimeType(invocation.TypeArguments, out var runtimeType))
                 return false;
 
-            projectedInstruction = new Instruction(UOpCode.Intrinsic, [intrinsicName, dataOperand, runtimeType]);
+            normalizedInstruction = new Instruction(UOpCode.Intrinsic, [intrinsicName, dataOperand, runtimeType]);
             return true;
         }
 
@@ -59,7 +67,7 @@ internal static class IntrinsicInstructionLegacyProjector
             if (!TryGetDataOperand(invocation.DataOperands, 0, out var dataOperand))
                 return false;
 
-            projectedInstruction = new Instruction(UOpCode.Intrinsic, [intrinsicName, dataOperand]);
+            normalizedInstruction = new Instruction(UOpCode.Intrinsic, [intrinsicName, dataOperand]);
             return true;
         }
 
@@ -70,7 +78,7 @@ internal static class IntrinsicInstructionLegacyProjector
                 || !TryGetSingleRuntimeType(invocation.TypeArguments, out var runtimeType))
                 return false;
 
-            projectedInstruction = new Instruction(UOpCode.Intrinsic, [intrinsicName, dataOperand, runtimeType]);
+            normalizedInstruction = new Instruction(UOpCode.Intrinsic, [intrinsicName, dataOperand, runtimeType]);
             return true;
         }
 
@@ -81,7 +89,7 @@ internal static class IntrinsicInstructionLegacyProjector
 
             if (TryGetSingleRuntimeType(invocation.TypeArguments, out var runtimeTypeFromTypeArguments))
             {
-                projectedInstruction = new Instruction(UOpCode.Intrinsic, [intrinsicName, dataOperand, runtimeTypeFromTypeArguments]);
+                normalizedInstruction = new Instruction(UOpCode.Intrinsic, [intrinsicName, dataOperand, runtimeTypeFromTypeArguments]);
                 return true;
             }
 
@@ -89,7 +97,7 @@ internal static class IntrinsicInstructionLegacyProjector
                 && invocation.DataOperands.Count >= 2
                 && invocation.DataOperands[1] is Type runtimeTypeFromData)
             {
-                projectedInstruction = new Instruction(UOpCode.Intrinsic, [intrinsicName, dataOperand, runtimeTypeFromData]);
+                normalizedInstruction = new Instruction(UOpCode.Intrinsic, [intrinsicName, dataOperand, runtimeTypeFromData]);
                 return true;
             }
 
@@ -100,20 +108,19 @@ internal static class IntrinsicInstructionLegacyProjector
             || invocation.Symbol == BuiltinIntrinsicSymbols.Boolean.Or
             || invocation.Symbol == BuiltinIntrinsicSymbols.Boolean.Not)
         {
-            projectedInstruction = new Instruction(UOpCode.Intrinsic, [intrinsicName]);
+            normalizedInstruction = new Instruction(UOpCode.Intrinsic, [intrinsicName]);
             return true;
         }
 
         if (invocation.Symbol.Namespace == BuiltinIntrinsicSymbols.Arithmetic.Add.Namespace
             || invocation.Symbol.Namespace == BuiltinIntrinsicSymbols.Comparison.Equal.Namespace)
         {
-            projectedInstruction = new Instruction(UOpCode.Intrinsic, [intrinsicName]);
+            normalizedInstruction = new Instruction(UOpCode.Intrinsic, [intrinsicName]);
             return true;
         }
 
         return false;
     }
-
 
     private static bool TryGetDataOperand(IReadOnlyList<object?> dataOperands, int index, out object operand)
     {

--- a/UniversalToolchain/Intrinsics/Core/IntrinsicTypeProcessor.cs
+++ b/UniversalToolchain/Intrinsics/Core/IntrinsicTypeProcessor.cs
@@ -1,7 +1,6 @@
 using System.Reflection;
 using DotnetHelper;
 using ObjectExtensions;
-using UniversalToolchain.Intrinsics.Legacy;
 
 namespace UniversalToolchain.Intrinsics.Core;
 
@@ -27,10 +26,7 @@ internal static class IntrinsicTypeProcessor
         if (instruction.Operands.Count > 0 && instruction.Operands[0] is string)
             return instruction;
 
-        if (IntrinsicInstructionLegacyProjector.TryProject(instruction, out var projectedInstruction))
-            return projectedInstruction;
-
-        return Thrower.InvalidOpEx<Instruction>($"Unsupported intrinsic instruction payload: {instruction}");
+        return IntrinsicInstructionNormalizer.NormalizeOrThrow(instruction);
     }
 
     private static void ProcessNormalizedInstruction(Instruction instruction, List<Type> stack)

--- a/UniversalToolchain/Tests/Backends/InterpreterBackendIrExecutionTests.cs
+++ b/UniversalToolchain/Tests/Backends/InterpreterBackendIrExecutionTests.cs
@@ -198,7 +198,7 @@ public class InterpreterBackendIrExecutionTests
 
 
     [Test]
-    public void TypedArithmeticIntrinsicI32_OnCoreInterpreterPath_RemainsUnsupported()
+    public void TypedArithmeticIntrinsicI32_OnCoreInterpreterPath_ExecutesSuccessfully()
     {
         var ir = BuildIr(
             new Instruction(UOpCode.Push, [20]),
@@ -206,22 +206,22 @@ public class InterpreterBackendIrExecutionTests
             CreateTypedIntrinsic(BuiltinIntrinsicSymbols.Arithmetic.Add, [IntrinsicTypeArgument.From(typeof(int))])
         );
 
-        var exception = Assert.Throws<RuntimeExecutionException>(() => ExecuteInInterpreter(ir));
+        var result = ExecuteInInterpreter(ir);
 
-        Assert.That(exception!.Message, Does.Contain("Unknown intrinsic call: add_i32."));
+        Assert.That(result, Is.EqualTo(42));
     }
 
     [Test]
-    public void TypedBooleanNotIntrinsic_OnCoreInterpreterPath_RemainsUnsupported()
+    public void TypedBooleanNotIntrinsic_OnCoreInterpreterPath_ExecutesSuccessfully()
     {
         var ir = BuildIr(
             new Instruction(UOpCode.Push, [true]),
             CreateTypedIntrinsic(BuiltinIntrinsicSymbols.Boolean.Not)
         );
 
-        var exception = Assert.Throws<RuntimeExecutionException>(() => ExecuteInInterpreter(ir));
+        var result = ExecuteInInterpreter(ir);
 
-        Assert.That(exception!.Message, Does.Contain("Unknown intrinsic call: boolean_not."));
+        Assert.That(result, Is.EqualTo(false));
     }
 
     private static int CombineDigits(int acc, int nextDigit) => acc * 10 + nextDigit;

--- a/UniversalToolchain/Tests/Backends/InterpreterBackendIrExecutionTests.cs
+++ b/UniversalToolchain/Tests/Backends/InterpreterBackendIrExecutionTests.cs
@@ -8,6 +8,24 @@ namespace Tests.Backends;
 [TestFixture]
 public class InterpreterBackendIrExecutionTests
 {
+    private static class RefInteropSamples
+    {
+        public static void Increment(ref int value)
+        {
+            value++;
+        }
+
+        public static void Set42(out int value)
+        {
+            value = 42;
+        }
+
+        public static void AddTen(ref int value)
+        {
+            value += 10;
+        }
+    }
+
     [Test]
     public void ConditionalJump_PreservesExpectedStackState()
     {
@@ -224,6 +242,127 @@ public class InterpreterBackendIrExecutionTests
         Assert.That(result, Is.EqualTo(false));
     }
 
+    [Test]
+    public void InterpreterAndCil_StoreLocalThenLoadLocal_ReturnSameValue()
+    {
+        var air = Air(
+            Intrinsic("load_i32", 123),
+            Intrinsic("store_local", "x", typeof(int)),
+            Intrinsic("load_local", "x", typeof(int))
+        );
+
+        var interpreterResult = ExecuteWithInterpreter(air);
+        var cilResult = ExecuteWithCil(air);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(interpreterResult, Is.EqualTo(123));
+            Assert.That(cilResult, Is.EqualTo(123));
+        });
+    }
+
+    [Test]
+    public void InterpreterAndCil_LoadLocalRef_CallRefMethod_MutatesLocal()
+    {
+        var method = typeof(RefInteropSamples)
+            .GetMethod(nameof(RefInteropSamples.Increment), BindingFlags.Public | BindingFlags.Static)!;
+
+        var air = Air(
+            Intrinsic("load_i32", 10),
+            Intrinsic("store_local", "x", typeof(int)),
+            Intrinsic("load_local_ref", "x", typeof(int)),
+            Intrinsic("call C#", method),
+            Intrinsic("load_local", "x", typeof(int))
+        );
+
+        var interpreterResult = ExecuteWithInterpreter(air);
+        var cilResult = ExecuteWithCil(air);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(interpreterResult, Is.EqualTo(11));
+            Assert.That(cilResult, Is.EqualTo(11));
+        });
+    }
+
+    [Test]
+    public void InterpreterAndCil_LoadLocalRef_CallOutMethod_AssignsLocal()
+    {
+        var method = typeof(RefInteropSamples)
+            .GetMethod(nameof(RefInteropSamples.Set42), BindingFlags.Public | BindingFlags.Static)!;
+
+        var air = Air(
+            Intrinsic("load_i32", 0),
+            Intrinsic("store_local", "x", typeof(int)),
+            Intrinsic("load_local_ref", "x", typeof(int)),
+            Intrinsic("call C#", method),
+            Intrinsic("load_local", "x", typeof(int))
+        );
+
+        var interpreterResult = ExecuteWithInterpreter(air);
+        var cilResult = ExecuteWithCil(air);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(interpreterResult, Is.EqualTo(42));
+            Assert.That(cilResult, Is.EqualTo(42));
+        });
+    }
+
+    [Test]
+    public void InterpreterAndCil_LoadLocalRef_MutatesOnlyTargetLocal()
+    {
+        var method = typeof(RefInteropSamples)
+            .GetMethod(nameof(RefInteropSamples.Increment), BindingFlags.Public | BindingFlags.Static)!;
+
+        var air = Air(
+            Intrinsic("load_i32", 10),
+            Intrinsic("store_local", "x", typeof(int)),
+            Intrinsic("load_i32", 20),
+            Intrinsic("store_local", "y", typeof(int)),
+            Intrinsic("load_local_ref", "y", typeof(int)),
+            Intrinsic("call C#", method),
+            Intrinsic("load_local", "x", typeof(int)),
+            Intrinsic("load_local", "y", typeof(int)),
+            Intrinsic("add_i32")
+        );
+
+        var interpreterResult = ExecuteWithInterpreter(air);
+        var cilResult = ExecuteWithCil(air);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(interpreterResult, Is.EqualTo(31));
+            Assert.That(cilResult, Is.EqualTo(31));
+        });
+    }
+
+    [Test]
+    public void InterpreterAndCil_RepeatedRefMutation_KeepsLatestLocalValue()
+    {
+        var method = typeof(RefInteropSamples)
+            .GetMethod(nameof(RefInteropSamples.AddTen), BindingFlags.Public | BindingFlags.Static)!;
+
+        var air = Air(
+            Intrinsic("load_i32", 5),
+            Intrinsic("store_local", "x", typeof(int)),
+            Intrinsic("load_local_ref", "x", typeof(int)),
+            Intrinsic("call C#", method),
+            Intrinsic("load_local_ref", "x", typeof(int)),
+            Intrinsic("call C#", method),
+            Intrinsic("load_local", "x", typeof(int))
+        );
+
+        var interpreterResult = ExecuteWithInterpreter(air);
+        var cilResult = ExecuteWithCil(air);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(interpreterResult, Is.EqualTo(25));
+            Assert.That(cilResult, Is.EqualTo(25));
+        });
+    }
+
     private static int CombineDigits(int acc, int nextDigit) => acc * 10 + nextDigit;
 
     private static T Echo<T>(T value) => value;
@@ -252,6 +391,35 @@ public class InterpreterBackendIrExecutionTests
     {
         var interpreter = new InterpreterImpl();
         return interpreter.Execute(ir, environment);
+    }
+
+    private static object? ExecuteWithInterpreter(IAbstractIR air)
+    {
+        var interpreter = new InterpreterImpl();
+        return interpreter.Execute(air, new ExecutionEnvironment([]));
+    }
+
+    private static object? ExecuteWithCil(IAbstractIR air)
+    {
+        var compiler = new AbstractMethodsCompilerImpl();
+        var dynamicMethod = compiler.Compile(air, new CompilationInput { SourceText = string.Empty });
+
+        var executor = new DynamicMethodExecutor();
+        return executor.Execute(dynamicMethod, new ExecutionEnvironment([]));
+    }
+
+    private static Instruction Intrinsic(string name, params object?[] args)
+    {
+        var operands = new List<object>(args.Length + 1) { name };
+        for (var i = 0; i < args.Length; i++)
+            operands.Add(args[i]!);
+
+        return new Instruction(UOpCode.Intrinsic, operands);
+    }
+
+    private static IAbstractIR Air(params Instruction[] instructions)
+    {
+        return BuildIr(instructions);
     }
 
     private static IAbstractIR BuildIr(params Instruction[] instructions)

--- a/UniversalToolchain/Tests/Backends/InterpreterBackendOptimizerIntrinsicSurfaceTests.cs
+++ b/UniversalToolchain/Tests/Backends/InterpreterBackendOptimizerIntrinsicSurfaceTests.cs
@@ -1,21 +1,13 @@
 using Tests.Infrastructure;
-using UniversalToolchain.Intrinsics.Legacy;
+using UniversalToolchain.Intrinsics.Core;
 
 namespace Tests.Backends;
 
 [TestFixture]
 public sealed class InterpreterBackendOptimizerIntrinsicSurfaceTests
 {
-    private static readonly HashSet<string> SupportedInterpreterIntrinsics =
-    [
-        "call C#",
-        "call C# ctor",
-        "load_external",
-        "store_external"
-    ];
-
     [Test]
-    public void InterpreterBackend_WithOptimizersEnabled_DoesNotContainBackendSpecificIntrinsics()
+    public void InterpreterBackend_WithOptimizersEnabled_ContainsOnlyInterpreterSupportedIntrinsics()
     {
         var dialect = """
                       dialect Tiny
@@ -36,8 +28,31 @@ public sealed class InterpreterBackendOptimizerIntrinsicSurfaceTests
         var intrinsicNames = CollectIntrinsicNames(artifact.CompilationOutput).ToArray();
 
         Assert.That(intrinsicNames, Is.Not.Empty);
-        Assert.That(intrinsicNames.All(SupportedInterpreterIntrinsics.Contains), Is.True,
-            $"Interpreter IR contains unsupported intrinsic names: {string.Join(", ", intrinsicNames.Where(x => !SupportedInterpreterIntrinsics.Contains(x)).Distinct(StringComparer.Ordinal))}");
+        Assert.That(intrinsicNames.All(IsSupportedInterpreterIntrinsic), Is.True,
+            $"Interpreter IR contains unsupported intrinsic names: {string.Join(", ", intrinsicNames.Where(x => !IsSupportedInterpreterIntrinsic(x)).Distinct(StringComparer.Ordinal))}");
+    }
+
+    private static bool IsSupportedInterpreterIntrinsic(string intrinsicName)
+    {
+        if (intrinsicName == "call C#"
+            || intrinsicName == "call C# ctor"
+            || intrinsicName == "load_external"
+            || intrinsicName == "store_external"
+            || intrinsicName == "store_local"
+            || intrinsicName == "load_local"
+            || intrinsicName == "load_local_ref"
+            || intrinsicName == "load_bool"
+            || intrinsicName == "boolean_and"
+            || intrinsicName == "boolean_or"
+            || intrinsicName == "boolean_not")
+            return true;
+
+        return intrinsicName.StartsWith("load_", StringComparison.Ordinal)
+               || intrinsicName.StartsWith("add_", StringComparison.Ordinal)
+               || intrinsicName.StartsWith("sub_", StringComparison.Ordinal)
+               || intrinsicName.StartsWith("mul_", StringComparison.Ordinal)
+               || intrinsicName.StartsWith("div_", StringComparison.Ordinal)
+               || intrinsicName.StartsWith("cmp_", StringComparison.Ordinal);
     }
 
     private static IEnumerable<string> CollectIntrinsicNames(IAbstractIR air)
@@ -47,10 +62,10 @@ public sealed class InterpreterBackendOptimizerIntrinsicSurfaceTests
             if (instruction.UOpCode != UOpCode.Intrinsic)
                 continue;
 
-            if (!IntrinsicInstructionLegacyProjector.TryProject(instruction, out var projectedInstruction))
-                Assert.Fail($"Failed to project intrinsic instruction to legacy form: {instruction}");
+            if (!IntrinsicInstructionNormalizer.TryNormalize(instruction, out var normalizedInstruction))
+                Assert.Fail($"Failed to normalize intrinsic instruction: {instruction}");
 
-            yield return (string)projectedInstruction.Operands[0];
+            yield return (string)normalizedInstruction.Operands[0];
         }
     }
 }

--- a/UniversalToolchain/Tests/Intrinsics/IntrinsicInstructionNormalizerTests.cs
+++ b/UniversalToolchain/Tests/Intrinsics/IntrinsicInstructionNormalizerTests.cs
@@ -111,6 +111,49 @@ public class IntrinsicInstructionNormalizerTests
         Assert.That(exception!.Message, Does.Contain("Unsupported intrinsic instruction payload"));
     }
 
+    [Test]
+    public void NormalizeOrThrow_ForAlreadyNormalizedLoadLocalRef_IsIdempotent()
+    {
+        var instruction = Intrinsic("load_local_ref", "x", typeof(int));
+
+        var normalized1 = IntrinsicInstructionNormalizer.NormalizeOrThrow(instruction);
+        var normalized2 = IntrinsicInstructionNormalizer.NormalizeOrThrow(normalized1);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(normalized2.UOpCode, Is.EqualTo(normalized1.UOpCode));
+            Assert.That(normalized2.Operands.Count, Is.EqualTo(normalized1.Operands.Count));
+            Assert.That(normalized2.Operands[0], Is.EqualTo("load_local_ref"));
+            Assert.That(normalized2.Operands[1], Is.EqualTo("x"));
+            Assert.That(normalized2.Operands[2], Is.EqualTo(typeof(int)));
+        });
+    }
+
+    [Test]
+    public void TryNormalize_UnknownIntrinsic_ReturnsFalse()
+    {
+        var instruction = Intrinsic("definitely_unknown_intrinsic");
+
+        var ok = IntrinsicInstructionNormalizer.TryNormalize(instruction, out var normalized);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(ok, Is.False);
+            Assert.That(normalized, Is.Null);
+        });
+    }
+
+    [Test]
+    public void NormalizeOrThrow_UnknownIntrinsic_Throws()
+    {
+        var instruction = Intrinsic("definitely_unknown_intrinsic");
+
+        Assert.Throws<InvalidOperationException>(() =>
+        {
+            _ = IntrinsicInstructionNormalizer.NormalizeOrThrow(instruction);
+        });
+    }
+
     private static Instruction CreateTypedInstruction(
         IntrinsicSymbol symbol,
         IReadOnlyList<IntrinsicTypeArgument>? typeArguments = null,
@@ -122,5 +165,14 @@ public class IntrinsicInstructionNormalizerTests
             dataOperands ?? []);
 
         return new Instruction(UOpCode.Intrinsic, [invocation]);
+    }
+
+    private static Instruction Intrinsic(string name, params object?[] args)
+    {
+        var operands = new List<object>(args.Length + 1) { name };
+        for (var i = 0; i < args.Length; i++)
+            operands.Add(args[i]!);
+
+        return new Instruction(UOpCode.Intrinsic, operands);
     }
 }

--- a/UniversalToolchain/Tests/Intrinsics/IntrinsicInstructionNormalizerTests.cs
+++ b/UniversalToolchain/Tests/Intrinsics/IntrinsicInstructionNormalizerTests.cs
@@ -1,126 +1,114 @@
-using System.Reflection;
 using UniversalToolchain.Intrinsics.Builtins;
 using UniversalToolchain.Intrinsics.Contracts;
+using UniversalToolchain.Intrinsics.Core;
 
 namespace Tests.Intrinsics;
 
 [TestFixture]
-public class IntrinsicInstructionLegacyProjectorTests
+public class IntrinsicInstructionNormalizerTests
 {
     [Test]
-    public void TryProject_TypedBooleanIntrinsic_ProjectsToLegacyName()
+    public void TryNormalize_TypedBooleanIntrinsic_ProjectsToLegacyName()
     {
         var instruction = CreateTypedInstruction(BuiltinIntrinsicSymbols.Boolean.Not);
 
-        var success = TryProject(instruction, out var projectedInstruction);
+        var success = IntrinsicInstructionNormalizer.TryNormalize(instruction, out var projectedInstruction);
 
         Assert.That(success, Is.True);
         Assert.That(projectedInstruction.Operands, Is.EqualTo(new object?[] { "boolean_not" }));
     }
 
     [Test]
-    public void TryProject_TypedArithmeticIntrinsic_ProjectsToTypedLegacyName()
+    public void TryNormalize_TypedArithmeticIntrinsic_ProjectsToTypedLegacyName()
     {
         var instruction = CreateTypedInstruction(
             BuiltinIntrinsicSymbols.Arithmetic.Add,
             [IntrinsicTypeArgument.From(typeof(double))]);
 
-        var success = TryProject(instruction, out var projectedInstruction);
+        var success = IntrinsicInstructionNormalizer.TryNormalize(instruction, out var projectedInstruction);
 
         Assert.That(success, Is.True);
         Assert.That(projectedInstruction.Operands, Is.EqualTo(new object?[] { "add_f64" }));
     }
 
     [Test]
-    public void TryProject_TypedComparisonIntrinsic_ProjectsToTypedLegacyName()
+    public void TryNormalize_TypedComparisonIntrinsic_ProjectsToTypedLegacyName()
     {
         var instruction = CreateTypedInstruction(
             BuiltinIntrinsicSymbols.Comparison.LessOrEqual,
             [IntrinsicTypeArgument.From(typeof(double))]);
 
-        var success = TryProject(instruction, out var projectedInstruction);
+        var success = IntrinsicInstructionNormalizer.TryNormalize(instruction, out var projectedInstruction);
 
         Assert.That(success, Is.True);
         Assert.That(projectedInstruction.Operands, Is.EqualTo(new object?[] { "cmp_le_f64" }));
     }
 
     [Test]
-    public void TryProject_TypedLoadConst_ProjectsToLegacyNameAndDataOperand()
+    public void TryNormalize_TypedLoadConst_ProjectsToLegacyNameAndDataOperand()
     {
         var instruction = CreateTypedInstruction(
             BuiltinIntrinsicSymbols.Core.LoadConst,
             [IntrinsicTypeArgument.From(typeof(double))],
             [12.5d]);
 
-        var success = TryProject(instruction, out var projectedInstruction);
+        var success = IntrinsicInstructionNormalizer.TryNormalize(instruction, out var projectedInstruction);
 
         Assert.That(success, Is.True);
         Assert.That(projectedInstruction.Operands, Is.EqualTo(new object?[] { "load_f64", 12.5d }));
     }
 
     [Test]
-    public void TryProject_TypedLoadLocal_ProjectsToLegacyShape()
+    public void TryNormalize_TypedLoadLocal_ProjectsToLegacyShape()
     {
         var instruction = CreateTypedInstruction(
             BuiltinIntrinsicSymbols.Storage.LoadLocal,
             [IntrinsicTypeArgument.From(typeof(int))],
             ["value"]);
 
-        var success = TryProject(instruction, out var projectedInstruction);
+        var success = IntrinsicInstructionNormalizer.TryNormalize(instruction, out var projectedInstruction);
 
         Assert.That(success, Is.True);
         Assert.That(projectedInstruction.Operands, Is.EqualTo(new object?[] { "load_local", "value", typeof(int) }));
     }
 
     [Test]
-    public void TryProject_TypedLoadLocalRef_ProjectsToLegacyShape()
+    public void TryNormalize_TypedLoadLocalRef_ProjectsToLegacyShape()
     {
         var instruction = CreateTypedInstruction(
             BuiltinIntrinsicSymbols.Storage.LoadLocalRef,
             [IntrinsicTypeArgument.From(typeof(int))],
             ["value"]);
 
-        var success = TryProject(instruction, out var projectedInstruction);
+        var success = IntrinsicInstructionNormalizer.TryNormalize(instruction, out var projectedInstruction);
 
         Assert.That(success, Is.True);
         Assert.That(projectedInstruction.Operands, Is.EqualTo(new object?[] { "load_local_ref", "value", typeof(int) }));
     }
 
     [Test]
-    public void TryProject_TypedCallCSharp_ProjectsToLegacyShape()
+    public void TryNormalize_TypedCallCSharp_ProjectsToLegacyShape()
     {
         var method = typeof(Math).GetMethod(nameof(Math.Abs), [typeof(int)]);
         var instruction = CreateTypedInstruction(
             BuiltinIntrinsicSymbols.Core.CallCSharp,
             dataOperands: [method]);
 
-        var success = TryProject(instruction, out var projectedInstruction);
+        var success = IntrinsicInstructionNormalizer.TryNormalize(instruction, out var projectedInstruction);
 
         Assert.That(success, Is.True);
         Assert.That(projectedInstruction.Operands, Is.EqualTo(new object?[] { "call C#", method }));
     }
 
     [Test]
-    public void TryProject_MalformedTypedPayload_ReturnsFalse()
+    public void NormalizeOrThrow_MalformedTypedPayload_Throws()
     {
         var instruction = CreateTypedInstruction(BuiltinIntrinsicSymbols.Core.LoadExternal);
 
-        var success = TryProject(instruction, out _);
+        var exception = Assert.Throws<InvalidOperationException>(() => IntrinsicInstructionNormalizer.NormalizeOrThrow(instruction));
 
-        Assert.That(success, Is.False);
-    }
-
-
-    private static bool TryProject(Instruction instruction, out Instruction projectedInstruction)
-    {
-        var projectorType = typeof(IntrinsicInvocation).Assembly
-            .GetType("UniversalToolchain.Intrinsics.Legacy.IntrinsicInstructionLegacyProjector", throwOnError: true)!;
-        var method = projectorType.GetMethod("TryProject", BindingFlags.Public | BindingFlags.Static)!;
-
-        var args = new object?[] { instruction, null };
-        var success = (bool)(method.Invoke(null, args) ?? false);
-        projectedInstruction = args[1] is Instruction projected ? projected : default!;
-        return success;
+        Assert.That(exception, Is.Not.Null);
+        Assert.That(exception!.Message, Does.Contain("Unsupported intrinsic instruction payload"));
     }
 
     private static Instruction CreateTypedInstruction(

--- a/UniversalToolchain/Tests/Intrinsics/IntrinsicTypeProcessorTests.cs
+++ b/UniversalToolchain/Tests/Intrinsics/IntrinsicTypeProcessorTests.cs
@@ -52,6 +52,18 @@ public sealed class IntrinsicTypeProcessorTests
     }
 
     [Test]
+    public void ProcessTypes_LoadLocalRef_PushesByRefType()
+    {
+        var stack = new List<Type>();
+        var instruction = new Instruction(UOpCode.Intrinsic, ["load_local_ref", "x", typeof(int)]);
+
+        IntrinsicTypeProcessor.ProcessTypes(instruction, stack);
+
+        Assert.That(stack, Has.Count.EqualTo(1));
+        Assert.That(stack[0], Is.EqualTo(typeof(int).MakeByRefType()));
+    }
+
+    [Test]
     public void TypedComparisonIntrinsic_IsProjected_AndProducesBooleanResult()
     {
         var instruction = CreateTypedInstruction(

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/DialectIntrinsicPolicyCompiler.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/DialectIntrinsicPolicyCompiler.cs
@@ -3,7 +3,7 @@ using BasicCore.Contracts;
 using ExceptionsManager;
 using IntermediateRepresentationAbstractions;
 using ObjectExtensions;
-using UniversalToolchain.Intrinsics.Legacy;
+using UniversalToolchain.Intrinsics.Core;
 
 namespace UniversalToolchain.Dialects.Wist;
 
@@ -54,10 +54,10 @@ internal sealed class DialectIntrinsicPolicyCompiler<TCompilationOutput> : IAbst
             if (instruction.UOpCode != UOpCode.Intrinsic)
                 continue;
 
-            if (!IntrinsicInstructionLegacyProjector.TryProject(instruction, out var projectedInstruction))
+            if (!IntrinsicInstructionNormalizer.TryNormalize(instruction, out var normalizedInstruction))
                 Thrower.InvalidOpEx($"Intrinsic payload cannot be validated against dialect policy: {instruction}");
 
-            var intrinsicName = projectedInstruction.Operands[0].Get<string>();
+            var intrinsicName = normalizedInstruction.Operands[0].Get<string>();
 
             if (_forbiddenIntrinsics.Contains(intrinsicName))
                 Thrower.InvalidOpEx($"Intrinsic '{intrinsicName}' is forbidden by the selected dialect.");


### PR DESCRIPTION
### Motivation
- Remove the active dependency on the legacy intrinsic projector and provide a single core normalization entry for both compiler and interpreter paths to ensure consistent intrinsic semantics.
- Centralize type-stack processing for intrinsics and reduce duplicated legacy handlers in the compiler path.
- Make the interpreter handle the same intrinsic surface as the compiler (boolean, arithmetic, comparison, load/store, call/ctor) through a dedicated executor and add proper local storage support.

### Description
- Added `IntrinsicInstructionNormalizer` (`UniversalToolchain/Intrinsics/Core/IntrinsicInstructionNormalizer.cs`) with `TryNormalize` and `NormalizeOrThrow` to replace the legacy projector behavior for typed intrinsics and to provide a neutral core normalization surface.
- Replaced uses of the legacy projector with the normalizer in compiler and validation code: `AbstractMethodsIntrinsicCompiler.Compile(...)` now normalizes via `IntrinsicInstructionNormalizer`, and `DialectIntrinsicPolicyCompiler` validates intrinsics using `IntrinsicInstructionNormalizer.TryNormalize(...)`.
- Kept a single shared type-stack handler by making `IntrinsicTypeProcessor.ProcessTypes(...)` normalize via `IntrinsicInstructionNormalizer` before processing.
- Introduced `InterpreterIntrinsicExecutor` (`UniversalToolchain/BasicInterpreter/InterpreterIntrinsicExecutor.cs`) and delegated `InterpreterImpl.ExecuteIntrinsic(...)` to it; the executor dispatches and executes the expanded intrinsic surface (call/ctor, load/store local/external, boolean ops, numeric loads, arithmetic, comparisons) using normalized instructions.
- Added explicit local storage APIs in `InterpreterState` (`GetLocalValue` / `SetLocalValue`) so the interpreter can support local/load-ref semantics without relying on external bindings.
- Removed the legacy projector file and migrated tests and references: `UniversalToolchain/Intrinsics/Legacy/IntrinsicInstructionLegacyProjector.cs` was deleted and projector tests were renamed/migrated to `IntrinsicInstructionNormalizerTests`.
- Updated and extended tests to reflect the new normalization and interpreter behavior (moved/renamed tests and updated expectations for typed-intrinsic execution and optimizer surface checks).

### Testing
- Performed `dotnet restore` for the solution successfully to ensure dependencies resolved.
- Ran targeted test selection for the changed areas with: `dotnet test UniversalToolchain/Tests/Tests.csproj -c Release --filter "FullyQualifiedName~Tests.Intrinsics|FullyQualifiedName~InterpreterBackendIrExecutionTests|FullyQualifiedName~CilBackendAbstractIrCompilationTests"`, and the run passed (96 passed, 0 failed).
- Ran a full `dotnet test` for the Tests project; it reported existing unrelated failures in the environment baseline that are outside the modified code scope (full-suite failure not caused by these changes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7fecc41a08324a3841e37637c9bf5)