### PR TITLE
Clarify pricing-restricted negative-path wording and add README example

### DIFF
--- a/UniversalToolchain/Dialects/examples/wist/pricing-restricted/README.md
+++ b/UniversalToolchain/Dialects/examples/wist/pricing-restricted/README.md
@@ -31,7 +31,7 @@ It should not include:
 - loops
 - labels
 - conditions
-- local variables
+- statement-style bindings
 - comments
 - C# interop
 - general statement syntax

--- a/UniversalToolchain/Example/Scenarios/PricingDiscountScenario.cs
+++ b/UniversalToolchain/Example/Scenarios/PricingDiscountScenario.cs
@@ -40,10 +40,10 @@ public static class PricingDiscountScenario
         var restrictedPositiveAttempt = restrictedDslPricingCalculator.TryCompileWithInterpreter(Formula);
         Console.WriteLine($"Restricted pricing accepts positive formula: {restrictedPositiveAttempt.IsSuccess}");
 
-        var restrictedLocalVariableAttempt = restrictedDslPricingCalculator.TryCompileWithInterpreter(DisallowedFormula);
-        var restrictedRejectsLocalVariables = !restrictedLocalVariableAttempt.IsSuccess;
-        Console.WriteLine($"Restricted pricing rejects local variables: {restrictedRejectsLocalVariables}");
-        Console.WriteLine($"Restricted pricing local variable rejection reason: {restrictedLocalVariableAttempt.ErrorMessage}");
+        var restrictedStatementStyleBindingAttempt = restrictedDslPricingCalculator.TryCompileWithInterpreter(DisallowedFormula);
+        var restrictedRejectsUnsupportedStatementStyleBindings = !restrictedStatementStyleBindingAttempt.IsSuccess;
+        Console.WriteLine($"Restricted pricing rejects unsupported statement-style bindings: {restrictedRejectsUnsupportedStatementStyleBindings}");
+        Console.WriteLine($"Restricted pricing statement-style binding rejection reason: {restrictedStatementStyleBindingAttempt.ErrorMessage}");
 
         var allResultsMatch = ResultsMatch(
             hardcodedResult,

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/PricingRestrictedDialectExecutionTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/PricingRestrictedDialectExecutionTests.cs
@@ -12,7 +12,7 @@ public sealed class PricingRestrictedDialectExecutionTests
 {
     private const string PricingFormula = "price * 0.9 + fee";
 
-    private const string LocalVariableFormula = """
+    private const string StatementStyleBindingFormula = """
                                                 let discount = 0.9
                                                 price * discount + fee
                                                 """;
@@ -38,19 +38,19 @@ public sealed class PricingRestrictedDialectExecutionTests
     }
 
     [Test]
-    public void PricingRestricted_Dialect_Rejects_LocalVariableFormula()
+    public void PricingRestricted_Dialect_Rejects_UnsupportedStatementStyleBindingFormula()
     {
         var result = BackendParityInfrastructure.ExecuteSafely(() =>
         {
             using var host = CreatePricingHost();
             var interpreter = host.GetArtifactCompiler<IAbstractIR>("interpreter");
-            _ = interpreter.Compile(LocalVariableFormula, CreateDeclaredBindings());
+            _ = interpreter.Compile(StatementStyleBindingFormula, CreateDeclaredBindings());
             return null;
         });
 
         Assert.Multiple(() =>
         {
-            Assert.That(result.IsSuccess, Is.False, "Pricing-restricted must reject local variable formulas.");
+            Assert.That(result.IsSuccess, Is.False, "Pricing-restricted must reject unsupported statement-style binding formulas.");
             Assert.That(result.Exception, Is.Not.Null);
             Assert.That(result.Exception!.Message, Is.Not.Empty);
             Assert.That(

--- a/readme.md
+++ b/readme.md
@@ -187,6 +187,7 @@ Located under `UniversalToolchain/Dialects/examples/wist`:
 - `full-default`
 - `full-default-native`
 - `minimal-arithmetic`
+- `pricing-restricted` *(narrow pricing profile with restricted runtime surface)*
 - `restricted-sandbox` *(composition-constrained profile, not OS-level sandboxing)*
 
 ## Why .NET 10 right now?


### PR DESCRIPTION
### Motivation
- Remove an overbroad claim that the `pricing-restricted` dialect "rejects local variables" and keep demo/tests/docs aligned with the actual negative-path surface (statement-style binding/newline shape), and ensure the root `readme.md` lists the `pricing-restricted` example.

### Description
- Update `UniversalToolchain/Example/Scenarios/PricingDiscountScenario.cs` to rename local variables and console messages to describe the negative path as rejecting `unsupported statement-style bindings` instead of claiming a general local-variable prohibition.
- Rename the negative test and related constant in `UniversalToolchain/UniversalToolchain.Dialects.Tests/PricingRestrictedDialectExecutionTests.cs` from `LocalVariableFormula` / `PricingRestricted_Dialect_Rejects_LocalVariableFormula` to `StatementStyleBindingFormula` / `PricingRestricted_Dialect_Rejects_UnsupportedStatementStyleBindingFormula` and adjust the assertion message accordingly.
- Change the `Not allowed` entry in `UniversalToolchain/Dialects/examples/wist/pricing-restricted/README.md` to replace `local variables` with `statement-style bindings` to match the demonstrated restriction.
- Add `pricing-restricted` to the `## Dialect examples` list in the repository root `readme.md` (short, factual annotation).

### Testing
- Installed .NET SDK `10.0.103` with the `dotnet-install.sh` script and verified `dotnet --version` succeeded. (success)
- Ran `dotnet restore UniversalToolchain/Wist.sln` and `dotnet build UniversalToolchain/Wist.sln -c Release --no-restore`, which completed with warnings but no errors. (success)
- Ran unit tests: `dotnet test UniversalToolchain/Tests/Tests.csproj -c Release --no-build`, `dotnet test UniversalToolchain/UniversalToolchain.Modules.Tests/UniversalToolchain.Modules.Tests.csproj -c Release --no-build`, and `dotnet test UniversalToolchain/UniversalToolchain.Dialects.Tests/UniversalToolchain.Dialects.Tests.csproj -c Release --no-build`, and all test suites passed. (success)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfc62b5ac883248725f3c3214ecafa)