### PR TITLE
Add additive external execution-only arithmetic benchmark suite

### DIFF
--- a/UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/ExternalExecutionBenchmarks/ExternalArithmeticExecutionBenchmarkEnvironmentBase.cs
+++ b/UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/ExternalExecutionBenchmarks/ExternalArithmeticExecutionBenchmarkEnvironmentBase.cs
@@ -1,0 +1,166 @@
+using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
+using BenchmarkDotNet.Attributes;
+using DynamicMethodCalling.Core;
+using ExceptionsManager;
+using Microsoft.Extensions.DependencyInjection;
+using UniversalToolchain.Dialects.Integration;
+using UniversalToolchain.Dialects.Wist;
+using UniversalToolchain.Dialects.Wist.Presets;
+
+namespace UniversalToolchain.Benchmarks.ExternalExecutionBenchmarks;
+
+public abstract class ExternalArithmeticExecutionBenchmarkEnvironmentBase
+{
+    protected const int DataSize = 4096;
+
+    private WistDialectExecutionHost? _host;
+    private ServiceProvider? _provider;
+    private int _index;
+
+    protected double[] A = [];
+    protected double[] B = [];
+    protected double[] C = [];
+    protected double[] D = [];
+    protected double[] E = [];
+    protected double[] F = [];
+    protected double[] G = [];
+    protected double[] H = [];
+    protected double[] I = [];
+    protected double[] J = [];
+    protected double[] K = [];
+
+    protected void InitializeInputData()
+    {
+        A = new double[DataSize];
+        B = new double[DataSize];
+        C = new double[DataSize];
+        D = new double[DataSize];
+        E = new double[DataSize];
+        F = new double[DataSize];
+        G = new double[DataSize];
+        H = new double[DataSize];
+        I = new double[DataSize];
+        J = new double[DataSize];
+        K = new double[DataSize];
+
+        var random = new Random(42);
+        Fill(random, A);
+        Fill(random, B);
+        Fill(random, C);
+        Fill(random, D);
+        Fill(random, E);
+        Fill(random, F);
+        Fill(random, G);
+        Fill(random, H);
+        Fill(random, I);
+        Fill(random, J);
+        Fill(random, K);
+    }
+
+    protected void CreateProviderAndHost()
+    {
+        var services = new ServiceCollection();
+        services.AddWistDialectServices();
+        services.AddWistCilBackend();
+        services.AddWistInterpreterBackend();
+
+        _provider = services.BuildServiceProvider();
+
+        var workflow = _provider.GetRequiredService<WistDialectExecutionWorkflow>();
+        var dialectFile = new WistShippedDialectFileResolver().Resolve(WistShippedDialectPresets.FullDefaultNative);
+        var composition = workflow.ComposeFile(dialectFile);
+
+        if (!composition.IsSuccess)
+        {
+            Thrower.InvalidOpEx(
+                $"Failed to compose dialect file: {DialectCompositionExplanationFormatter.FormatDeterministic(DialectCompositionExplanationProjector.Project(composition))}");
+        }
+
+        _host = workflow.CreateHost(composition);
+    }
+
+    protected DynamicMethod CompileWistDynamicMethod(string formula, string[] bindingNames)
+    {
+        var host = _host ?? Thrower.InvalidOpEx<WistDialectExecutionHost>(
+            "Wist host must be initialized before compilation.");
+
+        var compiler = host.GetArtifactCompiler<DynamicMethod>("compiler");
+        var declaredBindings = CreateDeclaredBindings(bindingNames);
+        var compiledArtifact = compiler.Compile(formula, declaredBindings);
+
+        return compiledArtifact.CompilationOutput;
+    }
+
+    protected OrderedDictionary<string, Type> CreateDeclaredBindings(string[] bindingNames)
+    {
+        var declaredBindings = new OrderedDictionary<string, Type>();
+
+        foreach (var bindingName in bindingNames)
+        {
+            declaredBindings[bindingName] = typeof(double);
+        }
+
+        return declaredBindings;
+    }
+
+    protected void EnsureResultParityAcrossIndexes(
+        Func<int, double> cSharp,
+        Func<int, double> dynamicExpresso,
+        Func<int, double> nCalc,
+        Func<int, double> wist)
+    {
+        var validationIndexes = new[] { 0, 1, 17, 255, 1023, 2047, 4095 };
+
+        foreach (var index in validationIndexes)
+        {
+            var cSharpResult = cSharp(index);
+            var dynamicExpressoResult = dynamicExpresso(index);
+            var nCalcResult = nCalc(index);
+            var wistResult = wist(index);
+
+            if (!AreEqual(cSharpResult, dynamicExpressoResult) ||
+                !AreEqual(cSharpResult, nCalcResult) ||
+                !AreEqual(cSharpResult, wistResult))
+            {
+                Thrower.InvalidOpEx(
+                    $"Result mismatch at index {index}. " +
+                    $"C#: {cSharpResult}, DynamicExpresso: {dynamicExpressoResult}, NCalc: {nCalcResult}, Wist: {wistResult}.");
+            }
+        }
+    }
+
+    [GlobalCleanup]
+    public void GlobalCleanup()
+    {
+        _host?.Dispose();
+        _provider?.Dispose();
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    protected int NextIndex()
+    {
+        var i = _index;
+        _index = (i + 1) & (DataSize - 1);
+        return i;
+    }
+
+    private static bool AreEqual(double left, double right)
+    {
+        const double absoluteEpsilon = 1e-9;
+        const double relativeEpsilon = 1e-12;
+
+        var delta = Math.Abs(left - right);
+        var scale = Math.Max(1.0, Math.Max(Math.Abs(left), Math.Abs(right)));
+
+        return delta <= Math.Max(absoluteEpsilon, relativeEpsilon * scale);
+    }
+
+    private static void Fill(Random random, double[] values)
+    {
+        for (var i = 0; i < values.Length; i++)
+        {
+            values[i] = 0.1 + random.NextDouble() * 999.9;
+        }
+    }
+}

--- a/UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/ExternalExecutionBenchmarks/ExternalBenchContexts.cs
+++ b/UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/ExternalExecutionBenchmarks/ExternalBenchContexts.cs
@@ -1,0 +1,54 @@
+namespace UniversalToolchain.Benchmarks.ExternalExecutionBenchmarks;
+
+public sealed class ExternalBenchContext3
+{
+    public double A { get; set; }
+    public double B { get; set; }
+    public double C { get; set; }
+}
+
+public sealed class ExternalBenchContext5
+{
+    public double A { get; set; }
+    public double B { get; set; }
+    public double C { get; set; }
+    public double D { get; set; }
+    public double E { get; set; }
+}
+
+public sealed class ExternalBenchContext6
+{
+    public double A { get; set; }
+    public double B { get; set; }
+    public double C { get; set; }
+    public double D { get; set; }
+    public double E { get; set; }
+    public double F { get; set; }
+}
+
+public sealed class ExternalBenchContext8
+{
+    public double A { get; set; }
+    public double B { get; set; }
+    public double C { get; set; }
+    public double D { get; set; }
+    public double E { get; set; }
+    public double F { get; set; }
+    public double G { get; set; }
+    public double H { get; set; }
+}
+
+public sealed class ExternalBenchContext11
+{
+    public double A { get; set; }
+    public double B { get; set; }
+    public double C { get; set; }
+    public double D { get; set; }
+    public double E { get; set; }
+    public double F { get; set; }
+    public double G { get; set; }
+    public double H { get; set; }
+    public double I { get; set; }
+    public double J { get; set; }
+    public double K { get; set; }
+}

--- a/UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/ExternalExecutionBenchmarks/ExternalConstantsHeavy6ExecutionBenchmarks.cs
+++ b/UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/ExternalExecutionBenchmarks/ExternalConstantsHeavy6ExecutionBenchmarks.cs
@@ -1,0 +1,119 @@
+using System.Runtime.CompilerServices;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Order;
+using DynamicExpresso;
+using DynamicMethodCalling.Core;
+using NCalc;
+using NCalc.LambdaCompilation;
+
+namespace UniversalToolchain.Benchmarks.ExternalExecutionBenchmarks;
+
+[MemoryDiagnoser]
+[DryJob]
+[Orderer(SummaryOrderPolicy.FastestToSlowest)]
+[RankColumn]
+public sealed class ExternalConstantsHeavy6ExecutionBenchmarks : ExternalArithmeticExecutionBenchmarkEnvironmentBase
+{
+    private const string WistFormula = "(A * 1.5 + B * 2.0 - C * 3.0 + D / 4.0 + E / 5.0) * 0.75 + F";
+    private const string NCalcFormula = "([A] * 1.5 + [B] * 2.0 - [C] * 3.0 + [D] / 4.0 + [E] / 5.0) * 0.75 + [F]";
+    private const string DynamicExpressoFormula = "(A * 1.5 + B * 2.0 - C * 3.0 + D / 4.0 + E / 5.0) * 0.75 + F";
+    private const int InnerCount = 4096;
+
+    private ExternalBenchContext6 _nCalcContext = null!;
+    private Func<ExternalBenchContext6, double> _nCalcLambda = null!;
+    private Func<double, double, double, double, double, double, double> _dynamicExpressoDelegate = null!;
+    private DynamicMethodInvoker<double, double, double, double, double, double, double> _wistFastInvoker = null!;
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        InitializeInputData();
+        CreateProviderAndHost();
+
+        var dynamicMethod = CompileWistDynamicMethod(WistFormula, ["A", "B", "C", "D", "E", "F"]);
+        _wistFastInvoker = new DynamicMethodInvoker<double, double, double, double, double, double, double>(dynamicMethod);
+
+        var nCalcExpression = new Expression(NCalcFormula);
+        _nCalcLambda = nCalcExpression.ToLambda<ExternalBenchContext6, double>();
+        _nCalcContext = new ExternalBenchContext6();
+
+        var dynamicExpressoInterpreter = new Interpreter();
+        _dynamicExpressoDelegate = dynamicExpressoInterpreter.ParseAsDelegate<Func<double, double, double, double, double, double, double>>(
+            DynamicExpressoFormula,
+            "A", "B", "C", "D", "E", "F");
+
+        EnsureResultParityAcrossIndexes(CSharpAt, DynamicExpressoAt, NCalcAt, WistAt);
+    }
+
+    [Benchmark(Baseline = true)]
+    public double CSharp_NoInliningMethod()
+    {
+        var sum = 0.0;
+        for (var k = 0; k < InnerCount; k++)
+        {
+            var i = NextIndex();
+            sum += CSharp_NoInliningMethodCore(A[i], B[i], C[i], D[i], E[i], F[i]);
+        }
+
+        return sum;
+    }
+
+    [Benchmark]
+    public double DynamicExpresso_Delegate()
+    {
+        var sum = 0.0;
+        for (var k = 0; k < InnerCount; k++)
+        {
+            var i = NextIndex();
+            sum += _dynamicExpressoDelegate(A[i], B[i], C[i], D[i], E[i], F[i]);
+        }
+
+        return sum;
+    }
+
+    [Benchmark]
+    public double NCalc_Lambda()
+    {
+        var sum = 0.0;
+        for (var k = 0; k < InnerCount; k++)
+        {
+            var i = NextIndex();
+            _nCalcContext.A = A[i]; _nCalcContext.B = B[i]; _nCalcContext.C = C[i];
+            _nCalcContext.D = D[i]; _nCalcContext.E = E[i]; _nCalcContext.F = F[i];
+            sum += _nCalcLambda(_nCalcContext);
+        }
+
+        return sum;
+    }
+
+    [Benchmark]
+    public double Wist_Cil_FastInvoker()
+    {
+        var sum = 0.0;
+        for (var k = 0; k < InnerCount; k++)
+        {
+            var i = NextIndex();
+            sum += _wistFastInvoker.Invoke(A[i], B[i], C[i], D[i], E[i], F[i]);
+        }
+
+        return sum;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static double CSharp_NoInliningMethodCore(double a, double b, double c, double d, double e, double f)
+        => (a * 1.5 + b * 2.0 - c * 3.0 + d / 4.0 + e / 5.0) * 0.75 + f;
+
+    private double CSharpAt(int index) => CSharp_NoInliningMethodCore(A[index], B[index], C[index], D[index], E[index], F[index]);
+
+    private double DynamicExpressoAt(int index) => _dynamicExpressoDelegate(A[index], B[index], C[index], D[index], E[index], F[index]);
+
+    private double NCalcAt(int index)
+    {
+        _nCalcContext.A = A[index]; _nCalcContext.B = B[index]; _nCalcContext.C = C[index];
+        _nCalcContext.D = D[index]; _nCalcContext.E = E[index]; _nCalcContext.F = F[index];
+        return _nCalcLambda(_nCalcContext);
+    }
+
+    private double WistAt(int index) => _wistFastInvoker.Invoke(A[index], B[index], C[index], D[index], E[index], F[index]);
+}

--- a/UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/ExternalExecutionBenchmarks/ExternalConstantsHeavy6ExecutionBenchmarks.cs
+++ b/UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/ExternalExecutionBenchmarks/ExternalConstantsHeavy6ExecutionBenchmarks.cs
@@ -10,7 +10,7 @@ using NCalc.LambdaCompilation;
 namespace UniversalToolchain.Benchmarks.ExternalExecutionBenchmarks;
 
 [MemoryDiagnoser]
-[DryJob]
+[SimpleJob]
 [Orderer(SummaryOrderPolicy.FastestToSlowest)]
 [RankColumn]
 public sealed class ExternalConstantsHeavy6ExecutionBenchmarks : ExternalArithmeticExecutionBenchmarkEnvironmentBase

--- a/UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/ExternalExecutionBenchmarks/ExternalDeepChain6ExecutionBenchmarks.cs
+++ b/UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/ExternalExecutionBenchmarks/ExternalDeepChain6ExecutionBenchmarks.cs
@@ -10,7 +10,7 @@ using NCalc.LambdaCompilation;
 namespace UniversalToolchain.Benchmarks.ExternalExecutionBenchmarks;
 
 [MemoryDiagnoser]
-[DryJob]
+[SimpleJob]
 [Orderer(SummaryOrderPolicy.FastestToSlowest)]
 [RankColumn]
 public sealed class ExternalDeepChain6ExecutionBenchmarks : ExternalArithmeticExecutionBenchmarkEnvironmentBase

--- a/UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/ExternalExecutionBenchmarks/ExternalDeepChain6ExecutionBenchmarks.cs
+++ b/UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/ExternalExecutionBenchmarks/ExternalDeepChain6ExecutionBenchmarks.cs
@@ -1,0 +1,119 @@
+using System.Runtime.CompilerServices;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Order;
+using DynamicExpresso;
+using DynamicMethodCalling.Core;
+using NCalc;
+using NCalc.LambdaCompilation;
+
+namespace UniversalToolchain.Benchmarks.ExternalExecutionBenchmarks;
+
+[MemoryDiagnoser]
+[DryJob]
+[Orderer(SummaryOrderPolicy.FastestToSlowest)]
+[RankColumn]
+public sealed class ExternalDeepChain6ExecutionBenchmarks : ExternalArithmeticExecutionBenchmarkEnvironmentBase
+{
+    private const string WistFormula = "((((A * 1.1 + B) * 1.2 + C) * 1.3 + D) * 1.4 + E) / (F + 1.0)";
+    private const string NCalcFormula = "(((([A] * 1.1 + [B]) * 1.2 + [C]) * 1.3 + [D]) * 1.4 + [E]) / ([F] + 1.0)";
+    private const string DynamicExpressoFormula = "((((A * 1.1 + B) * 1.2 + C) * 1.3 + D) * 1.4 + E) / (F + 1.0)";
+    private const int InnerCount = 4096;
+
+    private ExternalBenchContext6 _nCalcContext = null!;
+    private Func<ExternalBenchContext6, double> _nCalcLambda = null!;
+    private Func<double, double, double, double, double, double, double> _dynamicExpressoDelegate = null!;
+    private DynamicMethodInvoker<double, double, double, double, double, double, double> _wistFastInvoker = null!;
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        InitializeInputData();
+        CreateProviderAndHost();
+
+        var dynamicMethod = CompileWistDynamicMethod(WistFormula, ["A", "B", "C", "D", "E", "F"]);
+        _wistFastInvoker = new DynamicMethodInvoker<double, double, double, double, double, double, double>(dynamicMethod);
+
+        var nCalcExpression = new Expression(NCalcFormula);
+        _nCalcLambda = nCalcExpression.ToLambda<ExternalBenchContext6, double>();
+        _nCalcContext = new ExternalBenchContext6();
+
+        var dynamicExpressoInterpreter = new Interpreter();
+        _dynamicExpressoDelegate = dynamicExpressoInterpreter.ParseAsDelegate<Func<double, double, double, double, double, double, double>>(
+            DynamicExpressoFormula,
+            "A", "B", "C", "D", "E", "F");
+
+        EnsureResultParityAcrossIndexes(CSharpAt, DynamicExpressoAt, NCalcAt, WistAt);
+    }
+
+    [Benchmark(Baseline = true)]
+    public double CSharp_NoInliningMethod()
+    {
+        var sum = 0.0;
+        for (var k = 0; k < InnerCount; k++)
+        {
+            var i = NextIndex();
+            sum += CSharp_NoInliningMethodCore(A[i], B[i], C[i], D[i], E[i], F[i]);
+        }
+
+        return sum;
+    }
+
+    [Benchmark]
+    public double DynamicExpresso_Delegate()
+    {
+        var sum = 0.0;
+        for (var k = 0; k < InnerCount; k++)
+        {
+            var i = NextIndex();
+            sum += _dynamicExpressoDelegate(A[i], B[i], C[i], D[i], E[i], F[i]);
+        }
+
+        return sum;
+    }
+
+    [Benchmark]
+    public double NCalc_Lambda()
+    {
+        var sum = 0.0;
+        for (var k = 0; k < InnerCount; k++)
+        {
+            var i = NextIndex();
+            _nCalcContext.A = A[i]; _nCalcContext.B = B[i]; _nCalcContext.C = C[i];
+            _nCalcContext.D = D[i]; _nCalcContext.E = E[i]; _nCalcContext.F = F[i];
+            sum += _nCalcLambda(_nCalcContext);
+        }
+
+        return sum;
+    }
+
+    [Benchmark]
+    public double Wist_Cil_FastInvoker()
+    {
+        var sum = 0.0;
+        for (var k = 0; k < InnerCount; k++)
+        {
+            var i = NextIndex();
+            sum += _wistFastInvoker.Invoke(A[i], B[i], C[i], D[i], E[i], F[i]);
+        }
+
+        return sum;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static double CSharp_NoInliningMethodCore(double a, double b, double c, double d, double e, double f)
+        => ((((a * 1.1 + b) * 1.2 + c) * 1.3 + d) * 1.4 + e) / (f + 1.0);
+
+    private double CSharpAt(int index) => CSharp_NoInliningMethodCore(A[index], B[index], C[index], D[index], E[index], F[index]);
+
+    private double DynamicExpressoAt(int index) => _dynamicExpressoDelegate(A[index], B[index], C[index], D[index], E[index], F[index]);
+
+    private double NCalcAt(int index)
+    {
+        _nCalcContext.A = A[index]; _nCalcContext.B = B[index]; _nCalcContext.C = C[index];
+        _nCalcContext.D = D[index]; _nCalcContext.E = E[index]; _nCalcContext.F = F[index];
+        return _nCalcLambda(_nCalcContext);
+    }
+
+    private double WistAt(int index) => _wistFastInvoker.Invoke(A[index], B[index], C[index], D[index], E[index], F[index]);
+}

--- a/UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/ExternalExecutionBenchmarks/ExternalMedium8ExecutionBenchmarks.cs
+++ b/UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/ExternalExecutionBenchmarks/ExternalMedium8ExecutionBenchmarks.cs
@@ -1,0 +1,119 @@
+using System.Runtime.CompilerServices;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Order;
+using DynamicExpresso;
+using DynamicMethodCalling.Core;
+using NCalc;
+using NCalc.LambdaCompilation;
+
+namespace UniversalToolchain.Benchmarks.ExternalExecutionBenchmarks;
+
+[MemoryDiagnoser]
+[DryJob]
+[Orderer(SummaryOrderPolicy.FastestToSlowest)]
+[RankColumn]
+public sealed class ExternalMedium8ExecutionBenchmarks : ExternalArithmeticExecutionBenchmarkEnvironmentBase
+{
+    private const string WistFormula = "((A + B) * (C - D) / (E + 1.0)) + F * G - H / 3.0";
+    private const string NCalcFormula = "(([A] + [B]) * ([C] - [D]) / ([E] + 1.0)) + [F] * [G] - [H] / 3.0";
+    private const string DynamicExpressoFormula = "((A + B) * (C - D) / (E + 1.0)) + F * G - H / 3.0";
+    private const int InnerCount = 4096;
+
+    private ExternalBenchContext8 _nCalcContext = null!;
+    private Func<ExternalBenchContext8, double> _nCalcLambda = null!;
+    private Func<double, double, double, double, double, double, double, double, double> _dynamicExpressoDelegate = null!;
+    private DynamicMethodInvoker<double, double, double, double, double, double, double, double, double> _wistFastInvoker = null!;
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        InitializeInputData();
+        CreateProviderAndHost();
+
+        var dynamicMethod = CompileWistDynamicMethod(WistFormula, ["A", "B", "C", "D", "E", "F", "G", "H"]);
+        _wistFastInvoker = new DynamicMethodInvoker<double, double, double, double, double, double, double, double, double>(dynamicMethod);
+
+        var nCalcExpression = new Expression(NCalcFormula);
+        _nCalcLambda = nCalcExpression.ToLambda<ExternalBenchContext8, double>();
+        _nCalcContext = new ExternalBenchContext8();
+
+        var dynamicExpressoInterpreter = new Interpreter();
+        _dynamicExpressoDelegate = dynamicExpressoInterpreter.ParseAsDelegate<Func<double, double, double, double, double, double, double, double, double>>(
+            DynamicExpressoFormula,
+            "A", "B", "C", "D", "E", "F", "G", "H");
+
+        EnsureResultParityAcrossIndexes(CSharpAt, DynamicExpressoAt, NCalcAt, WistAt);
+    }
+
+    [Benchmark(Baseline = true)]
+    public double CSharp_NoInliningMethod()
+    {
+        var sum = 0.0;
+        for (var k = 0; k < InnerCount; k++)
+        {
+            var i = NextIndex();
+            sum += CSharp_NoInliningMethodCore(A[i], B[i], C[i], D[i], E[i], F[i], G[i], H[i]);
+        }
+
+        return sum;
+    }
+
+    [Benchmark]
+    public double DynamicExpresso_Delegate()
+    {
+        var sum = 0.0;
+        for (var k = 0; k < InnerCount; k++)
+        {
+            var i = NextIndex();
+            sum += _dynamicExpressoDelegate(A[i], B[i], C[i], D[i], E[i], F[i], G[i], H[i]);
+        }
+
+        return sum;
+    }
+
+    [Benchmark]
+    public double NCalc_Lambda()
+    {
+        var sum = 0.0;
+        for (var k = 0; k < InnerCount; k++)
+        {
+            var i = NextIndex();
+            _nCalcContext.A = A[i]; _nCalcContext.B = B[i]; _nCalcContext.C = C[i]; _nCalcContext.D = D[i];
+            _nCalcContext.E = E[i]; _nCalcContext.F = F[i]; _nCalcContext.G = G[i]; _nCalcContext.H = H[i];
+            sum += _nCalcLambda(_nCalcContext);
+        }
+
+        return sum;
+    }
+
+    [Benchmark]
+    public double Wist_Cil_FastInvoker()
+    {
+        var sum = 0.0;
+        for (var k = 0; k < InnerCount; k++)
+        {
+            var i = NextIndex();
+            sum += _wistFastInvoker.Invoke(A[i], B[i], C[i], D[i], E[i], F[i], G[i], H[i]);
+        }
+
+        return sum;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static double CSharp_NoInliningMethodCore(double a, double b, double c, double d, double e, double f, double g, double h)
+        => ((a + b) * (c - d) / (e + 1.0)) + f * g - h / 3.0;
+
+    private double CSharpAt(int index) => CSharp_NoInliningMethodCore(A[index], B[index], C[index], D[index], E[index], F[index], G[index], H[index]);
+
+    private double DynamicExpressoAt(int index) => _dynamicExpressoDelegate(A[index], B[index], C[index], D[index], E[index], F[index], G[index], H[index]);
+
+    private double NCalcAt(int index)
+    {
+        _nCalcContext.A = A[index]; _nCalcContext.B = B[index]; _nCalcContext.C = C[index]; _nCalcContext.D = D[index];
+        _nCalcContext.E = E[index]; _nCalcContext.F = F[index]; _nCalcContext.G = G[index]; _nCalcContext.H = H[index];
+        return _nCalcLambda(_nCalcContext);
+    }
+
+    private double WistAt(int index) => _wistFastInvoker.Invoke(A[index], B[index], C[index], D[index], E[index], F[index], G[index], H[index]);
+}

--- a/UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/ExternalExecutionBenchmarks/ExternalMedium8ExecutionBenchmarks.cs
+++ b/UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/ExternalExecutionBenchmarks/ExternalMedium8ExecutionBenchmarks.cs
@@ -10,7 +10,7 @@ using NCalc.LambdaCompilation;
 namespace UniversalToolchain.Benchmarks.ExternalExecutionBenchmarks;
 
 [MemoryDiagnoser]
-[DryJob]
+[SimpleJob]
 [Orderer(SummaryOrderPolicy.FastestToSlowest)]
 [RankColumn]
 public sealed class ExternalMedium8ExecutionBenchmarks : ExternalArithmeticExecutionBenchmarkEnvironmentBase

--- a/UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/ExternalExecutionBenchmarks/ExternalRepeatedSubexpressions5ExecutionBenchmarks.cs
+++ b/UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/ExternalExecutionBenchmarks/ExternalRepeatedSubexpressions5ExecutionBenchmarks.cs
@@ -10,7 +10,7 @@ using NCalc.LambdaCompilation;
 namespace UniversalToolchain.Benchmarks.ExternalExecutionBenchmarks;
 
 [MemoryDiagnoser]
-[DryJob]
+[SimpleJob]
 [Orderer(SummaryOrderPolicy.FastestToSlowest)]
 [RankColumn]
 public sealed class ExternalRepeatedSubexpressions5ExecutionBenchmarks : ExternalArithmeticExecutionBenchmarkEnvironmentBase

--- a/UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/ExternalExecutionBenchmarks/ExternalRepeatedSubexpressions5ExecutionBenchmarks.cs
+++ b/UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/ExternalExecutionBenchmarks/ExternalRepeatedSubexpressions5ExecutionBenchmarks.cs
@@ -1,0 +1,119 @@
+using System.Runtime.CompilerServices;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Order;
+using DynamicExpresso;
+using DynamicMethodCalling.Core;
+using NCalc;
+using NCalc.LambdaCompilation;
+
+namespace UniversalToolchain.Benchmarks.ExternalExecutionBenchmarks;
+
+[MemoryDiagnoser]
+[DryJob]
+[Orderer(SummaryOrderPolicy.FastestToSlowest)]
+[RankColumn]
+public sealed class ExternalRepeatedSubexpressions5ExecutionBenchmarks : ExternalArithmeticExecutionBenchmarkEnvironmentBase
+{
+    private const string WistFormula = "((A * B) + (A * B) + (A * B) + (C * D)) / (E + 1.0)";
+    private const string NCalcFormula = "(([A] * [B]) + ([A] * [B]) + ([A] * [B]) + ([C] * [D])) / ([E] + 1.0)";
+    private const string DynamicExpressoFormula = "((A * B) + (A * B) + (A * B) + (C * D)) / (E + 1.0)";
+    private const int InnerCount = 4096;
+
+    private ExternalBenchContext5 _nCalcContext = null!;
+    private Func<ExternalBenchContext5, double> _nCalcLambda = null!;
+    private Func<double, double, double, double, double, double> _dynamicExpressoDelegate = null!;
+    private DynamicMethodInvoker<double, double, double, double, double, double> _wistFastInvoker = null!;
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        InitializeInputData();
+        CreateProviderAndHost();
+
+        var dynamicMethod = CompileWistDynamicMethod(WistFormula, ["A", "B", "C", "D", "E"]);
+        _wistFastInvoker = new DynamicMethodInvoker<double, double, double, double, double, double>(dynamicMethod);
+
+        var nCalcExpression = new Expression(NCalcFormula);
+        _nCalcLambda = nCalcExpression.ToLambda<ExternalBenchContext5, double>();
+        _nCalcContext = new ExternalBenchContext5();
+
+        var dynamicExpressoInterpreter = new Interpreter();
+        _dynamicExpressoDelegate = dynamicExpressoInterpreter.ParseAsDelegate<Func<double, double, double, double, double, double>>(
+            DynamicExpressoFormula,
+            "A", "B", "C", "D", "E");
+
+        EnsureResultParityAcrossIndexes(CSharpAt, DynamicExpressoAt, NCalcAt, WistAt);
+    }
+
+    [Benchmark(Baseline = true)]
+    public double CSharp_NoInliningMethod()
+    {
+        var sum = 0.0;
+        for (var k = 0; k < InnerCount; k++)
+        {
+            var i = NextIndex();
+            sum += CSharp_NoInliningMethodCore(A[i], B[i], C[i], D[i], E[i]);
+        }
+
+        return sum;
+    }
+
+    [Benchmark]
+    public double DynamicExpresso_Delegate()
+    {
+        var sum = 0.0;
+        for (var k = 0; k < InnerCount; k++)
+        {
+            var i = NextIndex();
+            sum += _dynamicExpressoDelegate(A[i], B[i], C[i], D[i], E[i]);
+        }
+
+        return sum;
+    }
+
+    [Benchmark]
+    public double NCalc_Lambda()
+    {
+        var sum = 0.0;
+        for (var k = 0; k < InnerCount; k++)
+        {
+            var i = NextIndex();
+            _nCalcContext.A = A[i]; _nCalcContext.B = B[i]; _nCalcContext.C = C[i];
+            _nCalcContext.D = D[i]; _nCalcContext.E = E[i];
+            sum += _nCalcLambda(_nCalcContext);
+        }
+
+        return sum;
+    }
+
+    [Benchmark]
+    public double Wist_Cil_FastInvoker()
+    {
+        var sum = 0.0;
+        for (var k = 0; k < InnerCount; k++)
+        {
+            var i = NextIndex();
+            sum += _wistFastInvoker.Invoke(A[i], B[i], C[i], D[i], E[i]);
+        }
+
+        return sum;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static double CSharp_NoInliningMethodCore(double a, double b, double c, double d, double e)
+        => ((a * b) + (a * b) + (a * b) + (c * d)) / (e + 1.0);
+
+    private double CSharpAt(int index) => CSharp_NoInliningMethodCore(A[index], B[index], C[index], D[index], E[index]);
+
+    private double DynamicExpressoAt(int index) => _dynamicExpressoDelegate(A[index], B[index], C[index], D[index], E[index]);
+
+    private double NCalcAt(int index)
+    {
+        _nCalcContext.A = A[index]; _nCalcContext.B = B[index]; _nCalcContext.C = C[index];
+        _nCalcContext.D = D[index]; _nCalcContext.E = E[index];
+        return _nCalcLambda(_nCalcContext);
+    }
+
+    private double WistAt(int index) => _wistFastInvoker.Invoke(A[index], B[index], C[index], D[index], E[index]);
+}

--- a/UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/ExternalExecutionBenchmarks/ExternalSimple3ExecutionBenchmarks.cs
+++ b/UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/ExternalExecutionBenchmarks/ExternalSimple3ExecutionBenchmarks.cs
@@ -10,7 +10,7 @@ using NCalc.LambdaCompilation;
 namespace UniversalToolchain.Benchmarks.ExternalExecutionBenchmarks;
 
 [MemoryDiagnoser]
-[DryJob]
+[SimpleJob]
 [Orderer(SummaryOrderPolicy.FastestToSlowest)]
 [RankColumn]
 public sealed class ExternalSimple3ExecutionBenchmarks : ExternalArithmeticExecutionBenchmarkEnvironmentBase

--- a/UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/ExternalExecutionBenchmarks/ExternalSimple3ExecutionBenchmarks.cs
+++ b/UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/ExternalExecutionBenchmarks/ExternalSimple3ExecutionBenchmarks.cs
@@ -1,0 +1,142 @@
+using System.Runtime.CompilerServices;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Order;
+using DynamicExpresso;
+using DynamicMethodCalling.Core;
+using NCalc;
+using NCalc.LambdaCompilation;
+
+namespace UniversalToolchain.Benchmarks.ExternalExecutionBenchmarks;
+
+[MemoryDiagnoser]
+[DryJob]
+[Orderer(SummaryOrderPolicy.FastestToSlowest)]
+[RankColumn]
+public sealed class ExternalSimple3ExecutionBenchmarks : ExternalArithmeticExecutionBenchmarkEnvironmentBase
+{
+    private const string WistFormula = "A + B * C / 5.0";
+    private const string NCalcFormula = "[A] + [B] * [C] / 5.0";
+    private const string DynamicExpressoFormula = "A + B * C / 5.0";
+    private const int InnerCount = 4096;
+
+    private ExternalBenchContext3 _nCalcContext = null!;
+    private Func<ExternalBenchContext3, double> _nCalcLambda = null!;
+    private Func<double, double, double, double> _dynamicExpressoDelegate = null!;
+    private DynamicMethodInvoker<double, double, double, double> _wistFastInvoker = null!;
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        InitializeInputData();
+        CreateProviderAndHost();
+
+        var dynamicMethod = CompileWistDynamicMethod(WistFormula, ["A", "B", "C"]);
+        _wistFastInvoker = new DynamicMethodInvoker<double, double, double, double>(dynamicMethod);
+
+        var nCalcExpression = new Expression(NCalcFormula);
+        _nCalcLambda = nCalcExpression.ToLambda<ExternalBenchContext3, double>();
+        _nCalcContext = new ExternalBenchContext3();
+
+        var dynamicExpressoInterpreter = new Interpreter();
+        _dynamicExpressoDelegate =
+            dynamicExpressoInterpreter.ParseAsDelegate<Func<double, double, double, double>>(
+                DynamicExpressoFormula,
+                "A",
+                "B",
+                "C");
+
+        EnsureResultParityAcrossIndexes(CSharpAt, DynamicExpressoAt, NCalcAt, WistAt);
+    }
+
+    [Benchmark(Baseline = true)]
+    public double CSharp_NoInliningMethod()
+    {
+        var sum = 0.0;
+
+        for (var k = 0; k < InnerCount; k++)
+        {
+            var i = NextIndex();
+            sum += CSharp_NoInliningMethodCore(A[i], B[i], C[i]);
+        }
+
+        return sum;
+    }
+
+    [Benchmark]
+    public double DynamicExpresso_Delegate()
+    {
+        var sum = 0.0;
+
+        for (var k = 0; k < InnerCount; k++)
+        {
+            var i = NextIndex();
+            sum += _dynamicExpressoDelegate(A[i], B[i], C[i]);
+        }
+
+        return sum;
+    }
+
+    [Benchmark]
+    public double NCalc_Lambda()
+    {
+        var sum = 0.0;
+
+        for (var k = 0; k < InnerCount; k++)
+        {
+            var i = NextIndex();
+
+            _nCalcContext.A = A[i];
+            _nCalcContext.B = B[i];
+            _nCalcContext.C = C[i];
+
+            sum += _nCalcLambda(_nCalcContext);
+        }
+
+        return sum;
+    }
+
+    [Benchmark]
+    public double Wist_Cil_FastInvoker()
+    {
+        var sum = 0.0;
+
+        for (var k = 0; k < InnerCount; k++)
+        {
+            var i = NextIndex();
+            sum += _wistFastInvoker.Invoke(A[i], B[i], C[i]);
+        }
+
+        return sum;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static double CSharp_NoInliningMethodCore(double a, double b, double c)
+    {
+        return a + b * c / 5.0;
+    }
+
+    private double CSharpAt(int index)
+    {
+        return CSharp_NoInliningMethodCore(A[index], B[index], C[index]);
+    }
+
+    private double DynamicExpressoAt(int index)
+    {
+        return _dynamicExpressoDelegate(A[index], B[index], C[index]);
+    }
+
+    private double NCalcAt(int index)
+    {
+        _nCalcContext.A = A[index];
+        _nCalcContext.B = B[index];
+        _nCalcContext.C = C[index];
+
+        return _nCalcLambda(_nCalcContext);
+    }
+
+    private double WistAt(int index)
+    {
+        return _wistFastInvoker.Invoke(A[index], B[index], C[index]);
+    }
+}

--- a/UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/ExternalExecutionBenchmarks/ExternalWideExpression11ExecutionBenchmarks.cs
+++ b/UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/ExternalExecutionBenchmarks/ExternalWideExpression11ExecutionBenchmarks.cs
@@ -10,7 +10,7 @@ using NCalc.LambdaCompilation;
 namespace UniversalToolchain.Benchmarks.ExternalExecutionBenchmarks;
 
 [MemoryDiagnoser]
-[DryJob]
+[SimpleJob]
 [Orderer(SummaryOrderPolicy.FastestToSlowest)]
 [RankColumn]
 public sealed class ExternalWideExpression11ExecutionBenchmarks : ExternalArithmeticExecutionBenchmarkEnvironmentBase

--- a/UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/ExternalExecutionBenchmarks/ExternalWideExpression11ExecutionBenchmarks.cs
+++ b/UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/ExternalExecutionBenchmarks/ExternalWideExpression11ExecutionBenchmarks.cs
@@ -1,0 +1,121 @@
+using System.Runtime.CompilerServices;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Order;
+using DynamicExpresso;
+using DynamicMethodCalling.Core;
+using NCalc;
+using NCalc.LambdaCompilation;
+
+namespace UniversalToolchain.Benchmarks.ExternalExecutionBenchmarks;
+
+[MemoryDiagnoser]
+[DryJob]
+[Orderer(SummaryOrderPolicy.FastestToSlowest)]
+[RankColumn]
+public sealed class ExternalWideExpression11ExecutionBenchmarks : ExternalArithmeticExecutionBenchmarkEnvironmentBase
+{
+    private const string WistFormula = "(A + B + C + D) * (E - F + G) / (H + 1.0) + I * J - K / 3.0";
+    private const string NCalcFormula = "([A] + [B] + [C] + [D]) * ([E] - [F] + [G]) / ([H] + 1.0) + [I] * [J] - [K] / 3.0";
+    private const string DynamicExpressoFormula = "(A + B + C + D) * (E - F + G) / (H + 1.0) + I * J - K / 3.0";
+    private const int InnerCount = 4096;
+
+    private ExternalBenchContext11 _nCalcContext = null!;
+    private Func<ExternalBenchContext11, double> _nCalcLambda = null!;
+    private Func<double, double, double, double, double, double, double, double, double, double, double, double> _dynamicExpressoDelegate = null!;
+    private DynamicMethodInvoker<double, double, double, double, double, double, double, double, double, double, double, double> _wistFastInvoker = null!;
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        InitializeInputData();
+        CreateProviderAndHost();
+
+        var dynamicMethod = CompileWistDynamicMethod(WistFormula, ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K"]);
+        _wistFastInvoker = new DynamicMethodInvoker<double, double, double, double, double, double, double, double, double, double, double, double>(dynamicMethod);
+
+        var nCalcExpression = new Expression(NCalcFormula);
+        _nCalcLambda = nCalcExpression.ToLambda<ExternalBenchContext11, double>();
+        _nCalcContext = new ExternalBenchContext11();
+
+        var dynamicExpressoInterpreter = new Interpreter();
+        _dynamicExpressoDelegate = dynamicExpressoInterpreter.ParseAsDelegate<Func<double, double, double, double, double, double, double, double, double, double, double, double>>(
+            DynamicExpressoFormula,
+            "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K");
+
+        EnsureResultParityAcrossIndexes(CSharpAt, DynamicExpressoAt, NCalcAt, WistAt);
+    }
+
+    [Benchmark(Baseline = true)]
+    public double CSharp_NoInliningMethod()
+    {
+        var sum = 0.0;
+        for (var k = 0; k < InnerCount; k++)
+        {
+            var i = NextIndex();
+            sum += CSharp_NoInliningMethodCore(A[i], B[i], C[i], D[i], E[i], F[i], G[i], H[i], I[i], J[i], K[i]);
+        }
+
+        return sum;
+    }
+
+    [Benchmark]
+    public double DynamicExpresso_Delegate()
+    {
+        var sum = 0.0;
+        for (var k = 0; k < InnerCount; k++)
+        {
+            var i = NextIndex();
+            sum += _dynamicExpressoDelegate(A[i], B[i], C[i], D[i], E[i], F[i], G[i], H[i], I[i], J[i], K[i]);
+        }
+
+        return sum;
+    }
+
+    [Benchmark]
+    public double NCalc_Lambda()
+    {
+        var sum = 0.0;
+        for (var k = 0; k < InnerCount; k++)
+        {
+            var i = NextIndex();
+            _nCalcContext.A = A[i]; _nCalcContext.B = B[i]; _nCalcContext.C = C[i]; _nCalcContext.D = D[i];
+            _nCalcContext.E = E[i]; _nCalcContext.F = F[i]; _nCalcContext.G = G[i]; _nCalcContext.H = H[i];
+            _nCalcContext.I = I[i]; _nCalcContext.J = J[i]; _nCalcContext.K = K[i];
+            sum += _nCalcLambda(_nCalcContext);
+        }
+
+        return sum;
+    }
+
+    [Benchmark]
+    public double Wist_Cil_FastInvoker()
+    {
+        var sum = 0.0;
+        for (var k = 0; k < InnerCount; k++)
+        {
+            var i = NextIndex();
+            sum += _wistFastInvoker.Invoke(A[i], B[i], C[i], D[i], E[i], F[i], G[i], H[i], I[i], J[i], K[i]);
+        }
+
+        return sum;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static double CSharp_NoInliningMethodCore(double a, double b, double c, double d, double e, double f, double g, double h, double i, double j, double k)
+        => (a + b + c + d) * (e - f + g) / (h + 1.0) + i * j - k / 3.0;
+
+    private double CSharpAt(int index) => CSharp_NoInliningMethodCore(A[index], B[index], C[index], D[index], E[index], F[index], G[index], H[index], I[index], J[index], K[index]);
+
+    private double DynamicExpressoAt(int index) => _dynamicExpressoDelegate(A[index], B[index], C[index], D[index], E[index], F[index], G[index], H[index], I[index], J[index], K[index]);
+
+    private double NCalcAt(int index)
+    {
+        _nCalcContext.A = A[index]; _nCalcContext.B = B[index]; _nCalcContext.C = C[index]; _nCalcContext.D = D[index];
+        _nCalcContext.E = E[index]; _nCalcContext.F = F[index]; _nCalcContext.G = G[index]; _nCalcContext.H = H[index];
+        _nCalcContext.I = I[index]; _nCalcContext.J = J[index]; _nCalcContext.K = K[index];
+        return _nCalcLambda(_nCalcContext);
+    }
+
+    private double WistAt(int index) => _wistFastInvoker.Invoke(A[index], B[index], C[index], D[index], E[index], F[index], G[index], H[index], I[index], J[index], K[index]);
+}

--- a/UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/Program.cs
+++ b/UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/Program.cs
@@ -1,8 +1,16 @@
 using BenchmarkDotNet.Running;
 using UniversalToolchain.Benchmarks;
+using UniversalToolchain.Benchmarks.ExternalExecutionBenchmarks;
 
 BenchmarkRunner.Run<Simple3Benchmarks>();
 BenchmarkRunner.Run<Medium8Benchmarks>();
 BenchmarkRunner.Run<DeepChain6Benchmarks>();
 BenchmarkRunner.Run<RepeatedSubexpressionsBenchmarks>();
 BenchmarkRunner.Run<WideExpression11Benchmarks>();
+
+BenchmarkRunner.Run<ExternalSimple3ExecutionBenchmarks>();
+BenchmarkRunner.Run<ExternalMedium8ExecutionBenchmarks>();
+BenchmarkRunner.Run<ExternalDeepChain6ExecutionBenchmarks>();
+BenchmarkRunner.Run<ExternalRepeatedSubexpressions5ExecutionBenchmarks>();
+BenchmarkRunner.Run<ExternalWideExpression11ExecutionBenchmarks>();
+BenchmarkRunner.Run<ExternalConstantsHeavy6ExecutionBenchmarks>();

--- a/UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/UniversalToolchain.Benchmarks.csproj
+++ b/UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/UniversalToolchain.Benchmarks.csproj
@@ -19,6 +19,8 @@
         <PackageReference Include="NCalcSync" Version="5.12.0"/>
         <PackageReference Include="NCalc.LambdaCompilation" Version="5.12.0"/>
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.2"/>
+        <PackageReference Include="DynamicExpresso.Core" Version="2.19.3"/>
+
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
### Motivation
- Provide an additive benchmark suite that compares hot-path execution speed (already-prepared delegates/invokers) between C# baseline, Wist fast `DynamicMethodInvoker`, NCalc precompiled lambda, and Dynamic Expresso `ParseAsDelegate` without touching existing benchmarks. 
- Keep all preparation in `GlobalSetup` and ensure the benchmark body measures only prepared delegate invocation with deterministic inputs.

### Description
- Added a shared environment and parity/inputs helper: `ExternalArithmeticExecutionBenchmarkEnvironmentBase.cs` that builds a Wist host, prepares `DynamicMethod` artifacts, initializes deterministic inputs (`Random(42)`), and validates parity at indexes `0,1,17,255,1023,2047,4095`.
- Added external benchmark context POCOs in `ExternalBenchContexts.cs` for 3/5/6/8/11-parameter formulas used by NCalc lambda delegates.
- Added six new benchmark classes (one per file) under `ExternalExecutionBenchmarks/` that follow the requested formulas and rules: `ExternalSimple3ExecutionBenchmarks.cs`, `ExternalMedium8ExecutionBenchmarks.cs`, `ExternalDeepChain6ExecutionBenchmarks.cs`, `ExternalRepeatedSubexpressions5ExecutionBenchmarks.cs`, `ExternalWideExpression11ExecutionBenchmarks.cs`, and `ExternalConstantsHeavy6ExecutionBenchmarks.cs` (all use `InnerCount = 4096`, `[MemoryDiagnoser]`, `[DryJob]`, `[Orderer(SummaryOrderPolicy.FastestToSlowest)]`, `[RankColumn]`).
- Added `DynamicExpresso.Core` package reference (`2.19.3`) to `UniversalToolchain.Benchmarks.csproj` and appended `BenchmarkRunner.Run<...>()` lines for all new classes to `Program.cs` while preserving existing runners.

### Testing
- Ran `dotnet restore UniversalToolchain/Wist.sln`, which completed successfully. 
- Ran `dotnet build UniversalToolchain/Wist.sln -c Release`, which completed successfully with warnings and produced a Release build. 
- Attempted a smoke dry run for the new smoke target with `dotnet run --project UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/UniversalToolchain.Benchmarks.csproj -c Release -- --filter "*ExternalSimple3ExecutionBenchmarks*"`, and BenchmarkDotNet invocation began, but the generated benchmark process hit the environment-configured build/launch timeout during the auto-generated benchmark build/launch step (the smoke run did not complete to execution in this environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea5a21a28883249268fe96818dfe92)