### PR TITLE
Fix docs README links for docs site compatibility

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -764,7 +764,7 @@
             </div>
             <div class="actions">
                 <a class="btn primary" href="https://github.com/Misha1302/Wist2/tree/master/UniversalToolchain/Example">Run Pricing Demo</a>
-                <a class="btn" href="../readme.md">README</a>
+                <a class="btn" href="https://github.com/Misha1302/Wist2/blob/master/readme.md">README</a>
                 <a class="btn" href="https://github.com/Misha1302/Wist2">GitHub</a>
                 <a class="btn" href="why-this-exists.md">Why this exists</a>
                 <a class="btn" href="alternatives.md">Nearby alternatives</a>
@@ -1128,7 +1128,7 @@ x</pre>
         <p>Reusable .NET DSL infrastructure, validated by the Wist reference language.</p>
         <div class="links">
             <a href="https://github.com/Misha1302/Wist2">Repository</a>
-            <a href="../readme.md">README</a>
+            <a href="https://github.com/Misha1302/Wist2/blob/master/readme.md">README</a>
             <a href="current-canonical-runtime-pipeline.md">Current Runtime Pipeline</a>
             <a href="why-this-exists.md">Why This Exists</a>
             <a href="alternatives.md">Nearby Alternatives</a>


### PR DESCRIPTION
### Motivation
- Prevent broken docs-site links by avoiding `../readme.md` references in `docs/index.html` which escape the docs root and can break GitHub Pages publishing. 

### Description
- Replace both `href="../readme.md"` occurrences in `docs/index.html` with the stable repository README URL `https://github.com/Misha1302/Wist2/blob/master/readme.md` and review the touched runtime-selection files for overstated wording without making further scope changes. 

### Testing
- Ran `dotnet restore UniversalToolchain/Wist.sln`, `dotnet build UniversalToolchain/Wist.sln -c Release --no-restore`, and `dotnet test` for `UniversalToolchain/UniversalToolchain.Dialects.Tests`, `UniversalToolchain/UniversalToolchain.Modules.Tests`, and `UniversalToolchain/Tests` and confirmed the test suites completed successfully with no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea38fe92c08324b6c194329c477487)