### PR TITLE
Remove stale comparison links and add manifest-based CI smoke checks

### DIFF
--- a/.github/scripts/cli-smoke-manifest.tsv
+++ b/.github/scripts/cli-smoke-manifest.tsv
@@ -1,0 +1,6 @@
+# name<TAB>command<TAB>expected substrings separated by ';;'
+example-pricing	dotnet run --project UniversalToolchain/Example/Example.csproj -c Release --no-build	All results match: True;;Restricted pricing rejects unsupported statement-style bindings: True
+cli-run-eval	dotnet run --project UniversalToolchain/Wistc/Wistc.csproj -c Release --no-build -- run --eval "(2 + 2) * 3" --mode compiler	12
+cli-run-file	dotnet run --project UniversalToolchain/Wistc/Wistc.csproj -c Release --no-build -- run --file UniversalToolchain/Dialects/examples/wist/minimal-arithmetic/program.wist --mode interpreter	14
+cli-dialect-inspect	dotnet run --project UniversalToolchain/Wistc/Wistc.csproj -c Release --no-build -- dialect-inspect --file UniversalToolchain/Dialects/examples/wist/full-default/dialect.wistdialect	Dialect: FullDefault
+cli-dialect-demo	dotnet run --project UniversalToolchain/Wistc/Wistc.csproj -c Release --no-build -- dialect-demo --file UniversalToolchain/Dialects/examples/wist/full-default/dialect.wistdialect	Success: True

--- a/.github/scripts/run-smoke-manifest.sh
+++ b/.github/scripts/run-smoke-manifest.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <manifest-path>"
+  exit 1
+fi
+
+manifest_path="$1"
+
+if [[ ! -f "$manifest_path" ]]; then
+  echo "Smoke manifest not found: $manifest_path"
+  exit 1
+fi
+
+while IFS=$'\t' read -r smoke_name smoke_command expected_substrings; do
+  if [[ -z "${smoke_name// }" ]] || [[ "${smoke_name}" == \#* ]]; then
+    continue
+  fi
+
+  if [[ -z "${smoke_command// }" ]]; then
+    echo "Smoke command is empty for entry: $smoke_name"
+    exit 1
+  fi
+
+  echo "::group::Smoke: $smoke_name"
+  echo "Running: $smoke_command"
+
+  output="$(bash -lc "$smoke_command")"
+  printf '%s\n' "$output"
+
+  if [[ -n "${expected_substrings// }" ]]; then
+    remaining_checks="$expected_substrings"
+    while [[ -n "$remaining_checks" ]]; do
+      current_check="$remaining_checks"
+      if [[ "$remaining_checks" == *';;'* ]]; then
+        current_check="${remaining_checks%%;;*}"
+        remaining_checks="${remaining_checks#*;;}"
+      else
+        remaining_checks=""
+      fi
+
+      if [[ -n "${current_check// }" ]]; then
+        grep -F -- "$current_check" <<< "$output" > /dev/null
+      fi
+    done
+  fi
+
+  echo "::endgroup::"
+done < "$manifest_path"

--- a/.github/workflows/dotnet-ci.yml
+++ b/.github/workflows/dotnet-ci.yml
@@ -36,11 +36,6 @@ jobs:
             dotnet test UniversalToolchain/UniversalToolchain.Modules.Tests/UniversalToolchain.Modules.Tests.csproj -c Release --no-build
           fi
 
-      - name: Example smoke test
+      - name: Smoke checks (manifest)
         shell: bash
-        run: |
-          set -euo pipefail
-
-          output="$(dotnet run --project UniversalToolchain/Example/Example.csproj -c Release --no-build)"
-          grep -F "All results match: True" <<< "$output"
-          grep -F "Restricted pricing rejects unsupported statement-style bindings: True" <<< "$output"
+        run: ./.github/scripts/run-smoke-manifest.sh .github/scripts/cli-smoke-manifest.tsv

--- a/readme.md
+++ b/readme.md
@@ -110,12 +110,6 @@ For those cases, a smaller evaluator, a rules library, or a parser generator is 
 
 ## Comparison
 
-- **NCalc** is strong for evaluating compact expressions. UniversalToolchain becomes relevant when expression evaluation
-  is not enough and you need dialect control, execution modes, or a reusable pipeline. See
-  [Wist2 vs NCalc](docs/comparisons/wist2-vs-ncalc.md).
-- **RulesEngine** is strong for JSON-defined business rules in .NET applications. UniversalToolchain becomes relevant
-  when the rule language itself needs custom syntax, restricted capabilities, or compiler/interpreter backends. See
-  [Wist2 vs RulesEngine](docs/comparisons/wist2-vs-rulesengine.md).
 - **ANTLR/csly** are strong for building parsers. UniversalToolchain becomes relevant when parsing is only the first
   step and you also need runtime composition, IR/bytecode translation, optimization, and execution.
 


### PR DESCRIPTION
### Motivation

- Remove broken README links to `wist2-vs-ncalc` and `wist2-vs-rulesengine` so the `Comparison` section remains coherent without dangling references. 
- Make CI smoke checks easier to maintain and extend by moving CLI command list out of the workflow YAML into a manifest-driven runner.

### Description

- Deleted references to `docs/comparisons/wist2-vs-ncalc.md` and `docs/comparisons/wist2-vs-rulesengine.md` from `readme.md` so no markdown links point to non-existent files. 
- Replaced the inline Example smoke step in `.github/workflows/dotnet-ci.yml` with a single call to `./.github/scripts/run-smoke-manifest.sh .github/scripts/cli-smoke-manifest.tsv` to keep the workflow concise. 
- Added `./.github/scripts/run-smoke-manifest.sh`, a small manifest runner that reads a TSV manifest and runs each command from the repository root while optionally asserting expected output substrings separated by `;;`. 
- Added `./.github/scripts/cli-smoke-manifest.tsv` with entries covering the README quick-start (`run --eval`), one `run --file`, `dialect-inspect --file`, `dialect-demo --file`, and the existing Example smoke assertions, all using `-c Release --no-build` where appropriate; new smoke commands can be added by appending `name<TAB>command<TAB>expected_substrings` to the TSV without editing the workflow.

### Testing

- Ran `dotnet restore UniversalToolchain/Wist.sln` and `dotnet build UniversalToolchain/Wist.sln -c Release --no-restore`, which completed successfully. 
- Executed `dotnet test` for `UniversalToolchain/Tests`, `UniversalToolchain/UniversalToolchain.Dialects.Tests`, and `UniversalToolchain/UniversalToolchain.Modules.Tests` (when present), and all tests passed. 
- Ran the new smoke runner with `./.github/scripts/run-smoke-manifest.sh .github/scripts/cli-smoke-manifest.tsv` and all manifest entries completed with the expected exit codes and output substring checks (including the `12` output for the `run --eval` quick-start and the Example smoke assertions).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e486bc57448324ba2615cfd85cafc8)