### PR TITLE
Fix dialect module ordering to use declaration-order stable topo sort

### DIFF
--- a/UniversalToolchain/UniversalToolchain.Dialects.Core/DialectSemanticNormalization.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Core/DialectSemanticNormalization.cs
@@ -11,10 +11,21 @@ internal static class DialectSemanticNormalization
         List<DialectDiagnostic> diagnostics,
         string conflictCode)
     {
-        var sortedUseModules = useModules.Distinct(StringComparer.Ordinal).OrderBy(x => x, StringComparer.Ordinal).ToList();
-        var sortedExcludeModules = excludeModules.Distinct(StringComparer.Ordinal).OrderBy(x => x, StringComparer.Ordinal).ToList();
+        var orderedUseModules = new List<string>();
+        var useSet = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var module in useModules)
+        {
+            if (useSet.Add(module))
+                orderedUseModules.Add(module);
+        }
 
-        foreach (var conflict in sortedUseModules.Intersect(sortedExcludeModules, StringComparer.Ordinal))
+        var sortedExcludeModules = excludeModules
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(x => x, StringComparer.Ordinal)
+            .ToList();
+        var excludeSet = sortedExcludeModules.ToHashSet(StringComparer.Ordinal);
+
+        foreach (var conflict in orderedUseModules.Where(excludeSet.Contains))
         {
             diagnostics.Add(new DialectDiagnostic(
                 conflictCode,
@@ -22,7 +33,7 @@ internal static class DialectSemanticNormalization
                 DialectDiagnosticSeverity.Error));
         }
 
-        return sortedUseModules.Where(x => !sortedExcludeModules.Contains(x, StringComparer.Ordinal)).ToList();
+        return orderedUseModules.Where(x => !excludeSet.Contains(x)).ToList();
     }
 
     public static Dictionary<DialectBackendId, bool> NormalizeBackendRules<TDirective>(
@@ -132,7 +143,18 @@ internal static class DialectSemanticNormalization
         string? missingReferenceCode = null,
         string? missingReferenceMessagePrefix = null)
     {
-        var nodes = activeModules.Distinct(StringComparer.Ordinal).OrderBy(x => x, StringComparer.Ordinal).ToList();
+        var nodes = new List<string>();
+        var nodeSet = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var module in activeModules)
+        {
+            if (nodeSet.Add(module))
+                nodes.Add(module);
+        }
+
+        var nodeIndices = nodes
+            .Select((module, index) => new { module, index })
+            .ToDictionary(x => x.module, x => x.index, StringComparer.Ordinal);
+
         var activeSet = nodes.ToHashSet(StringComparer.Ordinal);
         var edges = nodes.ToDictionary(x => x, _ => new HashSet<string>(StringComparer.Ordinal), StringComparer.Ordinal);
         var indegree = nodes.ToDictionary(x => x, _ => 0, StringComparer.Ordinal);
@@ -163,22 +185,26 @@ internal static class DialectSemanticNormalization
             indegree[to]++;
         }
 
-        var queue = new SortedSet<string>(nodes.Where(x => indegree[x] == 0), StringComparer.Ordinal);
+        var queue = new SortedSet<(int Index, string Name)>();
+        foreach (var node in nodes)
+        {
+            if (indegree[node] == 0)
+                queue.Add((nodeIndices[node], node));
+        }
+
         var ordered = new List<string>();
 
         while (queue.Count > 0)
         {
             var current = queue.Min;
-            if (current == null)
-                Thrower.InvalidOpEx("Queue minimum should exist.");
             queue.Remove(current);
-            ordered.Add(current);
+            ordered.Add(current.Name);
 
-            foreach (var next in edges[current])
+            foreach (var next in edges[current.Name])
             {
                 indegree[next]--;
                 if (indegree[next] == 0)
-                    queue.Add(next);
+                    queue.Add((nodeIndices[next], next));
             }
         }
 

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/BuildPlanCollaboratorsTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/BuildPlanCollaboratorsTests.cs
@@ -123,7 +123,7 @@ public class BuildPlanCollaboratorsTests
         Assert.Multiple(() =>
         {
             Assert.That(diagnostics, Is.Empty);
-            Assert.That(normalized.ActiveModules, Is.EqualTo(new[] { "A", "B" }));
+            Assert.That(normalized.ActiveModules, Is.EqualTo(new[] { "B", "A" }));
             Assert.That(normalized.BackendMap[TestBackendIds.Interpreter], Is.True);
             Assert.That(normalized.BackendMap[TestBackendIds.Cil], Is.False);
             Assert.That(normalized.OrderConstraints.Select(x => x.Kind), Is.EqualTo(new[] { DialectOrderConstraintKind.Before }));

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/DialectDirectiveHandlerTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/DialectDirectiveHandlerTests.cs
@@ -53,7 +53,7 @@ public class DialectDirectiveHandlerTests
 
         Assert.Multiple(() =>
         {
-            Assert.That(definition.ModulePolicy.IncludedModules, Is.EqualTo(new[] { "Arithmetic", "Variables" }));
+            Assert.That(definition.ModulePolicy.IncludedModules, Is.EqualTo(new[] { "Variables", "Arithmetic" }));
             Assert.That(definition.ModulePolicy.ExcludedModules, Is.EqualTo(new[] { "UnsafeInterop" }));
             Assert.That(diagnostics.Select(x => x.Code), Is.EqualTo(new[] { "S001" }));
         });
@@ -214,7 +214,7 @@ public class DialectDirectiveHandlerTests
 
         Assert.Multiple(() =>
         {
-            Assert.That(definition.ModulePolicy.IncludedModules, Is.EqualTo(new[] { "Arithmetic", "Variables" }));
+            Assert.That(definition.ModulePolicy.IncludedModules, Is.EqualTo(new[] { "Variables", "Arithmetic" }));
             Assert.That(definition.ModulePolicy.ExcludedModules, Is.EqualTo(new[] { "UnsafeInterop" }));
             Assert.That(definition.BackendPolicy.EnabledBackends, Is.EqualTo(new[] { TestBackendIds.Interpreter }));
             Assert.That(definition.BackendPolicy.DisabledBackends, Is.EqualTo(new[] { TestBackendIds.Cil }));
@@ -232,7 +232,7 @@ public class DialectDirectiveHandlerTests
 
         Assert.Multiple(() =>
         {
-            Assert.That(definition.ModulePolicy.IncludedModules, Is.EqualTo(new[] { "Arithmetic", "Variables" }));
+            Assert.That(definition.ModulePolicy.IncludedModules, Is.EqualTo(new[] { "Variables", "Arithmetic" }));
             Assert.That(definition.ModulePolicy.ExcludedModules, Is.EqualTo(new[] { "UnsafeInterop" }));
             Assert.That(definition.BackendPolicy.EnabledBackends, Is.EqualTo(new[] { TestBackendIds.Interpreter }));
             Assert.That(definition.BackendPolicy.DisabledBackends, Is.EqualTo(new[] { TestBackendIds.Cil }));

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/FrameworkNativeSemanticBuildPlanTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/FrameworkNativeSemanticBuildPlanTests.cs
@@ -21,13 +21,12 @@ public class FrameworkNativeSemanticBuildPlanTests
     }
 
     [Test]
-    public void BuildPlan_ListBasedOrdering_IsNormalizedDeterministically()
+    public void BuildPlan_ListBasedOrdering_UsesDeclarationOrderAsDefault()
     {
         const string source =
             """
             dialect D
             use C,B,A
-            before A,B,C
             backend interpreter,cil
             allow i1
             enable O1
@@ -41,7 +40,7 @@ public class FrameworkNativeSemanticBuildPlanTests
         Assert.Multiple(() =>
         {
             Assert.That(first.CanBuild, Is.True);
-            Assert.That(first.OrderedModules, Is.EqualTo(new[] { "A", "B", "C" }));
+            Assert.That(first.OrderedModules, Is.EqualTo(new[] { "C", "B", "A" }));
             Assert.That(first.EnabledBackends, Is.EqualTo(new[] { TestBackendIds.Cil, TestBackendIds.Interpreter }));
             Assert.That(first.Capabilities.Select(x => (x.Key, x.Value)), Is.EqualTo(new[] { ("cap1", true), ("cap2", true) }));
             Assert.That(first.OrderedModules, Is.EqualTo(second.OrderedModules));
@@ -54,7 +53,7 @@ public class FrameworkNativeSemanticBuildPlanTests
     }
 
     [Test]
-    public void BuildPlan_NoOrderRules_UsesLexicographicTieBreaker()
+    public void BuildPlan_NoOrderRules_PreservesDeclarationOrder()
     {
         var plan = BuildPlan(
             """
@@ -62,7 +61,33 @@ public class FrameworkNativeSemanticBuildPlanTests
             use C,B,A
             """);
 
-        Assert.That(plan.OrderedModules, Is.EqualTo(new[] { "A", "B", "C" }));
+        Assert.That(plan.OrderedModules, Is.EqualTo(new[] { "C", "B", "A" }));
+    }
+
+    [Test]
+    public void BuildPlan_OrderRules_OverrideDeclarationOrder()
+    {
+        var plan = BuildPlan(
+            """
+            dialect D
+            use C,B,A
+            before A,B
+            """);
+
+        Assert.That(plan.OrderedModules, Is.EqualTo(new[] { "C", "A", "B" }));
+    }
+
+    [Test]
+    public void BuildPlan_ReadySetTieBreaker_UsesDeclarationOrder()
+    {
+        var plan = BuildPlan(
+            """
+            dialect D
+            use D,C,B,A
+            before C,A
+            """);
+
+        Assert.That(plan.OrderedModules, Is.EqualTo(new[] { "D", "C", "B", "A" }));
     }
 
     [Test]

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/SemanticValidationTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/SemanticValidationTests.cs
@@ -180,7 +180,7 @@ public class SemanticValidationTests
             Assert.That(parsed.IsSuccess, Is.True);
             Assert.That(plan.CanBuild, Is.True);
             Assert.That(plan.Name, Is.EqualTo("Valid"));
-            Assert.That(plan.OrderedModules, Is.EqualTo(new[] { "A", "B" }));
+            Assert.That(plan.OrderedModules, Is.EqualTo(new[] { "B", "A" }));
             Assert.That(plan.EnabledBackends, Is.EqualTo(new[] { TestBackendIds.Cil }));
             Assert.That(plan.IntrinsicDirectives, Has.Count.EqualTo(1));
             Assert.That(plan.OptimizerDirectives, Has.Count.EqualTo(1));


### PR DESCRIPTION
### Motivation

- The existing pipeline lost `use` declaration order because active modules were sorted lexicographically early and the topo-sort used a lexicographic ready-set tie-break, which made declaration order non-authoritative.
- The goal is to make `use` declaration order the default relative priority while keeping explicit `before`/`after`/`requires` constraints authoritative and preserving deterministic diagnostics.
- Duplicate `use` entries must be removed preserving the first occurrence and `exclude` must still filter modules.

### Description

- Preserve `use` declaration order and first-occurrence duplicate-elimination in `DialectSemanticNormalization.NormalizeActiveModules(...)`, detect `use`/`exclude` conflicts, and return active modules in declaration order rather than lexicographically. (Modified: `UniversalToolchain/UniversalToolchain.Dialects.Core/DialectSemanticNormalization.cs`.)
- Implement a stable topological ordering in `DialectSemanticNormalization.ResolveOrder(...)` that builds nodes in incoming `activeModules` order, records original indices, and uses a deterministic ready-set keyed by `(Index, Name)` so indegree-0 tie-breaks pick the smallest declaration index while retaining explicit order constraints; cycle/missing-reference diagnostics remain deterministic. (Modified: `UniversalToolchain/UniversalToolchain.Dialects.Core/DialectSemanticNormalization.cs`.)
- Verified `ModuleDirectiveHandler.Apply(...)` continues to use the updated `NormalizeActiveModules(...)` behavior without additional changes. (Checked: `UniversalToolchain/UniversalToolchain.Dialects.Core/Binding/Handlers/ModuleDirectiveHandler.cs`.)
- Updated tests that asserted the old lexicographic behavior to reflect declaration-order semantics and constraint overrides: `FrameworkNativeSemanticBuildPlanTests` (reworked ordering tests), `BuildPlanCollaboratorsTests`, `DialectDirectiveHandlerTests`, and `SemanticValidationTests` (expectations adjusted to declaration order). (Modified test files under `UniversalToolchain/UniversalToolchain.Dialects.Tests`.)
- Files changed: `UniversalToolchain/UniversalToolchain.Dialects.Core/DialectSemanticNormalization.cs`, `UniversalToolchain/UniversalToolchain.Dialects.Tests/FrameworkNativeSemanticBuildPlanTests.cs`, `UniversalToolchain/UniversalToolchain.Dialects.Tests/BuildPlanCollaboratorsTests.cs`, `UniversalToolchain/UniversalToolchain.Dialects.Tests/DialectDirectiveHandlerTests.cs`, `UniversalToolchain/UniversalToolchain.Dialects.Tests/SemanticValidationTests.cs`.

### Testing

- Restored packages with `dotnet restore UniversalToolchain/Wist.sln` and built with `dotnet build UniversalToolchain/Wist.sln -c Release --no-restore`, both succeeded. 
- Ran the dialect unit tests with `dotnet test UniversalToolchain/UniversalToolchain.Dialects.Tests/UniversalToolchain.Dialects.Tests.csproj -c Release --no-build` and the test run passed completely (391 tests passed, 0 failed).
- The change is focused to the module-ordering pipeline and test updates were limited to tests that depended on prior lexicographic ordering; all automated tests for the dialect project are green.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7826c88d48324a25ba9951bb8cf30)