### PR TITLE
Decouple root scope traversal from Scopes module

### DIFF
--- a/UniversalToolchain/BasicCodeTranslator/BasicAstToBytecodeTranslatorImpl.cs
+++ b/UniversalToolchain/BasicCodeTranslator/BasicAstToBytecodeTranslatorImpl.cs
@@ -35,7 +35,7 @@ public class BasicAstToBytecodeTranslatorImpl(BytecodeTranslatorConfiguration co
         }
 
         if (!hasStructuralScopeVisitor)
-            visitors.Insert(0, new StructuralScopeAstVisitor());
+            visitors.Add(new StructuralScopeAstVisitor());
 
         return new BytecodeTranslatorConfiguration(visitors);
     }
@@ -47,7 +47,7 @@ public class BasicAstToBytecodeTranslatorImpl(BytecodeTranslatorConfiguration co
 
         public Bytecode Translate(AstNode root)
         {
-            var data = new BytecodeVisitorData(this, bytecode, root);
+            var data = new BytecodeVisitorData(this, bytecode, root, bytecode.Instructions.Count);
             foreach (var visitor in Configuration.Visitors)
                 visitor.TryVisit(data);
 

--- a/UniversalToolchain/BasicCodeTranslator/BasicAstToBytecodeTranslatorImpl.cs
+++ b/UniversalToolchain/BasicCodeTranslator/BasicAstToBytecodeTranslatorImpl.cs
@@ -1,3 +1,6 @@
+using BasicCodeTranslator.Visitors;
+using System.Collections.Generic;
+
 namespace BasicCodeTranslator;
 
 public class BasicAstToBytecodeTranslatorImpl(BytecodeTranslatorConfiguration configuration) : IAstToBytecodeTranslator
@@ -6,7 +9,7 @@ public class BasicAstToBytecodeTranslatorImpl(BytecodeTranslatorConfiguration co
     {
     }
 
-    public BytecodeTranslatorConfiguration Configuration { get; } = configuration;
+    public BytecodeTranslatorConfiguration Configuration { get; } = CreateConfiguration(configuration);
 
     public Bytecode Translate(AstNode root)
     {
@@ -16,6 +19,25 @@ public class BasicAstToBytecodeTranslatorImpl(BytecodeTranslatorConfiguration co
         requestTranslator.Translate(root);
 
         return bytecode;
+    }
+
+    private static BytecodeTranslatorConfiguration CreateConfiguration(BytecodeTranslatorConfiguration configuration)
+    {
+        var visitors = new List<IAstVisitor>(configuration.Visitors.Count + 1);
+        var hasStructuralScopeVisitor = false;
+
+        foreach (var visitor in configuration.Visitors)
+        {
+            if (visitor is StructuralScopeAstVisitor)
+                hasStructuralScopeVisitor = true;
+
+            visitors.Add(visitor);
+        }
+
+        if (!hasStructuralScopeVisitor)
+            visitors.Insert(0, new StructuralScopeAstVisitor());
+
+        return new BytecodeTranslatorConfiguration(visitors);
     }
 
     private sealed class RequestTranslator(BytecodeTranslatorConfiguration configuration, Bytecode bytecode)

--- a/UniversalToolchain/BasicCodeTranslator/Visitors/StructuralScopeAstVisitor.cs
+++ b/UniversalToolchain/BasicCodeTranslator/Visitors/StructuralScopeAstVisitor.cs
@@ -1,0 +1,17 @@
+namespace BasicCodeTranslator.Visitors;
+
+public sealed class StructuralScopeAstVisitor : IAstVisitor
+{
+    public void TryVisit(BytecodeVisitorData data)
+    {
+        if (data.Node.NodeType != ExtensibleEnum<AstNodeTag>.Get("Scope"))
+        {
+            return;
+        }
+
+        foreach (var child in data.Node.Children)
+        {
+            data.AstToBytecodeTranslator.Translate(child);
+        }
+    }
+}

--- a/UniversalToolchain/BasicCodeTranslator/Visitors/StructuralScopeAstVisitor.cs
+++ b/UniversalToolchain/BasicCodeTranslator/Visitors/StructuralScopeAstVisitor.cs
@@ -9,6 +9,11 @@ public sealed class StructuralScopeAstVisitor : IAstVisitor
             return;
         }
 
+        if (data.Bytecode.Instructions.Count != data.InstructionCountBeforeVisit)
+        {
+            return;
+        }
+
         foreach (var child in data.Node.Children)
         {
             data.AstToBytecodeTranslator.Translate(child);

--- a/UniversalToolchain/BasicCore/TranslatorWrapper/BytecodeVisitorData.cs
+++ b/UniversalToolchain/BasicCore/TranslatorWrapper/BytecodeVisitorData.cs
@@ -1,3 +1,7 @@
 namespace BasicCore.TranslatorWrapper;
 
-public record BytecodeVisitorData(IAstToBytecodeTranslator AstToBytecodeTranslator, Bytecode Bytecode, AstNode Node);
+public record BytecodeVisitorData(
+    IAstToBytecodeTranslator AstToBytecodeTranslator,
+    Bytecode Bytecode,
+    AstNode Node,
+    int InstructionCountBeforeVisit);

--- a/UniversalToolchain/ScopesModule/Module/ScopesModuleImpl.cs
+++ b/UniversalToolchain/ScopesModule/Module/ScopesModuleImpl.cs
@@ -22,5 +22,7 @@ public class ScopesModuleImpl : IFrontendCoreModule
 
     public void InitParser(IParser parser) => parser.AddNodeCreators(_nodeCreatorRegistrations);
 
-    public void InitAstTranslator(IAstToBytecodeTranslator translator) => translator.AddVisitors(new ScopeAstVisitor());
+    public void InitAstTranslator(IAstToBytecodeTranslator translator)
+    {
+    }
 }

--- a/UniversalToolchain/UniversalToolchain.Modules.Tests/ModuleCoverage/RootScopeTranslationContractsTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Modules.Tests/ModuleCoverage/RootScopeTranslationContractsTests.cs
@@ -1,0 +1,33 @@
+namespace UniversalToolchain.Modules.Tests.ModuleCoverage;
+
+[TestFixture]
+public class RootScopeTranslationContractsTests
+{
+    private static readonly string[] ModulesWithoutScopes = ["Arithmetic", "Identifier", "Numbers", "Variables", "Whitespaces"];
+    private static readonly string[] ModulesWithScopes = ["Arithmetic", "Identifier", "Numbers", "Scopes", "Variables", "Whitespaces"];
+
+    [Test]
+    public void RootScope_WithoutScopesModule_StillTranslatesSimpleExpression()
+    {
+        using var h = new ModulePipelineTestHelper();
+        var r = h.ExecuteBoth("2 + 3", ModulesWithoutScopes);
+        ModulePipelineTestHelper.AssertParity(r.Compiler, r.Interpreter);
+        Assert.That(ModulePipelineTestHelper.AsNumber(r.Compiler), Is.EqualTo(5));
+    }
+
+    [Test]
+    public void Parentheses_WithoutScopesModule_FailDeterministically()
+    {
+        using var h = new ModulePipelineTestHelper();
+        h.AssertCompilerAndInterpreterFailSameWay("(2 + 3) * 4", ModulesWithoutScopes);
+    }
+
+    [Test]
+    public void Parentheses_WithScopesModule_StillOverridePrecedence()
+    {
+        using var h = new ModulePipelineTestHelper();
+        var r = h.ExecuteBoth("(2 + 3) * 4", ModulesWithScopes);
+        ModulePipelineTestHelper.AssertParity(r.Compiler, r.Interpreter);
+        Assert.That(ModulePipelineTestHelper.AsNumber(r.Compiler), Is.EqualTo(20));
+    }
+}


### PR DESCRIPTION
## Summary
- move root `Scope` traversal into the basic AST-to-bytecode translator
- stop `Scopes` from owning mandatory root traversal behavior
- add regression tests for simple expressions without `Scopes` and parentheses behavior with and without `Scopes`

## Why
The parser always produces a root `Scope` node, even for expressions without parentheses. Because the basic translator only dispatches visitors for the current node, root traversal was implicitly provided by `ScopesModule`, which made `Scopes` a hidden runtime requirement for expressions like `2 + 3`.

This PR makes root `Scope` traversal part of the base translator so `Scopes` remains responsible only for parentheses syntax and nested scope construction.

## Notes
I prepared the patch directly through the GitHub API path available in this environment. I was not able to clone the repository into the local container because outbound GitHub network access is unavailable there, so I could not run the test suite locally from the container.