### PR TITLE
Preserve selected runtime order in Wist execution-shape projection

### DIFF
--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/Wist/WistRuntimePathGuardrailTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/Wist/WistRuntimePathGuardrailTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.DependencyInjection;
+using BasicCore.Contracts;
 using UniversalToolchain.Dialects.Abstractions;
 using UniversalToolchain.Dialects.Integration;
 using UniversalToolchain.Dialects.Wist;
@@ -12,19 +13,30 @@ public sealed class WistRuntimePathGuardrailTests
     [Test]
     public void WistRuntimeFacadeBuilder_DefaultPreset_MatchesDirectWorkflowSelection()
     {
+        var presetFile = new WistShippedDialectFileResolver().Resolve(WistShippedDialectPresets.Default);
         using var facade = WistRuntimeFacadeBuilder
             .CreateDefault()
             .Build();
         using var provider = WistDialectTestInfrastructure.CreateProviderWithExplicitBackends();
         var workflow = provider.GetRequiredService<WistDialectExecutionWorkflow>();
-        var presetFile = new WistShippedDialectFileResolver().Resolve(WistShippedDialectPresets.Default);
         var composition = workflow.ComposeFile(presetFile);
+        var shapeBuilder = provider.GetRequiredService<SelectedRuntimeExecutionShapeBuilder>();
 
         Assert.That(composition.IsSuccess, Is.True, FormatComposition(composition));
 
         using var host = workflow.CreateHost(composition);
+        var selection = (SelectedRuntimePlan)composition.RuntimeSelection!;
+        var expectedShape = shapeBuilder.Build(composition.BuildPlan!, selection);
 
-        Assert.That(WistDialectTestInfrastructure.BuildConfigurationSignature(facade.Configuration), Is.EqualTo(WistDialectTestInfrastructure.BuildConfigurationSignature(host.Configuration)));
+        Assert.Multiple(() =>
+        {
+            Assert.That(WistDialectTestInfrastructure.BuildConfigurationSignature(facade.Configuration), Is.EqualTo(WistDialectTestInfrastructure.BuildConfigurationSignature(host.Configuration)));
+            Assert.That(facade.Configuration.FrontendModules, Is.SupersetOf(expectedShape.FrontendModuleTypes));
+            Assert.That(facade.Configuration.IrModules, Is.EqualTo(expectedShape.IRModuleTypes));
+            Assert.That(
+                facade.Configuration.BackendConfigurations.Select(static x => x.BackendDescriptor.CanonicalId),
+                Is.EqualTo(expectedShape.BackendEntries.Select(static x => x.CanonicalAlias)));
+        });
     }
 
     [Test]
@@ -39,12 +51,23 @@ public sealed class WistRuntimePathGuardrailTests
         using var provider = WistDialectTestInfrastructure.CreateProviderWithExplicitBackends();
         var workflow = provider.GetRequiredService<WistDialectExecutionWorkflow>();
         var composition = workflow.ComposeFile(dialectFile);
+        var shapeBuilder = provider.GetRequiredService<SelectedRuntimeExecutionShapeBuilder>();
 
         Assert.That(composition.IsSuccess, Is.True, FormatComposition(composition));
 
         using var host = workflow.CreateHost(composition);
+        var selection = (SelectedRuntimePlan)composition.RuntimeSelection!;
+        var expectedShape = shapeBuilder.Build(composition.BuildPlan!, selection);
 
-        Assert.That(WistDialectTestInfrastructure.BuildConfigurationSignature(facade.Configuration), Is.EqualTo(WistDialectTestInfrastructure.BuildConfigurationSignature(host.Configuration)));
+        Assert.Multiple(() =>
+        {
+            Assert.That(WistDialectTestInfrastructure.BuildConfigurationSignature(facade.Configuration), Is.EqualTo(WistDialectTestInfrastructure.BuildConfigurationSignature(host.Configuration)));
+            Assert.That(facade.Configuration.FrontendModules, Is.SupersetOf(expectedShape.FrontendModuleTypes));
+            Assert.That(facade.Configuration.IrModules, Is.EqualTo(expectedShape.IRModuleTypes));
+            Assert.That(
+                facade.Configuration.BackendConfigurations.Select(static x => x.BackendDescriptor.CanonicalId),
+                Is.EqualTo(expectedShape.BackendEntries.Select(static x => x.CanonicalAlias)));
+        });
     }
 
     [Test]
@@ -212,6 +235,42 @@ public sealed class WistRuntimePathGuardrailTests
         Assert.That(arbitraryShape, Is.EqualTo(shippedShape));
     }
 
+    [Test]
+    public void SelectedRuntimeExecutionShapeBuilder_Build_PreservesSelectedModuleOrderWithStableDeduplication()
+    {
+        using var provider = WistDialectTestInfrastructure.CreateProviderWithExplicitBackends();
+        var workflow = provider.GetRequiredService<WistDialectExecutionWorkflow>();
+        var shapeBuilder = provider.GetRequiredService<SelectedRuntimeExecutionShapeBuilder>();
+        var typeLoader = provider.GetRequiredService<IRuntimeComponentTypeLoader>();
+        var requiredInfrastructure = provider.GetRequiredService<IWistRequiredInfrastructureModulesProvider>();
+        var composition = workflow.ComposeText(
+            "dialect Ordered\nuse Arithmetic,Whitespaces,Numbers\nbackend interpreter",
+            "ordered");
+
+        Assert.That(composition.IsSuccess, Is.True, FormatComposition(composition));
+
+        var selection = (SelectedRuntimePlan)composition.RuntimeSelection!;
+        var shape = shapeBuilder.Build(composition.BuildPlan!, selection);
+
+        var expectedFrontendTypes = DeduplicateStable(
+            requiredInfrastructure.GetFrontendModuleTypes()
+                .Concat(selection.OrderedModules
+                    .Select(typeLoader.LoadType)
+                    .Where(static x => typeof(IFrontendCoreModule).IsAssignableFrom(x))));
+        var expectedIrTypes = DeduplicateStable(
+            requiredInfrastructure.GetIRModuleTypes()
+                .Concat(selection.OrderedModules
+                    .Select(typeLoader.LoadType)
+                    .Where(static x => typeof(IIRProcessingModule).IsAssignableFrom(x))));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(shape.FrontendModuleTypes, Is.EqualTo(expectedFrontendTypes));
+            Assert.That(shape.IRModuleTypes, Is.EqualTo(expectedIrTypes));
+            Assert.That(shape.BackendEntries.Select(static x => x.CanonicalAlias), Is.EqualTo(new[] { "interpreter" }));
+        });
+    }
+
     private static string FormatComposition(DialectFrameworkCompositionResult composition)
     {
         return DialectCompositionExplanationFormatter.FormatDeterministic(DialectCompositionExplanationProjector.Project(composition));
@@ -233,6 +292,22 @@ public sealed class WistRuntimePathGuardrailTests
                + string.Join("|", shape.OptimizerEntries.Select(static x => x.CanonicalAlias))
                + "::"
                + string.Join("|", shape.BackendEntries.Select(static x => x.CanonicalAlias));
+    }
+
+    private static IReadOnlyList<Type> DeduplicateStable(IEnumerable<Type> types)
+    {
+        var snapshot = new List<Type>();
+        var seen = new HashSet<Type>();
+
+        foreach (var type in types)
+        {
+            if (seen.Add(type))
+            {
+                snapshot.Add(type);
+            }
+        }
+
+        return snapshot;
     }
 
     private sealed class CountingRegistrar(string backendId) : IDialectBackendRuntimeRegistrar

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/Wist/WistRuntimePathGuardrailTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/Wist/WistRuntimePathGuardrailTests.cs
@@ -30,6 +30,12 @@ public sealed class WistRuntimePathGuardrailTests
 
         Assert.Multiple(() =>
         {
+            Assert.That(
+                WistDialectTestInfrastructure.BuildSelectionSignature(facade.Composition),
+                Is.EqualTo(WistDialectTestInfrastructure.BuildSelectionSignature(composition)));
+            Assert.That(
+                WistDialectTestInfrastructure.BuildSelectionAndDiagnosticsSignature(facade.Composition),
+                Is.EqualTo(WistDialectTestInfrastructure.BuildSelectionAndDiagnosticsSignature(composition)));
             Assert.That(WistDialectTestInfrastructure.BuildConfigurationSignature(facade.Configuration), Is.EqualTo(WistDialectTestInfrastructure.BuildConfigurationSignature(host.Configuration)));
             Assert.That(facade.Configuration.FrontendModules, Is.SupersetOf(expectedShape.FrontendModuleTypes));
             Assert.That(facade.Configuration.IrModules, Is.EqualTo(expectedShape.IRModuleTypes));
@@ -61,6 +67,12 @@ public sealed class WistRuntimePathGuardrailTests
 
         Assert.Multiple(() =>
         {
+            Assert.That(
+                WistDialectTestInfrastructure.BuildSelectionSignature(facade.Composition),
+                Is.EqualTo(WistDialectTestInfrastructure.BuildSelectionSignature(composition)));
+            Assert.That(
+                WistDialectTestInfrastructure.BuildSelectionAndDiagnosticsSignature(facade.Composition),
+                Is.EqualTo(WistDialectTestInfrastructure.BuildSelectionAndDiagnosticsSignature(composition)));
             Assert.That(WistDialectTestInfrastructure.BuildConfigurationSignature(facade.Configuration), Is.EqualTo(WistDialectTestInfrastructure.BuildConfigurationSignature(host.Configuration)));
             Assert.That(facade.Configuration.FrontendModules, Is.SupersetOf(expectedShape.FrontendModuleTypes));
             Assert.That(facade.Configuration.IrModules, Is.EqualTo(expectedShape.IRModuleTypes));

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/Facade/WistRuntimeFacade.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/Facade/WistRuntimeFacade.cs
@@ -3,6 +3,7 @@ using BasicCore.Compilation;
 using ExceptionsManager;
 using IntermediateRepresentationAbstractions;
 using UniversalToolchain.Dialects.Abstractions;
+using UniversalToolchain.Dialects.Integration;
 
 namespace UniversalToolchain.Dialects.Wist.Facade;
 
@@ -13,12 +14,15 @@ public sealed class WistRuntimeFacade : IDisposable
 {
     private readonly WistDialectExecutionHost _host;
 
-    internal WistRuntimeFacade(WistDialectExecutionHost host)
+    internal WistRuntimeFacade(WistDialectExecutionHost host, DialectFrameworkCompositionResult composition)
     {
         _host = host.ArgNotNull();
+        Composition = composition.ArgNotNull();
     }
 
     internal WistDialectExecutionConfiguration Configuration => _host.Configuration;
+
+    internal DialectFrameworkCompositionResult Composition { get; }
 
     public void Dispose() => _host.Dispose();
 

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/Facade/WistRuntimeFacadeBuilder.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/Facade/WistRuntimeFacadeBuilder.cs
@@ -67,6 +67,6 @@ public sealed class WistRuntimeFacadeBuilder
         if (!composition.IsSuccess)
             Thrower.InvalidOpEx(DialectCompositionExplanationFormatter.FormatDeterministic(DialectCompositionExplanationProjector.Project(composition)));
 
-        return new WistRuntimeFacade(workflow.CreateHost(composition));
+        return new WistRuntimeFacade(workflow.CreateHost(composition), composition);
     }
 }

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/SelectedRuntimeExecutionShape.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/SelectedRuntimeExecutionShape.cs
@@ -45,11 +45,19 @@ public sealed class SelectedRuntimeExecutionShape
 
     private static List<Type> SnapshotTypes(IEnumerable<Type> values, string paramName)
     {
-        return values
-            .Select(x => x.NotNull(paramName))
-            .Distinct()
-            .OrderBy(x => x.FullName, StringComparer.Ordinal)
-            .ToList();
+        var snapshot = new List<Type>();
+        var seen = new HashSet<Type>();
+
+        foreach (var value in values)
+        {
+            var type = value.NotNull(paramName);
+            if (seen.Add(type))
+            {
+                snapshot.Add(type);
+            }
+        }
+
+        return snapshot;
     }
 
     private static List<RuntimeComponentManifestEntry> SnapshotEntries(
@@ -57,12 +65,19 @@ public sealed class SelectedRuntimeExecutionShape
         RuntimeComponentKind expectedKind,
         string paramName)
     {
-        return values
-            .Select(x => x.NotNull(paramName))
-            .Select(x => ValidateKind(x, expectedKind))
-            .Distinct()
-            .OrderBy(x => x.CanonicalAlias, StringComparer.Ordinal)
-            .ToList();
+        var snapshot = new List<RuntimeComponentManifestEntry>();
+        var seen = new HashSet<RuntimeComponentManifestEntry>();
+
+        foreach (var value in values)
+        {
+            var entry = ValidateKind(value.NotNull(paramName), expectedKind);
+            if (seen.Add(entry))
+            {
+                snapshot.Add(entry);
+            }
+        }
+
+        return snapshot;
     }
 
     private static RuntimeComponentManifestEntry ValidateKind(RuntimeComponentManifestEntry entry, RuntimeComponentKind expectedKind)

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/SelectedRuntimeModuleClassification.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/SelectedRuntimeModuleClassification.cs
@@ -25,10 +25,18 @@ public sealed class SelectedRuntimeModuleClassification
 
     private static List<Type> Snapshot(IEnumerable<Type> values, string paramName)
     {
-        return values
-            .Select(x => x.NotNull(paramName))
-            .Distinct()
-            .OrderBy(x => x.FullName, StringComparer.Ordinal)
-            .ToList();
+        var snapshot = new List<Type>();
+        var seen = new HashSet<Type>();
+
+        foreach (var value in values)
+        {
+            var type = value.NotNull(paramName);
+            if (seen.Add(type))
+            {
+                snapshot.Add(type);
+            }
+        }
+
+        return snapshot;
     }
 }


### PR DESCRIPTION
### Motivation
- The projection layer was re-sorting selected runtime modules and component entries, which risked making projection a second ordering authority and breaking plan-driven determinism.  
- The bridge should remain an explicit, thin projection of the resolved plan and required infrastructure rather than introducing hidden ordering or dialect-specific branching.  
- Tests comparing only final configuration were too weak to prove canonical composition equivalence and ordering preservation.  

### Description
- Replaced projection-layer sorting with stable first-seen deduplication in `SelectedRuntimeModuleClassification` by switching snapshot logic to a `HashSet` + `List` stable dedupe.  
- Updated `SelectedRuntimeExecutionShape` to perform stable deduplication for frontend/IR `Type` snapshots and optimizer/backend `RuntimeComponentManifestEntry` snapshots, while preserving the existing kind validation for component entries (no sorting by `FullName` or alias).  
- Strengthened guardrail tests in `WistRuntimePathGuardrailTests`: added `SelectedRuntimeExecutionShapeBuilder_Build_PreservesSelectedModuleOrderWithStableDeduplication` which computes expected frontend/IR module order from required infrastructure + selected plan modules resolved via `IRuntimeComponentTypeLoader` and compares to the projected `SelectedRuntimeExecutionShape`, and hardened facade tests to assert shape-derived expectations (modules/backends) in addition to the existing configuration signature checks.  
- Minor test adjustments to avoid brittle equality where the facade may include additional optional convenience modules, using `Is.SupersetOf` for facade vs expected-shape frontend modules when appropriate.  

### Testing
- Ran `dotnet --version` and observed `10.0.103`. (Passed)  
- Ran `dotnet restore UniversalToolchain/Wist.sln`. (Passed)  
- Ran `dotnet build UniversalToolchain/Wist.sln -c Release --no-restore`. (Passed)  
- Ran `dotnet test UniversalToolchain/UniversalToolchain.Dialects.Tests/UniversalToolchain.Dialects.Tests.csproj -c Release`. (Passed; tests executed and failures from an intermediate iteration were fixed)  
- Ran `dotnet test UniversalToolchain/Wist.sln -c Release --no-build`. (Passed; full solution tests passed in final run)  

Files changed (high level):  
- `UniversalToolchain/UniversalToolchain.Dialects.Wist/SelectedRuntimeModuleClassification.cs` — stable deduplication of module type snapshots.  
- `UniversalToolchain/UniversalToolchain.Dialects.Wist/SelectedRuntimeExecutionShape.cs` — stable deduplication for frontend/IR types and optimizer/backend entries; kind validation retained.  
- `UniversalToolchain/UniversalToolchain.Dialects.Tests/Wist/WistRuntimePathGuardrailTests.cs` — added ordering preservation test and strengthened facade guardrail checks; adjusted assertions to avoid brittle equality.  

All automated test commands listed above completed successfully in the final validation run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8d5c214608324b369cbd9669a8214)