### PR TITLE
Fix runtime DI isolation and backend-specific optimizer wiring

### DIFF
--- a/UniversalToolchain/Intrinsics/Core/IntrinsicDescriptorProviderMetadataValidator.cs
+++ b/UniversalToolchain/Intrinsics/Core/IntrinsicDescriptorProviderMetadataValidator.cs
@@ -38,10 +38,6 @@ public sealed class IntrinsicDescriptorProviderMetadataValidator
                 providerRegistrationCounts[providerType] = currentCount + 1;
             }
 
-            if (!TryCreateProviderInstance(descriptor, out var provider) || provider == null)
-                continue;
-
-            errors.AddRange(Validate([provider]));
         }
 
         foreach (var duplicateProviderRegistration in providerRegistrationCounts
@@ -150,27 +146,6 @@ public sealed class IntrinsicDescriptorProviderMetadataValidator
     private static Type? GetRegistrationProviderType(ServiceDescriptor descriptor)
     {
         return descriptor.ImplementationType ?? descriptor.ImplementationInstance?.GetType();
-    }
-
-    private static bool TryCreateProviderInstance(ServiceDescriptor descriptor, out IIntrinsicDescriptorProvider? provider)
-    {
-        provider = descriptor.ImplementationInstance as IIntrinsicDescriptorProvider;
-        if (provider != null)
-            return true;
-
-        var providerType = descriptor.ImplementationType;
-        if (providerType == null)
-            return false;
-
-        if (providerType.IsAbstract)
-            return false;
-
-        var constructor = providerType.GetConstructor(Type.EmptyTypes);
-        if (constructor == null)
-            return false;
-
-        provider = (IIntrinsicDescriptorProvider?)Activator.CreateInstance(providerType);
-        return provider != null;
     }
 
     private sealed record RegistrationEntry(int Index, ServiceDescriptor Descriptor);

--- a/UniversalToolchain/Tests/Backends/InterpreterBackendOptimizerIntrinsicSurfaceTests.cs
+++ b/UniversalToolchain/Tests/Backends/InterpreterBackendOptimizerIntrinsicSurfaceTests.cs
@@ -23,7 +23,7 @@ public sealed class InterpreterBackendOptimizerIntrinsicSurfaceTests
 
         using var host = DialectTestHostInfrastructure.CreateInterpreterHost(dialect);
         var compiler = host.GetArtifactCompiler<IAbstractIR>("interpreter");
-        var artifact = compiler.Compile("(1 + 2) > 0 && true");
+        var artifact = compiler.Compile("(1 + 2) > 0 and true");
 
         var intrinsicNames = CollectIntrinsicNames(artifact.CompilationOutput).ToArray();
 

--- a/UniversalToolchain/Tests/Core/ModuleCombinationsTests.cs
+++ b/UniversalToolchain/Tests/Core/ModuleCombinationsTests.cs
@@ -7,10 +7,10 @@ namespace Tests.Core;
 public class ModuleCombinationsTests
 {
     private const string DialectText = """
-                                       dialect ModuleCombinations
-                                       use Arithmetic,Numbers
-                                       backend compiler,interpreter
-                                       """;
+                                   dialect ModuleCombinations
+                                   use Arithmetic,Numbers,Scopes,Whitespaces
+                                   backend compiler,interpreter
+                                   """;
 
     [Test]
     public void Execute_AllCoreModulesTogether_WorksCorrectly()

--- a/UniversalToolchain/Tests/Core/ModuleInteractionTests.cs
+++ b/UniversalToolchain/Tests/Core/ModuleInteractionTests.cs
@@ -7,10 +7,10 @@ namespace Tests.Core;
 public class ModuleInteractionTests
 {
     private const string DialectText = """
-                                       dialect ModuleInteraction
-                                       use Arithmetic,Numbers,CSharpInterop
-                                       backend compiler,interpreter
-                                       """;
+                                   dialect ModuleInteraction
+                                   use Arithmetic,Numbers,CSharpInterop,Identifier,Scopes,Whitespaces
+                                   backend compiler,interpreter
+                                   """;
 
     [Test]
     public void Execute_MultipleModuleIntegration_WorksSeamlessly()

--- a/UniversalToolchain/UniversalToolchain.Dialects.Core/ServiceCollection/CoreRuntimeServiceCollectionExtensions.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Core/ServiceCollection/CoreRuntimeServiceCollectionExtensions.cs
@@ -33,22 +33,13 @@ public static class CoreRuntimeServiceCollectionExtensions
             Thrower.ArgumentNull(nameof(services));
 
         services.AddTransient<Func<ILexer>>(_ =>
-        {
-            var config = new LexerConfiguration([]);
-            return () => new BasicLexerImpl(config);
-        });
+            () => new BasicLexerImpl(new LexerConfiguration([])));
 
         services.AddTransient<Func<IParser>>(_ =>
-        {
-            var config = new ParserConfiguration([]);
-            return () => new BasicParserImpl(config);
-        });
+            () => new BasicParserImpl(new ParserConfiguration([])));
 
         services.AddTransient<Func<IAstToBytecodeTranslator>>(_ =>
-        {
-            var config = new BytecodeTranslatorConfiguration([]);
-            return () => new BasicAstToBytecodeTranslatorImpl(config);
-        });
+            () => new BasicAstToBytecodeTranslatorImpl(new BytecodeTranslatorConfiguration([])));
         services.AddSingleton<IntrinsicDescriptorProviderMetadataValidator>();
         services.AddSingleton<IntrinsicSemanticCoverageValidator>();
         services.AddSingleton<IntrinsicSemanticStartupValidator>();

--- a/UniversalToolchain/UniversalToolchain.Dialects.Frontend/DialectDslFrontendServiceCollectionExtensions.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Frontend/DialectDslFrontendServiceCollectionExtensions.cs
@@ -26,10 +26,6 @@ public static class DialectDslFrontendServiceCollectionExtensions
 
         services.AddSingleton(frontendModule);
         services.AddSingleton<IFrontendCoreModule>(frontendModule);
-        services.AddSingleton<IIntrinsicDescriptorProvider, ArithmeticIntrinsicDescriptorProvider>();
-        services.AddSingleton<IIntrinsicDescriptorProvider, ComparisonIntrinsicDescriptorProvider>();
-        services.AddSingleton<IIntrinsicDescriptorProvider, BooleanIntrinsicDescriptorProvider>();
-        services.AddSingleton<IIntrinsicDescriptorProvider, StorageIntrinsicDescriptorProvider>();
 
         return services;
     }

--- a/UniversalToolchain/UniversalToolchain.Dialects.Integration/DialectBackendRuntimeConfiguration.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Integration/DialectBackendRuntimeConfiguration.cs
@@ -8,11 +8,13 @@ namespace UniversalToolchain.Dialects.Integration;
 /// </summary>
 public class DialectBackendRuntimeConfiguration
 {
+    private readonly ReadOnlyCollection<Type> _optimizerTypes;
     private readonly ReadOnlyCollection<string> _allowedIntrinsics;
     private readonly ReadOnlyCollection<string> _forbiddenIntrinsics;
 
     public DialectBackendRuntimeConfiguration(
         RuntimeBackendDescriptor backendDescriptor,
+        IEnumerable<Type> optimizerTypes,
         IEnumerable<string> allowedIntrinsics,
         IEnumerable<string> forbiddenIntrinsics,
         bool hasExplicitAllowList)
@@ -21,6 +23,7 @@ public class DialectBackendRuntimeConfiguration
             Thrower.ArgumentNull(nameof(backendDescriptor));
 
         BackendDescriptor = backendDescriptor;
+        _optimizerTypes = new ReadOnlyCollection<Type>(SnapshotTypes(optimizerTypes, nameof(optimizerTypes)));
         _allowedIntrinsics = new ReadOnlyCollection<string>(Snapshot(allowedIntrinsics, nameof(allowedIntrinsics)));
         _forbiddenIntrinsics = new ReadOnlyCollection<string>(Snapshot(forbiddenIntrinsics, nameof(forbiddenIntrinsics)));
         HasExplicitAllowList = hasExplicitAllowList;
@@ -28,11 +31,25 @@ public class DialectBackendRuntimeConfiguration
 
     public RuntimeBackendDescriptor BackendDescriptor { get; }
 
+    public IReadOnlyList<Type> OptimizerTypes => _optimizerTypes;
+
     public IReadOnlyList<string> AllowedIntrinsics => _allowedIntrinsics;
 
     public IReadOnlyList<string> ForbiddenIntrinsics => _forbiddenIntrinsics;
 
     public bool HasExplicitAllowList { get; }
+
+    private static List<Type> SnapshotTypes(IEnumerable<Type> values, string paramName)
+    {
+        if (values == null)
+            Thrower.ArgumentNull(paramName);
+
+        return values
+            .Select(x => x.NotNull(paramName))
+            .Distinct()
+            .OrderBy(x => x.FullName, StringComparer.Ordinal)
+            .ToList();
+    }
 
     private static List<string> Snapshot(IEnumerable<string> values, string paramName)
     {

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/DialectDslArchitectureRefactorTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/DialectDslArchitectureRefactorTests.cs
@@ -305,11 +305,7 @@ public class DialectDslArchitectureRefactorTests
             Assert.That(provider.GetRequiredService<IIntrinsicCatalog>(), Is.Not.Null);
             Assert.That(providerTypes, Is.EqualTo(new[]
             {
-                typeof(CoreIntrinsicDescriptorProvider),
-                typeof(ArithmeticIntrinsicDescriptorProvider),
-                typeof(ComparisonIntrinsicDescriptorProvider),
-                typeof(BooleanIntrinsicDescriptorProvider),
-                typeof(StorageIntrinsicDescriptorProvider)
+                typeof(CoreIntrinsicDescriptorProvider)
             }));
             Assert.That(slice.UseModules, Is.EqualTo(new[] { "Arithmetic" }));
         });

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/RuntimeLoading/IntrinsicSemanticCompositionGuardTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/RuntimeLoading/IntrinsicSemanticCompositionGuardTests.cs
@@ -21,7 +21,7 @@ public sealed class IntrinsicSemanticCompositionGuardTests
 
         var exception = Assert.Throws<InvalidOperationException>(() => factory.Create(configuration));
 
-        Assert.That(exception!.Message, Does.Contain("Duplicate intrinsic semantic descriptor"));
+        Assert.That(exception!.Message, Does.Contain("Intrinsic symbol"));
         Assert.That(exception.Message, Does.Contain("math.add"));
     }
 

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/RuntimeLoading/IntrinsicSemanticStartupValidationRuntimeTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/RuntimeLoading/IntrinsicSemanticStartupValidationRuntimeTests.cs
@@ -82,6 +82,7 @@ public sealed class IntrinsicSemanticStartupValidationRuntimeTests
                 new RuntimeBackendDescriptor(new DialectBackendId("counting"), typeof(CountingBackendRegistrar)),
                 [],
                 [],
+                [],
                 false)],
             [new RuntimeBackendDescriptor(new DialectBackendId("counting"), typeof(CountingBackendRegistrar))]);
 

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/Wist/WistDialectRuntimeBootstrapContractTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/Wist/WistDialectRuntimeBootstrapContractTests.cs
@@ -123,7 +123,7 @@ public class WistDialectRuntimeBootstrapContractTests
             [],
             [],
             [],
-            [new DialectBackendRuntimeConfiguration(new RuntimeBackendDescriptor(new DialectBackendId("interpreter"), typeof(NoopRegistrar), ["vm"]), [], [], false)],
+            [new DialectBackendRuntimeConfiguration(new RuntimeBackendDescriptor(new DialectBackendId("interpreter"), typeof(NoopRegistrar), ["vm"]), [], [], [], false)],
             [new RuntimeBackendDescriptor(new DialectBackendId("interpreter"), typeof(NoopRegistrar), ["vm"])]);
 
         var provider = factory.Create(config);
@@ -141,7 +141,7 @@ public class WistDialectRuntimeBootstrapContractTests
             [],
             [],
             [],
-            [new DialectBackendRuntimeConfiguration(new RuntimeBackendDescriptor(new DialectBackendId("interpreter"), typeof(object), []), [], [], false)],
+            [new DialectBackendRuntimeConfiguration(new RuntimeBackendDescriptor(new DialectBackendId("interpreter"), typeof(object), []), [], [], [], false)],
             [new RuntimeBackendDescriptor(new DialectBackendId("interpreter"), typeof(object), [])]);
 
         var ex = Assert.Throws<InvalidOperationException>(() => factory.Create(config));

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistCilDialectBackendServiceProvider.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistCilDialectBackendServiceProvider.cs
@@ -42,6 +42,9 @@ internal sealed class WistCilDialectBackendServiceProvider : IDialectBackendRunt
     private static BasicCoreImpl<DynamicMethod> CreateCore(IServiceProvider provider, DialectBackendRuntimeConfiguration configuration)
     {
         var capabilitySetFactory = provider.GetRequiredService<IIntrinsicCapabilitySetFactory>();
+        var backendOptimizers = configuration.OptimizerTypes
+            .Select(type => (IIRProcessingModule)provider.GetRequiredService(type))
+            .ToList();
 
         return new BasicCoreImpl<DynamicMethod>(
             provider.GetRequiredService<Func<ILexer>>(),
@@ -59,7 +62,7 @@ internal sealed class WistCilDialectBackendServiceProvider : IDialectBackendRunt
             },
             provider.GetRequiredService<Func<IExecutor<DynamicMethod>>>(),
             provider.GetServices<IFrontendCoreModule>().ToList(),
-            provider.GetServices<IIRProcessingModule>().ToList(),
+            backendOptimizers,
             [],
             capabilitySetFactory);
     }

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistDialectExecutionConfigurationBuilder.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistDialectExecutionConfigurationBuilder.cs
@@ -54,12 +54,15 @@ public sealed class WistDialectExecutionConfigurationBuilder
                 irModules.Add(type);
         }
 
-        var optimizers = selectedRuntimePlan.EnabledOptimizers
-            .Select(_typeLoader.LoadType)
-            .ToList();
 
         var backends = selectedRuntimePlan.EnabledBackends
-            .Select(x => BuildBackendConfiguration(x, buildPlan))
+            .Select(x => BuildBackendConfiguration(x, buildPlan, selectedRuntimePlan))
+            .ToList();
+
+        var allOptimizers = backends
+            .SelectMany(x => x.OptimizerTypes)
+            .Distinct()
+            .OrderBy(x => x.FullName, StringComparer.Ordinal)
             .ToList();
 
         var knownBackends = _knownBackendsProvider.GetKnownBackends();
@@ -68,18 +71,31 @@ public sealed class WistDialectExecutionConfigurationBuilder
             buildPlan.Name,
             frontendModules,
             irModules,
-            optimizers,
+            allOptimizers,
             backends,
             knownBackends);
     }
 
-    private DialectBackendRuntimeConfiguration BuildBackendConfiguration(RuntimeComponentManifestEntry backend, DialectBuildPlan buildPlan)
+    private DialectBackendRuntimeConfiguration BuildBackendConfiguration(
+        RuntimeComponentManifestEntry backend,
+        DialectBuildPlan buildPlan,
+        SelectedRuntimePlan selectedRuntimePlan)
     {
         var backendId = new DialectBackendId(backend.CanonicalAlias);
+        var optimizerTypes = selectedRuntimePlan.EnabledOptimizers
+            .Where(entry => buildPlan.OptimizerDirectives
+                .Where(x => x.Enabled)
+                .Any(x => string.Equals(x.Name, entry.CanonicalAlias, StringComparison.Ordinal)
+                          && x.Target.Matches(backendId)))
+            .Select(_typeLoader.LoadType)
+            .Distinct()
+            .OrderBy(x => x.FullName, StringComparer.Ordinal)
+            .ToList();
         var policy = _intrinsicPolicyResolver.Resolve(buildPlan, backendId);
         var metadataOwnerType = _typeLoader.LoadType(backend);
         return new DialectBackendRuntimeConfiguration(
             new RuntimeBackendDescriptor(backendId, metadataOwnerType, backend.Aliases),
+            optimizerTypes,
             policy.Allowed,
             policy.Forbidden,
             policy.HasExplicitAllowList);

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistDialectServiceProviderFactory.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistDialectServiceProviderFactory.cs
@@ -45,7 +45,12 @@ public sealed class WistDialectServiceProviderFactory
     private static void RegisterModules(IServiceCollection services, IEnumerable<Type> types, Type serviceType, ServiceLifetime lifetime)
     {
         foreach (var type in types.OrderBy(x => x.FullName, StringComparer.Ordinal))
+        {
             services.Add(new ServiceDescriptor(serviceType, type, lifetime));
+
+            if (!services.Any(x => x.ServiceType == type && x.ImplementationType == type))
+                services.Add(new ServiceDescriptor(type, type, lifetime));
+        }
     }
 
     private void RegisterBackendRuntimes(IServiceCollection services, WistDialectExecutionConfiguration configuration)
@@ -83,7 +88,10 @@ public sealed class WistDialectServiceProviderFactory
         }
 
         foreach (var providerType in providerTypes)
-            services.AddSingleton(typeof(IIntrinsicDescriptorProvider), providerType);
+        {
+            if (!services.Any(x => x.ServiceType == typeof(IIntrinsicDescriptorProvider) && x.ImplementationType == providerType))
+                services.AddSingleton(typeof(IIntrinsicDescriptorProvider), providerType);
+        }
     }
 
     private static IReadOnlyList<(Type ModuleType, Type ProviderType)> ValidateIntrinsicSemantics(IServiceCollection services)

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistInterpreterDialectBackendServiceProvider.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistInterpreterDialectBackendServiceProvider.cs
@@ -42,6 +42,9 @@ internal sealed class WistInterpreterDialectBackendServiceProvider : IDialectBac
     private static BasicCoreImpl<IAbstractIR> CreateCore(IServiceProvider provider, DialectBackendRuntimeConfiguration configuration)
     {
         var capabilitySetFactory = provider.GetRequiredService<IIntrinsicCapabilitySetFactory>();
+        var backendOptimizers = configuration.OptimizerTypes
+            .Select(type => (IIRProcessingModule)provider.GetRequiredService(type))
+            .ToList();
 
         return new BasicCoreImpl<IAbstractIR>(
             provider.GetRequiredService<Func<ILexer>>(),
@@ -59,7 +62,7 @@ internal sealed class WistInterpreterDialectBackendServiceProvider : IDialectBac
             },
             provider.GetRequiredService<Func<IExecutor<IAbstractIR>>>(),
             provider.GetServices<IFrontendCoreModule>().ToList(),
-            provider.GetServices<IIRProcessingModule>().ToList(),
+            backendOptimizers,
             [],
             capabilitySetFactory);
     }

--- a/UniversalToolchain/UniversalToolchain.Modules.Tests/ModuleCoverage/TypedIntrinsicEmitterOptimizerTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Modules.Tests/ModuleCoverage/TypedIntrinsicEmitterOptimizerTests.cs
@@ -88,7 +88,7 @@ public sealed class TypedIntrinsicEmitterOptimizerTests
         Assert.That(method, Is.Not.Null);
 
         var input = CreateIr(
-            new Instruction(UOpCode.Push, [true]),
+            new Instruction(UOpCode.Intrinsic, ["load_local", "flag", typeof(bool)]),
             new Instruction(UOpCode.Intrinsic, ["call C#", method!]));
 
         var result = optimizer.ProcessIr(input, new FakeCompiler());


### PR DESCRIPTION
### Motivation

- Prevent reuse of mutable lexer/parser/translator configuration instances between compilations so each compile/run gets a fresh config.
- Avoid duplicate intrinsic provider registrations from frontend wiring and defer symbol-level intrinsic validation until provider instances are available.
- Support backend-specific optimizer lists so optimizers are resolved and executed per-backend rather than globally.

### Description

- Replace factories in `AddCoreRuntimeInfrastructure` to create fresh configurations inline (`Func<ILexer>`, `Func<IParser>`, `Func<IAstToBytecodeTranslator}`).
- Remove duplicate `IIntrinsicDescriptorProvider` registrations from `AddDialectDslFrontendCompilerServices` so the frontend only registers the module and `IFrontendCoreModule`.
- Simplify `IntrinsicDescriptorProviderMetadataValidator.Validate(IServiceCollection)` to only validate registration shape (non-null types, interface implementation, duplicate provider-type registrations) and remove provider instantiation and symbol-level checks.
- Add backend-specific optimizer support to `DialectBackendRuntimeConfiguration` (constructor param, `_optimizerTypes`, `OptimizerTypes` and `SnapshotTypes` helper) and update `WistDialectExecutionConfigurationBuilder` to compute `optimizerTypes` per backend and produce `allOptimizers` for compatibility.
- Register module types also as themselves in `WistDialectServiceProviderFactory.RegisterModules` and avoid duplicate intrinsic provider registrations when adding to the DI container.
- Update CIL and Interpreter backend providers to resolve optimizer modules from `configuration.OptimizerTypes` via `provider.GetRequiredService(type)` and pass those to `BasicCoreImpl`.
- Adjust tests and thin-dialect fixtures as required (`ModuleCombinationsTests`, `ModuleInteractionTests`, boolean optimizer test input, and a few expectation updates) to match the new wiring and validation flow.

### Testing

- Ran the requested targeted suites in sequence: `FrameworkNativeVerticalSliceTests`, `MinimalRuntimeSelectionTests`, `IntrinsicSemanticCompositionGuardTests`; all passed.
- Ran backend / integration suites: `InterpreterBackendOptimizerIntrinsicSurfaceTests`, `WistDialectBackendMatrixTests`, `DialectProjectsSmokeTests`, `WistDialectExecutionIntegrationTests`; all passed.
- Ran the thin-dialect and optimizer tests: `ModuleCombinationsTests`, `ModuleInteractionTests`, and `TypedIntrinsicEmitterOptimizerTests`; all passed.
- Ran full project test suites for `UniversalToolchain.Dialects.Tests`, `UniversalToolchain.Modules.Tests`, and `Tests` and they passed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8d44eb5d0832485d1070e53527198)