### PR TITLE
Support structured runtime type references (assembly + type) and derive backend registry/known-backends from selection

### DIFF
--- a/UniversalToolchain/UniversalToolchain.Dialects.Integration/DefaultRuntimeBackendRegistrarResolver.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Integration/DefaultRuntimeBackendRegistrarResolver.cs
@@ -30,14 +30,15 @@ public sealed class DefaultRuntimeBackendRegistrarResolver : IRuntimeBackendRegi
                 $"Runtime component '{backendEntry.CanonicalAlias}' has kind '{RuntimeComponentKindCodec.Format(backendEntry.Kind)}', but '{RuntimeComponentKindCodec.Format(RuntimeComponentKind.Backend)}' was expected.");
         }
 
-        var registrarTypeFullName = backendEntry.Activation?.RegistrarTypeFullName;
-        if (string.IsNullOrWhiteSpace(registrarTypeFullName))
+        var registrarTypeReference = backendEntry.Activation?.RegistrarType;
+        if (registrarTypeReference == null)
         {
             Thrower.InvalidOpEx(
                 $"Runtime backend manifest entry '{backendEntry.CanonicalAlias}' does not declare registrarTypeFullName activation metadata.");
         }
 
-        var registrarType = _typeLoader.LoadType(backendEntry.AssemblySimpleName, registrarTypeFullName);
+        var registrarAssemblySimpleName = ResolveAssemblySimpleName(registrarTypeReference.AssemblySimpleName, backendEntry.AssemblySimpleName);
+        var registrarType = _typeLoader.LoadType(registrarAssemblySimpleName, registrarTypeReference.TypeFullName);
         if (!typeof(IDialectBackendRuntimeRegistrar).IsAssignableFrom(registrarType))
         {
             Thrower.InvalidOpEx(
@@ -58,5 +59,12 @@ public sealed class DefaultRuntimeBackendRegistrarResolver : IRuntimeBackendRegi
     private static string DisplayName(Type type)
     {
         return type.FullName ?? type.Name;
+    }
+
+    private static string ResolveAssemblySimpleName(string assemblySimpleName, string fallbackAssemblySimpleName)
+    {
+        return string.Equals(assemblySimpleName, RuntimeAssemblyIdentity.UnspecifiedAssemblySimpleName, StringComparison.Ordinal)
+            ? fallbackAssemblySimpleName
+            : assemblySimpleName;
     }
 }

--- a/UniversalToolchain/UniversalToolchain.Dialects.Integration/DefaultRuntimeComponentResolver.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Integration/DefaultRuntimeComponentResolver.cs
@@ -35,7 +35,9 @@ public sealed class DefaultRuntimeComponentResolver : IRuntimeComponentResolver
 
     private RuntimeComponentDescriptor ResolveExactActivation(RuntimeComponentManifestEntry entry)
     {
-        var type = _assemblyTypeLoader.LoadType(entry.AssemblySimpleName, entry.Activation!.ActivationTypeFullName);
+        var activationTypeReference = entry.Activation!.ActivationType;
+        var assemblySimpleName = ResolveAssemblySimpleName(activationTypeReference.AssemblySimpleName, entry.AssemblySimpleName);
+        var type = _assemblyTypeLoader.LoadType(assemblySimpleName, activationTypeReference.TypeFullName);
         var export = type.GetCustomAttribute<DialectRuntimeExportAttribute>(false);
         if (export == null)
             Thrower.InvalidOpEx(
@@ -151,6 +153,13 @@ public sealed class DefaultRuntimeComponentResolver : IRuntimeComponentResolver
     }
 
     private static string GetTypeName(Type type) => type.FullName ?? type.Name;
+
+    private static string ResolveAssemblySimpleName(string assemblySimpleName, string fallbackAssemblySimpleName)
+    {
+        return string.Equals(assemblySimpleName, RuntimeAssemblyIdentity.UnspecifiedAssemblySimpleName, StringComparison.Ordinal)
+            ? fallbackAssemblySimpleName
+            : assemblySimpleName;
+    }
 
     private sealed record RuntimeComponentExportDescriptor(
         RuntimeComponentId Id,

--- a/UniversalToolchain/UniversalToolchain.Dialects.Integration/FileBasedRuntimeComponentCatalog.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Integration/FileBasedRuntimeComponentCatalog.cs
@@ -130,7 +130,7 @@ public sealed class FileBasedRuntimeComponentCatalog : IRuntimeComponentCatalog
             Aliases = aliases,
             AssemblySimpleName = assemblySimpleName,
             ComponentId = new RuntimeComponentId(entry.ComponentId.Value.Trim()),
-            Activation = NormalizeActivation(entry.Activation)
+            Activation = NormalizeActivation(entry.Activation, assemblySimpleName)
         };
     }
 
@@ -138,22 +138,52 @@ public sealed class FileBasedRuntimeComponentCatalog : IRuntimeComponentCatalog
     {
         return activation == null
             ? null
-            : new RuntimeComponentActivationInfo(activation.ActivationTypeFullName, activation.RegistrarTypeFullName);
+            : new RuntimeComponentActivationInfo(activation.ActivationType, activation.RegistrarType);
     }
 
-    private static RuntimeComponentActivationInfo? NormalizeActivation(RuntimeComponentActivationInfo? activation)
+    private static RuntimeComponentActivationInfo? NormalizeActivation(RuntimeComponentActivationInfo? activation, string ownerAssemblySimpleName)
     {
         if (activation == null)
             return null;
 
-        var activationTypeFullName = activation.ActivationTypeFullName?.Trim();
-        if (string.IsNullOrWhiteSpace(activationTypeFullName))
-            Thrower.Argument(nameof(activation), "ActivationTypeFullName must not be empty when activation metadata is provided.");
+        var activationType = NormalizeTypeReference(
+            activation.ActivationType,
+            ownerAssemblySimpleName,
+            nameof(activation),
+            "ActivationTypeFullName must not be empty when activation metadata is provided.");
+        var registrarType = activation.RegistrarType == null
+            ? null
+            : NormalizeTypeReference(
+                activation.RegistrarType,
+                ownerAssemblySimpleName,
+                nameof(activation),
+                "RegistrarTypeFullName must not be empty when activation metadata is provided.");
 
-        var registrarTypeFullName = activation.RegistrarTypeFullName?.Trim();
         return new RuntimeComponentActivationInfo(
-            activationTypeFullName,
-            string.IsNullOrWhiteSpace(registrarTypeFullName) ? null : registrarTypeFullName);
+            activationType,
+            registrarType);
+    }
+
+    private static RuntimeTypeReference NormalizeTypeReference(
+        RuntimeTypeReference typeReference,
+        string ownerAssemblySimpleName,
+        string paramName,
+        string emptyTypeMessage)
+    {
+        typeReference = typeReference.NotNull(paramName);
+
+        var typeFullName = typeReference.TypeFullName?.Trim();
+        if (string.IsNullOrWhiteSpace(typeFullName))
+            Thrower.Argument(paramName, emptyTypeMessage);
+
+        var assemblySimpleName = typeReference.AssemblySimpleName?.Trim();
+        if (string.IsNullOrWhiteSpace(assemblySimpleName) ||
+            string.Equals(assemblySimpleName, RuntimeAssemblyIdentity.UnspecifiedAssemblySimpleName, StringComparison.Ordinal))
+        {
+            assemblySimpleName = ownerAssemblySimpleName;
+        }
+
+        return new RuntimeTypeReference(assemblySimpleName, typeFullName);
     }
 
     private static IReadOnlyDictionary<string, RuntimeComponentManifestEntry> CreateAliasMap(IEnumerable<RuntimeComponentManifestEntry> entries, string kindName)

--- a/UniversalToolchain/UniversalToolchain.Dialects.Integration/FileRuntimeComponentActivationEntry.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Integration/FileRuntimeComponentActivationEntry.cs
@@ -1,5 +1,23 @@
 namespace UniversalToolchain.Dialects.Integration;
 
 public sealed record FileRuntimeComponentActivationEntry(
-    string ActivationTypeFullName,
-    string? RegistrarTypeFullName = null);
+    RuntimeTypeReference ActivationType,
+    RuntimeTypeReference? RegistrarType = null)
+{
+    public FileRuntimeComponentActivationEntry(string activationTypeFullName, string? registrarTypeFullName = null)
+        : this(
+            new RuntimeTypeReference(RuntimeAssemblyIdentity.UnspecifiedAssemblySimpleName, activationTypeFullName),
+            string.IsNullOrWhiteSpace(registrarTypeFullName)
+                ? null
+                : new RuntimeTypeReference(RuntimeAssemblyIdentity.UnspecifiedAssemblySimpleName, registrarTypeFullName))
+    {
+    }
+
+    public string ActivationTypeFullName => ActivationType.TypeFullName;
+
+    public string ActivationAssemblySimpleName => ActivationType.AssemblySimpleName;
+
+    public string? RegistrarTypeFullName => RegistrarType?.TypeFullName;
+
+    public string? RegistrarAssemblySimpleName => RegistrarType?.AssemblySimpleName;
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Integration/RuntimeAssemblyIdentity.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Integration/RuntimeAssemblyIdentity.cs
@@ -1,0 +1,6 @@
+namespace UniversalToolchain.Dialects.Integration;
+
+public static class RuntimeAssemblyIdentity
+{
+    public const string UnspecifiedAssemblySimpleName = "<unspecified>";
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Integration/RuntimeComponentActivationInfo.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Integration/RuntimeComponentActivationInfo.cs
@@ -1,5 +1,23 @@
 namespace UniversalToolchain.Dialects.Integration;
 
 public sealed record RuntimeComponentActivationInfo(
-    string ActivationTypeFullName,
-    string? RegistrarTypeFullName = null);
+    RuntimeTypeReference ActivationType,
+    RuntimeTypeReference? RegistrarType = null)
+{
+    public RuntimeComponentActivationInfo(string activationTypeFullName, string? registrarTypeFullName = null)
+        : this(
+            new RuntimeTypeReference(RuntimeAssemblyIdentity.UnspecifiedAssemblySimpleName, activationTypeFullName),
+            string.IsNullOrWhiteSpace(registrarTypeFullName)
+                ? null
+                : new RuntimeTypeReference(RuntimeAssemblyIdentity.UnspecifiedAssemblySimpleName, registrarTypeFullName))
+    {
+    }
+
+    public string ActivationTypeFullName => ActivationType.TypeFullName;
+
+    public string ActivationAssemblySimpleName => ActivationType.AssemblySimpleName;
+
+    public string? RegistrarTypeFullName => RegistrarType?.TypeFullName;
+
+    public string? RegistrarAssemblySimpleName => RegistrarType?.AssemblySimpleName;
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Integration/RuntimeManifestJsonSerializer.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Integration/RuntimeManifestJsonSerializer.cs
@@ -43,8 +43,12 @@ public sealed class RuntimeManifestJsonSerializer : IRuntimeManifestSerializer
                         ? null
                         : new SerializableManifestActivationEntry
                         {
-                            ActivationTypeFullName = x.Activation.ActivationTypeFullName,
-                            RegistrarTypeFullName = x.Activation.RegistrarTypeFullName
+                            ActivationType = CreateSerializableTypeReference(x.Activation.ActivationType),
+                            RegistrarType = CreateSerializableTypeReference(x.Activation.RegistrarType),
+                            ActivationTypeFullName = x.Activation.ActivationType.TypeFullName,
+                            ActivationAssemblySimpleName = ResolveAssemblySimpleNameForSerialization(x.Activation.ActivationType),
+                            RegistrarTypeFullName = x.Activation.RegistrarType?.TypeFullName,
+                            RegistrarAssemblySimpleName = ResolveAssemblySimpleNameForSerialization(x.Activation.RegistrarType)
                         }
                 })
                 .ToList()
@@ -66,9 +70,21 @@ public sealed class RuntimeManifestJsonSerializer : IRuntimeManifestSerializer
     private static FileRuntimeComponentActivationEntry? ResolveActivation(SerializableManifestComponentEntry entry)
     {
         if (entry.Activation != null)
+        {
+            var activationType = ResolveTypeReference(
+                entry.Activation.ActivationType,
+                entry.Activation.ActivationTypeFullName,
+                entry.Activation.ActivationAssemblySimpleName);
+            var registrarType = ResolveTypeReference(
+                entry.Activation.RegistrarType,
+                entry.Activation.RegistrarTypeFullName,
+                entry.Activation.RegistrarAssemblySimpleName,
+                allowMissingType: true);
+
             return new FileRuntimeComponentActivationEntry(
-                entry.Activation.ActivationTypeFullName ?? string.Empty,
-                entry.Activation.RegistrarTypeFullName);
+                activationType.NotNull(nameof(entry)),
+                registrarType);
+        }
 
         if (!string.IsNullOrWhiteSpace(entry.TypeFullName))
             return new FileRuntimeComponentActivationEntry(entry.TypeFullName);
@@ -100,8 +116,62 @@ public sealed class RuntimeManifestJsonSerializer : IRuntimeManifestSerializer
 
     private sealed class SerializableManifestActivationEntry
     {
+        public SerializableManifestTypeReference? ActivationType { get; init; }
+
+        public SerializableManifestTypeReference? RegistrarType { get; init; }
+
         public string? ActivationTypeFullName { get; init; }
 
+        public string? ActivationAssemblySimpleName { get; init; }
+
         public string? RegistrarTypeFullName { get; init; }
+
+        public string? RegistrarAssemblySimpleName { get; init; }
+    }
+
+    private sealed class SerializableManifestTypeReference
+    {
+        public string? AssemblySimpleName { get; init; }
+
+        public string? TypeFullName { get; init; }
+    }
+
+    private static SerializableManifestTypeReference? CreateSerializableTypeReference(RuntimeTypeReference? typeReference)
+    {
+        if (typeReference == null)
+            return null;
+
+        return new SerializableManifestTypeReference
+        {
+            AssemblySimpleName = ResolveAssemblySimpleNameForSerialization(typeReference),
+            TypeFullName = typeReference.TypeFullName
+        };
+    }
+
+    private static RuntimeTypeReference? ResolveTypeReference(
+        SerializableManifestTypeReference? structuredReference,
+        string? legacyTypeFullName,
+        string? legacyAssemblySimpleName,
+        bool allowMissingType = false)
+    {
+        var typeFullName = structuredReference?.TypeFullName ?? legacyTypeFullName ?? string.Empty;
+        if (allowMissingType && string.IsNullOrWhiteSpace(typeFullName))
+            return null;
+
+        var assemblySimpleName = structuredReference?.AssemblySimpleName
+                                 ?? legacyAssemblySimpleName
+                                 ?? RuntimeAssemblyIdentity.UnspecifiedAssemblySimpleName;
+
+        return new RuntimeTypeReference(assemblySimpleName, typeFullName);
+    }
+
+    private static string? ResolveAssemblySimpleNameForSerialization(RuntimeTypeReference? typeReference)
+    {
+        if (typeReference == null)
+            return null;
+
+        return string.Equals(typeReference.AssemblySimpleName, RuntimeAssemblyIdentity.UnspecifiedAssemblySimpleName, StringComparison.Ordinal)
+            ? null
+            : typeReference.AssemblySimpleName;
     }
 }

--- a/UniversalToolchain/UniversalToolchain.Dialects.Integration/RuntimeTypeReference.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Integration/RuntimeTypeReference.cs
@@ -1,5 +1,25 @@
+using ExceptionsManager;
+
 namespace UniversalToolchain.Dialects.Integration;
 
-public sealed record RuntimeTypeReference(
-    string AssemblySimpleName,
-    string TypeFullName);
+public sealed record RuntimeTypeReference
+{
+    public RuntimeTypeReference(string assemblySimpleName, string typeFullName)
+    {
+        AssemblySimpleName = NormalizeRequired(assemblySimpleName, nameof(assemblySimpleName));
+        TypeFullName = NormalizeRequired(typeFullName, nameof(typeFullName));
+    }
+
+    public string AssemblySimpleName { get; }
+
+    public string TypeFullName { get; }
+
+    private static string NormalizeRequired(string value, string paramName)
+    {
+        var normalized = value?.Trim();
+        if (string.IsNullOrWhiteSpace(normalized))
+            Thrower.Argument(paramName, $"{paramName} must not be empty.");
+
+        return normalized;
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.ManifestEmitter/Program.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.ManifestEmitter/Program.cs
@@ -99,11 +99,13 @@ internal static class ManifestEmitter
             aliases,
             RuntimeId(kind, canonicalAlias),
             new ManifestActivationEntry(
-                type.FullName.NotNull("Runtime activation type full name must not be null."),
-                FindRegistrarTypeFullName(type, kind)))];
+                new ManifestTypeReference(
+                    type.Assembly.GetName().Name.NotNull("Runtime activation type assembly simple name must not be null."),
+                    type.FullName.NotNull("Runtime activation type full name must not be null.")),
+                FindRegistrarTypeReference(type, kind)))];
     }
 
-    private static string? FindRegistrarTypeFullName(Type type, string kind)
+    private static ManifestTypeReference? FindRegistrarTypeReference(Type type, string kind)
     {
         if (!string.Equals(kind, BackendKind, StringComparison.Ordinal))
             return null;
@@ -111,7 +113,12 @@ internal static class ManifestEmitter
         var attribute = type.CustomAttributes.FirstOrDefault(static x => x.AttributeType.FullName == BackendRegistrarTypeAttributeFullName);
         var registrarType = attribute?.ConstructorArguments.FirstOrDefault().Value as Type;
 
-        return registrarType?.FullName;
+        if (registrarType == null)
+            return null;
+
+        return new ManifestTypeReference(
+            registrarType.Assembly.GetName().Name.NotNull("Runtime backend registrar type assembly simple name must not be null."),
+            registrarType.FullName.NotNull("Runtime backend registrar type full name must not be null."));
     }
 
     private static string RuntimeId(string kind, string canonicalAlias)
@@ -137,7 +144,13 @@ internal sealed record ManifestComponentEntry(
     string ComponentId,
     ManifestActivationEntry Activation);
 
-internal sealed record ManifestActivationEntry(string ActivationTypeFullName, string? RegistrarTypeFullName = null);
+internal sealed record ManifestActivationEntry(
+    ManifestTypeReference ActivationType,
+    ManifestTypeReference? RegistrarType = null);
+
+internal sealed record ManifestTypeReference(
+    string AssemblySimpleName,
+    string TypeFullName);
 
 internal static class JsonOptions
 {

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/RuntimeCatalog/RuntimeManifestCatalogContractTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/RuntimeCatalog/RuntimeManifestCatalogContractTests.cs
@@ -111,7 +111,33 @@ public class RuntimeManifestCatalogContractTests
         Assert.Multiple(() =>
         {
             Assert.That(entry!.Activation!.ActivationTypeFullName, Is.EqualTo("Modules.ArithmeticModule"));
+            Assert.That(entry.Activation.ActivationAssemblySimpleName, Is.EqualTo("Asm"));
             Assert.That(entry.Activation.RegistrarTypeFullName, Is.EqualTo("Modules.ArithmeticRegistrar"));
+            Assert.That(entry.Activation.RegistrarAssemblySimpleName, Is.EqualTo("Asm"));
+        });
+    }
+
+    [Test]
+    public void LoadEntries_ManifestWithStructuredActivationMetadata_PreservesAssemblyIdentity()
+    {
+        using var temp = new TempDirectory();
+        var serializer = new RuntimeManifestJsonSerializer();
+        var path = WriteRawManifest(
+            temp.Path,
+            "structured-activation.dialect.runtime.json",
+            """
+            {"assemblySimpleName":"OwnerAssembly","components":[{"kind":"Backend","canonicalAlias":"interpreter","aliases":[],"componentId":"backend.interpreter","activation":{"activationType":{"assemblySimpleName":"DeclarationAssembly","typeFullName":"Runtime.InterpreterDeclaration"},"registrarType":{"assemblySimpleName":"RegistrarAssembly","typeFullName":"Runtime.InterpreterRegistrar"}}}]}
+            """);
+
+        var catalog = new FileBasedRuntimeComponentCatalog(new StaticManifestLocator([path]), serializer);
+        Assert.That(catalog.TryResolveBackend("interpreter", out var entry), Is.True);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(entry!.Activation!.ActivationAssemblySimpleName, Is.EqualTo("DeclarationAssembly"));
+            Assert.That(entry.Activation.ActivationTypeFullName, Is.EqualTo("Runtime.InterpreterDeclaration"));
+            Assert.That(entry.Activation.RegistrarAssemblySimpleName, Is.EqualTo("RegistrarAssembly"));
+            Assert.That(entry.Activation.RegistrarTypeFullName, Is.EqualTo("Runtime.InterpreterRegistrar"));
         });
     }
 
@@ -128,7 +154,7 @@ public class RuntimeManifestCatalogContractTests
             """);
 
         var ex = Assert.Throws<ArgumentException>(() => new FileBasedRuntimeComponentCatalog(new StaticManifestLocator([path]), serializer));
-        Assert.That(ex!.Message, Does.Contain("ActivationTypeFullName must not be empty"));
+        Assert.That(ex!.Message, Does.Contain("typeFullName must not be empty"));
     }
 
     [Test]

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/RuntimeLoading/RuntimeBackendRegistrarResolverTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/RuntimeLoading/RuntimeBackendRegistrarResolverTests.cs
@@ -13,7 +13,7 @@ public sealed class RuntimeBackendRegistrarResolverTests
             new StubAssemblyTypeLoader([]),
             new ServiceCollection().BuildServiceProvider());
 
-        var exception = Assert.Throws<InvalidOperationException>(() => resolver.Resolve(Entry("backend", null)));
+        var exception = Assert.Throws<InvalidOperationException>(() => resolver.Resolve(Entry("backend", (string?)null)));
 
         Assert.That(exception!.Message, Does.Contain("registrarTypeFullName"));
     }
@@ -22,7 +22,7 @@ public sealed class RuntimeBackendRegistrarResolverTests
     public void Resolve_WhenRegistrarTypeDoesNotImplementBackendRegistrar_ThrowsClearError()
     {
         var resolver = new DefaultRuntimeBackendRegistrarResolver(
-            new StubAssemblyTypeLoader([(typeof(NotARegistrar).FullName!, typeof(NotARegistrar))]),
+            new StubAssemblyTypeLoader([("TestAssembly", typeof(NotARegistrar).FullName!, typeof(NotARegistrar))]),
             new ServiceCollection().BuildServiceProvider());
 
         var exception = Assert.Throws<InvalidOperationException>(() => resolver.Resolve(Entry("backend", typeof(NotARegistrar).FullName)));
@@ -34,7 +34,7 @@ public sealed class RuntimeBackendRegistrarResolverTests
     public void Resolve_WhenRegistrarBackendIdDoesNotMatchManifestAlias_ThrowsClearError()
     {
         var resolver = new DefaultRuntimeBackendRegistrarResolver(
-            new StubAssemblyTypeLoader([(typeof(MismatchedRegistrar).FullName!, typeof(MismatchedRegistrar))]),
+            new StubAssemblyTypeLoader([("TestAssembly", typeof(MismatchedRegistrar).FullName!, typeof(MismatchedRegistrar))]),
             new ServiceCollection().BuildServiceProvider());
 
         var exception = Assert.Throws<InvalidOperationException>(() => resolver.Resolve(Entry("selected", typeof(MismatchedRegistrar).FullName)));
@@ -48,7 +48,7 @@ public sealed class RuntimeBackendRegistrarResolverTests
         var services = new ServiceCollection();
         services.AddSingleton(new RegistrarDependency("injected"));
         using var provider = services.BuildServiceProvider();
-        var typeLoader = new StubAssemblyTypeLoader([(typeof(DependencyBackedRegistrar).FullName!, typeof(DependencyBackedRegistrar))]);
+        var typeLoader = new StubAssemblyTypeLoader([("TestAssembly", typeof(DependencyBackedRegistrar).FullName!, typeof(DependencyBackedRegistrar))]);
         var resolver = new DefaultRuntimeBackendRegistrarResolver(typeLoader, provider);
 
         var registrar = resolver.Resolve(Entry("backend", typeof(DependencyBackedRegistrar).FullName));
@@ -57,8 +57,37 @@ public sealed class RuntimeBackendRegistrarResolverTests
         {
             Assert.That(registrar, Is.InstanceOf<DependencyBackedRegistrar>());
             Assert.That(((DependencyBackedRegistrar)registrar).Dependency.Value, Is.EqualTo("injected"));
-            Assert.That(typeLoader.LoadedTypes, Is.EqualTo(new[] { typeof(DependencyBackedRegistrar).FullName }));
+            Assert.That(typeLoader.LoadedTypes, Is.EqualTo(new[] { "TestAssembly::" + typeof(DependencyBackedRegistrar).FullName }));
         });
+    }
+
+    [Test]
+    public void Resolve_WhenRegistrarAssemblyIsExplicit_LoadsFromRegistrarAssembly()
+    {
+        var resolver = new DefaultRuntimeBackendRegistrarResolver(
+            new StubAssemblyTypeLoader([("RegistrarAssembly", typeof(SimpleRegistrar).FullName!, typeof(SimpleRegistrar))]),
+            new ServiceCollection().BuildServiceProvider());
+
+        var entry = Entry(
+            "backend",
+            new RuntimeTypeReference("RegistrarAssembly", typeof(SimpleRegistrar).FullName!));
+
+        var registrar = resolver.Resolve(entry);
+
+        Assert.That(registrar, Is.InstanceOf<SimpleRegistrar>());
+    }
+
+    [Test]
+    public void Resolve_WhenLegacyRegistrarAssemblyIsMissing_UsesBackendAssemblyFallback()
+    {
+        var resolver = new DefaultRuntimeBackendRegistrarResolver(
+            new StubAssemblyTypeLoader([("TestAssembly", typeof(SimpleRegistrar).FullName!, typeof(SimpleRegistrar))]),
+            new ServiceCollection().BuildServiceProvider());
+
+        var entry = Entry("backend", typeof(SimpleRegistrar).FullName);
+        var registrar = resolver.Resolve(entry);
+
+        Assert.That(registrar, Is.InstanceOf<SimpleRegistrar>());
     }
 
     private static RuntimeComponentManifestEntry Entry(string alias, string? registrarTypeFullName)
@@ -69,6 +98,17 @@ public sealed class RuntimeBackendRegistrarResolverTests
             RuntimeComponentIdFactory.Create(RuntimeComponentKind.Backend, alias),
             "TestAssembly",
             new RuntimeComponentActivationInfo(typeof(object).FullName!, registrarTypeFullName));
+
+    private static RuntimeComponentManifestEntry Entry(string alias, RuntimeTypeReference registrarTypeReference)
+        => new(
+            RuntimeComponentKind.Backend,
+            alias,
+            [],
+            RuntimeComponentIdFactory.Create(RuntimeComponentKind.Backend, alias),
+            "TestAssembly",
+            new RuntimeComponentActivationInfo(
+                new RuntimeTypeReference("TestAssembly", typeof(object).FullName!),
+                registrarTypeReference));
 
     private sealed class NotARegistrar;
 
@@ -95,12 +135,21 @@ public sealed class RuntimeBackendRegistrarResolverTests
 
     private sealed record RegistrarDependency(string Value);
 
-    private sealed class StubAssemblyTypeLoader(IEnumerable<(string FullName, Type Type)> types) : IRuntimeAssemblyTypeLoader
+    private sealed class SimpleRegistrar : IDialectBackendRuntimeRegistrar
     {
-        private readonly IReadOnlyDictionary<string, Type> _types = types.ToDictionary(
-            static x => x.FullName,
-            static x => x.Type,
-            StringComparer.Ordinal);
+        public DialectBackendId BackendId { get; } = new("backend");
+        public IReadOnlyList<string> SupportedIntrinsics => [];
+
+        public void RegisterRuntime(IServiceCollection services, DialectBackendRuntimeConfiguration configuration)
+        {
+        }
+    }
+
+    private sealed class StubAssemblyTypeLoader(IEnumerable<(string AssemblySimpleName, string FullName, Type Type)> types) : IRuntimeAssemblyTypeLoader
+    {
+        private readonly IReadOnlyDictionary<(string AssemblySimpleName, string FullName), Type> _types = types.ToDictionary(
+            static x => (x.AssemblySimpleName, x.FullName),
+            static x => x.Type);
         private readonly List<string> _loadedTypes = [];
 
         public IReadOnlyList<string> LoadedTypes => _loadedTypes;
@@ -112,9 +161,8 @@ public sealed class RuntimeBackendRegistrarResolverTests
 
         public Type LoadType(string assemblySimpleName, string activationTypeFullName)
         {
-            Assert.That(assemblySimpleName, Is.EqualTo("TestAssembly"));
-            _loadedTypes.Add(activationTypeFullName);
-            return _types[activationTypeFullName];
+            _loadedTypes.Add(assemblySimpleName + "::" + activationTypeFullName);
+            return _types[(assemblySimpleName, activationTypeFullName)];
         }
     }
 }

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/Wist/WistDialectBackendMatrixTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/Wist/WistDialectBackendMatrixTests.cs
@@ -38,7 +38,7 @@ public sealed class WistDialectBackendMatrixTests
         yield return BuildCase(
             "minimal-arithmetic",
             ExpectedOutcome.Success("14"),
-            ExpectedOutcome.Failure("does not enable the 'compiler' backend"));
+            ExpectedOutcome.Failure("Unknown execution mode 'compiler'"));
 
         yield return BuildCase(
             "full-default",

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/Wist/WistRuntimeFacadeBuilderPresetTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/Wist/WistRuntimeFacadeBuilderPresetTests.cs
@@ -33,7 +33,7 @@ public sealed class WistRuntimeFacadeBuilderPresetTests
         Assert.Multiple(() =>
         {
             Assert.That(attempt.IsSuccess, Is.False);
-            Assert.That(attempt.ErrorMessage, Does.Contain("does not enable the 'compiler' backend"));
+            Assert.That(attempt.ErrorMessage, Does.Contain("Unknown execution mode 'compiler'"));
         });
     }
 

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/WistDialectBackendCompatibilityTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/WistDialectBackendCompatibilityTests.cs
@@ -40,24 +40,23 @@ public class WistDialectBackendCompatibilityTests
     }
 
     [Test]
-    public void WistDialectExecutionConfigurationBuilder_KnownBackendsComeFromRuntimeKnownBackendsProvider()
+    public void WistDialectExecutionConfigurationBuilder_KnownBackendsComeFromSelectedRuntimeBackends()
     {
-        var knownBackendsProvider = new RecordingKnownBackendsProvider(
-            [new RuntimeBackendDescriptor(new DialectBackendId("wist-only"), ["wo"])]);
+        var backendEntry = Entry("interpreter", ["run"]);
         var builder = new WistDialectExecutionConfigurationBuilder(
             CreateShapeBuilder(new StubRuntimeComponentTypeLoader()),
-            CreateBackendConfigurationBuilder(new StubRuntimeComponentTypeLoader()),
-            knownBackendsProvider);
+            CreateBackendConfigurationBuilder(new StubRuntimeComponentTypeLoader()));
 
         var configuration = builder.Build(
-            new DialectBuildPlan("Demo", null, [], [], [], [], [], null, [], new DialectValidationResult([])),
-            new SelectedRuntimePlan([], [], [], []));
+            new DialectBuildPlan("Demo", null, [], [new DialectBackendId("interpreter")], [], [], [], null, [], new DialectValidationResult([])),
+            new SelectedRuntimePlan([], [], [backendEntry], []));
 
         Assert.Multiple(() =>
         {
-            Assert.That(knownBackendsProvider.Calls, Is.EqualTo(1));
-            Assert.That(configuration.TryResolveKnownBackendId("wist-only", out var backendId), Is.True);
-            Assert.That(backendId.Value, Is.EqualTo("wist-only"));
+            Assert.That(configuration.TryResolveKnownBackendId("interpreter", out var backendId), Is.True);
+            Assert.That(backendId.Value, Is.EqualTo("interpreter"));
+            Assert.That(configuration.TryResolveKnownBackendId("run", out var aliasId), Is.True);
+            Assert.That(aliasId.Value, Is.EqualTo("interpreter"));
             Assert.That(configuration.TryResolveKnownBackendId("foreign-backend", out _), Is.False);
         });
     }
@@ -126,8 +125,7 @@ public class WistDialectBackendCompatibilityTests
     {
         return new WistDialectExecutionConfigurationBuilder(
             CreateShapeBuilder(typeLoader),
-            CreateBackendConfigurationBuilder(typeLoader),
-            new RecordingKnownBackendsProvider([]));
+            CreateBackendConfigurationBuilder(typeLoader));
     }
 
     private static SelectedRuntimeExecutionShapeBuilder CreateShapeBuilder(IRuntimeComponentTypeLoader typeLoader)
@@ -222,14 +220,4 @@ public class WistDialectBackendCompatibilityTests
         }
     }
 
-    private sealed class RecordingKnownBackendsProvider(IReadOnlyList<RuntimeBackendDescriptor> knownBackends) : IRuntimeKnownBackendsProvider
-    {
-        public int Calls { get; private set; }
-
-        public IReadOnlyList<RuntimeBackendDescriptor> GetKnownBackends()
-        {
-            Calls++;
-            return knownBackends;
-        }
-    }
 }

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/WistDialectExecutionHostContractTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/WistDialectExecutionHostContractTests.cs
@@ -92,7 +92,7 @@ public class WistDialectExecutionHostContractTests
 
         AssertThrowsWithMessageFragment<InvalidOperationException>(
             () => host.GetCore("compiler"),
-            "does not enable the 'compiler' backend");
+            "Unknown execution mode 'compiler'");
     }
 
     [Test]

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/WistDialectExecutionIntegrationTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/WistDialectExecutionIntegrationTests.cs
@@ -131,7 +131,7 @@ public class WistDialectExecutionIntegrationTests
 
         var ex = Assert.Throws<InvalidOperationException>(() => host.GetCore("compiler"));
 
-        Assert.That(ex!.Message, Does.Contain("does not enable the 'compiler' backend"));
+        Assert.That(ex!.Message, Does.Contain("Unknown execution mode 'compiler'"));
     }
 
     [Test]

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/WistRuntimeManifestMetadataValidationTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/WistRuntimeManifestMetadataValidationTests.cs
@@ -107,7 +107,9 @@ public class WistRuntimeManifestMetadataValidationTests
         {
             Assert.That(activation, Is.Not.Null);
             Assert.That(activation?.ActivationTypeFullName, Is.EqualTo("ArithmeticModule.Module.ArithmeticModuleImpl"));
+            Assert.That(activation?.ActivationAssemblySimpleName, Is.EqualTo("ArithmeticModule"));
             Assert.That(activation?.RegistrarTypeFullName, Is.Null);
+            Assert.That(activation?.RegistrarAssemblySimpleName, Is.Null);
         });
     }
 
@@ -127,9 +129,13 @@ public class WistRuntimeManifestMetadataValidationTests
         Assert.Multiple(() =>
         {
             Assert.That(cilActivation?.ActivationTypeFullName, Is.EqualTo(typeof(WistCilBackendDeclaration).FullName));
+            Assert.That(cilActivation?.ActivationAssemblySimpleName, Is.EqualTo(typeof(WistCilBackendDeclaration).Assembly.GetName().Name));
             Assert.That(cilActivation?.RegistrarTypeFullName, Is.EqualTo(typeof(WistCilDialectBackendServiceProvider).FullName));
+            Assert.That(cilActivation?.RegistrarAssemblySimpleName, Is.EqualTo(typeof(WistCilDialectBackendServiceProvider).Assembly.GetName().Name));
             Assert.That(interpreterActivation?.ActivationTypeFullName, Is.EqualTo(typeof(WistInterpreterBackendDeclaration).FullName));
+            Assert.That(interpreterActivation?.ActivationAssemblySimpleName, Is.EqualTo(typeof(WistInterpreterBackendDeclaration).Assembly.GetName().Name));
             Assert.That(interpreterActivation?.RegistrarTypeFullName, Is.EqualTo(typeof(WistInterpreterDialectBackendServiceProvider).FullName));
+            Assert.That(interpreterActivation?.RegistrarAssemblySimpleName, Is.EqualTo(typeof(WistInterpreterDialectBackendServiceProvider).Assembly.GetName().Name));
         });
     }
 

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistDialectExecutionConfigurationBuilder.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistDialectExecutionConfigurationBuilder.cs
@@ -7,23 +7,18 @@ namespace UniversalToolchain.Dialects.Wist;
 public sealed class WistDialectExecutionConfigurationBuilder
 {
     private readonly DialectBackendRuntimeConfigurationBuilder _backendConfigurationBuilder;
-    private readonly IRuntimeKnownBackendsProvider _knownBackendsProvider;
     private readonly SelectedRuntimeExecutionShapeBuilder _shapeBuilder;
 
     public WistDialectExecutionConfigurationBuilder(
         SelectedRuntimeExecutionShapeBuilder shapeBuilder,
-        DialectBackendRuntimeConfigurationBuilder backendConfigurationBuilder,
-        IRuntimeKnownBackendsProvider knownBackendsProvider)
+        DialectBackendRuntimeConfigurationBuilder backendConfigurationBuilder)
     {
         shapeBuilder = shapeBuilder.ArgNotNull();
 
         backendConfigurationBuilder = backendConfigurationBuilder.ArgNotNull();
 
-        knownBackendsProvider = knownBackendsProvider.ArgNotNull();
-
         _shapeBuilder = shapeBuilder;
         _backendConfigurationBuilder = backendConfigurationBuilder;
-        _knownBackendsProvider = knownBackendsProvider;
     }
 
     public WistDialectExecutionConfiguration Build(DialectBuildPlan buildPlan, SelectedRuntimePlan selectedRuntimePlan)
@@ -43,7 +38,11 @@ public sealed class WistDialectExecutionConfigurationBuilder
             .OrderBy(x => x.FullName, StringComparer.Ordinal)
             .ToList();
 
-        var knownBackends = _knownBackendsProvider.GetKnownBackends();
+        var knownBackends = backends
+            .Select(x => x.BackendDescriptor)
+            .OrderBy(x => x.BackendId)
+            .ThenBy(x => string.Join("|", x.Aliases), StringComparer.Ordinal)
+            .ToList();
 
         return new WistDialectExecutionConfiguration(
             shape.DialectName,


### PR DESCRIPTION
### Motivation

- Allow runtime manifests to carry structured type references that include both assembly simple name and type full name so activation and registrar types can be loaded from the intended assembly.  
- Preserve backwards compatibility with legacy manifests that only contain `*TypeFullName` and provide a deterministic fallback to the component's owning assembly when the assembly is unspecified.  
- Simplify how known backends are discovered by deriving the known-backends list from selected backends instead of a separate provider.

### Description

- Introduced `RuntimeTypeReference` (validated `AssemblySimpleName` + `TypeFullName`) and `RuntimeAssemblyIdentity.UnspecifiedAssemblySimpleName` to represent unspecified assembly identity.  
- Replaced string-based activation/registrar fields with structured references in `RuntimeComponentActivationInfo` and `FileRuntimeComponentActivationEntry`, while keeping legacy constructors/properties for compatibility.  
- Updated `RuntimeManifestJsonSerializer` to emit and consume structured `SerializableManifestTypeReference` entries and to resolve legacy fields into `RuntimeTypeReference` with correct fallback behavior.  
- Normalized activation metadata in `FileBasedRuntimeComponentCatalog` with `NormalizeTypeReference` to validate and fill missing assembly names using the owning assembly.  
- Updated type loading logic in `DefaultRuntimeBackendRegistrarResolver` and `DefaultRuntimeComponentResolver` to use the structured assembly name when provided and to fall back to the manifest entry assembly when the reference uses the unspecified marker via `ResolveAssemblySimpleName`.  
- Adjusted `ManifestEmitter` to emit assembly simple names for activation and registrar types.  
- Modified Wist execution configuration flow to compute `knownBackends` from the selected `backends` list instead of pulling them from an external `IRuntimeKnownBackendsProvider`.  
- Updated and added unit tests to reflect the new structured reference behavior and the new known-backends selection logic, and adapted test stubs (e.g. `StubAssemblyTypeLoader`) to include assembly simple name keys.

### Testing

- Ran the Dialects unit test suite in `UniversalToolchain.Dialects.Tests`, including updated tests in `RuntimeManifestCatalogContractTests`, `RuntimeBackendRegistrarResolverTests`, and Wist-related tests; all tests passed.  
- Exercised serialization/deserialization scenarios for both legacy (type-only) and structured (assembly+type) manifest payloads via `RuntimeManifestJsonSerializer` tests; all assertions succeeded.  
- Verified resolver behavior for registrar loading with explicit registrar assembly, fallback to component assembly, and DI construction usage in `RuntimeBackendRegistrarResolverTests`; tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea082ea9108324bd7a792fffcb9db0)