### PR TITLE
Add intrinsic semantic bootstrap plan and validators; refactor runtime integration types

### DIFF
--- a/UniversalToolchain/UniversalToolchain.Dialects.Integration/DialectBackendRuntimeConfigurationBuilder.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Integration/DialectBackendRuntimeConfigurationBuilder.cs
@@ -1,21 +1,20 @@
 using BasicCore.Contracts;
 using ExceptionsManager;
 using UniversalToolchain.Dialects.Abstractions;
-using UniversalToolchain.Dialects.Integration;
 
-namespace UniversalToolchain.Dialects.Wist;
+namespace UniversalToolchain.Dialects.Integration;
 
 /// <summary>
 ///     Builds backend-specific runtime configuration from selected runtime metadata.
 /// </summary>
 public sealed class DialectBackendRuntimeConfigurationBuilder
 {
-    private readonly DialectIntrinsicPolicyResolver _intrinsicPolicyResolver;
+    private readonly IDialectBackendIntrinsicPolicyResolver _intrinsicPolicyResolver;
     private readonly IRuntimeComponentTypeLoader _typeLoader;
 
     public DialectBackendRuntimeConfigurationBuilder(
         IRuntimeComponentTypeLoader typeLoader,
-        DialectIntrinsicPolicyResolver intrinsicPolicyResolver)
+        IDialectBackendIntrinsicPolicyResolver intrinsicPolicyResolver)
     {
         _typeLoader = typeLoader.ArgNotNull();
         _intrinsicPolicyResolver = intrinsicPolicyResolver.ArgNotNull();

--- a/UniversalToolchain/UniversalToolchain.Dialects.Integration/IDialectBackendIntrinsicPolicyResolver.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Integration/IDialectBackendIntrinsicPolicyResolver.cs
@@ -1,0 +1,13 @@
+using UniversalToolchain.Dialects.Abstractions;
+
+namespace UniversalToolchain.Dialects.Integration;
+
+/// <summary>
+///     Resolves backend-targeted intrinsic policy directives for dialect runtime activation.
+/// </summary>
+public interface IDialectBackendIntrinsicPolicyResolver
+{
+    (IReadOnlyList<string> Allowed, IReadOnlyList<string> Forbidden, bool HasExplicitAllowList) Resolve(
+        DialectBuildPlan buildPlan,
+        DialectBackendId backendId);
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Integration/IntrinsicDescriptorProviderRegistration.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Integration/IntrinsicDescriptorProviderRegistration.cs
@@ -1,0 +1,32 @@
+using ExceptionsManager;
+
+namespace UniversalToolchain.Dialects.Integration;
+
+/// <summary>
+///     Captures declaration-time details for an intrinsic descriptor provider registration.
+/// </summary>
+public sealed class IntrinsicDescriptorProviderRegistration
+{
+    public IntrinsicDescriptorProviderRegistration(
+        int registrationIndex,
+        IntrinsicDescriptorProviderRegistrationKind kind,
+        Type? providerType)
+    {
+        if (registrationIndex < 0)
+        {
+            Thrower.Argument(nameof(registrationIndex), "Registration index must not be negative.");
+        }
+
+        RegistrationIndex = registrationIndex;
+        Kind = kind;
+        ProviderType = providerType;
+    }
+
+    public int RegistrationIndex { get; }
+
+    public IntrinsicDescriptorProviderRegistrationKind Kind { get; }
+
+    public Type? ProviderType { get; }
+
+    public bool CanValidateBeforeProviderBuild => ProviderType != null;
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Integration/IntrinsicDescriptorProviderRegistrationKind.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Integration/IntrinsicDescriptorProviderRegistrationKind.cs
@@ -1,0 +1,11 @@
+namespace UniversalToolchain.Dialects.Integration;
+
+/// <summary>
+///     Describes how an intrinsic descriptor provider is registered in the service collection.
+/// </summary>
+public enum IntrinsicDescriptorProviderRegistrationKind
+{
+    ImplementationType,
+    ImplementationInstance,
+    Factory
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Integration/IntrinsicProviderRequirement.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Integration/IntrinsicProviderRequirement.cs
@@ -1,0 +1,19 @@
+using ExceptionsManager;
+
+namespace UniversalToolchain.Dialects.Integration;
+
+/// <summary>
+///     Describes an intrinsic descriptor provider requirement declared by a runtime activation module.
+/// </summary>
+public sealed record IntrinsicProviderRequirement
+{
+    public IntrinsicProviderRequirement(Type moduleType, Type providerType)
+    {
+        ModuleType = moduleType.NotNull(nameof(moduleType));
+        ProviderType = providerType.NotNull(nameof(providerType));
+    }
+
+    public Type ModuleType { get; }
+
+    public Type ProviderType { get; }
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Integration/IntrinsicSemanticBootstrapPlan.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Integration/IntrinsicSemanticBootstrapPlan.cs
@@ -8,27 +8,43 @@ namespace UniversalToolchain.Dialects.Integration;
 /// </summary>
 public sealed class IntrinsicSemanticBootstrapPlan
 {
-    private readonly ReadOnlyCollection<Type> _registeredProviderTypes;
+    private readonly ReadOnlyCollection<IntrinsicDescriptorProviderRegistration> _providerRegistrations;
     private readonly ReadOnlyCollection<IntrinsicProviderRequirement> _requirements;
 
     public IntrinsicSemanticBootstrapPlan(
-        IEnumerable<Type> registeredProviderTypes,
+        IEnumerable<IntrinsicDescriptorProviderRegistration> providerRegistrations,
         IEnumerable<IntrinsicProviderRequirement> requirements)
     {
-        _registeredProviderTypes = new ReadOnlyCollection<Type>(SnapshotTypes(registeredProviderTypes, nameof(registeredProviderTypes)));
+        _providerRegistrations = new ReadOnlyCollection<IntrinsicDescriptorProviderRegistration>(
+            SnapshotRegistrations(providerRegistrations, nameof(providerRegistrations)));
         _requirements = new ReadOnlyCollection<IntrinsicProviderRequirement>(SnapshotRequirements(requirements, nameof(requirements)));
     }
 
-    public IReadOnlyList<Type> RegisteredProviderTypes => _registeredProviderTypes;
+    public IReadOnlyList<IntrinsicDescriptorProviderRegistration> ProviderRegistrations => _providerRegistrations;
 
     public IReadOnlyList<IntrinsicProviderRequirement> Requirements => _requirements;
 
-    private static List<Type> SnapshotTypes(IEnumerable<Type> values, string paramName)
+    public IReadOnlyList<Type> GetPreBuildResolvableProviderTypes()
+    {
+        return _providerRegistrations
+            .Where(static x => x.CanValidateBeforeProviderBuild)
+            .Select(static x => x.ProviderType)
+            .Where(static x => x != null)
+            .Cast<Type>()
+            .Distinct()
+            .OrderBy(x => x.FullName, StringComparer.Ordinal)
+            .ToList();
+    }
+
+    private static List<IntrinsicDescriptorProviderRegistration> SnapshotRegistrations(
+        IEnumerable<IntrinsicDescriptorProviderRegistration> values,
+        string paramName)
     {
         return values
             .Select(x => x.NotNull(paramName))
-            .Distinct()
-            .OrderBy(x => x.FullName, StringComparer.Ordinal)
+            .OrderBy(x => x.RegistrationIndex)
+            .ThenBy(x => x.Kind)
+            .ThenBy(x => x.ProviderType?.FullName, StringComparer.Ordinal)
             .ToList();
     }
 

--- a/UniversalToolchain/UniversalToolchain.Dialects.Integration/IntrinsicSemanticBootstrapPlan.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Integration/IntrinsicSemanticBootstrapPlan.cs
@@ -1,0 +1,44 @@
+using System.Collections.ObjectModel;
+using ExceptionsManager;
+
+namespace UniversalToolchain.Dialects.Integration;
+
+/// <summary>
+///     Immutable startup contract for intrinsic provider registration and coverage validation.
+/// </summary>
+public sealed class IntrinsicSemanticBootstrapPlan
+{
+    private readonly ReadOnlyCollection<Type> _registeredProviderTypes;
+    private readonly ReadOnlyCollection<IntrinsicProviderRequirement> _requirements;
+
+    public IntrinsicSemanticBootstrapPlan(
+        IEnumerable<Type> registeredProviderTypes,
+        IEnumerable<IntrinsicProviderRequirement> requirements)
+    {
+        _registeredProviderTypes = new ReadOnlyCollection<Type>(SnapshotTypes(registeredProviderTypes, nameof(registeredProviderTypes)));
+        _requirements = new ReadOnlyCollection<IntrinsicProviderRequirement>(SnapshotRequirements(requirements, nameof(requirements)));
+    }
+
+    public IReadOnlyList<Type> RegisteredProviderTypes => _registeredProviderTypes;
+
+    public IReadOnlyList<IntrinsicProviderRequirement> Requirements => _requirements;
+
+    private static List<Type> SnapshotTypes(IEnumerable<Type> values, string paramName)
+    {
+        return values
+            .Select(x => x.NotNull(paramName))
+            .Distinct()
+            .OrderBy(x => x.FullName, StringComparer.Ordinal)
+            .ToList();
+    }
+
+    private static List<IntrinsicProviderRequirement> SnapshotRequirements(IEnumerable<IntrinsicProviderRequirement> values, string paramName)
+    {
+        return values
+            .Select(x => x.NotNull(paramName))
+            .Distinct()
+            .OrderBy(x => x.ModuleType.FullName, StringComparer.Ordinal)
+            .ThenBy(x => x.ProviderType.FullName, StringComparer.Ordinal)
+            .ToList();
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Integration/IntrinsicSemanticBootstrapPlanBuilder.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Integration/IntrinsicSemanticBootstrapPlanBuilder.cs
@@ -1,0 +1,52 @@
+using BasicCore.Contracts;
+using ExceptionsManager;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace UniversalToolchain.Dialects.Integration;
+
+/// <summary>
+///     Builds intrinsic semantic bootstrap plans from service registrations before provider creation.
+/// </summary>
+public sealed class IntrinsicSemanticBootstrapPlanBuilder
+{
+    public IntrinsicSemanticBootstrapPlan Build(IServiceCollection services)
+    {
+        services = services.ArgNotNull();
+
+        var providerTypes = services
+            .Where(static x => x.ServiceType == typeof(IIntrinsicDescriptorProvider))
+            .Select(static x => x.ImplementationType ?? x.ImplementationInstance?.GetType())
+            .Where(static x => x != null)
+            .Cast<Type>()
+            .OrderBy(x => x.FullName, StringComparer.Ordinal)
+            .ToList();
+
+        var moduleTypes = GetRegisteredImplementationTypes(services, typeof(IFrontendCoreModule))
+            .Concat(GetRegisteredImplementationTypes(services, typeof(IIRProcessingModule)))
+            .Distinct()
+            .OrderBy(x => x.FullName, StringComparer.Ordinal)
+            .ToList();
+
+        var requirements = moduleTypes
+            .SelectMany(static moduleType =>
+                moduleType.GetCustomAttributes(typeof(IntrinsicDescriptorProviderAttribute), false)
+                    .Cast<IntrinsicDescriptorProviderAttribute>()
+                    .Select(attribute => new IntrinsicProviderRequirement(moduleType, attribute.ProviderType)))
+            .OrderBy(x => x.ModuleType.FullName, StringComparer.Ordinal)
+            .ThenBy(x => x.ProviderType.FullName, StringComparer.Ordinal)
+            .ToList();
+
+        return new IntrinsicSemanticBootstrapPlan(providerTypes, requirements);
+    }
+
+    private static IReadOnlyList<Type> GetRegisteredImplementationTypes(IServiceCollection services, Type serviceType)
+    {
+        return services
+            .Where(x => x.ServiceType == serviceType)
+            .Select(x => x.ImplementationType ?? x.ImplementationInstance?.GetType())
+            .Where(static x => x != null)
+            .Cast<Type>()
+            .OrderBy(x => x.FullName, StringComparer.Ordinal)
+            .ToList();
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Integration/IntrinsicSemanticBootstrapPlanBuilder.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Integration/IntrinsicSemanticBootstrapPlanBuilder.cs
@@ -13,12 +13,11 @@ public sealed class IntrinsicSemanticBootstrapPlanBuilder
     {
         services = services.ArgNotNull();
 
-        var providerTypes = services
-            .Where(static x => x.ServiceType == typeof(IIntrinsicDescriptorProvider))
-            .Select(static x => x.ImplementationType ?? x.ImplementationInstance?.GetType())
-            .Where(static x => x != null)
-            .Cast<Type>()
-            .OrderBy(x => x.FullName, StringComparer.Ordinal)
+        var providerRegistrations = services
+            .Select(static (descriptor, index) => new RegistrationEntry(index, descriptor))
+            .Where(static x => x.Descriptor.ServiceType == typeof(IIntrinsicDescriptorProvider))
+            .Select(static x => ToProviderRegistration(x.Index, x.Descriptor))
+            .OrderBy(x => x.RegistrationIndex)
             .ToList();
 
         var moduleTypes = GetRegisteredImplementationTypes(services, typeof(IFrontendCoreModule))
@@ -36,7 +35,38 @@ public sealed class IntrinsicSemanticBootstrapPlanBuilder
             .ThenBy(x => x.ProviderType.FullName, StringComparer.Ordinal)
             .ToList();
 
-        return new IntrinsicSemanticBootstrapPlan(providerTypes, requirements);
+        return new IntrinsicSemanticBootstrapPlan(providerRegistrations, requirements);
+    }
+
+    private static IntrinsicDescriptorProviderRegistration ToProviderRegistration(int registrationIndex, ServiceDescriptor descriptor)
+    {
+        if (descriptor.ImplementationType != null)
+        {
+            return new IntrinsicDescriptorProviderRegistration(
+                registrationIndex,
+                IntrinsicDescriptorProviderRegistrationKind.ImplementationType,
+                descriptor.ImplementationType);
+        }
+
+        if (descriptor.ImplementationInstance != null)
+        {
+            return new IntrinsicDescriptorProviderRegistration(
+                registrationIndex,
+                IntrinsicDescriptorProviderRegistrationKind.ImplementationInstance,
+                descriptor.ImplementationInstance.GetType());
+        }
+
+        if (descriptor.ImplementationFactory != null)
+        {
+            return new IntrinsicDescriptorProviderRegistration(
+                registrationIndex,
+                IntrinsicDescriptorProviderRegistrationKind.Factory,
+                null);
+        }
+
+        Thrower.InvalidOpEx(
+            $"Intrinsic descriptor provider registration at index {registrationIndex} has no implementation type, instance, or factory.");
+        return null!;
     }
 
     private static IReadOnlyList<Type> GetRegisteredImplementationTypes(IServiceCollection services, Type serviceType)
@@ -49,4 +79,6 @@ public sealed class IntrinsicSemanticBootstrapPlanBuilder
             .OrderBy(x => x.FullName, StringComparer.Ordinal)
             .ToList();
     }
+
+    private sealed record RegistrationEntry(int Index, ServiceDescriptor Descriptor);
 }

--- a/UniversalToolchain/UniversalToolchain.Dialects.Integration/IntrinsicSemanticBootstrapPreProviderValidator.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Integration/IntrinsicSemanticBootstrapPreProviderValidator.cs
@@ -19,13 +19,26 @@ public sealed class IntrinsicSemanticBootstrapPreProviderValidator
         var errors = new List<string>();
 
         errors.AddRange(metadataValidator.Validate(services));
+        errors.AddRange(GetUnsupportedRegistrationErrors(plan.ProviderRegistrations));
+
+        var preBuildResolvableProviderTypes = plan.GetPreBuildResolvableProviderTypes();
         errors.AddRange(coverageValidator.Validate(
-            plan.RegisteredProviderTypes,
+            preBuildResolvableProviderTypes,
             plan.Requirements.Select(static x => (x.ModuleType, x.ProviderType)).ToList()));
 
         if (errors.Count > 0)
         {
             Thrower.InvalidOpEx("Intrinsic semantic startup validation failed:" + Environment.NewLine + string.Join(Environment.NewLine, errors));
         }
+    }
+
+    private static IReadOnlyList<string> GetUnsupportedRegistrationErrors(IReadOnlyList<IntrinsicDescriptorProviderRegistration> registrations)
+    {
+        return registrations
+            .Where(static x => x.Kind == IntrinsicDescriptorProviderRegistrationKind.Factory)
+            .OrderBy(x => x.RegistrationIndex)
+            .Select(static x =>
+                $"Intrinsic descriptor provider registration at index {x.RegistrationIndex} uses factory-based registration. Pre-provider bootstrap validation cannot infer provider type from factories. Use implementation-type or implementation-instance registration for IIntrinsicDescriptorProvider.")
+            .ToList();
     }
 }

--- a/UniversalToolchain/UniversalToolchain.Dialects.Integration/IntrinsicSemanticBootstrapPreProviderValidator.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Integration/IntrinsicSemanticBootstrapPreProviderValidator.cs
@@ -1,0 +1,31 @@
+using BasicCore.Core;
+using ExceptionsManager;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace UniversalToolchain.Dialects.Integration;
+
+/// <summary>
+///     Validates intrinsic bootstrap requirements before building a provider instance.
+/// </summary>
+public sealed class IntrinsicSemanticBootstrapPreProviderValidator
+{
+    public void Validate(IntrinsicSemanticBootstrapPlan plan, IServiceCollection services)
+    {
+        plan = plan.ArgNotNull();
+        services = services.ArgNotNull();
+
+        var metadataValidator = new IntrinsicDescriptorProviderMetadataValidator();
+        var coverageValidator = new IntrinsicSemanticCoverageValidator();
+        var errors = new List<string>();
+
+        errors.AddRange(metadataValidator.Validate(services));
+        errors.AddRange(coverageValidator.Validate(
+            plan.RegisteredProviderTypes,
+            plan.Requirements.Select(static x => (x.ModuleType, x.ProviderType)).ToList()));
+
+        if (errors.Count > 0)
+        {
+            Thrower.InvalidOpEx("Intrinsic semantic startup validation failed:" + Environment.NewLine + string.Join(Environment.NewLine, errors));
+        }
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Integration/IntrinsicSemanticBootstrapRuntimeValidator.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Integration/IntrinsicSemanticBootstrapRuntimeValidator.cs
@@ -1,0 +1,26 @@
+using BasicCore.Core;
+using BasicCore.Contracts;
+using ExceptionsManager;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace UniversalToolchain.Dialects.Integration;
+
+/// <summary>
+///     Validates intrinsic bootstrap requirements against provider-built instances.
+/// </summary>
+public sealed class IntrinsicSemanticBootstrapRuntimeValidator
+{
+    public void Validate(IServiceProvider provider, IntrinsicSemanticBootstrapPlan plan)
+    {
+        provider = provider.ArgNotNull();
+        plan = plan.ArgNotNull();
+
+        var validator = provider.GetRequiredService<IntrinsicSemanticStartupValidator>();
+        var providers = provider.GetServices<IIntrinsicDescriptorProvider>();
+        var requirements = plan.Requirements
+            .Select(static x => (x.ModuleType, x.ProviderType))
+            .ToList();
+
+        validator.Validate(providers, requirements);
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Integration/SelectedRuntimeModuleClassification.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Integration/SelectedRuntimeModuleClassification.cs
@@ -1,7 +1,7 @@
 using System.Collections.ObjectModel;
 using ExceptionsManager;
 
-namespace UniversalToolchain.Dialects.Wist;
+namespace UniversalToolchain.Dialects.Integration;
 
 /// <summary>
 ///     Immutable role classification for runtime-selected module activation types.

--- a/UniversalToolchain/UniversalToolchain.Dialects.Integration/SelectedRuntimeModuleClassifier.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Integration/SelectedRuntimeModuleClassifier.cs
@@ -1,11 +1,10 @@
 using BasicCore.Contracts;
 using ExceptionsManager;
-using UniversalToolchain.Dialects.Integration;
 
-namespace UniversalToolchain.Dialects.Wist;
+namespace UniversalToolchain.Dialects.Integration;
 
 /// <summary>
-///     Classifies selected runtime modules by execution role and validates activation compatibility.
+///     Classifies selected runtime modules by activation role and validates activation compatibility.
 /// </summary>
 public sealed class SelectedRuntimeModuleClassifier
 {

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/RuntimeLoading/IntrinsicDescriptorProviderRegistrationTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/RuntimeLoading/IntrinsicDescriptorProviderRegistrationTests.cs
@@ -86,12 +86,22 @@ public class IntrinsicDescriptorProviderRegistrationTests
         }));
     }
 
+
+    private static WistDialectServiceProviderFactory CreateFactory(IEnumerable<IDialectBackendRuntimeRegistrar> backendRegistrars)
+    {
+        return new WistDialectServiceProviderFactory(
+            backendRegistrars,
+            new IntrinsicSemanticBootstrapPlanBuilder(),
+            new IntrinsicSemanticBootstrapPreProviderValidator(),
+            new IntrinsicSemanticBootstrapRuntimeValidator());
+    }
+
     private static ServiceProvider CreateProvider(
         IReadOnlyList<Type>? frontendModules = null,
         IReadOnlyList<Type>? irModules = null,
         IReadOnlyList<Type>? optimizers = null)
     {
-        var factory = new WistDialectServiceProviderFactory([]);
+        var factory = CreateFactory([]);
         var configuration = new WistDialectExecutionConfiguration(
             "Test",
             frontendModules ?? [],

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/RuntimeLoading/IntrinsicSemanticBootstrapPlanContractTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/RuntimeLoading/IntrinsicSemanticBootstrapPlanContractTests.cs
@@ -1,0 +1,114 @@
+using BasicCore.Contracts;
+using BasicCore.Core;
+using Microsoft.Extensions.DependencyInjection;
+using UniversalToolchain.Dialects.Core.ServiceCollection;
+using UniversalToolchain.Dialects.Integration;
+
+namespace UniversalToolchain.Dialects.Tests.RuntimeLoading;
+
+public sealed class IntrinsicSemanticBootstrapPlanContractTests
+{
+    [Test]
+    public void Build_RegisteredModulesAndProviders_ProducesDeterministicPlan()
+    {
+        var services = new ServiceCollection();
+        services.AddCoreRuntimeInfrastructure();
+        services.AddSingleton<IFrontendCoreModule, ValidProviderFrontendModule>();
+        services.AddSingleton<IIRProcessingModule, ValidProviderOptimizerModule>();
+        services.AddSingleton<IIntrinsicDescriptorProvider, ValidProvider>();
+
+        var builder = new IntrinsicSemanticBootstrapPlanBuilder();
+        var first = builder.Build(services);
+        var second = builder.Build(services);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(first.RegisteredProviderTypes, Is.EqualTo(second.RegisteredProviderTypes));
+            Assert.That(first.Requirements, Is.EqualTo(second.Requirements));
+            Assert.That(first.Requirements.Select(static x => x.ProviderType), Is.EqualTo(new[]
+            {
+                typeof(ValidProvider),
+                typeof(ValidProvider)
+            }));
+        });
+    }
+
+    [Test]
+    public void ValidatePreProvider_WhenRequirementMissingRegisteredProvider_Throws()
+    {
+        var services = new ServiceCollection();
+        services.AddCoreRuntimeInfrastructure();
+        services.AddSingleton<IFrontendCoreModule, MissingProviderFrontendModule>();
+
+        var builder = new IntrinsicSemanticBootstrapPlanBuilder();
+        var plan = builder.Build(services);
+        var validator = new IntrinsicSemanticBootstrapPreProviderValidator();
+
+        var exception = Assert.Throws<InvalidOperationException>(() => validator.Validate(plan, services));
+
+        Assert.That(exception!.Message, Does.Contain(typeof(MissingProvider).FullName));
+    }
+
+    [Test]
+    public void ValidateRuntime_WhenProvidersSatisfyPlan_DoesNotThrow()
+    {
+        var services = new ServiceCollection();
+        services.AddCoreRuntimeInfrastructure();
+        services.AddSingleton<IFrontendCoreModule, ValidProviderFrontendModule>();
+        services.AddSingleton<IIntrinsicDescriptorProvider, ValidProvider>();
+
+        var builder = new IntrinsicSemanticBootstrapPlanBuilder();
+        var plan = builder.Build(services);
+        var preProviderValidator = new IntrinsicSemanticBootstrapPreProviderValidator();
+        preProviderValidator.Validate(plan, services);
+
+        using var provider = services.BuildServiceProvider();
+        var runtimeValidator = new IntrinsicSemanticBootstrapRuntimeValidator();
+
+        Assert.DoesNotThrow(() => runtimeValidator.Validate(provider, plan));
+    }
+
+    private static IntrinsicSemanticDescriptor CreateDescriptor(string @namespace, string name) =>
+        new()
+        {
+            Symbol = new IntrinsicSymbol(@namespace, name),
+            Category = IntrinsicCategory.Core,
+            StackRule = new NoOpStackRule(),
+            ValidationRule = new NoOpValidationRule()
+        };
+
+    private sealed class MissingProvider : IIntrinsicDescriptorProvider
+    {
+        public IReadOnlyList<IntrinsicSemanticDescriptor> GetDescriptors() =>
+            [CreateDescriptor("logic", "missing")];
+    }
+
+    private sealed class ValidProvider : IIntrinsicDescriptorProvider
+    {
+        public IReadOnlyList<IntrinsicSemanticDescriptor> GetDescriptors() =>
+            [CreateDescriptor("logic", "valid")];
+    }
+
+    [IntrinsicDescriptorProvider(typeof(MissingProvider))]
+    private sealed class MissingProviderFrontendModule : IFrontendCoreModule;
+
+    [IntrinsicDescriptorProvider(typeof(ValidProvider))]
+    private sealed class ValidProviderFrontendModule : IFrontendCoreModule;
+
+    [IntrinsicDescriptorProvider(typeof(ValidProvider))]
+    private sealed class ValidProviderOptimizerModule : IIRProcessingModule;
+
+    private sealed class NoOpStackRule : IIntrinsicStackRule
+    {
+        public void Apply(IntrinsicInvocation invocation, List<Type> stack, IIntrinsicTypeResolutionContext context)
+        {
+        }
+    }
+
+    private sealed class NoOpValidationRule : IIntrinsicValidationRule
+    {
+        public void Validate(IntrinsicInvocation invocation, IIntrinsicTypeResolutionContext context)
+        {
+        }
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/RuntimeLoading/IntrinsicSemanticBootstrapPlanContractTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/RuntimeLoading/IntrinsicSemanticBootstrapPlanContractTests.cs
@@ -9,51 +9,73 @@ namespace UniversalToolchain.Dialects.Tests.RuntimeLoading;
 public sealed class IntrinsicSemanticBootstrapPlanContractTests
 {
     [Test]
-    public void Build_RegisteredModulesAndProviders_ProducesDeterministicPlan()
+    public void Build_SameServiceRegistrations_ProducesDeterministicPlan()
     {
-        var services = new ServiceCollection();
-        services.AddCoreRuntimeInfrastructure();
+        var services = CreateServices();
         services.AddSingleton<IFrontendCoreModule, ValidProviderFrontendModule>();
-        services.AddSingleton<IIRProcessingModule, ValidProviderOptimizerModule>();
         services.AddSingleton<IIntrinsicDescriptorProvider, ValidProvider>();
+        services.AddSingleton<IIntrinsicDescriptorProvider>(new ValidProvider());
 
         var builder = new IntrinsicSemanticBootstrapPlanBuilder();
         var first = builder.Build(services);
         var second = builder.Build(services);
 
-        Assert.Multiple(() =>
-        {
-            Assert.That(first.RegisteredProviderTypes, Is.EqualTo(second.RegisteredProviderTypes));
-            Assert.That(first.Requirements, Is.EqualTo(second.Requirements));
-            Assert.That(first.Requirements.Select(static x => x.ProviderType), Is.EqualTo(new[]
-            {
-                typeof(ValidProvider),
-                typeof(ValidProvider)
-            }));
-        });
+        Assert.That(BuildPlanSignature(first), Is.EqualTo(BuildPlanSignature(second)));
     }
 
     [Test]
-    public void ValidatePreProvider_WhenRequirementMissingRegisteredProvider_Throws()
+    public void ValidatePreProvider_ImplementationTypeRegistration_ParticipatesInCoverageValidation()
     {
-        var services = new ServiceCollection();
-        services.AddCoreRuntimeInfrastructure();
-        services.AddSingleton<IFrontendCoreModule, MissingProviderFrontendModule>();
+        var services = CreateServices();
+        services.AddSingleton<IFrontendCoreModule, ValidProviderFrontendModule>();
+        services.AddSingleton<IIntrinsicDescriptorProvider, ValidProvider>();
 
         var builder = new IntrinsicSemanticBootstrapPlanBuilder();
         var plan = builder.Build(services);
         var validator = new IntrinsicSemanticBootstrapPreProviderValidator();
 
-        var exception = Assert.Throws<InvalidOperationException>(() => validator.Validate(plan, services));
-
-        Assert.That(exception!.Message, Does.Contain(typeof(MissingProvider).FullName));
+        Assert.DoesNotThrow(() => validator.Validate(plan, services));
     }
 
     [Test]
-    public void ValidateRuntime_WhenProvidersSatisfyPlan_DoesNotThrow()
+    public void ValidatePreProvider_ImplementationInstanceRegistration_ParticipatesInCoverageValidation()
     {
-        var services = new ServiceCollection();
-        services.AddCoreRuntimeInfrastructure();
+        var services = CreateServices();
+        services.AddSingleton<IFrontendCoreModule, ValidProviderFrontendModule>();
+        services.AddSingleton<IIntrinsicDescriptorProvider>(new ValidProvider());
+
+        var builder = new IntrinsicSemanticBootstrapPlanBuilder();
+        var plan = builder.Build(services);
+        var validator = new IntrinsicSemanticBootstrapPreProviderValidator();
+
+        Assert.DoesNotThrow(() => validator.Validate(plan, services));
+    }
+
+    [Test]
+    public void ValidatePreProvider_FactoryRegistration_FailsFastWithClearMessage()
+    {
+        var services = CreateServices();
+        services.AddSingleton<IFrontendCoreModule, ValidProviderFrontendModule>();
+        services.AddSingleton<IIntrinsicDescriptorProvider>(_ => new ValidProvider());
+
+        var builder = new IntrinsicSemanticBootstrapPlanBuilder();
+        var plan = builder.Build(services);
+        var validator = new IntrinsicSemanticBootstrapPreProviderValidator();
+
+        Assert.That(
+            plan.ProviderRegistrations.Select(static x => x.Kind),
+            Does.Contain(IntrinsicDescriptorProviderRegistrationKind.Factory));
+
+        var exception = Assert.Throws<InvalidOperationException>(() => validator.Validate(plan, services));
+
+        Assert.That(exception!.Message, Does.Contain("factory-based registration"));
+        Assert.That(exception.Message, Does.Contain("cannot infer provider type"));
+    }
+
+    [Test]
+    public void ValidateRuntime_SupportedRegistrationPaths_SucceedsAfterPreProviderValidation()
+    {
+        var services = CreateServices();
         services.AddSingleton<IFrontendCoreModule, ValidProviderFrontendModule>();
         services.AddSingleton<IIntrinsicDescriptorProvider, ValidProvider>();
 
@@ -68,6 +90,25 @@ public sealed class IntrinsicSemanticBootstrapPlanContractTests
         Assert.DoesNotThrow(() => runtimeValidator.Validate(provider, plan));
     }
 
+    private static ServiceCollection CreateServices()
+    {
+        var services = new ServiceCollection();
+        services.AddCoreRuntimeInfrastructure();
+        return services;
+    }
+
+    private static string BuildPlanSignature(IntrinsicSemanticBootstrapPlan plan)
+    {
+        return string.Join(
+                   "|",
+                   plan.ProviderRegistrations.Select(static x =>
+                       x.RegistrationIndex + ":" + x.Kind + ":" + (x.ProviderType?.FullName ?? "<null>")))
+               + "::"
+               + string.Join(
+                   "|",
+                   plan.Requirements.Select(static x => x.ModuleType.FullName + ":" + x.ProviderType.FullName));
+    }
+
     private static IntrinsicSemanticDescriptor CreateDescriptor(string @namespace, string name) =>
         new()
         {
@@ -77,26 +118,14 @@ public sealed class IntrinsicSemanticBootstrapPlanContractTests
             ValidationRule = new NoOpValidationRule()
         };
 
-    private sealed class MissingProvider : IIntrinsicDescriptorProvider
-    {
-        public IReadOnlyList<IntrinsicSemanticDescriptor> GetDescriptors() =>
-            [CreateDescriptor("logic", "missing")];
-    }
-
     private sealed class ValidProvider : IIntrinsicDescriptorProvider
     {
         public IReadOnlyList<IntrinsicSemanticDescriptor> GetDescriptors() =>
             [CreateDescriptor("logic", "valid")];
     }
 
-    [IntrinsicDescriptorProvider(typeof(MissingProvider))]
-    private sealed class MissingProviderFrontendModule : IFrontendCoreModule;
-
     [IntrinsicDescriptorProvider(typeof(ValidProvider))]
     private sealed class ValidProviderFrontendModule : IFrontendCoreModule;
-
-    [IntrinsicDescriptorProvider(typeof(ValidProvider))]
-    private sealed class ValidProviderOptimizerModule : IIRProcessingModule;
 
     private sealed class NoOpStackRule : IIntrinsicStackRule
     {

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/RuntimeLoading/IntrinsicSemanticCompositionGuardTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/RuntimeLoading/IntrinsicSemanticCompositionGuardTests.cs
@@ -9,7 +9,7 @@ public sealed class IntrinsicSemanticCompositionGuardTests
     [Test]
     public void RuntimeFactory_ShouldFailFast_WhenDuplicateIntrinsicSymbolsAreRegistered()
     {
-        var factory = new WistDialectServiceProviderFactory([]);
+        var factory = CreateFactory([]);
         var configuration = new WistDialectExecutionConfiguration(
             "DuplicateIntrinsicGuard",
             [typeof(DuplicateAlphaFrontendModule), typeof(DuplicateBetaFrontendModule)],
@@ -22,6 +22,16 @@ public sealed class IntrinsicSemanticCompositionGuardTests
 
         Assert.That(exception!.Message, Does.Contain("Intrinsic symbol"));
         Assert.That(exception.Message, Does.Contain("math.add"));
+    }
+
+
+    private static WistDialectServiceProviderFactory CreateFactory(IEnumerable<IDialectBackendRuntimeRegistrar> backendRegistrars)
+    {
+        return new WistDialectServiceProviderFactory(
+            backendRegistrars,
+            new IntrinsicSemanticBootstrapPlanBuilder(),
+            new IntrinsicSemanticBootstrapPreProviderValidator(),
+            new IntrinsicSemanticBootstrapRuntimeValidator());
     }
 
     private static IntrinsicSemanticDescriptor CreateDescriptor(string @namespace, string name) =>

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/RuntimeLoading/IntrinsicSemanticStartupValidationRuntimeTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/RuntimeLoading/IntrinsicSemanticStartupValidationRuntimeTests.cs
@@ -13,7 +13,7 @@ public sealed class IntrinsicSemanticStartupValidationRuntimeTests
     [Test]
     public void RuntimeFactory_ShouldFail_WhenModuleDeclaresInvalidProviderType()
     {
-        var factory = new WistDialectServiceProviderFactory([]);
+        var factory = CreateFactory([]);
         var configuration = new WistDialectExecutionConfiguration(
             "InvalidProviderType",
             [typeof(InvalidProviderTypeFrontendModule)],
@@ -51,7 +51,7 @@ public sealed class IntrinsicSemanticStartupValidationRuntimeTests
     [Test]
     public void RuntimeFactory_ShouldSucceed_WhenIntrinsicProvidersCoverSelectedModules()
     {
-        var factory = new WistDialectServiceProviderFactory([]);
+        var factory = CreateFactory([]);
         var configuration = new WistDialectExecutionConfiguration(
             "ValidProviderCoverage",
             [typeof(ValidProviderFrontendModule)],
@@ -68,7 +68,7 @@ public sealed class IntrinsicSemanticStartupValidationRuntimeTests
     {
         CountingDependency.Reset();
 
-        var factory = new WistDialectServiceProviderFactory([new CountingBackendRegistrar()]);
+        var factory = CreateFactory([new CountingBackendRegistrar()]);
         var configuration = new WistDialectExecutionConfiguration(
             "CountingProvider",
             [],
@@ -90,6 +90,16 @@ public sealed class IntrinsicSemanticStartupValidationRuntimeTests
             .Single(static x => x.GetType() == typeof(CountingDescriptorProvider));
 
         Assert.That(CountingDependency.CreationCount, Is.EqualTo(1));
+    }
+
+
+    private static WistDialectServiceProviderFactory CreateFactory(IEnumerable<IDialectBackendRuntimeRegistrar> backendRegistrars)
+    {
+        return new WistDialectServiceProviderFactory(
+            backendRegistrars,
+            new IntrinsicSemanticBootstrapPlanBuilder(),
+            new IntrinsicSemanticBootstrapPreProviderValidator(),
+            new IntrinsicSemanticBootstrapRuntimeValidator());
     }
 
     private static IntrinsicSemanticDescriptor CreateDescriptor(string @namespace, string name) =>

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/Wist/RuntimeInfrastructureCompositionTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/Wist/RuntimeInfrastructureCompositionTests.cs
@@ -114,7 +114,7 @@ public class RuntimeInfrastructureCompositionTests
     public void WistDialectServiceProviderFactory_ShouldUseNeutralInfrastructurePlusFrontendDefaults()
     {
         var descriptor = new RuntimeBackendDescriptor(new DialectBackendId("noop"), typeof(NoopRegistrar), ["noop"]);
-        var factory = new WistDialectServiceProviderFactory([new NoopRegistrar(descriptor.BackendId)]);
+        var factory = CreateFactory([new NoopRegistrar(descriptor.BackendId)]);
         var configuration = new WistDialectExecutionConfiguration(
             "Demo",
             [],
@@ -142,6 +142,16 @@ public class RuntimeInfrastructureCompositionTests
         {
             (provider as IDisposable)?.Dispose();
         }
+    }
+
+
+    private static WistDialectServiceProviderFactory CreateFactory(IEnumerable<IDialectBackendRuntimeRegistrar> backendRegistrars)
+    {
+        return new WistDialectServiceProviderFactory(
+            backendRegistrars,
+            new IntrinsicSemanticBootstrapPlanBuilder(),
+            new IntrinsicSemanticBootstrapPreProviderValidator(),
+            new IntrinsicSemanticBootstrapRuntimeValidator());
     }
 
     [Test]

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/Wist/WistDialectRuntimeBootstrapContractTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/Wist/WistDialectRuntimeBootstrapContractTests.cs
@@ -26,6 +26,20 @@ public class WistDialectRuntimeBootstrapContractTests
     }
 
     [Test]
+    public void AddWistDialectCoreServices_ShouldRegisterIntrinsicBootstrapOrchestrationServices()
+    {
+        var services = new ServiceCollection();
+        services.AddWistDialectCoreServices();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(services.Any(static x => x.ServiceType == typeof(IntrinsicSemanticBootstrapPlanBuilder)), Is.True);
+            Assert.That(services.Any(static x => x.ServiceType == typeof(IntrinsicSemanticBootstrapPreProviderValidator)), Is.True);
+            Assert.That(services.Any(static x => x.ServiceType == typeof(IntrinsicSemanticBootstrapRuntimeValidator)), Is.True);
+        });
+    }
+
+    [Test]
     public void AddWistDialectServices_ShouldRegisterCanonicalRuntimeInfrastructure()
     {
         var services = new ServiceCollection();
@@ -190,7 +204,7 @@ public class WistDialectRuntimeBootstrapContractTests
     [Test]
     public void WistDialectServiceProviderFactory_ShouldRegisterFrontendDefaultsWithoutBackendDefaults()
     {
-        var factory = new WistDialectServiceProviderFactory([new NoopRegistrar("interpreter")]);
+        var factory = CreateFactory([new NoopRegistrar("interpreter")]);
         var config = new WistDialectExecutionConfiguration(
             "Demo",
             [],
@@ -213,7 +227,7 @@ public class WistDialectRuntimeBootstrapContractTests
     [Test]
     public void CreateHost_ShouldFailClearly_IfRequestedBackendRegistrarIsMissing()
     {
-        var factory = new WistDialectServiceProviderFactory([]);
+        var factory = CreateFactory([]);
         var config = new WistDialectExecutionConfiguration(
             "Demo",
             [],
@@ -276,6 +290,16 @@ public class WistDialectRuntimeBootstrapContractTests
         }
 
         Assert.That(signatures.Distinct(StringComparer.Ordinal).Count(), Is.EqualTo(1));
+    }
+
+
+    private static WistDialectServiceProviderFactory CreateFactory(IEnumerable<IDialectBackendRuntimeRegistrar> backendRegistrars)
+    {
+        return new WistDialectServiceProviderFactory(
+            backendRegistrars,
+            new IntrinsicSemanticBootstrapPlanBuilder(),
+            new IntrinsicSemanticBootstrapPreProviderValidator(),
+            new IntrinsicSemanticBootstrapRuntimeValidator());
     }
 
     private static string FormatComposition(DialectFrameworkCompositionResult composition)

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/DialectIntrinsicPolicyResolver.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/DialectIntrinsicPolicyResolver.cs
@@ -1,9 +1,10 @@
 using ExceptionsManager;
 using UniversalToolchain.Dialects.Abstractions;
+using UniversalToolchain.Dialects.Integration;
 
 namespace UniversalToolchain.Dialects.Wist;
 
-public sealed class DialectIntrinsicPolicyResolver
+public sealed class DialectIntrinsicPolicyResolver : IDialectBackendIntrinsicPolicyResolver
 {
     public (IReadOnlyList<string> Allowed, IReadOnlyList<string> Forbidden, bool HasExplicitAllowList) Resolve(
         DialectBuildPlan buildPlan,

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistDialectCoreServiceCollectionExtensions.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistDialectCoreServiceCollectionExtensions.cs
@@ -22,7 +22,7 @@ public static class WistDialectCoreServiceCollectionExtensions
         services.AddDialectDslDefaultComposition();
 
         services.TryAddSingleton<SelectedRuntimePlanResolver>();
-        services.TryAddSingleton<DialectIntrinsicPolicyResolver>();
+        services.TryAddSingleton<IDialectBackendIntrinsicPolicyResolver, DialectIntrinsicPolicyResolver>();
         services.TryAddSingleton<IWistRequiredInfrastructureModulesProvider, WistRequiredInfrastructureModulesProvider>();
         services.TryAddSingleton<SelectedRuntimeModuleClassifier>();
         services.TryAddSingleton<SelectedRuntimeExecutionShapeBuilder>();

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistDialectCoreServiceCollectionExtensions.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistDialectCoreServiceCollectionExtensions.cs
@@ -27,6 +27,9 @@ public static class WistDialectCoreServiceCollectionExtensions
         services.TryAddSingleton<SelectedRuntimeModuleClassifier>();
         services.TryAddSingleton<SelectedRuntimeExecutionShapeBuilder>();
         services.TryAddSingleton<DialectBackendRuntimeConfigurationBuilder>();
+        services.TryAddSingleton<IntrinsicSemanticBootstrapPlanBuilder>();
+        services.TryAddSingleton<IntrinsicSemanticBootstrapPreProviderValidator>();
+        services.TryAddSingleton<IntrinsicSemanticBootstrapRuntimeValidator>();
         services.TryAddSingleton<IDialectCompiledDialectBuildPlanBuilder, DialectCompiledDialectBuildPlanBuilder>();
         services.TryAddSingleton<WistDialectExecutionConfigurationBuilder>();
         services.TryAddSingleton<WistDialectServiceProviderFactory>();

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistDialectServiceProviderFactory.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistDialectServiceProviderFactory.cs
@@ -18,15 +18,6 @@ public sealed class WistDialectServiceProviderFactory
     private readonly IntrinsicSemanticBootstrapPreProviderValidator _intrinsicBootstrapPreProviderValidator;
     private readonly IntrinsicSemanticBootstrapRuntimeValidator _intrinsicBootstrapRuntimeValidator;
 
-    public WistDialectServiceProviderFactory(IEnumerable<IDialectBackendRuntimeRegistrar> backendProviders)
-        : this(
-            backendProviders,
-            new IntrinsicSemanticBootstrapPlanBuilder(),
-            new IntrinsicSemanticBootstrapPreProviderValidator(),
-            new IntrinsicSemanticBootstrapRuntimeValidator())
-    {
-    }
-
     public WistDialectServiceProviderFactory(
         IEnumerable<IDialectBackendRuntimeRegistrar> backendProviders,
         IntrinsicSemanticBootstrapPlanBuilder intrinsicBootstrapPlanBuilder,

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistDialectServiceProviderFactory.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistDialectServiceProviderFactory.cs
@@ -1,5 +1,4 @@
 using BasicCore.Contracts;
-using BasicCore.Core;
 using ExceptionsManager;
 using Microsoft.Extensions.DependencyInjection;
 using UniversalToolchain.Dialects.Abstractions;
@@ -15,10 +14,29 @@ namespace UniversalToolchain.Dialects.Wist;
 public sealed class WistDialectServiceProviderFactory
 {
     private readonly IReadOnlyDictionary<DialectBackendId, IDialectBackendRuntimeRegistrar> _backendProviders;
+    private readonly IntrinsicSemanticBootstrapPlanBuilder _intrinsicBootstrapPlanBuilder;
+    private readonly IntrinsicSemanticBootstrapPreProviderValidator _intrinsicBootstrapPreProviderValidator;
+    private readonly IntrinsicSemanticBootstrapRuntimeValidator _intrinsicBootstrapRuntimeValidator;
 
     public WistDialectServiceProviderFactory(IEnumerable<IDialectBackendRuntimeRegistrar> backendProviders)
+        : this(
+            backendProviders,
+            new IntrinsicSemanticBootstrapPlanBuilder(),
+            new IntrinsicSemanticBootstrapPreProviderValidator(),
+            new IntrinsicSemanticBootstrapRuntimeValidator())
+    {
+    }
+
+    public WistDialectServiceProviderFactory(
+        IEnumerable<IDialectBackendRuntimeRegistrar> backendProviders,
+        IntrinsicSemanticBootstrapPlanBuilder intrinsicBootstrapPlanBuilder,
+        IntrinsicSemanticBootstrapPreProviderValidator intrinsicBootstrapPreProviderValidator,
+        IntrinsicSemanticBootstrapRuntimeValidator intrinsicBootstrapRuntimeValidator)
     {
         _backendProviders = CreateBackendProviderMap(backendProviders);
+        _intrinsicBootstrapPlanBuilder = intrinsicBootstrapPlanBuilder.ArgNotNull();
+        _intrinsicBootstrapPreProviderValidator = intrinsicBootstrapPreProviderValidator.ArgNotNull();
+        _intrinsicBootstrapRuntimeValidator = intrinsicBootstrapRuntimeValidator.ArgNotNull();
     }
 
     public IServiceProvider Create(WistDialectExecutionConfiguration configuration)
@@ -34,10 +52,12 @@ public sealed class WistDialectServiceProviderFactory
         RegisterModules(services, configuration.Optimizers, typeof(IIRProcessingModule), ServiceLifetime.Transient);
         RegisterIntrinsicDescriptorProviders(services, configuration);
         RegisterBackendRuntimes(services, configuration);
-        var coverageRequirements = ValidateIntrinsicSemantics(services);
+
+        var bootstrapPlan = _intrinsicBootstrapPlanBuilder.Build(services);
+        _intrinsicBootstrapPreProviderValidator.Validate(bootstrapPlan, services);
 
         var provider = services.BuildServiceProvider();
-        ValidateIntrinsicSemantics(provider, coverageRequirements);
+        _intrinsicBootstrapRuntimeValidator.Validate(provider, bootstrapPlan);
         return provider;
     }
 
@@ -48,7 +68,9 @@ public sealed class WistDialectServiceProviderFactory
             services.Add(new ServiceDescriptor(serviceType, type, lifetime));
 
             if (!services.Any(x => x.ServiceType == type && x.ImplementationType == type))
+            {
                 services.Add(new ServiceDescriptor(type, type, lifetime));
+            }
         }
     }
 
@@ -57,7 +79,9 @@ public sealed class WistDialectServiceProviderFactory
         foreach (var backend in configuration.BackendConfigurations.OrderBy(x => x.BackendDescriptor.BackendId))
         {
             if (!_backendProviders.TryGetValue(backend.BackendDescriptor.BackendId, out var backendProvider))
+            {
                 Thrower.InvalidOpEx($"No backend runtime registrar is registered for backend '{backend.BackendDescriptor.CanonicalId}'.");
+            }
 
             backendProvider.RegisterRuntime(services, backend);
         }
@@ -89,72 +113,10 @@ public sealed class WistDialectServiceProviderFactory
         foreach (var providerType in providerTypes)
         {
             if (!services.Any(x => x.ServiceType == typeof(IIntrinsicDescriptorProvider) && x.ImplementationType == providerType))
+            {
                 services.AddSingleton(typeof(IIntrinsicDescriptorProvider), providerType);
+            }
         }
-    }
-
-    private static IReadOnlyList<(Type ModuleType, Type ProviderType)> ValidateIntrinsicSemantics(IServiceCollection services)
-    {
-        var coverageRequirements = GetIntrinsicCoverageRequirements(services);
-        var metadataValidator = new IntrinsicDescriptorProviderMetadataValidator();
-        var coverageValidator = new IntrinsicSemanticCoverageValidator();
-        var errors = new List<string>();
-
-        errors.AddRange(metadataValidator.Validate(services));
-        errors.AddRange(coverageValidator.Validate(GetRegisteredProviderTypes(services), coverageRequirements));
-
-        if (errors.Count > 0)
-            Thrower.InvalidOpEx("Intrinsic semantic startup validation failed:" + Environment.NewLine + string.Join(Environment.NewLine, errors));
-
-        return coverageRequirements;
-    }
-
-    private static void ValidateIntrinsicSemantics(
-        IServiceProvider provider,
-        IReadOnlyList<(Type ModuleType, Type ProviderType)> coverageRequirements)
-    {
-        var validator = provider.GetRequiredService<IntrinsicSemanticStartupValidator>();
-        var providers = provider.GetServices<IIntrinsicDescriptorProvider>();
-        validator.Validate(providers, coverageRequirements);
-    }
-
-    private static IReadOnlyList<Type> GetRegisteredProviderTypes(IServiceCollection services)
-    {
-        return services
-            .Where(static x => x.ServiceType == typeof(IIntrinsicDescriptorProvider))
-            .Select(static x => x.ImplementationType ?? x.ImplementationInstance?.GetType())
-            .Where(static x => x != null)
-            .Cast<Type>()
-            .OrderBy(x => x.FullName, StringComparer.Ordinal)
-            .ToList();
-    }
-
-    private static IReadOnlyList<Type> GetRegisteredImplementationTypes(IServiceCollection services, Type serviceType)
-    {
-        return services
-            .Where(x => x.ServiceType == serviceType)
-            .Select(x => x.ImplementationType ?? x.ImplementationInstance?.GetType())
-            .Where(static x => x != null)
-            .Cast<Type>()
-            .OrderBy(x => x.FullName, StringComparer.Ordinal)
-            .ToList();
-    }
-
-    private static IReadOnlyList<(Type ModuleType, Type ProviderType)> GetIntrinsicCoverageRequirements(IServiceCollection services)
-    {
-        var moduleTypes = GetRegisteredImplementationTypes(services, typeof(IFrontendCoreModule))
-            .Concat(GetRegisteredImplementationTypes(services, typeof(IIRProcessingModule)))
-            .Distinct()
-            .OrderBy(x => x.FullName, StringComparer.Ordinal);
-
-        return moduleTypes
-            .SelectMany(static moduleType =>
-                moduleType.GetCustomAttributes(typeof(IntrinsicDescriptorProviderAttribute), false)
-                    .Cast<IntrinsicDescriptorProviderAttribute>()
-                    .Select(attribute => (ModuleType: moduleType, attribute.ProviderType)))
-            .OrderBy(x => x.ModuleType.FullName, StringComparer.Ordinal)
-            .ThenBy(x => x.ProviderType.FullName, StringComparer.Ordinal)
-            .ToList();
     }
 
     private static IReadOnlyDictionary<DialectBackendId, IDialectBackendRuntimeRegistrar> CreateBackendProviderMap(IEnumerable<IDialectBackendRuntimeRegistrar> backendProviders)
@@ -167,7 +129,9 @@ public sealed class WistDialectServiceProviderFactory
                      .OrderBy(x => x.BackendId))
         {
             if (!map.TryAdd(backendProvider.BackendId, backendProvider))
+            {
                 Thrower.InvalidOpEx($"Duplicate backend runtime registrar registration for backend '{backendProvider.BackendId.Value}'.");
+            }
         }
 
         return map;
@@ -180,13 +144,19 @@ public sealed class WistDialectServiceProviderFactory
         public int Compare(Type? x, Type? y)
         {
             if (ReferenceEquals(x, y))
+            {
                 return 0;
+            }
 
             if (x is null)
+            {
                 return -1;
+            }
 
             if (y is null)
+            {
                 return 1;
+            }
 
             return StringComparer.Ordinal.Compare(x.FullName, y.FullName);
         }

--- a/docs/current-canonical-runtime-pipeline.md
+++ b/docs/current-canonical-runtime-pipeline.md
@@ -17,7 +17,9 @@ It is intentionally limited to behavior that exists today.
 
 - `UniversalToolchain.Dialects.Integration` owns **generic runtime infrastructure** bootstrap:
   - file-system runtime catalog registrations,
-  - reflection-based runtime resolution registrations.
+  - reflection-based runtime resolution registrations,
+  - selected-runtime activation classification and backend runtime configuration projection,
+  - intrinsic semantic bootstrap contracts and two-phase validation helpers.
 - `UniversalToolchain.Dialects.Wist` owns **Wist-specific orchestration**:
   - Wist workflow composition,
   - Wist execution configuration building,


### PR DESCRIPTION
### Motivation

- Centralize generic runtime activation responsibilities into `UniversalToolchain.Dialects.Integration` and introduce an explicit intrinsic semantic bootstrap contract to validate provider coverage before and after DI container creation.
- Expose a backend intrinsic policy abstraction to decouple backend runtime configuration from a concrete resolver implementation.

### Description

- Introduced `IDialectBackendIntrinsicPolicyResolver` and updated `DialectIntrinsicPolicyResolver` to implement the interface and registered it via `services.TryAddSingleton<IDialectBackendIntrinsicPolicyResolver, DialectIntrinsicPolicyResolver>()` in `AddWistDialectCoreServices`.
- Moved several runtime classification types from the `Wist` namespace into `UniversalToolchain.Dialects.Integration` (`SelectedRuntimeModuleClassifier`, `SelectedRuntimeModuleClassification`, and `DialectBackendRuntimeConfigurationBuilder` now depend on the integration types/interfaces).
- Added intrinsic bootstrap contract and implementation classes: `IntrinsicProviderRequirement`, `IntrinsicSemanticBootstrapPlan`, `IntrinsicSemanticBootstrapPlanBuilder`, `IntrinsicSemanticBootstrapPreProviderValidator`, and `IntrinsicSemanticBootstrapRuntimeValidator` to enable two-phase intrinsic provider coverage validation (pre-provider metadata phase and runtime instance phase).
- Updated `WistDialectServiceProviderFactory` to build a bootstrap plan with `IntrinsicSemanticBootstrapPlanBuilder`, run pre-provider validation before building the `IServiceProvider`, and run runtime validation against the resolved provider, plus minor DI registration safeguards and improved error handling.
- Added unit tests `IntrinsicSemanticBootstrapPlanContractTests` covering deterministic plan building, pre-provider validation failure case, and successful runtime validation, and updated docs (`current-canonical-runtime-pipeline.md`) to reflect the new integration responsibilities.

### Testing

- Ran `dotnet build` to ensure the solution compiles after the refactor and additions, which succeeded.
- Ran unit tests for the dialects project with `dotnet test` including `IntrinsicSemanticBootstrapPlanContractTests`, which executed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e906bdc7bc8324a1e205c2c6963c3f)