### PR TITLE
Replace direct exceptions with Thrower and use .NotNull() guards

### DIFF
--- a/UniversalToolchain/ConditionsModule/Optimizers/BooleanOptimizer.cs
+++ b/UniversalToolchain/ConditionsModule/Optimizers/BooleanOptimizer.cs
@@ -17,18 +17,13 @@ public class BooleanOptimizerModule : IIRProcessingModule
 
     public void InitIntrinsicCapabilityContext(IOptimizerIntrinsicCapabilityContext capabilityContext)
     {
-        if (capabilityContext == null)
-            Thrower.ArgumentNull(nameof(capabilityContext));
-
-        _capabilityContext = capabilityContext;
+        _capabilityContext = capabilityContext.NotNull("Argument 'capabilityContext' cannot be null.");
     }
 
     public IAbstractIR ProcessIr<TCompilationOutput>(IAbstractIR current, IAbstractIrCompiler<TCompilationOutput> compiler)
     {
-        if (_capabilityContext == null)
-            Thrower.InvalidOpEx("Boolean optimizer requires intrinsic capability context initialization.");
-
-        var capabilityContext = _capabilityContext;
+        var capabilityContext = _capabilityContext.NotNull(
+            "Boolean optimizer requires intrinsic capability context initialization.");
 
         if (!OptimizerCapabilityGuards.SupportsAll(
                 capabilityContext,

--- a/UniversalToolchain/NativeMathModule/NativeCILOptimizerModule.cs
+++ b/UniversalToolchain/NativeMathModule/NativeCILOptimizerModule.cs
@@ -31,18 +31,13 @@ public class NativeCilOptimizerModule : IIRProcessingModule
 
     public void InitIntrinsicCapabilityContext(IOptimizerIntrinsicCapabilityContext capabilityContext)
     {
-        if (capabilityContext == null)
-            Thrower.ArgumentNull(nameof(capabilityContext));
-
-        _capabilityContext = capabilityContext;
+        _capabilityContext = capabilityContext.NotNull("Argument 'capabilityContext' cannot be null.");
     }
 
     public IAbstractIR ProcessIr<TCompilationOutput>(IAbstractIR current, IAbstractIrCompiler<TCompilationOutput> compiler)
     {
-        if (_capabilityContext == null)
-            Thrower.InvalidOpEx("Native CIL optimizer requires intrinsic capability context initialization.");
-
-        var capabilityContext = _capabilityContext;
+        var capabilityContext = _capabilityContext.NotNull(
+            "Native CIL optimizer requires intrinsic capability context initialization.");
 
         var requirements = _supportedLoadTypes
             .Select(type => (BuiltinIntrinsicSymbols.Core.LoadConst, new[] { type }));

--- a/UniversalToolchain/Tests/Infrastructure/BackendValueNormalizer.cs
+++ b/UniversalToolchain/Tests/Infrastructure/BackendValueNormalizer.cs
@@ -43,7 +43,7 @@ internal static class BackendValueNormalizer
         if (normalized is IConvertible convertible)
             return (T)Convert.ChangeType(convertible, typeof(T));
 
-        throw new InvalidOperationException(
+        return Thrower.InvalidOpEx<T>(
             $"Cannot convert normalized backend value from {normalized?.GetType().FullName ?? "<null>"} to {typeof(T).FullName}.");
     }
 }

--- a/UniversalToolchain/UniversalToolchain.Dialects.ManifestEmitter/Program.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.ManifestEmitter/Program.cs
@@ -4,7 +4,8 @@ using ExceptionsManager;
 
 var arguments = CliArguments.Parse(args);
 var manifest = ManifestEmitter.Emit(arguments.AssemblyPath);
-Directory.CreateDirectory(Path.GetDirectoryName(arguments.OutputPath)!);
+Directory.CreateDirectory(
+    Path.GetDirectoryName(arguments.OutputPath).NotNull("Output directory path must not be null."));
 File.WriteAllText(arguments.OutputPath, JsonSerializer.Serialize(manifest, JsonOptions.Instance));
 
 internal sealed record CliArguments(string AssemblyPath, string OutputPath)
@@ -16,16 +17,16 @@ internal sealed record CliArguments(string AssemblyPath, string OutputPath)
             values[args[i]] = args[i + 1];
 
         if (!values.TryGetValue("--assembly", out var assemblyPath) || string.IsNullOrWhiteSpace(assemblyPath))
-            throw new ArgumentException("Missing '--assembly <absolute path>' argument.");
+            Thrower.Argument(nameof(args), "Missing '--assembly <absolute path>' argument.");
 
         if (!Path.IsPathRooted(assemblyPath))
-            throw new ArgumentException("--assembly must be an absolute path.");
+            Thrower.Argument(nameof(args), "--assembly must be an absolute path.");
 
         if (!values.TryGetValue("--output", out var outputPath) || string.IsNullOrWhiteSpace(outputPath))
-            throw new ArgumentException("Missing '--output <absolute path>' argument.");
+            Thrower.Argument(nameof(args), "Missing '--output <absolute path>' argument.");
 
         if (!Path.IsPathRooted(outputPath))
-            throw new ArgumentException("--output must be an absolute path.");
+            Thrower.Argument(nameof(args), "--output must be an absolute path.");
 
         return new CliArguments(Path.GetFullPath(assemblyPath), Path.GetFullPath(outputPath));
     }


### PR DESCRIPTION
### Motivation
- Align exception handling with the repository-wide `Thrower` helpers and avoid direct `throw new ...` sites in new changes. 
- Remove null-forgiving `!` usage and apply the `.NotNull(...)` guard to make null diagnostics explicit and consistent with project rules. 

### Description
- In `UniversalToolchain.Dialects.ManifestEmitter/Program.cs` replaced four `throw new ArgumentException(...)` calls inside `CliArguments.Parse(...)` with `Thrower.Argument(...)` and replaced `Path.GetDirectoryName(arguments.OutputPath)!` with `Path.GetDirectoryName(arguments.OutputPath).NotNull("Output directory path must not be null.")` when creating the output directory. 
- In `UniversalToolchain/Tests/Infrastructure/BackendValueNormalizer.cs` replaced a direct `throw new InvalidOperationException(...)` with `return Thrower.InvalidOpEx<T>(...)` in `ConvertTo<T>(...)`. 
- Optional style cleanups applied to use `.NotNull(...)` in `NativeMathModule/NativeCILOptimizerModule.cs` and `ConditionsModule/Optimizers/BooleanOptimizer.cs` for `InitIntrinsicCapabilityContext(...)` and `ProcessIr(...)` null guards without changing logic. 

### Testing
- Ran `dotnet --version` and installed the .NET 10 SDK successfully. 
- Restored the solution with `dotnet restore UniversalToolchain/Wist.sln` and built/tested the test assembly with `dotnet test UniversalToolchain/Tests/Tests.csproj -c Release`, which passed: `Passed!  - Failed:     0, Passed:   188, Skipped:     0, Total:   188`. 
- Ran repository scans requested with `rg` for direct `throw new ...` patterns, `?? throw`, and `Path.GetDirectoryName(... )!` and validated the targeted occurrences were addressed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd11da0bbc83249b03f4f8c101d061)