### PR TITLE
Refactor neutral core runtime and Wist backend assembly

### DIFF
--- a/UniversalToolchain/UniversalToolchain.Dialects.Core/ServiceCollection/CoreRuntimeServiceCollectionExtensions.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Core/ServiceCollection/CoreRuntimeServiceCollectionExtensions.cs
@@ -1,0 +1,59 @@
+using AbstractIrConverters;
+using BasicCodeTranslator;
+using BasicCore.Contracts;
+using BasicCore.LexerWrapper;
+using BasicCore.ParserWrapper;
+using BasicCore.TranslatorWrapper;
+using BasicLexer.Core;
+using BasicParser.Core;
+using ExceptionsManager;
+using Microsoft.Extensions.DependencyInjection;
+using UniversalToolchain.Intrinsics.Builtins;
+using UniversalToolchain.Intrinsics.Capabilities;
+using UniversalToolchain.Intrinsics.Contracts;
+using UniversalToolchain.Intrinsics.Core;
+using UniversalToolchain.Intrinsics.Legacy;
+
+namespace UniversalToolchain.Dialects.Core.ServiceCollection;
+
+/// <summary>
+///     Registers neutral core runtime services required to construct executable runtimes.
+/// </summary>
+public static class CoreRuntimeServiceCollectionExtensions
+{
+    public static IServiceCollection AddCoreRuntimeInfrastructure(this IServiceCollection services)
+    {
+        if (services == null)
+            Thrower.ArgumentNull(nameof(services));
+
+        services.AddTransient<Func<ILexer>>(_ =>
+            () => new BasicLexerImpl(new LexerConfiguration([])));
+
+        services.AddTransient<Func<IParser>>(_ =>
+            () => new BasicParserImpl(new ParserConfiguration([])));
+
+        services.AddTransient<Func<IAstToBytecodeTranslator>>(_ =>
+            () => new BasicAstToBytecodeTranslatorImpl(new BytecodeTranslatorConfiguration([])));
+        services.AddSingleton<IntrinsicDescriptorProviderMetadataValidator>();
+        services.AddSingleton<IntrinsicSemanticCoverageValidator>();
+        services.AddSingleton<IntrinsicSemanticStartupValidator>();
+        services.AddSingleton<IIntrinsicTypeResolutionContext, IntrinsicTypeResolutionContext>();
+        services.AddSingleton<MethodCallTypeSemanticsResolver>();
+        services.AddTransient<IIntrinsicDescriptorProvider, CoreIntrinsicDescriptorProvider>();
+        services.AddSingleton<IIntrinsicCatalog>(sp =>
+        {
+            var providers = sp.GetServices<IIntrinsicDescriptorProvider>();
+            return new IntrinsicCatalogBuilder().Build(providers);
+        });
+        services.AddSingleton<ILegacyIntrinsicDecoder, LegacyIntrinsicDecoder>();
+        services.AddSingleton<IInstructionIntrinsicReader, InstructionIntrinsicReader>();
+        services.AddSingleton<IIntrinsicTypeStackProcessor, IntrinsicTypeStackProcessor>();
+        services.AddSingleton<IIntrinsicCapabilitySetFactory, CompilerIntrinsicCapabilitySetFactory>();
+        services.AddTransient<Func<IAbstractMethodsTranslator>>(sp =>
+            () => new BytecodeToAbstractIrConverterImpl(
+                sp.GetRequiredService<IInstructionIntrinsicReader>(),
+                sp.GetRequiredService<IIntrinsicTypeStackProcessor>()));
+
+        return services;
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistCilDialectBackendServiceProvider.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistCilDialectBackendServiceProvider.cs
@@ -1,0 +1,51 @@
+using System.Reflection.Emit;
+using BasicCore.Contracts;
+using BasicCore.Core;
+using BasicCore.ExecutorWrapper;
+using BytecodeDynamicMethodsCompiler.Compilers;
+using ExceptionsManager;
+using Microsoft.Extensions.DependencyInjection;
+using UniversalToolchain.Dialects.Abstractions;
+using UniversalToolchain.Dialects.Integration;
+
+namespace UniversalToolchain.Dialects.Wist;
+
+internal sealed class WistCilDialectBackendServiceProvider : IDialectBackendRuntimeRegistrar
+{
+    private static readonly IReadOnlyList<string> _supportedIntrinsics = new AbstractMethodsCompilerImpl().SupportedIntrinsics
+        .Distinct(StringComparer.Ordinal)
+        .OrderBy(x => x, StringComparer.Ordinal)
+        .ToList();
+
+    public DialectBackendId BackendId => WistDialectBackendIds.Cil;
+
+    public IReadOnlyList<string> SupportedIntrinsics => _supportedIntrinsics;
+
+    public void RegisterRuntime(IServiceCollection services, DialectBackendRuntimeConfiguration configuration)
+    {
+        if (services == null)
+            Thrower.ArgumentNull(nameof(services));
+
+        if (configuration == null)
+            Thrower.ArgumentNull(nameof(configuration));
+
+        services.AddWistCilRuntimeServices();
+        services.AddTransient<ICoreRunnable>(provider => CreateCore(provider, configuration));
+        services.AddTransient<ICoreOptimizedRunnable>(provider => CreateCore(provider, configuration));
+        services.AddTransient<IExecutableGiver<DynamicMethod>>(provider => CreateCore(provider, configuration));
+        services.AddTransient(provider => new WistDialectBackendRuntime(configuration.BackendDescriptor, CreateCore(provider, configuration)));
+    }
+
+    private static BasicCoreImpl<DynamicMethod> CreateCore(IServiceProvider provider, DialectBackendRuntimeConfiguration configuration)
+    {
+        return WistDialectBackendCoreFactory.Create(
+            provider,
+            configuration,
+            static (serviceProvider, runtimeConfiguration) => new DialectIntrinsicPolicyCompiler<DynamicMethod>(
+                serviceProvider.GetRequiredService<AbstractMethodsCompilerImpl>(),
+                runtimeConfiguration.AllowedIntrinsics,
+                runtimeConfiguration.ForbiddenIntrinsics,
+                runtimeConfiguration.HasExplicitAllowList),
+            static serviceProvider => serviceProvider.GetRequiredService<Func<IExecutor<DynamicMethod>>>()());
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistCilRuntimeServiceCollectionExtensions.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistCilRuntimeServiceCollectionExtensions.cs
@@ -1,0 +1,22 @@
+using System.Reflection.Emit;
+using BasicCilCompiler.Execution;
+using BasicCore.ExecutorWrapper;
+using BytecodeDynamicMethodsCompiler.Compilers;
+using ExceptionsManager;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace UniversalToolchain.Dialects.Wist;
+
+internal static class WistCilRuntimeServiceCollectionExtensions
+{
+    public static IServiceCollection AddWistCilRuntimeServices(this IServiceCollection services)
+    {
+        if (services == null)
+            Thrower.ArgumentNull(nameof(services));
+
+        services.TryAddTransient<AbstractMethodsCompilerImpl>();
+        services.TryAddTransient<Func<IExecutor<DynamicMethod>>>(_ => () => new DynamicMethodExecutor());
+        return services;
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistDialectBackendCoreFactory.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistDialectBackendCoreFactory.cs
@@ -1,0 +1,51 @@
+using BasicCore.Contracts;
+using BasicCore.Core;
+using BasicCore.ExecutorWrapper;
+using BasicCore.LexerWrapper;
+using BasicCore.ParserWrapper;
+using BasicCore.TranslatorWrapper;
+using ExceptionsManager;
+using Microsoft.Extensions.DependencyInjection;
+using UniversalToolchain.Dialects.Integration;
+using UniversalToolchain.Intrinsics.Capabilities;
+
+namespace UniversalToolchain.Dialects.Wist;
+
+internal static class WistDialectBackendCoreFactory
+{
+    public static BasicCoreImpl<TCompilationOutput> Create<TCompilationOutput>(
+        IServiceProvider provider,
+        DialectBackendRuntimeConfiguration configuration,
+        Func<IServiceProvider, DialectBackendRuntimeConfiguration, IAbstractIrCompiler<TCompilationOutput>> compilerFactory,
+        Func<IServiceProvider, IExecutor<TCompilationOutput>> executorFactory)
+    {
+        if (provider == null)
+            Thrower.ArgumentNull(nameof(provider));
+
+        if (configuration == null)
+            Thrower.ArgumentNull(nameof(configuration));
+
+        if (compilerFactory == null)
+            Thrower.ArgumentNull(nameof(compilerFactory));
+
+        if (executorFactory == null)
+            Thrower.ArgumentNull(nameof(executorFactory));
+
+        var capabilitySetFactory = provider.GetRequiredService<IIntrinsicCapabilitySetFactory>();
+        var backendOptimizers = configuration.OptimizerTypes
+            .Select(type => (IIRProcessingModule)provider.GetRequiredService(type))
+            .ToList();
+
+        return new BasicCoreImpl<TCompilationOutput>(
+            provider.GetRequiredService<Func<ILexer>>(),
+            provider.GetRequiredService<Func<IParser>>(),
+            provider.GetRequiredService<Func<IAstToBytecodeTranslator>>(),
+            provider.GetRequiredService<Func<IAbstractMethodsTranslator>>(),
+            () => compilerFactory(provider, configuration),
+            () => executorFactory(provider),
+            provider.GetServices<IFrontendCoreModule>().ToList(),
+            backendOptimizers,
+            [],
+            capabilitySetFactory);
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistInterpreterDialectBackendServiceProvider.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistInterpreterDialectBackendServiceProvider.cs
@@ -1,0 +1,51 @@
+using AbstractIrConverters;
+using BasicCore.Contracts;
+using BasicCore.Core;
+using BasicCore.ExecutorWrapper;
+using ExceptionsManager;
+using IntermediateRepresentationAbstractions;
+using Microsoft.Extensions.DependencyInjection;
+using UniversalToolchain.Dialects.Abstractions;
+using UniversalToolchain.Dialects.Integration;
+
+namespace UniversalToolchain.Dialects.Wist;
+
+internal sealed class WistInterpreterDialectBackendServiceProvider : IDialectBackendRuntimeRegistrar
+{
+    private static readonly IReadOnlyList<string> _supportedIntrinsics = new AbstractIrToAbstractIrStub().SupportedIntrinsics
+        .Distinct(StringComparer.Ordinal)
+        .OrderBy(x => x, StringComparer.Ordinal)
+        .ToList();
+
+    public DialectBackendId BackendId => WistDialectBackendIds.Interpreter;
+
+    public IReadOnlyList<string> SupportedIntrinsics => _supportedIntrinsics;
+
+    public void RegisterRuntime(IServiceCollection services, DialectBackendRuntimeConfiguration configuration)
+    {
+        if (services == null)
+            Thrower.ArgumentNull(nameof(services));
+
+        if (configuration == null)
+            Thrower.ArgumentNull(nameof(configuration));
+
+        services.AddWistInterpreterRuntimeServices();
+        services.AddTransient<ICoreRunnable>(provider => CreateCore(provider, configuration));
+        services.AddTransient<ICoreOptimizedRunnable>(provider => CreateCore(provider, configuration));
+        services.AddTransient<IExecutableGiver<IAbstractIR>>(provider => CreateCore(provider, configuration));
+        services.AddTransient(provider => new WistDialectBackendRuntime(configuration.BackendDescriptor, CreateCore(provider, configuration)));
+    }
+
+    private static BasicCoreImpl<IAbstractIR> CreateCore(IServiceProvider provider, DialectBackendRuntimeConfiguration configuration)
+    {
+        return WistDialectBackendCoreFactory.Create(
+            provider,
+            configuration,
+            static (serviceProvider, runtimeConfiguration) => new DialectIntrinsicPolicyCompiler<IAbstractIR>(
+                serviceProvider.GetRequiredService<AbstractIrToAbstractIrStub>(),
+                runtimeConfiguration.AllowedIntrinsics,
+                runtimeConfiguration.ForbiddenIntrinsics,
+                runtimeConfiguration.HasExplicitAllowList),
+            static serviceProvider => serviceProvider.GetRequiredService<Func<IExecutor<IAbstractIR>>>()());
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistInterpreterRuntimeServiceCollectionExtensions.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistInterpreterRuntimeServiceCollectionExtensions.cs
@@ -1,0 +1,22 @@
+using AbstractIrConverters;
+using BasicCore.ExecutorWrapper;
+using BasicInterpreter;
+using ExceptionsManager;
+using IntermediateRepresentationAbstractions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace UniversalToolchain.Dialects.Wist;
+
+internal static class WistInterpreterRuntimeServiceCollectionExtensions
+{
+    public static IServiceCollection AddWistInterpreterRuntimeServices(this IServiceCollection services)
+    {
+        if (services == null)
+            Thrower.ArgumentNull(nameof(services));
+
+        services.TryAddTransient<AbstractIrToAbstractIrStub>();
+        services.TryAddTransient<Func<IExecutor<IAbstractIR>>>(_ => () => new InterpreterImpl());
+        return services;
+    }
+}


### PR DESCRIPTION
## What changed

This PR applies the minimal refactoring discussed for problems 2 and 3:

- moves backend-specific runtime registrations out of `AddCoreRuntimeInfrastructure()`
- adds backend-local runtime service registration helpers for CIL and interpreter
- introduces a shared `WistDialectBackendCoreFactory` to remove duplicated `BasicCoreImpl<T>` assembly logic
- rewrites the two Wist backend registrars to use the shared factory and backend-local registrations

## Why

This keeps the core runtime layer backend-neutral and reduces Wist-specific manual wiring duplication without changing the public backend registrar contract.

## Scope

Touched files:

- `UniversalToolchain.Dialects.Core/ServiceCollection/CoreRuntimeServiceCollectionExtensions.cs`
- `UniversalToolchain.Dialects.Wist/WistCilDialectBackendServiceProvider.cs`
- `UniversalToolchain.Dialects.Wist/WistInterpreterDialectBackendServiceProvider.cs`
- `UniversalToolchain.Dialects.Wist/WistDialectBackendCoreFactory.cs`
- `UniversalToolchain.Dialects.Wist/WistCilRuntimeServiceCollectionExtensions.cs`
- `UniversalToolchain.Dialects.Wist/WistInterpreterRuntimeServiceCollectionExtensions.cs`

## Notes

I did not run the test suite from this environment, so CI/local verification is still needed.
