### PR TITLE
Separate generic runtime bootstrap registrations from Wist bootstrap

### DIFF
--- a/UniversalToolchain/UniversalToolchain.Dialects.Integration/FileSystemRuntimeCatalogServiceCollectionExtensions.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Integration/FileSystemRuntimeCatalogServiceCollectionExtensions.cs
@@ -1,9 +1,8 @@
 using ExceptionsManager;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
-using UniversalToolchain.Dialects.Integration;
 
-namespace UniversalToolchain.Dialects.Wist;
+namespace UniversalToolchain.Dialects.Integration;
 
 /// <summary>
 ///     Registers file-system-backed runtime catalog services.

--- a/UniversalToolchain/UniversalToolchain.Dialects.Integration/ReflectionRuntimeResolutionServiceCollectionExtensions.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Integration/ReflectionRuntimeResolutionServiceCollectionExtensions.cs
@@ -1,9 +1,8 @@
 using ExceptionsManager;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
-using UniversalToolchain.Dialects.Integration;
 
-namespace UniversalToolchain.Dialects.Wist;
+namespace UniversalToolchain.Dialects.Integration;
 
 /// <summary>
 ///     Registers reflection-based runtime component resolution services.

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/RuntimeLoading/RuntimeInfrastructureBootstrapContractTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/RuntimeLoading/RuntimeInfrastructureBootstrapContractTests.cs
@@ -1,0 +1,58 @@
+using Microsoft.Extensions.DependencyInjection;
+using UniversalToolchain.Dialects.Integration;
+using UniversalToolchain.Dialects.Wist;
+
+namespace UniversalToolchain.Dialects.Tests.RuntimeLoading;
+
+public class RuntimeInfrastructureBootstrapContractTests
+{
+    [Test]
+    public void AddFileSystemRuntimeCatalogServices_ShouldRegisterCatalogArtifactsOnly()
+    {
+        var services = new ServiceCollection();
+        services.AddFileSystemRuntimeCatalogServices();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(services.Any(static x => x.ServiceType == typeof(RuntimeArtifactLocatorOptions)), Is.True);
+            Assert.That(services.Any(static x => x.ServiceType == typeof(IRuntimeManifestFileLocator)), Is.True);
+            Assert.That(services.Any(static x => x.ServiceType == typeof(IRuntimeManifestSerializer)), Is.True);
+            Assert.That(services.Any(static x => x.ServiceType == typeof(IRuntimeComponentCatalog)), Is.True);
+            Assert.That(services.Any(static x => x.ServiceType == typeof(IRuntimeComponentTypeLoader)), Is.False);
+            Assert.That(services.Any(static x => x.ServiceType == typeof(WistDialectExecutionWorkflow)), Is.False);
+        });
+    }
+
+    [Test]
+    public void AddReflectionRuntimeResolutionServices_ShouldRegisterResolutionArtifactsOnly()
+    {
+        var services = new ServiceCollection();
+        services.AddReflectionRuntimeResolutionServices();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(services.Any(static x => x.ServiceType == typeof(IRuntimeAssemblyLocator)), Is.True);
+            Assert.That(services.Any(static x => x.ServiceType == typeof(IRuntimeAssemblyLoadStrategy)), Is.True);
+            Assert.That(services.Any(static x => x.ServiceType == typeof(IRuntimeComponentResolver)), Is.True);
+            Assert.That(services.Any(static x => x.ServiceType == typeof(IRuntimeComponentTypeLoader)), Is.True);
+            Assert.That(services.Any(static x => x.ServiceType == typeof(IRuntimeKnownBackendsProvider)), Is.True);
+            Assert.That(services.Any(static x => x.ServiceType == typeof(WistDialectExecutionWorkflow)), Is.False);
+            Assert.That(services.Any(static x => x.ServiceType == typeof(WistDialectServiceProviderFactory)), Is.False);
+        });
+    }
+
+    [Test]
+    public void GenericRuntimeBootstrap_ComposedBlocks_ShouldNotRegisterWistSpecificRuntimeTypes()
+    {
+        var services = new ServiceCollection();
+        services
+            .AddFileSystemRuntimeCatalogServices()
+            .AddReflectionRuntimeResolutionServices();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(services.Any(static x => x.ServiceType == typeof(WistDialectExecutionWorkflow)), Is.False);
+            Assert.That(services.Any(static x => x.ServiceType == typeof(WistDialectServiceProviderFactory)), Is.False);
+        });
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/Wist/WistDialectRuntimeBootstrapContractTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/Wist/WistDialectRuntimeBootstrapContractTests.cs
@@ -26,39 +26,6 @@ public class WistDialectRuntimeBootstrapContractTests
     }
 
     [Test]
-    public void AddFileSystemRuntimeCatalogServices_ShouldRegisterCatalogArtifactsOnly()
-    {
-        var services = new ServiceCollection();
-        services.AddFileSystemRuntimeCatalogServices();
-
-        Assert.Multiple(() =>
-        {
-            Assert.That(services.Any(static x => x.ServiceType == typeof(IRuntimeManifestFileLocator)), Is.True);
-            Assert.That(services.Any(static x => x.ServiceType == typeof(IRuntimeManifestSerializer)), Is.True);
-            Assert.That(services.Any(static x => x.ServiceType == typeof(IRuntimeComponentCatalog)), Is.True);
-            Assert.That(services.Any(static x => x.ServiceType == typeof(IRuntimeComponentTypeLoader)), Is.False);
-            Assert.That(services.Any(static x => x.ServiceType == typeof(WistDialectExecutionWorkflow)), Is.False);
-        });
-    }
-
-    [Test]
-    public void AddReflectionRuntimeResolutionServices_ShouldRegisterResolutionArtifactsOnly()
-    {
-        var services = new ServiceCollection();
-        services.AddReflectionRuntimeResolutionServices();
-
-        Assert.Multiple(() =>
-        {
-            Assert.That(services.Any(static x => x.ServiceType == typeof(IRuntimeAssemblyLocator)), Is.True);
-            Assert.That(services.Any(static x => x.ServiceType == typeof(IRuntimeAssemblyLoadStrategy)), Is.True);
-            Assert.That(services.Any(static x => x.ServiceType == typeof(IRuntimeComponentResolver)), Is.True);
-            Assert.That(services.Any(static x => x.ServiceType == typeof(IRuntimeComponentTypeLoader)), Is.True);
-            Assert.That(services.Any(static x => x.ServiceType == typeof(IRuntimeKnownBackendsProvider)), Is.True);
-            Assert.That(services.Any(static x => x.ServiceType == typeof(WistDialectExecutionWorkflow)), Is.False);
-        });
-    }
-
-    [Test]
     public void AddWistDialectServices_ShouldRegisterCanonicalRuntimeInfrastructure()
     {
         var services = new ServiceCollection();
@@ -258,6 +225,35 @@ public class WistDialectRuntimeBootstrapContractTests
         var ex = Assert.Throws<InvalidOperationException>(() => factory.Create(config));
 
         Assert.That(ex!.Message, Does.Contain("No backend runtime registrar is registered for backend 'interpreter'"));
+    }
+
+    [Test]
+    public void ComposeCreateRun_CanonicalPath_RepeatedCycles_ShouldKeepDeterministicCompositeSignature()
+    {
+        using var provider = WistDialectTestInfrastructure.CreateProviderWithExplicitBackends();
+        var workflow = provider.GetRequiredService<WistDialectExecutionWorkflow>();
+
+        var signatures = new List<string>();
+        for (var i = 0; i < 30; i++)
+        {
+            var composition = workflow.ComposeText(
+                "dialect Stable\nuse Arithmetic,Numbers,Whitespaces\nenable LocalVariablesOptimization\nbackend interpreter,compiler",
+                $"stable-{i}");
+
+            Assert.That(composition.IsSuccess, Is.True, composition.ToDeterministicText());
+
+            using var host = workflow.CreateHost(composition);
+            var runResult = host.Run("2 + 5", "interpreter");
+
+            signatures.Add(
+                WistDialectTestInfrastructure.BuildSelectionAndDiagnosticsSignature(composition)
+                + "::host::"
+                + WistDialectTestInfrastructure.BuildHostSignature(host)
+                + "::result::"
+                + runResult);
+        }
+
+        Assert.That(signatures.Distinct(StringComparer.Ordinal).Count(), Is.EqualTo(1));
     }
 
     [Test]

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistDialectServiceCollectionExtensions.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistDialectServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 using ExceptionsManager;
 using Microsoft.Extensions.DependencyInjection;
+using UniversalToolchain.Dialects.Integration;
 
 namespace UniversalToolchain.Dialects.Wist;
 

--- a/docs/current-canonical-runtime-pipeline.md
+++ b/docs/current-canonical-runtime-pipeline.md
@@ -1,0 +1,26 @@
+# Current Canonical Runtime Pipeline
+
+This document describes the currently supported runtime composition flow in this repository.
+It is intentionally limited to behavior that exists today.
+
+## Canonical pipeline
+
+1. **Dialect DSL compilation** — compile `.wistdialect` text or file into a dialect model.
+2. **Build-plan projection** — convert the dialect model into `DialectBuildPlan`.
+3. **Runtime selection** — resolve a deterministic `SelectedRuntimePlan` from runtime manifests.
+4. **Wist execution configuration** — map the selected runtime plan to `WistDialectExecutionConfiguration`.
+5. **Host creation** — create a `WistDialectExecutionHost` from that configuration.
+6. **Explicit backend registration** — backend runtime registrars must be added explicitly before host creation.
+7. **Execution** — run source text through the created host in the selected mode.
+
+## Ownership boundary
+
+- `UniversalToolchain.Dialects.Integration` owns **generic runtime infrastructure** bootstrap:
+  - file-system runtime catalog registrations,
+  - reflection-based runtime resolution registrations.
+- `UniversalToolchain.Dialects.Wist` owns **Wist-specific orchestration**:
+  - Wist workflow composition,
+  - Wist execution configuration building,
+  - Wist host/provider creation.
+
+`AddWistDialectServices()` remains the canonical convenience method for Wist and composes Wist core services with the generic Integration runtime infrastructure blocks.


### PR DESCRIPTION
### Motivation
- Clarify ownership by moving generic runtime bootstrap (file-system catalog + reflection resolution) out of the Wist layer into the Integration layer so framework-level infrastructure is not owned by the reference dialect.
- Preserve the canonical Wist runtime path and convenience composition while preventing accidental leakage of Wist-only orchestration into generic bootstrap code.
- Add automated guardrails and a deterministic regression test to protect the architecture boundary going forward.

### Description
- Moved `FileSystemRuntimeCatalogServiceCollectionExtensions` into `UniversalToolchain.Dialects.Integration` and kept the public API and registration behavior, including `AddFileSystemRuntimeCatalogServices()` which still registers `RuntimeArtifactLocatorOptions`, `IRuntimeManifestFileLocator`, `IRuntimeManifestSerializer`, and `IRuntimeComponentCatalog`.
- Moved `ReflectionRuntimeResolutionServiceCollectionExtensions` into `UniversalToolchain.Dialects.Integration` and kept the public API and registration behavior, including `AddReflectionRuntimeResolutionServices()` which still registers `IRuntimeAssemblyLocator`, `IRuntimeAssemblyLoadStrategy`, `IRuntimeComponentResolver`, `IRuntimeComponentTypeLoader`, and `IRuntimeKnownBackendsProvider`.
- Kept `AddWistDialectServices()` as the canonical Wist convenience composition and updated it to consume the moved Integration-layer extension methods without changing its public shape (`AddWistDialectCoreServices().AddFileSystemRuntimeCatalogServices().AddReflectionRuntimeResolutionServices()`).
- Removed the Wist-owned duplicates and updated imports so there is one canonical owner in Integration; no wrapper pass-throughs were left behind.
- Tests reorganized: added `RuntimeInfrastructureBootstrapContractTests` to assert generic bootstrap contracts and a guardrail preventing Wist-only types from being registered by generic blocks; updated `WistDialectRuntimeBootstrapContractTests` to retain Wist-oriented assertions and added an end-to-end deterministic compose→create host→run regression test that repeats the canonical path and verifies a stable composite signature.
- Added `docs/current-canonical-runtime-pipeline.md` documenting the current canonical runtime pipeline and the ownership boundary between Integration (generic runtime infrastructure) and Wist (orchestration).

### Testing
- Installed .NET SDK `10.0.103` and validated `dotnet` tooling before running validation commands.
- `dotnet restore UniversalToolchain/Wist.sln` — succeeded.
- `dotnet build UniversalToolchain/Wist.sln -c Release --no-restore` — succeeded (build OK, no errors).
- `dotnet test UniversalToolchain/Tests/Tests.csproj -c Release --no-build` — passed (Passed: 189, Failed: 0).
- `dotnet test UniversalToolchain/UniversalToolchain.Modules.Tests/UniversalToolchain.Modules.Tests.csproj -c Release --no-build` — passed (Passed: 214, Failed: 0).
- `dotnet test UniversalToolchain/UniversalToolchain.Dialects.Tests/UniversalToolchain.Dialects.Tests.csproj -c Release --no-build` — passed (Passed: 393, Failed: 0) after a minor test input adjustment to use an expression accepted by the lexer; the deterministic regression test was executed and validated stability across repeated cycles.
- `python3 ./.github/scripts/run-markdown-bash-blocks.py` — attempted but timed out in this environment (300s); markdown doc was added and validated for content locally in the tree.

Small tradeoff/notes: this is a minimal ownership/placement cleanup only; no new abstractions or interfaces were introduced and Wist orchestration types were left intact except for updated imports and composition usage. The `run-markdown` script timed out in this environment but the added document is present in `docs/` and the code/tests compile and pass locally under the targeted SDK.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7a465f3408324801d68f5b9f5c07e)