### PR TITLE
Add Unrolled16 external execution benchmark suite (generated inline hot-paths)

### DIFF
--- a/UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/ExternalExecutionBenchmarks/Unrolled16/ExternalArithmeticExecutionUnrolled16BenchmarkEnvironmentBase.cs
+++ b/UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/ExternalExecutionBenchmarks/Unrolled16/ExternalArithmeticExecutionUnrolled16BenchmarkEnvironmentBase.cs
@@ -1,0 +1,166 @@
+using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
+using BenchmarkDotNet.Attributes;
+using DynamicMethodCalling.Core;
+using ExceptionsManager;
+using Microsoft.Extensions.DependencyInjection;
+using UniversalToolchain.Dialects.Integration;
+using UniversalToolchain.Dialects.Wist;
+using UniversalToolchain.Dialects.Wist.Presets;
+
+namespace UniversalToolchain.Benchmarks.ExternalExecutionBenchmarks.Unrolled16;
+
+public abstract class ExternalArithmeticExecutionUnrolled16BenchmarkEnvironmentBase
+{
+    protected const int DataSize = 4096;
+
+    private WistDialectExecutionHost? _host;
+    private ServiceProvider? _provider;
+    private int _index;
+
+    protected double[] A = [];
+    protected double[] B = [];
+    protected double[] C = [];
+    protected double[] D = [];
+    protected double[] E = [];
+    protected double[] F = [];
+    protected double[] G = [];
+    protected double[] H = [];
+    protected double[] I = [];
+    protected double[] J = [];
+    protected double[] K = [];
+
+    protected void InitializeInputData()
+    {
+        A = new double[DataSize];
+        B = new double[DataSize];
+        C = new double[DataSize];
+        D = new double[DataSize];
+        E = new double[DataSize];
+        F = new double[DataSize];
+        G = new double[DataSize];
+        H = new double[DataSize];
+        I = new double[DataSize];
+        J = new double[DataSize];
+        K = new double[DataSize];
+
+        var random = new Random(42);
+        Fill(random, A);
+        Fill(random, B);
+        Fill(random, C);
+        Fill(random, D);
+        Fill(random, E);
+        Fill(random, F);
+        Fill(random, G);
+        Fill(random, H);
+        Fill(random, I);
+        Fill(random, J);
+        Fill(random, K);
+    }
+
+    protected void CreateProviderAndHost()
+    {
+        var services = new ServiceCollection();
+        services.AddWistDialectServices();
+        services.AddWistCilBackend();
+        services.AddWistInterpreterBackend();
+
+        _provider = services.BuildServiceProvider();
+
+        var workflow = _provider.GetRequiredService<WistDialectExecutionWorkflow>();
+        var dialectFile = new WistShippedDialectFileResolver().Resolve(WistShippedDialectPresets.FullDefaultNative);
+        var composition = workflow.ComposeFile(dialectFile);
+
+        if (!composition.IsSuccess)
+        {
+            Thrower.InvalidOpEx(
+                $"Failed to compose dialect file: {DialectCompositionExplanationFormatter.FormatDeterministic(DialectCompositionExplanationProjector.Project(composition))}");
+        }
+
+        _host = workflow.CreateHost(composition);
+    }
+
+    protected DynamicMethod CompileWistDynamicMethod(string formula, string[] bindingNames)
+    {
+        var host = _host ?? Thrower.InvalidOpEx<WistDialectExecutionHost>(
+            "Wist host must be initialized before compilation.");
+
+        var compiler = host.GetArtifactCompiler<DynamicMethod>("compiler");
+        var declaredBindings = CreateDeclaredBindings(bindingNames);
+        var compiledArtifact = compiler.Compile(formula, declaredBindings);
+
+        return compiledArtifact.CompilationOutput;
+    }
+
+    protected OrderedDictionary<string, Type> CreateDeclaredBindings(string[] bindingNames)
+    {
+        var declaredBindings = new OrderedDictionary<string, Type>();
+
+        foreach (var bindingName in bindingNames)
+        {
+            declaredBindings[bindingName] = typeof(double);
+        }
+
+        return declaredBindings;
+    }
+
+    protected void EnsureResultParityAcrossIndexes(
+        Func<int, double> cSharp,
+        Func<int, double> dynamicExpresso,
+        Func<int, double> nCalc,
+        Func<int, double> wist)
+    {
+        var validationIndexes = new[] { 0, 1, 17, 255, 1023, 2047, 4095 };
+
+        foreach (var index in validationIndexes)
+        {
+            var cSharpResult = cSharp(index);
+            var dynamicExpressoResult = dynamicExpresso(index);
+            var nCalcResult = nCalc(index);
+            var wistResult = wist(index);
+
+            if (!AreEqual(cSharpResult, dynamicExpressoResult) ||
+                !AreEqual(cSharpResult, nCalcResult) ||
+                !AreEqual(cSharpResult, wistResult))
+            {
+                Thrower.InvalidOpEx(
+                    $"Result mismatch at index {index}. " +
+                    $"C#: {cSharpResult}, DynamicExpresso: {dynamicExpressoResult}, NCalc: {nCalcResult}, Wist: {wistResult}.");
+            }
+        }
+    }
+
+    [GlobalCleanup]
+    public void GlobalCleanup()
+    {
+        _host?.Dispose();
+        _provider?.Dispose();
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    protected int NextIndex()
+    {
+        var i = _index;
+        _index = (i + 1) & (DataSize - 1);
+        return i;
+    }
+
+    private static bool AreEqual(double left, double right)
+    {
+        const double absoluteEpsilon = 1e-9;
+        const double relativeEpsilon = 1e-12;
+
+        var delta = Math.Abs(left - right);
+        var scale = Math.Max(1.0, Math.Max(Math.Abs(left), Math.Abs(right)));
+
+        return delta <= Math.Max(absoluteEpsilon, relativeEpsilon * scale);
+    }
+
+    private static void Fill(Random random, double[] values)
+    {
+        for (var i = 0; i < values.Length; i++)
+        {
+            values[i] = 0.1 + random.NextDouble() * 999.9;
+        }
+    }
+}

--- a/UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/ExternalExecutionBenchmarks/Unrolled16/ExternalBenchContexts.Unrolled16.cs
+++ b/UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/ExternalExecutionBenchmarks/Unrolled16/ExternalBenchContexts.Unrolled16.cs
@@ -1,0 +1,54 @@
+namespace UniversalToolchain.Benchmarks.ExternalExecutionBenchmarks.Unrolled16;
+
+public sealed class ExternalBenchContext3Unrolled16
+{
+    public double A { get; set; }
+    public double B { get; set; }
+    public double C { get; set; }
+}
+
+public sealed class ExternalBenchContext5Unrolled16
+{
+    public double A { get; set; }
+    public double B { get; set; }
+    public double C { get; set; }
+    public double D { get; set; }
+    public double E { get; set; }
+}
+
+public sealed class ExternalBenchContext6Unrolled16
+{
+    public double A { get; set; }
+    public double B { get; set; }
+    public double C { get; set; }
+    public double D { get; set; }
+    public double E { get; set; }
+    public double F { get; set; }
+}
+
+public sealed class ExternalBenchContext8Unrolled16
+{
+    public double A { get; set; }
+    public double B { get; set; }
+    public double C { get; set; }
+    public double D { get; set; }
+    public double E { get; set; }
+    public double F { get; set; }
+    public double G { get; set; }
+    public double H { get; set; }
+}
+
+public sealed class ExternalBenchContext11Unrolled16
+{
+    public double A { get; set; }
+    public double B { get; set; }
+    public double C { get; set; }
+    public double D { get; set; }
+    public double E { get; set; }
+    public double F { get; set; }
+    public double G { get; set; }
+    public double H { get; set; }
+    public double I { get; set; }
+    public double J { get; set; }
+    public double K { get; set; }
+}

--- a/UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/ExternalExecutionBenchmarks/Unrolled16/ExternalConstantsHeavy6ExecutionUnrolled16Benchmarks.cs
+++ b/UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/ExternalExecutionBenchmarks/Unrolled16/ExternalConstantsHeavy6ExecutionUnrolled16Benchmarks.cs
@@ -1,0 +1,392 @@
+using System.Runtime.CompilerServices;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Order;
+using DynamicExpresso;
+using DynamicMethodCalling.Core;
+using NCalc;
+using NCalc.LambdaCompilation;
+
+namespace UniversalToolchain.Benchmarks.ExternalExecutionBenchmarks.Unrolled16;
+
+[MemoryDiagnoser]
+[SimpleJob]
+[Orderer(SummaryOrderPolicy.FastestToSlowest)]
+[RankColumn]
+public sealed class ExternalConstantsHeavy6ExecutionUnrolled16Benchmarks : ExternalArithmeticExecutionUnrolled16BenchmarkEnvironmentBase
+{
+    private const string WistFormula = "(A * 1.5 + B * 2.0 - C * 3.0 + D / 4.0 + E / 5.0) * 0.75 + F";
+    private const string NCalcFormula = "([A] * 1.5 + [B] * 2.0 - [C] * 3.0 + [D] / 4.0 + [E] / 5.0) * 0.75 + [F]";
+    private const string DynamicExpressoFormula = "(A * 1.5 + B * 2.0 - C * 3.0 + D / 4.0 + E / 5.0) * 0.75 + F";
+
+    private ExternalBenchContext6Unrolled16 _nCalcContext = null!;
+    private Func<ExternalBenchContext6Unrolled16, double> _nCalcLambda = null!;
+    private Func<double, double, double, double, double, double, double> _dynamicExpressoDelegate = null!;
+    private DynamicMethodInvoker<double, double, double, double, double, double, double> _wistFastInvoker = null!;
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        InitializeInputData();
+        CreateProviderAndHost();
+
+        var dynamicMethod = CompileWistDynamicMethod(WistFormula, ["A", "B", "C", "D", "E", "F"]);
+        _wistFastInvoker = new DynamicMethodInvoker<double, double, double, double, double, double, double>(dynamicMethod);
+
+        var nCalcExpression = new Expression(NCalcFormula);
+        _nCalcLambda = nCalcExpression.ToLambda<ExternalBenchContext6Unrolled16, double>();
+        _nCalcContext = new ExternalBenchContext6Unrolled16();
+
+        var dynamicExpressoInterpreter = new Interpreter();
+        _dynamicExpressoDelegate =
+            dynamicExpressoInterpreter.ParseAsDelegate<Func<double, double, double, double, double, double, double>>(
+                DynamicExpressoFormula,
+                "A", "B", "C", "D", "E", "F");
+
+        EnsureResultParityAcrossIndexes(CSharpAt, DynamicExpressoAt, NCalcAt, WistAt);
+    }
+
+    [Benchmark(Baseline = true, OperationsPerInvoke = 16)]
+    public double CSharp_NoInliningMethod_Unrolled16()
+    {
+        var sum = 0.0;
+
+        var i0 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i0], B[i0], C[i0], D[i0], E[i0], F[i0]);
+
+        var i1 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i1], B[i1], C[i1], D[i1], E[i1], F[i1]);
+
+        var i2 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i2], B[i2], C[i2], D[i2], E[i2], F[i2]);
+
+        var i3 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i3], B[i3], C[i3], D[i3], E[i3], F[i3]);
+
+        var i4 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i4], B[i4], C[i4], D[i4], E[i4], F[i4]);
+
+        var i5 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i5], B[i5], C[i5], D[i5], E[i5], F[i5]);
+
+        var i6 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i6], B[i6], C[i6], D[i6], E[i6], F[i6]);
+
+        var i7 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i7], B[i7], C[i7], D[i7], E[i7], F[i7]);
+
+        var i8 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i8], B[i8], C[i8], D[i8], E[i8], F[i8]);
+
+        var i9 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i9], B[i9], C[i9], D[i9], E[i9], F[i9]);
+
+        var i10 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i10], B[i10], C[i10], D[i10], E[i10], F[i10]);
+
+        var i11 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i11], B[i11], C[i11], D[i11], E[i11], F[i11]);
+
+        var i12 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i12], B[i12], C[i12], D[i12], E[i12], F[i12]);
+
+        var i13 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i13], B[i13], C[i13], D[i13], E[i13], F[i13]);
+
+        var i14 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i14], B[i14], C[i14], D[i14], E[i14], F[i14]);
+
+        var i15 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i15], B[i15], C[i15], D[i15], E[i15], F[i15]);
+
+        return sum;
+    }
+
+    [Benchmark(OperationsPerInvoke = 16)]
+    public double DynamicExpresso_Delegate_Unrolled16()
+    {
+        var sum = 0.0;
+
+        var i0 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i0], B[i0], C[i0], D[i0], E[i0], F[i0]);
+
+        var i1 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i1], B[i1], C[i1], D[i1], E[i1], F[i1]);
+
+        var i2 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i2], B[i2], C[i2], D[i2], E[i2], F[i2]);
+
+        var i3 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i3], B[i3], C[i3], D[i3], E[i3], F[i3]);
+
+        var i4 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i4], B[i4], C[i4], D[i4], E[i4], F[i4]);
+
+        var i5 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i5], B[i5], C[i5], D[i5], E[i5], F[i5]);
+
+        var i6 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i6], B[i6], C[i6], D[i6], E[i6], F[i6]);
+
+        var i7 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i7], B[i7], C[i7], D[i7], E[i7], F[i7]);
+
+        var i8 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i8], B[i8], C[i8], D[i8], E[i8], F[i8]);
+
+        var i9 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i9], B[i9], C[i9], D[i9], E[i9], F[i9]);
+
+        var i10 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i10], B[i10], C[i10], D[i10], E[i10], F[i10]);
+
+        var i11 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i11], B[i11], C[i11], D[i11], E[i11], F[i11]);
+
+        var i12 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i12], B[i12], C[i12], D[i12], E[i12], F[i12]);
+
+        var i13 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i13], B[i13], C[i13], D[i13], E[i13], F[i13]);
+
+        var i14 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i14], B[i14], C[i14], D[i14], E[i14], F[i14]);
+
+        var i15 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i15], B[i15], C[i15], D[i15], E[i15], F[i15]);
+
+        return sum;
+    }
+
+    [Benchmark(OperationsPerInvoke = 16)]
+    public double NCalc_Lambda_Unrolled16()
+    {
+        var sum = 0.0;
+
+        var i0 = NextIndex();
+        _nCalcContext.A = A[i0];
+        _nCalcContext.B = B[i0];
+        _nCalcContext.C = C[i0];
+        _nCalcContext.D = D[i0];
+        _nCalcContext.E = E[i0];
+        _nCalcContext.F = F[i0];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i1 = NextIndex();
+        _nCalcContext.A = A[i1];
+        _nCalcContext.B = B[i1];
+        _nCalcContext.C = C[i1];
+        _nCalcContext.D = D[i1];
+        _nCalcContext.E = E[i1];
+        _nCalcContext.F = F[i1];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i2 = NextIndex();
+        _nCalcContext.A = A[i2];
+        _nCalcContext.B = B[i2];
+        _nCalcContext.C = C[i2];
+        _nCalcContext.D = D[i2];
+        _nCalcContext.E = E[i2];
+        _nCalcContext.F = F[i2];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i3 = NextIndex();
+        _nCalcContext.A = A[i3];
+        _nCalcContext.B = B[i3];
+        _nCalcContext.C = C[i3];
+        _nCalcContext.D = D[i3];
+        _nCalcContext.E = E[i3];
+        _nCalcContext.F = F[i3];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i4 = NextIndex();
+        _nCalcContext.A = A[i4];
+        _nCalcContext.B = B[i4];
+        _nCalcContext.C = C[i4];
+        _nCalcContext.D = D[i4];
+        _nCalcContext.E = E[i4];
+        _nCalcContext.F = F[i4];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i5 = NextIndex();
+        _nCalcContext.A = A[i5];
+        _nCalcContext.B = B[i5];
+        _nCalcContext.C = C[i5];
+        _nCalcContext.D = D[i5];
+        _nCalcContext.E = E[i5];
+        _nCalcContext.F = F[i5];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i6 = NextIndex();
+        _nCalcContext.A = A[i6];
+        _nCalcContext.B = B[i6];
+        _nCalcContext.C = C[i6];
+        _nCalcContext.D = D[i6];
+        _nCalcContext.E = E[i6];
+        _nCalcContext.F = F[i6];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i7 = NextIndex();
+        _nCalcContext.A = A[i7];
+        _nCalcContext.B = B[i7];
+        _nCalcContext.C = C[i7];
+        _nCalcContext.D = D[i7];
+        _nCalcContext.E = E[i7];
+        _nCalcContext.F = F[i7];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i8 = NextIndex();
+        _nCalcContext.A = A[i8];
+        _nCalcContext.B = B[i8];
+        _nCalcContext.C = C[i8];
+        _nCalcContext.D = D[i8];
+        _nCalcContext.E = E[i8];
+        _nCalcContext.F = F[i8];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i9 = NextIndex();
+        _nCalcContext.A = A[i9];
+        _nCalcContext.B = B[i9];
+        _nCalcContext.C = C[i9];
+        _nCalcContext.D = D[i9];
+        _nCalcContext.E = E[i9];
+        _nCalcContext.F = F[i9];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i10 = NextIndex();
+        _nCalcContext.A = A[i10];
+        _nCalcContext.B = B[i10];
+        _nCalcContext.C = C[i10];
+        _nCalcContext.D = D[i10];
+        _nCalcContext.E = E[i10];
+        _nCalcContext.F = F[i10];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i11 = NextIndex();
+        _nCalcContext.A = A[i11];
+        _nCalcContext.B = B[i11];
+        _nCalcContext.C = C[i11];
+        _nCalcContext.D = D[i11];
+        _nCalcContext.E = E[i11];
+        _nCalcContext.F = F[i11];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i12 = NextIndex();
+        _nCalcContext.A = A[i12];
+        _nCalcContext.B = B[i12];
+        _nCalcContext.C = C[i12];
+        _nCalcContext.D = D[i12];
+        _nCalcContext.E = E[i12];
+        _nCalcContext.F = F[i12];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i13 = NextIndex();
+        _nCalcContext.A = A[i13];
+        _nCalcContext.B = B[i13];
+        _nCalcContext.C = C[i13];
+        _nCalcContext.D = D[i13];
+        _nCalcContext.E = E[i13];
+        _nCalcContext.F = F[i13];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i14 = NextIndex();
+        _nCalcContext.A = A[i14];
+        _nCalcContext.B = B[i14];
+        _nCalcContext.C = C[i14];
+        _nCalcContext.D = D[i14];
+        _nCalcContext.E = E[i14];
+        _nCalcContext.F = F[i14];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i15 = NextIndex();
+        _nCalcContext.A = A[i15];
+        _nCalcContext.B = B[i15];
+        _nCalcContext.C = C[i15];
+        _nCalcContext.D = D[i15];
+        _nCalcContext.E = E[i15];
+        _nCalcContext.F = F[i15];
+        sum += _nCalcLambda(_nCalcContext);
+
+        return sum;
+    }
+
+    [Benchmark(OperationsPerInvoke = 16)]
+    public double Wist_Cil_FastInvoker_Unrolled16()
+    {
+        var sum = 0.0;
+
+        var i0 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i0], B[i0], C[i0], D[i0], E[i0], F[i0]);
+
+        var i1 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i1], B[i1], C[i1], D[i1], E[i1], F[i1]);
+
+        var i2 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i2], B[i2], C[i2], D[i2], E[i2], F[i2]);
+
+        var i3 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i3], B[i3], C[i3], D[i3], E[i3], F[i3]);
+
+        var i4 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i4], B[i4], C[i4], D[i4], E[i4], F[i4]);
+
+        var i5 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i5], B[i5], C[i5], D[i5], E[i5], F[i5]);
+
+        var i6 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i6], B[i6], C[i6], D[i6], E[i6], F[i6]);
+
+        var i7 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i7], B[i7], C[i7], D[i7], E[i7], F[i7]);
+
+        var i8 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i8], B[i8], C[i8], D[i8], E[i8], F[i8]);
+
+        var i9 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i9], B[i9], C[i9], D[i9], E[i9], F[i9]);
+
+        var i10 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i10], B[i10], C[i10], D[i10], E[i10], F[i10]);
+
+        var i11 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i11], B[i11], C[i11], D[i11], E[i11], F[i11]);
+
+        var i12 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i12], B[i12], C[i12], D[i12], E[i12], F[i12]);
+
+        var i13 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i13], B[i13], C[i13], D[i13], E[i13], F[i13]);
+
+        var i14 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i14], B[i14], C[i14], D[i14], E[i14], F[i14]);
+
+        var i15 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i15], B[i15], C[i15], D[i15], E[i15], F[i15]);
+
+        return sum;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static double CSharp_NoInliningMethodCore(double a, double b, double c, double d, double e, double f)
+        => (a * 1.5 + b * 2.0 - c * 3.0 + d / 4.0 + e / 5.0) * 0.75 + f;
+
+    private double CSharpAt(int index)
+        => CSharp_NoInliningMethodCore(A[index], B[index], C[index], D[index], E[index], F[index]);
+
+    private double DynamicExpressoAt(int index)
+        => _dynamicExpressoDelegate(A[index], B[index], C[index], D[index], E[index], F[index]);
+
+    private double NCalcAt(int index)
+    {
+            _nCalcContext.A = A[index];
+            _nCalcContext.B = B[index];
+            _nCalcContext.C = C[index];
+            _nCalcContext.D = D[index];
+            _nCalcContext.E = E[index];
+            _nCalcContext.F = F[index];
+        return _nCalcLambda(_nCalcContext);
+    }
+
+    private double WistAt(int index)
+        => _wistFastInvoker.Invoke(A[index], B[index], C[index], D[index], E[index], F[index]);
+}

--- a/UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/ExternalExecutionBenchmarks/Unrolled16/ExternalDeepChain6ExecutionUnrolled16Benchmarks.cs
+++ b/UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/ExternalExecutionBenchmarks/Unrolled16/ExternalDeepChain6ExecutionUnrolled16Benchmarks.cs
@@ -1,0 +1,392 @@
+using System.Runtime.CompilerServices;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Order;
+using DynamicExpresso;
+using DynamicMethodCalling.Core;
+using NCalc;
+using NCalc.LambdaCompilation;
+
+namespace UniversalToolchain.Benchmarks.ExternalExecutionBenchmarks.Unrolled16;
+
+[MemoryDiagnoser]
+[SimpleJob]
+[Orderer(SummaryOrderPolicy.FastestToSlowest)]
+[RankColumn]
+public sealed class ExternalDeepChain6ExecutionUnrolled16Benchmarks : ExternalArithmeticExecutionUnrolled16BenchmarkEnvironmentBase
+{
+    private const string WistFormula = "((((A * 1.1 + B) * 1.2 + C) * 1.3 + D) * 1.4 + E) / (F + 1.0)";
+    private const string NCalcFormula = "(((([A] * 1.1 + [B]) * 1.2 + [C]) * 1.3 + [D]) * 1.4 + [E]) / ([F] + 1.0)";
+    private const string DynamicExpressoFormula = "((((A * 1.1 + B) * 1.2 + C) * 1.3 + D) * 1.4 + E) / (F + 1.0)";
+
+    private ExternalBenchContext6Unrolled16 _nCalcContext = null!;
+    private Func<ExternalBenchContext6Unrolled16, double> _nCalcLambda = null!;
+    private Func<double, double, double, double, double, double, double> _dynamicExpressoDelegate = null!;
+    private DynamicMethodInvoker<double, double, double, double, double, double, double> _wistFastInvoker = null!;
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        InitializeInputData();
+        CreateProviderAndHost();
+
+        var dynamicMethod = CompileWistDynamicMethod(WistFormula, ["A", "B", "C", "D", "E", "F"]);
+        _wistFastInvoker = new DynamicMethodInvoker<double, double, double, double, double, double, double>(dynamicMethod);
+
+        var nCalcExpression = new Expression(NCalcFormula);
+        _nCalcLambda = nCalcExpression.ToLambda<ExternalBenchContext6Unrolled16, double>();
+        _nCalcContext = new ExternalBenchContext6Unrolled16();
+
+        var dynamicExpressoInterpreter = new Interpreter();
+        _dynamicExpressoDelegate =
+            dynamicExpressoInterpreter.ParseAsDelegate<Func<double, double, double, double, double, double, double>>(
+                DynamicExpressoFormula,
+                "A", "B", "C", "D", "E", "F");
+
+        EnsureResultParityAcrossIndexes(CSharpAt, DynamicExpressoAt, NCalcAt, WistAt);
+    }
+
+    [Benchmark(Baseline = true, OperationsPerInvoke = 16)]
+    public double CSharp_NoInliningMethod_Unrolled16()
+    {
+        var sum = 0.0;
+
+        var i0 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i0], B[i0], C[i0], D[i0], E[i0], F[i0]);
+
+        var i1 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i1], B[i1], C[i1], D[i1], E[i1], F[i1]);
+
+        var i2 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i2], B[i2], C[i2], D[i2], E[i2], F[i2]);
+
+        var i3 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i3], B[i3], C[i3], D[i3], E[i3], F[i3]);
+
+        var i4 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i4], B[i4], C[i4], D[i4], E[i4], F[i4]);
+
+        var i5 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i5], B[i5], C[i5], D[i5], E[i5], F[i5]);
+
+        var i6 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i6], B[i6], C[i6], D[i6], E[i6], F[i6]);
+
+        var i7 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i7], B[i7], C[i7], D[i7], E[i7], F[i7]);
+
+        var i8 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i8], B[i8], C[i8], D[i8], E[i8], F[i8]);
+
+        var i9 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i9], B[i9], C[i9], D[i9], E[i9], F[i9]);
+
+        var i10 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i10], B[i10], C[i10], D[i10], E[i10], F[i10]);
+
+        var i11 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i11], B[i11], C[i11], D[i11], E[i11], F[i11]);
+
+        var i12 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i12], B[i12], C[i12], D[i12], E[i12], F[i12]);
+
+        var i13 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i13], B[i13], C[i13], D[i13], E[i13], F[i13]);
+
+        var i14 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i14], B[i14], C[i14], D[i14], E[i14], F[i14]);
+
+        var i15 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i15], B[i15], C[i15], D[i15], E[i15], F[i15]);
+
+        return sum;
+    }
+
+    [Benchmark(OperationsPerInvoke = 16)]
+    public double DynamicExpresso_Delegate_Unrolled16()
+    {
+        var sum = 0.0;
+
+        var i0 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i0], B[i0], C[i0], D[i0], E[i0], F[i0]);
+
+        var i1 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i1], B[i1], C[i1], D[i1], E[i1], F[i1]);
+
+        var i2 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i2], B[i2], C[i2], D[i2], E[i2], F[i2]);
+
+        var i3 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i3], B[i3], C[i3], D[i3], E[i3], F[i3]);
+
+        var i4 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i4], B[i4], C[i4], D[i4], E[i4], F[i4]);
+
+        var i5 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i5], B[i5], C[i5], D[i5], E[i5], F[i5]);
+
+        var i6 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i6], B[i6], C[i6], D[i6], E[i6], F[i6]);
+
+        var i7 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i7], B[i7], C[i7], D[i7], E[i7], F[i7]);
+
+        var i8 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i8], B[i8], C[i8], D[i8], E[i8], F[i8]);
+
+        var i9 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i9], B[i9], C[i9], D[i9], E[i9], F[i9]);
+
+        var i10 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i10], B[i10], C[i10], D[i10], E[i10], F[i10]);
+
+        var i11 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i11], B[i11], C[i11], D[i11], E[i11], F[i11]);
+
+        var i12 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i12], B[i12], C[i12], D[i12], E[i12], F[i12]);
+
+        var i13 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i13], B[i13], C[i13], D[i13], E[i13], F[i13]);
+
+        var i14 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i14], B[i14], C[i14], D[i14], E[i14], F[i14]);
+
+        var i15 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i15], B[i15], C[i15], D[i15], E[i15], F[i15]);
+
+        return sum;
+    }
+
+    [Benchmark(OperationsPerInvoke = 16)]
+    public double NCalc_Lambda_Unrolled16()
+    {
+        var sum = 0.0;
+
+        var i0 = NextIndex();
+        _nCalcContext.A = A[i0];
+        _nCalcContext.B = B[i0];
+        _nCalcContext.C = C[i0];
+        _nCalcContext.D = D[i0];
+        _nCalcContext.E = E[i0];
+        _nCalcContext.F = F[i0];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i1 = NextIndex();
+        _nCalcContext.A = A[i1];
+        _nCalcContext.B = B[i1];
+        _nCalcContext.C = C[i1];
+        _nCalcContext.D = D[i1];
+        _nCalcContext.E = E[i1];
+        _nCalcContext.F = F[i1];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i2 = NextIndex();
+        _nCalcContext.A = A[i2];
+        _nCalcContext.B = B[i2];
+        _nCalcContext.C = C[i2];
+        _nCalcContext.D = D[i2];
+        _nCalcContext.E = E[i2];
+        _nCalcContext.F = F[i2];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i3 = NextIndex();
+        _nCalcContext.A = A[i3];
+        _nCalcContext.B = B[i3];
+        _nCalcContext.C = C[i3];
+        _nCalcContext.D = D[i3];
+        _nCalcContext.E = E[i3];
+        _nCalcContext.F = F[i3];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i4 = NextIndex();
+        _nCalcContext.A = A[i4];
+        _nCalcContext.B = B[i4];
+        _nCalcContext.C = C[i4];
+        _nCalcContext.D = D[i4];
+        _nCalcContext.E = E[i4];
+        _nCalcContext.F = F[i4];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i5 = NextIndex();
+        _nCalcContext.A = A[i5];
+        _nCalcContext.B = B[i5];
+        _nCalcContext.C = C[i5];
+        _nCalcContext.D = D[i5];
+        _nCalcContext.E = E[i5];
+        _nCalcContext.F = F[i5];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i6 = NextIndex();
+        _nCalcContext.A = A[i6];
+        _nCalcContext.B = B[i6];
+        _nCalcContext.C = C[i6];
+        _nCalcContext.D = D[i6];
+        _nCalcContext.E = E[i6];
+        _nCalcContext.F = F[i6];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i7 = NextIndex();
+        _nCalcContext.A = A[i7];
+        _nCalcContext.B = B[i7];
+        _nCalcContext.C = C[i7];
+        _nCalcContext.D = D[i7];
+        _nCalcContext.E = E[i7];
+        _nCalcContext.F = F[i7];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i8 = NextIndex();
+        _nCalcContext.A = A[i8];
+        _nCalcContext.B = B[i8];
+        _nCalcContext.C = C[i8];
+        _nCalcContext.D = D[i8];
+        _nCalcContext.E = E[i8];
+        _nCalcContext.F = F[i8];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i9 = NextIndex();
+        _nCalcContext.A = A[i9];
+        _nCalcContext.B = B[i9];
+        _nCalcContext.C = C[i9];
+        _nCalcContext.D = D[i9];
+        _nCalcContext.E = E[i9];
+        _nCalcContext.F = F[i9];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i10 = NextIndex();
+        _nCalcContext.A = A[i10];
+        _nCalcContext.B = B[i10];
+        _nCalcContext.C = C[i10];
+        _nCalcContext.D = D[i10];
+        _nCalcContext.E = E[i10];
+        _nCalcContext.F = F[i10];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i11 = NextIndex();
+        _nCalcContext.A = A[i11];
+        _nCalcContext.B = B[i11];
+        _nCalcContext.C = C[i11];
+        _nCalcContext.D = D[i11];
+        _nCalcContext.E = E[i11];
+        _nCalcContext.F = F[i11];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i12 = NextIndex();
+        _nCalcContext.A = A[i12];
+        _nCalcContext.B = B[i12];
+        _nCalcContext.C = C[i12];
+        _nCalcContext.D = D[i12];
+        _nCalcContext.E = E[i12];
+        _nCalcContext.F = F[i12];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i13 = NextIndex();
+        _nCalcContext.A = A[i13];
+        _nCalcContext.B = B[i13];
+        _nCalcContext.C = C[i13];
+        _nCalcContext.D = D[i13];
+        _nCalcContext.E = E[i13];
+        _nCalcContext.F = F[i13];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i14 = NextIndex();
+        _nCalcContext.A = A[i14];
+        _nCalcContext.B = B[i14];
+        _nCalcContext.C = C[i14];
+        _nCalcContext.D = D[i14];
+        _nCalcContext.E = E[i14];
+        _nCalcContext.F = F[i14];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i15 = NextIndex();
+        _nCalcContext.A = A[i15];
+        _nCalcContext.B = B[i15];
+        _nCalcContext.C = C[i15];
+        _nCalcContext.D = D[i15];
+        _nCalcContext.E = E[i15];
+        _nCalcContext.F = F[i15];
+        sum += _nCalcLambda(_nCalcContext);
+
+        return sum;
+    }
+
+    [Benchmark(OperationsPerInvoke = 16)]
+    public double Wist_Cil_FastInvoker_Unrolled16()
+    {
+        var sum = 0.0;
+
+        var i0 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i0], B[i0], C[i0], D[i0], E[i0], F[i0]);
+
+        var i1 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i1], B[i1], C[i1], D[i1], E[i1], F[i1]);
+
+        var i2 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i2], B[i2], C[i2], D[i2], E[i2], F[i2]);
+
+        var i3 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i3], B[i3], C[i3], D[i3], E[i3], F[i3]);
+
+        var i4 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i4], B[i4], C[i4], D[i4], E[i4], F[i4]);
+
+        var i5 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i5], B[i5], C[i5], D[i5], E[i5], F[i5]);
+
+        var i6 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i6], B[i6], C[i6], D[i6], E[i6], F[i6]);
+
+        var i7 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i7], B[i7], C[i7], D[i7], E[i7], F[i7]);
+
+        var i8 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i8], B[i8], C[i8], D[i8], E[i8], F[i8]);
+
+        var i9 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i9], B[i9], C[i9], D[i9], E[i9], F[i9]);
+
+        var i10 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i10], B[i10], C[i10], D[i10], E[i10], F[i10]);
+
+        var i11 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i11], B[i11], C[i11], D[i11], E[i11], F[i11]);
+
+        var i12 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i12], B[i12], C[i12], D[i12], E[i12], F[i12]);
+
+        var i13 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i13], B[i13], C[i13], D[i13], E[i13], F[i13]);
+
+        var i14 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i14], B[i14], C[i14], D[i14], E[i14], F[i14]);
+
+        var i15 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i15], B[i15], C[i15], D[i15], E[i15], F[i15]);
+
+        return sum;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static double CSharp_NoInliningMethodCore(double a, double b, double c, double d, double e, double f)
+        => ((((a * 1.1 + b) * 1.2 + c) * 1.3 + d) * 1.4 + e) / (f + 1.0);
+
+    private double CSharpAt(int index)
+        => CSharp_NoInliningMethodCore(A[index], B[index], C[index], D[index], E[index], F[index]);
+
+    private double DynamicExpressoAt(int index)
+        => _dynamicExpressoDelegate(A[index], B[index], C[index], D[index], E[index], F[index]);
+
+    private double NCalcAt(int index)
+    {
+            _nCalcContext.A = A[index];
+            _nCalcContext.B = B[index];
+            _nCalcContext.C = C[index];
+            _nCalcContext.D = D[index];
+            _nCalcContext.E = E[index];
+            _nCalcContext.F = F[index];
+        return _nCalcLambda(_nCalcContext);
+    }
+
+    private double WistAt(int index)
+        => _wistFastInvoker.Invoke(A[index], B[index], C[index], D[index], E[index], F[index]);
+}

--- a/UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/ExternalExecutionBenchmarks/Unrolled16/ExternalMedium8ExecutionUnrolled16Benchmarks.cs
+++ b/UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/ExternalExecutionBenchmarks/Unrolled16/ExternalMedium8ExecutionUnrolled16Benchmarks.cs
@@ -1,0 +1,426 @@
+using System.Runtime.CompilerServices;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Order;
+using DynamicExpresso;
+using DynamicMethodCalling.Core;
+using NCalc;
+using NCalc.LambdaCompilation;
+
+namespace UniversalToolchain.Benchmarks.ExternalExecutionBenchmarks.Unrolled16;
+
+[MemoryDiagnoser]
+[SimpleJob]
+[Orderer(SummaryOrderPolicy.FastestToSlowest)]
+[RankColumn]
+public sealed class ExternalMedium8ExecutionUnrolled16Benchmarks : ExternalArithmeticExecutionUnrolled16BenchmarkEnvironmentBase
+{
+    private const string WistFormula = "((A + B) * (C - D) / (E + 1.0)) + F * G - H / 3.0";
+    private const string NCalcFormula = "(([A] + [B]) * ([C] - [D]) / ([E] + 1.0)) + [F] * [G] - [H] / 3.0";
+    private const string DynamicExpressoFormula = "((A + B) * (C - D) / (E + 1.0)) + F * G - H / 3.0";
+
+    private ExternalBenchContext8Unrolled16 _nCalcContext = null!;
+    private Func<ExternalBenchContext8Unrolled16, double> _nCalcLambda = null!;
+    private Func<double, double, double, double, double, double, double, double, double> _dynamicExpressoDelegate = null!;
+    private DynamicMethodInvoker<double, double, double, double, double, double, double, double, double> _wistFastInvoker = null!;
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        InitializeInputData();
+        CreateProviderAndHost();
+
+        var dynamicMethod = CompileWistDynamicMethod(WistFormula, ["A", "B", "C", "D", "E", "F", "G", "H"]);
+        _wistFastInvoker = new DynamicMethodInvoker<double, double, double, double, double, double, double, double, double>(dynamicMethod);
+
+        var nCalcExpression = new Expression(NCalcFormula);
+        _nCalcLambda = nCalcExpression.ToLambda<ExternalBenchContext8Unrolled16, double>();
+        _nCalcContext = new ExternalBenchContext8Unrolled16();
+
+        var dynamicExpressoInterpreter = new Interpreter();
+        _dynamicExpressoDelegate =
+            dynamicExpressoInterpreter.ParseAsDelegate<Func<double, double, double, double, double, double, double, double, double>>(
+                DynamicExpressoFormula,
+                "A", "B", "C", "D", "E", "F", "G", "H");
+
+        EnsureResultParityAcrossIndexes(CSharpAt, DynamicExpressoAt, NCalcAt, WistAt);
+    }
+
+    [Benchmark(Baseline = true, OperationsPerInvoke = 16)]
+    public double CSharp_NoInliningMethod_Unrolled16()
+    {
+        var sum = 0.0;
+
+        var i0 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i0], B[i0], C[i0], D[i0], E[i0], F[i0], G[i0], H[i0]);
+
+        var i1 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i1], B[i1], C[i1], D[i1], E[i1], F[i1], G[i1], H[i1]);
+
+        var i2 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i2], B[i2], C[i2], D[i2], E[i2], F[i2], G[i2], H[i2]);
+
+        var i3 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i3], B[i3], C[i3], D[i3], E[i3], F[i3], G[i3], H[i3]);
+
+        var i4 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i4], B[i4], C[i4], D[i4], E[i4], F[i4], G[i4], H[i4]);
+
+        var i5 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i5], B[i5], C[i5], D[i5], E[i5], F[i5], G[i5], H[i5]);
+
+        var i6 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i6], B[i6], C[i6], D[i6], E[i6], F[i6], G[i6], H[i6]);
+
+        var i7 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i7], B[i7], C[i7], D[i7], E[i7], F[i7], G[i7], H[i7]);
+
+        var i8 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i8], B[i8], C[i8], D[i8], E[i8], F[i8], G[i8], H[i8]);
+
+        var i9 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i9], B[i9], C[i9], D[i9], E[i9], F[i9], G[i9], H[i9]);
+
+        var i10 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i10], B[i10], C[i10], D[i10], E[i10], F[i10], G[i10], H[i10]);
+
+        var i11 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i11], B[i11], C[i11], D[i11], E[i11], F[i11], G[i11], H[i11]);
+
+        var i12 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i12], B[i12], C[i12], D[i12], E[i12], F[i12], G[i12], H[i12]);
+
+        var i13 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i13], B[i13], C[i13], D[i13], E[i13], F[i13], G[i13], H[i13]);
+
+        var i14 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i14], B[i14], C[i14], D[i14], E[i14], F[i14], G[i14], H[i14]);
+
+        var i15 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i15], B[i15], C[i15], D[i15], E[i15], F[i15], G[i15], H[i15]);
+
+        return sum;
+    }
+
+    [Benchmark(OperationsPerInvoke = 16)]
+    public double DynamicExpresso_Delegate_Unrolled16()
+    {
+        var sum = 0.0;
+
+        var i0 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i0], B[i0], C[i0], D[i0], E[i0], F[i0], G[i0], H[i0]);
+
+        var i1 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i1], B[i1], C[i1], D[i1], E[i1], F[i1], G[i1], H[i1]);
+
+        var i2 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i2], B[i2], C[i2], D[i2], E[i2], F[i2], G[i2], H[i2]);
+
+        var i3 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i3], B[i3], C[i3], D[i3], E[i3], F[i3], G[i3], H[i3]);
+
+        var i4 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i4], B[i4], C[i4], D[i4], E[i4], F[i4], G[i4], H[i4]);
+
+        var i5 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i5], B[i5], C[i5], D[i5], E[i5], F[i5], G[i5], H[i5]);
+
+        var i6 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i6], B[i6], C[i6], D[i6], E[i6], F[i6], G[i6], H[i6]);
+
+        var i7 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i7], B[i7], C[i7], D[i7], E[i7], F[i7], G[i7], H[i7]);
+
+        var i8 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i8], B[i8], C[i8], D[i8], E[i8], F[i8], G[i8], H[i8]);
+
+        var i9 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i9], B[i9], C[i9], D[i9], E[i9], F[i9], G[i9], H[i9]);
+
+        var i10 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i10], B[i10], C[i10], D[i10], E[i10], F[i10], G[i10], H[i10]);
+
+        var i11 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i11], B[i11], C[i11], D[i11], E[i11], F[i11], G[i11], H[i11]);
+
+        var i12 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i12], B[i12], C[i12], D[i12], E[i12], F[i12], G[i12], H[i12]);
+
+        var i13 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i13], B[i13], C[i13], D[i13], E[i13], F[i13], G[i13], H[i13]);
+
+        var i14 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i14], B[i14], C[i14], D[i14], E[i14], F[i14], G[i14], H[i14]);
+
+        var i15 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i15], B[i15], C[i15], D[i15], E[i15], F[i15], G[i15], H[i15]);
+
+        return sum;
+    }
+
+    [Benchmark(OperationsPerInvoke = 16)]
+    public double NCalc_Lambda_Unrolled16()
+    {
+        var sum = 0.0;
+
+        var i0 = NextIndex();
+        _nCalcContext.A = A[i0];
+        _nCalcContext.B = B[i0];
+        _nCalcContext.C = C[i0];
+        _nCalcContext.D = D[i0];
+        _nCalcContext.E = E[i0];
+        _nCalcContext.F = F[i0];
+        _nCalcContext.G = G[i0];
+        _nCalcContext.H = H[i0];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i1 = NextIndex();
+        _nCalcContext.A = A[i1];
+        _nCalcContext.B = B[i1];
+        _nCalcContext.C = C[i1];
+        _nCalcContext.D = D[i1];
+        _nCalcContext.E = E[i1];
+        _nCalcContext.F = F[i1];
+        _nCalcContext.G = G[i1];
+        _nCalcContext.H = H[i1];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i2 = NextIndex();
+        _nCalcContext.A = A[i2];
+        _nCalcContext.B = B[i2];
+        _nCalcContext.C = C[i2];
+        _nCalcContext.D = D[i2];
+        _nCalcContext.E = E[i2];
+        _nCalcContext.F = F[i2];
+        _nCalcContext.G = G[i2];
+        _nCalcContext.H = H[i2];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i3 = NextIndex();
+        _nCalcContext.A = A[i3];
+        _nCalcContext.B = B[i3];
+        _nCalcContext.C = C[i3];
+        _nCalcContext.D = D[i3];
+        _nCalcContext.E = E[i3];
+        _nCalcContext.F = F[i3];
+        _nCalcContext.G = G[i3];
+        _nCalcContext.H = H[i3];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i4 = NextIndex();
+        _nCalcContext.A = A[i4];
+        _nCalcContext.B = B[i4];
+        _nCalcContext.C = C[i4];
+        _nCalcContext.D = D[i4];
+        _nCalcContext.E = E[i4];
+        _nCalcContext.F = F[i4];
+        _nCalcContext.G = G[i4];
+        _nCalcContext.H = H[i4];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i5 = NextIndex();
+        _nCalcContext.A = A[i5];
+        _nCalcContext.B = B[i5];
+        _nCalcContext.C = C[i5];
+        _nCalcContext.D = D[i5];
+        _nCalcContext.E = E[i5];
+        _nCalcContext.F = F[i5];
+        _nCalcContext.G = G[i5];
+        _nCalcContext.H = H[i5];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i6 = NextIndex();
+        _nCalcContext.A = A[i6];
+        _nCalcContext.B = B[i6];
+        _nCalcContext.C = C[i6];
+        _nCalcContext.D = D[i6];
+        _nCalcContext.E = E[i6];
+        _nCalcContext.F = F[i6];
+        _nCalcContext.G = G[i6];
+        _nCalcContext.H = H[i6];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i7 = NextIndex();
+        _nCalcContext.A = A[i7];
+        _nCalcContext.B = B[i7];
+        _nCalcContext.C = C[i7];
+        _nCalcContext.D = D[i7];
+        _nCalcContext.E = E[i7];
+        _nCalcContext.F = F[i7];
+        _nCalcContext.G = G[i7];
+        _nCalcContext.H = H[i7];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i8 = NextIndex();
+        _nCalcContext.A = A[i8];
+        _nCalcContext.B = B[i8];
+        _nCalcContext.C = C[i8];
+        _nCalcContext.D = D[i8];
+        _nCalcContext.E = E[i8];
+        _nCalcContext.F = F[i8];
+        _nCalcContext.G = G[i8];
+        _nCalcContext.H = H[i8];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i9 = NextIndex();
+        _nCalcContext.A = A[i9];
+        _nCalcContext.B = B[i9];
+        _nCalcContext.C = C[i9];
+        _nCalcContext.D = D[i9];
+        _nCalcContext.E = E[i9];
+        _nCalcContext.F = F[i9];
+        _nCalcContext.G = G[i9];
+        _nCalcContext.H = H[i9];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i10 = NextIndex();
+        _nCalcContext.A = A[i10];
+        _nCalcContext.B = B[i10];
+        _nCalcContext.C = C[i10];
+        _nCalcContext.D = D[i10];
+        _nCalcContext.E = E[i10];
+        _nCalcContext.F = F[i10];
+        _nCalcContext.G = G[i10];
+        _nCalcContext.H = H[i10];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i11 = NextIndex();
+        _nCalcContext.A = A[i11];
+        _nCalcContext.B = B[i11];
+        _nCalcContext.C = C[i11];
+        _nCalcContext.D = D[i11];
+        _nCalcContext.E = E[i11];
+        _nCalcContext.F = F[i11];
+        _nCalcContext.G = G[i11];
+        _nCalcContext.H = H[i11];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i12 = NextIndex();
+        _nCalcContext.A = A[i12];
+        _nCalcContext.B = B[i12];
+        _nCalcContext.C = C[i12];
+        _nCalcContext.D = D[i12];
+        _nCalcContext.E = E[i12];
+        _nCalcContext.F = F[i12];
+        _nCalcContext.G = G[i12];
+        _nCalcContext.H = H[i12];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i13 = NextIndex();
+        _nCalcContext.A = A[i13];
+        _nCalcContext.B = B[i13];
+        _nCalcContext.C = C[i13];
+        _nCalcContext.D = D[i13];
+        _nCalcContext.E = E[i13];
+        _nCalcContext.F = F[i13];
+        _nCalcContext.G = G[i13];
+        _nCalcContext.H = H[i13];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i14 = NextIndex();
+        _nCalcContext.A = A[i14];
+        _nCalcContext.B = B[i14];
+        _nCalcContext.C = C[i14];
+        _nCalcContext.D = D[i14];
+        _nCalcContext.E = E[i14];
+        _nCalcContext.F = F[i14];
+        _nCalcContext.G = G[i14];
+        _nCalcContext.H = H[i14];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i15 = NextIndex();
+        _nCalcContext.A = A[i15];
+        _nCalcContext.B = B[i15];
+        _nCalcContext.C = C[i15];
+        _nCalcContext.D = D[i15];
+        _nCalcContext.E = E[i15];
+        _nCalcContext.F = F[i15];
+        _nCalcContext.G = G[i15];
+        _nCalcContext.H = H[i15];
+        sum += _nCalcLambda(_nCalcContext);
+
+        return sum;
+    }
+
+    [Benchmark(OperationsPerInvoke = 16)]
+    public double Wist_Cil_FastInvoker_Unrolled16()
+    {
+        var sum = 0.0;
+
+        var i0 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i0], B[i0], C[i0], D[i0], E[i0], F[i0], G[i0], H[i0]);
+
+        var i1 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i1], B[i1], C[i1], D[i1], E[i1], F[i1], G[i1], H[i1]);
+
+        var i2 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i2], B[i2], C[i2], D[i2], E[i2], F[i2], G[i2], H[i2]);
+
+        var i3 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i3], B[i3], C[i3], D[i3], E[i3], F[i3], G[i3], H[i3]);
+
+        var i4 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i4], B[i4], C[i4], D[i4], E[i4], F[i4], G[i4], H[i4]);
+
+        var i5 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i5], B[i5], C[i5], D[i5], E[i5], F[i5], G[i5], H[i5]);
+
+        var i6 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i6], B[i6], C[i6], D[i6], E[i6], F[i6], G[i6], H[i6]);
+
+        var i7 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i7], B[i7], C[i7], D[i7], E[i7], F[i7], G[i7], H[i7]);
+
+        var i8 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i8], B[i8], C[i8], D[i8], E[i8], F[i8], G[i8], H[i8]);
+
+        var i9 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i9], B[i9], C[i9], D[i9], E[i9], F[i9], G[i9], H[i9]);
+
+        var i10 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i10], B[i10], C[i10], D[i10], E[i10], F[i10], G[i10], H[i10]);
+
+        var i11 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i11], B[i11], C[i11], D[i11], E[i11], F[i11], G[i11], H[i11]);
+
+        var i12 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i12], B[i12], C[i12], D[i12], E[i12], F[i12], G[i12], H[i12]);
+
+        var i13 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i13], B[i13], C[i13], D[i13], E[i13], F[i13], G[i13], H[i13]);
+
+        var i14 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i14], B[i14], C[i14], D[i14], E[i14], F[i14], G[i14], H[i14]);
+
+        var i15 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i15], B[i15], C[i15], D[i15], E[i15], F[i15], G[i15], H[i15]);
+
+        return sum;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static double CSharp_NoInliningMethodCore(double a, double b, double c, double d, double e, double f, double g, double h)
+        => ((a + b) * (c - d) / (e + 1.0)) + f * g - h / 3.0;
+
+    private double CSharpAt(int index)
+        => CSharp_NoInliningMethodCore(A[index], B[index], C[index], D[index], E[index], F[index], G[index], H[index]);
+
+    private double DynamicExpressoAt(int index)
+        => _dynamicExpressoDelegate(A[index], B[index], C[index], D[index], E[index], F[index], G[index], H[index]);
+
+    private double NCalcAt(int index)
+    {
+            _nCalcContext.A = A[index];
+            _nCalcContext.B = B[index];
+            _nCalcContext.C = C[index];
+            _nCalcContext.D = D[index];
+            _nCalcContext.E = E[index];
+            _nCalcContext.F = F[index];
+            _nCalcContext.G = G[index];
+            _nCalcContext.H = H[index];
+        return _nCalcLambda(_nCalcContext);
+    }
+
+    private double WistAt(int index)
+        => _wistFastInvoker.Invoke(A[index], B[index], C[index], D[index], E[index], F[index], G[index], H[index]);
+}

--- a/UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/ExternalExecutionBenchmarks/Unrolled16/ExternalRepeatedSubexpressions5ExecutionUnrolled16Benchmarks.cs
+++ b/UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/ExternalExecutionBenchmarks/Unrolled16/ExternalRepeatedSubexpressions5ExecutionUnrolled16Benchmarks.cs
@@ -1,0 +1,375 @@
+using System.Runtime.CompilerServices;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Order;
+using DynamicExpresso;
+using DynamicMethodCalling.Core;
+using NCalc;
+using NCalc.LambdaCompilation;
+
+namespace UniversalToolchain.Benchmarks.ExternalExecutionBenchmarks.Unrolled16;
+
+[MemoryDiagnoser]
+[SimpleJob]
+[Orderer(SummaryOrderPolicy.FastestToSlowest)]
+[RankColumn]
+public sealed class ExternalRepeatedSubexpressions5ExecutionUnrolled16Benchmarks : ExternalArithmeticExecutionUnrolled16BenchmarkEnvironmentBase
+{
+    private const string WistFormula = "((A * B) + (A * B) + (A * B) + (C * D)) / (E + 1.0)";
+    private const string NCalcFormula = "(([A] * [B]) + ([A] * [B]) + ([A] * [B]) + ([C] * [D])) / ([E] + 1.0)";
+    private const string DynamicExpressoFormula = "((A * B) + (A * B) + (A * B) + (C * D)) / (E + 1.0)";
+
+    private ExternalBenchContext5Unrolled16 _nCalcContext = null!;
+    private Func<ExternalBenchContext5Unrolled16, double> _nCalcLambda = null!;
+    private Func<double, double, double, double, double, double> _dynamicExpressoDelegate = null!;
+    private DynamicMethodInvoker<double, double, double, double, double, double> _wistFastInvoker = null!;
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        InitializeInputData();
+        CreateProviderAndHost();
+
+        var dynamicMethod = CompileWistDynamicMethod(WistFormula, ["A", "B", "C", "D", "E"]);
+        _wistFastInvoker = new DynamicMethodInvoker<double, double, double, double, double, double>(dynamicMethod);
+
+        var nCalcExpression = new Expression(NCalcFormula);
+        _nCalcLambda = nCalcExpression.ToLambda<ExternalBenchContext5Unrolled16, double>();
+        _nCalcContext = new ExternalBenchContext5Unrolled16();
+
+        var dynamicExpressoInterpreter = new Interpreter();
+        _dynamicExpressoDelegate =
+            dynamicExpressoInterpreter.ParseAsDelegate<Func<double, double, double, double, double, double>>(
+                DynamicExpressoFormula,
+                "A", "B", "C", "D", "E");
+
+        EnsureResultParityAcrossIndexes(CSharpAt, DynamicExpressoAt, NCalcAt, WistAt);
+    }
+
+    [Benchmark(Baseline = true, OperationsPerInvoke = 16)]
+    public double CSharp_NoInliningMethod_Unrolled16()
+    {
+        var sum = 0.0;
+
+        var i0 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i0], B[i0], C[i0], D[i0], E[i0]);
+
+        var i1 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i1], B[i1], C[i1], D[i1], E[i1]);
+
+        var i2 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i2], B[i2], C[i2], D[i2], E[i2]);
+
+        var i3 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i3], B[i3], C[i3], D[i3], E[i3]);
+
+        var i4 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i4], B[i4], C[i4], D[i4], E[i4]);
+
+        var i5 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i5], B[i5], C[i5], D[i5], E[i5]);
+
+        var i6 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i6], B[i6], C[i6], D[i6], E[i6]);
+
+        var i7 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i7], B[i7], C[i7], D[i7], E[i7]);
+
+        var i8 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i8], B[i8], C[i8], D[i8], E[i8]);
+
+        var i9 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i9], B[i9], C[i9], D[i9], E[i9]);
+
+        var i10 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i10], B[i10], C[i10], D[i10], E[i10]);
+
+        var i11 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i11], B[i11], C[i11], D[i11], E[i11]);
+
+        var i12 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i12], B[i12], C[i12], D[i12], E[i12]);
+
+        var i13 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i13], B[i13], C[i13], D[i13], E[i13]);
+
+        var i14 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i14], B[i14], C[i14], D[i14], E[i14]);
+
+        var i15 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i15], B[i15], C[i15], D[i15], E[i15]);
+
+        return sum;
+    }
+
+    [Benchmark(OperationsPerInvoke = 16)]
+    public double DynamicExpresso_Delegate_Unrolled16()
+    {
+        var sum = 0.0;
+
+        var i0 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i0], B[i0], C[i0], D[i0], E[i0]);
+
+        var i1 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i1], B[i1], C[i1], D[i1], E[i1]);
+
+        var i2 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i2], B[i2], C[i2], D[i2], E[i2]);
+
+        var i3 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i3], B[i3], C[i3], D[i3], E[i3]);
+
+        var i4 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i4], B[i4], C[i4], D[i4], E[i4]);
+
+        var i5 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i5], B[i5], C[i5], D[i5], E[i5]);
+
+        var i6 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i6], B[i6], C[i6], D[i6], E[i6]);
+
+        var i7 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i7], B[i7], C[i7], D[i7], E[i7]);
+
+        var i8 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i8], B[i8], C[i8], D[i8], E[i8]);
+
+        var i9 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i9], B[i9], C[i9], D[i9], E[i9]);
+
+        var i10 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i10], B[i10], C[i10], D[i10], E[i10]);
+
+        var i11 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i11], B[i11], C[i11], D[i11], E[i11]);
+
+        var i12 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i12], B[i12], C[i12], D[i12], E[i12]);
+
+        var i13 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i13], B[i13], C[i13], D[i13], E[i13]);
+
+        var i14 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i14], B[i14], C[i14], D[i14], E[i14]);
+
+        var i15 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i15], B[i15], C[i15], D[i15], E[i15]);
+
+        return sum;
+    }
+
+    [Benchmark(OperationsPerInvoke = 16)]
+    public double NCalc_Lambda_Unrolled16()
+    {
+        var sum = 0.0;
+
+        var i0 = NextIndex();
+        _nCalcContext.A = A[i0];
+        _nCalcContext.B = B[i0];
+        _nCalcContext.C = C[i0];
+        _nCalcContext.D = D[i0];
+        _nCalcContext.E = E[i0];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i1 = NextIndex();
+        _nCalcContext.A = A[i1];
+        _nCalcContext.B = B[i1];
+        _nCalcContext.C = C[i1];
+        _nCalcContext.D = D[i1];
+        _nCalcContext.E = E[i1];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i2 = NextIndex();
+        _nCalcContext.A = A[i2];
+        _nCalcContext.B = B[i2];
+        _nCalcContext.C = C[i2];
+        _nCalcContext.D = D[i2];
+        _nCalcContext.E = E[i2];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i3 = NextIndex();
+        _nCalcContext.A = A[i3];
+        _nCalcContext.B = B[i3];
+        _nCalcContext.C = C[i3];
+        _nCalcContext.D = D[i3];
+        _nCalcContext.E = E[i3];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i4 = NextIndex();
+        _nCalcContext.A = A[i4];
+        _nCalcContext.B = B[i4];
+        _nCalcContext.C = C[i4];
+        _nCalcContext.D = D[i4];
+        _nCalcContext.E = E[i4];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i5 = NextIndex();
+        _nCalcContext.A = A[i5];
+        _nCalcContext.B = B[i5];
+        _nCalcContext.C = C[i5];
+        _nCalcContext.D = D[i5];
+        _nCalcContext.E = E[i5];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i6 = NextIndex();
+        _nCalcContext.A = A[i6];
+        _nCalcContext.B = B[i6];
+        _nCalcContext.C = C[i6];
+        _nCalcContext.D = D[i6];
+        _nCalcContext.E = E[i6];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i7 = NextIndex();
+        _nCalcContext.A = A[i7];
+        _nCalcContext.B = B[i7];
+        _nCalcContext.C = C[i7];
+        _nCalcContext.D = D[i7];
+        _nCalcContext.E = E[i7];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i8 = NextIndex();
+        _nCalcContext.A = A[i8];
+        _nCalcContext.B = B[i8];
+        _nCalcContext.C = C[i8];
+        _nCalcContext.D = D[i8];
+        _nCalcContext.E = E[i8];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i9 = NextIndex();
+        _nCalcContext.A = A[i9];
+        _nCalcContext.B = B[i9];
+        _nCalcContext.C = C[i9];
+        _nCalcContext.D = D[i9];
+        _nCalcContext.E = E[i9];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i10 = NextIndex();
+        _nCalcContext.A = A[i10];
+        _nCalcContext.B = B[i10];
+        _nCalcContext.C = C[i10];
+        _nCalcContext.D = D[i10];
+        _nCalcContext.E = E[i10];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i11 = NextIndex();
+        _nCalcContext.A = A[i11];
+        _nCalcContext.B = B[i11];
+        _nCalcContext.C = C[i11];
+        _nCalcContext.D = D[i11];
+        _nCalcContext.E = E[i11];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i12 = NextIndex();
+        _nCalcContext.A = A[i12];
+        _nCalcContext.B = B[i12];
+        _nCalcContext.C = C[i12];
+        _nCalcContext.D = D[i12];
+        _nCalcContext.E = E[i12];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i13 = NextIndex();
+        _nCalcContext.A = A[i13];
+        _nCalcContext.B = B[i13];
+        _nCalcContext.C = C[i13];
+        _nCalcContext.D = D[i13];
+        _nCalcContext.E = E[i13];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i14 = NextIndex();
+        _nCalcContext.A = A[i14];
+        _nCalcContext.B = B[i14];
+        _nCalcContext.C = C[i14];
+        _nCalcContext.D = D[i14];
+        _nCalcContext.E = E[i14];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i15 = NextIndex();
+        _nCalcContext.A = A[i15];
+        _nCalcContext.B = B[i15];
+        _nCalcContext.C = C[i15];
+        _nCalcContext.D = D[i15];
+        _nCalcContext.E = E[i15];
+        sum += _nCalcLambda(_nCalcContext);
+
+        return sum;
+    }
+
+    [Benchmark(OperationsPerInvoke = 16)]
+    public double Wist_Cil_FastInvoker_Unrolled16()
+    {
+        var sum = 0.0;
+
+        var i0 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i0], B[i0], C[i0], D[i0], E[i0]);
+
+        var i1 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i1], B[i1], C[i1], D[i1], E[i1]);
+
+        var i2 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i2], B[i2], C[i2], D[i2], E[i2]);
+
+        var i3 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i3], B[i3], C[i3], D[i3], E[i3]);
+
+        var i4 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i4], B[i4], C[i4], D[i4], E[i4]);
+
+        var i5 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i5], B[i5], C[i5], D[i5], E[i5]);
+
+        var i6 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i6], B[i6], C[i6], D[i6], E[i6]);
+
+        var i7 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i7], B[i7], C[i7], D[i7], E[i7]);
+
+        var i8 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i8], B[i8], C[i8], D[i8], E[i8]);
+
+        var i9 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i9], B[i9], C[i9], D[i9], E[i9]);
+
+        var i10 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i10], B[i10], C[i10], D[i10], E[i10]);
+
+        var i11 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i11], B[i11], C[i11], D[i11], E[i11]);
+
+        var i12 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i12], B[i12], C[i12], D[i12], E[i12]);
+
+        var i13 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i13], B[i13], C[i13], D[i13], E[i13]);
+
+        var i14 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i14], B[i14], C[i14], D[i14], E[i14]);
+
+        var i15 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i15], B[i15], C[i15], D[i15], E[i15]);
+
+        return sum;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static double CSharp_NoInliningMethodCore(double a, double b, double c, double d, double e)
+        => ((a * b) + (a * b) + (a * b) + (c * d)) / (e + 1.0);
+
+    private double CSharpAt(int index)
+        => CSharp_NoInliningMethodCore(A[index], B[index], C[index], D[index], E[index]);
+
+    private double DynamicExpressoAt(int index)
+        => _dynamicExpressoDelegate(A[index], B[index], C[index], D[index], E[index]);
+
+    private double NCalcAt(int index)
+    {
+            _nCalcContext.A = A[index];
+            _nCalcContext.B = B[index];
+            _nCalcContext.C = C[index];
+            _nCalcContext.D = D[index];
+            _nCalcContext.E = E[index];
+        return _nCalcLambda(_nCalcContext);
+    }
+
+    private double WistAt(int index)
+        => _wistFastInvoker.Invoke(A[index], B[index], C[index], D[index], E[index]);
+}

--- a/UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/ExternalExecutionBenchmarks/Unrolled16/ExternalSimple3ExecutionUnrolled16Benchmarks.cs
+++ b/UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/ExternalExecutionBenchmarks/Unrolled16/ExternalSimple3ExecutionUnrolled16Benchmarks.cs
@@ -1,0 +1,341 @@
+using System.Runtime.CompilerServices;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Order;
+using DynamicExpresso;
+using DynamicMethodCalling.Core;
+using NCalc;
+using NCalc.LambdaCompilation;
+
+namespace UniversalToolchain.Benchmarks.ExternalExecutionBenchmarks.Unrolled16;
+
+[MemoryDiagnoser]
+[SimpleJob]
+[Orderer(SummaryOrderPolicy.FastestToSlowest)]
+[RankColumn]
+public sealed class ExternalSimple3ExecutionUnrolled16Benchmarks : ExternalArithmeticExecutionUnrolled16BenchmarkEnvironmentBase
+{
+    private const string WistFormula = "A + B * C / 5.0";
+    private const string NCalcFormula = "[A] + [B] * [C] / 5.0";
+    private const string DynamicExpressoFormula = "A + B * C / 5.0";
+
+    private ExternalBenchContext3Unrolled16 _nCalcContext = null!;
+    private Func<ExternalBenchContext3Unrolled16, double> _nCalcLambda = null!;
+    private Func<double, double, double, double> _dynamicExpressoDelegate = null!;
+    private DynamicMethodInvoker<double, double, double, double> _wistFastInvoker = null!;
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        InitializeInputData();
+        CreateProviderAndHost();
+
+        var dynamicMethod = CompileWistDynamicMethod(WistFormula, ["A", "B", "C"]);
+        _wistFastInvoker = new DynamicMethodInvoker<double, double, double, double>(dynamicMethod);
+
+        var nCalcExpression = new Expression(NCalcFormula);
+        _nCalcLambda = nCalcExpression.ToLambda<ExternalBenchContext3Unrolled16, double>();
+        _nCalcContext = new ExternalBenchContext3Unrolled16();
+
+        var dynamicExpressoInterpreter = new Interpreter();
+        _dynamicExpressoDelegate =
+            dynamicExpressoInterpreter.ParseAsDelegate<Func<double, double, double, double>>(
+                DynamicExpressoFormula,
+                "A", "B", "C");
+
+        EnsureResultParityAcrossIndexes(CSharpAt, DynamicExpressoAt, NCalcAt, WistAt);
+    }
+
+    [Benchmark(Baseline = true, OperationsPerInvoke = 16)]
+    public double CSharp_NoInliningMethod_Unrolled16()
+    {
+        var sum = 0.0;
+
+        var i0 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i0], B[i0], C[i0]);
+
+        var i1 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i1], B[i1], C[i1]);
+
+        var i2 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i2], B[i2], C[i2]);
+
+        var i3 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i3], B[i3], C[i3]);
+
+        var i4 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i4], B[i4], C[i4]);
+
+        var i5 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i5], B[i5], C[i5]);
+
+        var i6 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i6], B[i6], C[i6]);
+
+        var i7 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i7], B[i7], C[i7]);
+
+        var i8 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i8], B[i8], C[i8]);
+
+        var i9 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i9], B[i9], C[i9]);
+
+        var i10 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i10], B[i10], C[i10]);
+
+        var i11 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i11], B[i11], C[i11]);
+
+        var i12 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i12], B[i12], C[i12]);
+
+        var i13 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i13], B[i13], C[i13]);
+
+        var i14 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i14], B[i14], C[i14]);
+
+        var i15 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i15], B[i15], C[i15]);
+
+        return sum;
+    }
+
+    [Benchmark(OperationsPerInvoke = 16)]
+    public double DynamicExpresso_Delegate_Unrolled16()
+    {
+        var sum = 0.0;
+
+        var i0 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i0], B[i0], C[i0]);
+
+        var i1 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i1], B[i1], C[i1]);
+
+        var i2 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i2], B[i2], C[i2]);
+
+        var i3 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i3], B[i3], C[i3]);
+
+        var i4 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i4], B[i4], C[i4]);
+
+        var i5 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i5], B[i5], C[i5]);
+
+        var i6 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i6], B[i6], C[i6]);
+
+        var i7 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i7], B[i7], C[i7]);
+
+        var i8 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i8], B[i8], C[i8]);
+
+        var i9 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i9], B[i9], C[i9]);
+
+        var i10 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i10], B[i10], C[i10]);
+
+        var i11 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i11], B[i11], C[i11]);
+
+        var i12 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i12], B[i12], C[i12]);
+
+        var i13 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i13], B[i13], C[i13]);
+
+        var i14 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i14], B[i14], C[i14]);
+
+        var i15 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i15], B[i15], C[i15]);
+
+        return sum;
+    }
+
+    [Benchmark(OperationsPerInvoke = 16)]
+    public double NCalc_Lambda_Unrolled16()
+    {
+        var sum = 0.0;
+
+        var i0 = NextIndex();
+        _nCalcContext.A = A[i0];
+        _nCalcContext.B = B[i0];
+        _nCalcContext.C = C[i0];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i1 = NextIndex();
+        _nCalcContext.A = A[i1];
+        _nCalcContext.B = B[i1];
+        _nCalcContext.C = C[i1];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i2 = NextIndex();
+        _nCalcContext.A = A[i2];
+        _nCalcContext.B = B[i2];
+        _nCalcContext.C = C[i2];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i3 = NextIndex();
+        _nCalcContext.A = A[i3];
+        _nCalcContext.B = B[i3];
+        _nCalcContext.C = C[i3];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i4 = NextIndex();
+        _nCalcContext.A = A[i4];
+        _nCalcContext.B = B[i4];
+        _nCalcContext.C = C[i4];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i5 = NextIndex();
+        _nCalcContext.A = A[i5];
+        _nCalcContext.B = B[i5];
+        _nCalcContext.C = C[i5];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i6 = NextIndex();
+        _nCalcContext.A = A[i6];
+        _nCalcContext.B = B[i6];
+        _nCalcContext.C = C[i6];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i7 = NextIndex();
+        _nCalcContext.A = A[i7];
+        _nCalcContext.B = B[i7];
+        _nCalcContext.C = C[i7];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i8 = NextIndex();
+        _nCalcContext.A = A[i8];
+        _nCalcContext.B = B[i8];
+        _nCalcContext.C = C[i8];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i9 = NextIndex();
+        _nCalcContext.A = A[i9];
+        _nCalcContext.B = B[i9];
+        _nCalcContext.C = C[i9];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i10 = NextIndex();
+        _nCalcContext.A = A[i10];
+        _nCalcContext.B = B[i10];
+        _nCalcContext.C = C[i10];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i11 = NextIndex();
+        _nCalcContext.A = A[i11];
+        _nCalcContext.B = B[i11];
+        _nCalcContext.C = C[i11];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i12 = NextIndex();
+        _nCalcContext.A = A[i12];
+        _nCalcContext.B = B[i12];
+        _nCalcContext.C = C[i12];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i13 = NextIndex();
+        _nCalcContext.A = A[i13];
+        _nCalcContext.B = B[i13];
+        _nCalcContext.C = C[i13];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i14 = NextIndex();
+        _nCalcContext.A = A[i14];
+        _nCalcContext.B = B[i14];
+        _nCalcContext.C = C[i14];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i15 = NextIndex();
+        _nCalcContext.A = A[i15];
+        _nCalcContext.B = B[i15];
+        _nCalcContext.C = C[i15];
+        sum += _nCalcLambda(_nCalcContext);
+
+        return sum;
+    }
+
+    [Benchmark(OperationsPerInvoke = 16)]
+    public double Wist_Cil_FastInvoker_Unrolled16()
+    {
+        var sum = 0.0;
+
+        var i0 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i0], B[i0], C[i0]);
+
+        var i1 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i1], B[i1], C[i1]);
+
+        var i2 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i2], B[i2], C[i2]);
+
+        var i3 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i3], B[i3], C[i3]);
+
+        var i4 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i4], B[i4], C[i4]);
+
+        var i5 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i5], B[i5], C[i5]);
+
+        var i6 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i6], B[i6], C[i6]);
+
+        var i7 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i7], B[i7], C[i7]);
+
+        var i8 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i8], B[i8], C[i8]);
+
+        var i9 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i9], B[i9], C[i9]);
+
+        var i10 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i10], B[i10], C[i10]);
+
+        var i11 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i11], B[i11], C[i11]);
+
+        var i12 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i12], B[i12], C[i12]);
+
+        var i13 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i13], B[i13], C[i13]);
+
+        var i14 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i14], B[i14], C[i14]);
+
+        var i15 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i15], B[i15], C[i15]);
+
+        return sum;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static double CSharp_NoInliningMethodCore(double a, double b, double c)
+        => a + b * c / 5.0;
+
+    private double CSharpAt(int index)
+        => CSharp_NoInliningMethodCore(A[index], B[index], C[index]);
+
+    private double DynamicExpressoAt(int index)
+        => _dynamicExpressoDelegate(A[index], B[index], C[index]);
+
+    private double NCalcAt(int index)
+    {
+            _nCalcContext.A = A[index];
+            _nCalcContext.B = B[index];
+            _nCalcContext.C = C[index];
+        return _nCalcLambda(_nCalcContext);
+    }
+
+    private double WistAt(int index)
+        => _wistFastInvoker.Invoke(A[index], B[index], C[index]);
+}

--- a/UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/ExternalExecutionBenchmarks/Unrolled16/ExternalWideExpression11ExecutionUnrolled16Benchmarks.cs
+++ b/UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/ExternalExecutionBenchmarks/Unrolled16/ExternalWideExpression11ExecutionUnrolled16Benchmarks.cs
@@ -1,0 +1,477 @@
+using System.Runtime.CompilerServices;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Order;
+using DynamicExpresso;
+using DynamicMethodCalling.Core;
+using NCalc;
+using NCalc.LambdaCompilation;
+
+namespace UniversalToolchain.Benchmarks.ExternalExecutionBenchmarks.Unrolled16;
+
+[MemoryDiagnoser]
+[SimpleJob]
+[Orderer(SummaryOrderPolicy.FastestToSlowest)]
+[RankColumn]
+public sealed class ExternalWideExpression11ExecutionUnrolled16Benchmarks : ExternalArithmeticExecutionUnrolled16BenchmarkEnvironmentBase
+{
+    private const string WistFormula = "(A + B + C + D) * (E - F + G) / (H + 1.0) + I * J - K / 3.0";
+    private const string NCalcFormula = "([A] + [B] + [C] + [D]) * ([E] - [F] + [G]) / ([H] + 1.0) + [I] * [J] - [K] / 3.0";
+    private const string DynamicExpressoFormula = "(A + B + C + D) * (E - F + G) / (H + 1.0) + I * J - K / 3.0";
+
+    private ExternalBenchContext11Unrolled16 _nCalcContext = null!;
+    private Func<ExternalBenchContext11Unrolled16, double> _nCalcLambda = null!;
+    private Func<double, double, double, double, double, double, double, double, double, double, double, double> _dynamicExpressoDelegate = null!;
+    private DynamicMethodInvoker<double, double, double, double, double, double, double, double, double, double, double, double> _wistFastInvoker = null!;
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        InitializeInputData();
+        CreateProviderAndHost();
+
+        var dynamicMethod = CompileWistDynamicMethod(WistFormula, ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K"]);
+        _wistFastInvoker = new DynamicMethodInvoker<double, double, double, double, double, double, double, double, double, double, double, double>(dynamicMethod);
+
+        var nCalcExpression = new Expression(NCalcFormula);
+        _nCalcLambda = nCalcExpression.ToLambda<ExternalBenchContext11Unrolled16, double>();
+        _nCalcContext = new ExternalBenchContext11Unrolled16();
+
+        var dynamicExpressoInterpreter = new Interpreter();
+        _dynamicExpressoDelegate =
+            dynamicExpressoInterpreter.ParseAsDelegate<Func<double, double, double, double, double, double, double, double, double, double, double, double>>(
+                DynamicExpressoFormula,
+                "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K");
+
+        EnsureResultParityAcrossIndexes(CSharpAt, DynamicExpressoAt, NCalcAt, WistAt);
+    }
+
+    [Benchmark(Baseline = true, OperationsPerInvoke = 16)]
+    public double CSharp_NoInliningMethod_Unrolled16()
+    {
+        var sum = 0.0;
+
+        var i0 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i0], B[i0], C[i0], D[i0], E[i0], F[i0], G[i0], H[i0], I[i0], J[i0], K[i0]);
+
+        var i1 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i1], B[i1], C[i1], D[i1], E[i1], F[i1], G[i1], H[i1], I[i1], J[i1], K[i1]);
+
+        var i2 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i2], B[i2], C[i2], D[i2], E[i2], F[i2], G[i2], H[i2], I[i2], J[i2], K[i2]);
+
+        var i3 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i3], B[i3], C[i3], D[i3], E[i3], F[i3], G[i3], H[i3], I[i3], J[i3], K[i3]);
+
+        var i4 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i4], B[i4], C[i4], D[i4], E[i4], F[i4], G[i4], H[i4], I[i4], J[i4], K[i4]);
+
+        var i5 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i5], B[i5], C[i5], D[i5], E[i5], F[i5], G[i5], H[i5], I[i5], J[i5], K[i5]);
+
+        var i6 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i6], B[i6], C[i6], D[i6], E[i6], F[i6], G[i6], H[i6], I[i6], J[i6], K[i6]);
+
+        var i7 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i7], B[i7], C[i7], D[i7], E[i7], F[i7], G[i7], H[i7], I[i7], J[i7], K[i7]);
+
+        var i8 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i8], B[i8], C[i8], D[i8], E[i8], F[i8], G[i8], H[i8], I[i8], J[i8], K[i8]);
+
+        var i9 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i9], B[i9], C[i9], D[i9], E[i9], F[i9], G[i9], H[i9], I[i9], J[i9], K[i9]);
+
+        var i10 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i10], B[i10], C[i10], D[i10], E[i10], F[i10], G[i10], H[i10], I[i10], J[i10], K[i10]);
+
+        var i11 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i11], B[i11], C[i11], D[i11], E[i11], F[i11], G[i11], H[i11], I[i11], J[i11], K[i11]);
+
+        var i12 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i12], B[i12], C[i12], D[i12], E[i12], F[i12], G[i12], H[i12], I[i12], J[i12], K[i12]);
+
+        var i13 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i13], B[i13], C[i13], D[i13], E[i13], F[i13], G[i13], H[i13], I[i13], J[i13], K[i13]);
+
+        var i14 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i14], B[i14], C[i14], D[i14], E[i14], F[i14], G[i14], H[i14], I[i14], J[i14], K[i14]);
+
+        var i15 = NextIndex();
+        sum += CSharp_NoInliningMethodCore(A[i15], B[i15], C[i15], D[i15], E[i15], F[i15], G[i15], H[i15], I[i15], J[i15], K[i15]);
+
+        return sum;
+    }
+
+    [Benchmark(OperationsPerInvoke = 16)]
+    public double DynamicExpresso_Delegate_Unrolled16()
+    {
+        var sum = 0.0;
+
+        var i0 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i0], B[i0], C[i0], D[i0], E[i0], F[i0], G[i0], H[i0], I[i0], J[i0], K[i0]);
+
+        var i1 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i1], B[i1], C[i1], D[i1], E[i1], F[i1], G[i1], H[i1], I[i1], J[i1], K[i1]);
+
+        var i2 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i2], B[i2], C[i2], D[i2], E[i2], F[i2], G[i2], H[i2], I[i2], J[i2], K[i2]);
+
+        var i3 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i3], B[i3], C[i3], D[i3], E[i3], F[i3], G[i3], H[i3], I[i3], J[i3], K[i3]);
+
+        var i4 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i4], B[i4], C[i4], D[i4], E[i4], F[i4], G[i4], H[i4], I[i4], J[i4], K[i4]);
+
+        var i5 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i5], B[i5], C[i5], D[i5], E[i5], F[i5], G[i5], H[i5], I[i5], J[i5], K[i5]);
+
+        var i6 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i6], B[i6], C[i6], D[i6], E[i6], F[i6], G[i6], H[i6], I[i6], J[i6], K[i6]);
+
+        var i7 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i7], B[i7], C[i7], D[i7], E[i7], F[i7], G[i7], H[i7], I[i7], J[i7], K[i7]);
+
+        var i8 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i8], B[i8], C[i8], D[i8], E[i8], F[i8], G[i8], H[i8], I[i8], J[i8], K[i8]);
+
+        var i9 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i9], B[i9], C[i9], D[i9], E[i9], F[i9], G[i9], H[i9], I[i9], J[i9], K[i9]);
+
+        var i10 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i10], B[i10], C[i10], D[i10], E[i10], F[i10], G[i10], H[i10], I[i10], J[i10], K[i10]);
+
+        var i11 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i11], B[i11], C[i11], D[i11], E[i11], F[i11], G[i11], H[i11], I[i11], J[i11], K[i11]);
+
+        var i12 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i12], B[i12], C[i12], D[i12], E[i12], F[i12], G[i12], H[i12], I[i12], J[i12], K[i12]);
+
+        var i13 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i13], B[i13], C[i13], D[i13], E[i13], F[i13], G[i13], H[i13], I[i13], J[i13], K[i13]);
+
+        var i14 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i14], B[i14], C[i14], D[i14], E[i14], F[i14], G[i14], H[i14], I[i14], J[i14], K[i14]);
+
+        var i15 = NextIndex();
+        sum += _dynamicExpressoDelegate(A[i15], B[i15], C[i15], D[i15], E[i15], F[i15], G[i15], H[i15], I[i15], J[i15], K[i15]);
+
+        return sum;
+    }
+
+    [Benchmark(OperationsPerInvoke = 16)]
+    public double NCalc_Lambda_Unrolled16()
+    {
+        var sum = 0.0;
+
+        var i0 = NextIndex();
+        _nCalcContext.A = A[i0];
+        _nCalcContext.B = B[i0];
+        _nCalcContext.C = C[i0];
+        _nCalcContext.D = D[i0];
+        _nCalcContext.E = E[i0];
+        _nCalcContext.F = F[i0];
+        _nCalcContext.G = G[i0];
+        _nCalcContext.H = H[i0];
+        _nCalcContext.I = I[i0];
+        _nCalcContext.J = J[i0];
+        _nCalcContext.K = K[i0];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i1 = NextIndex();
+        _nCalcContext.A = A[i1];
+        _nCalcContext.B = B[i1];
+        _nCalcContext.C = C[i1];
+        _nCalcContext.D = D[i1];
+        _nCalcContext.E = E[i1];
+        _nCalcContext.F = F[i1];
+        _nCalcContext.G = G[i1];
+        _nCalcContext.H = H[i1];
+        _nCalcContext.I = I[i1];
+        _nCalcContext.J = J[i1];
+        _nCalcContext.K = K[i1];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i2 = NextIndex();
+        _nCalcContext.A = A[i2];
+        _nCalcContext.B = B[i2];
+        _nCalcContext.C = C[i2];
+        _nCalcContext.D = D[i2];
+        _nCalcContext.E = E[i2];
+        _nCalcContext.F = F[i2];
+        _nCalcContext.G = G[i2];
+        _nCalcContext.H = H[i2];
+        _nCalcContext.I = I[i2];
+        _nCalcContext.J = J[i2];
+        _nCalcContext.K = K[i2];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i3 = NextIndex();
+        _nCalcContext.A = A[i3];
+        _nCalcContext.B = B[i3];
+        _nCalcContext.C = C[i3];
+        _nCalcContext.D = D[i3];
+        _nCalcContext.E = E[i3];
+        _nCalcContext.F = F[i3];
+        _nCalcContext.G = G[i3];
+        _nCalcContext.H = H[i3];
+        _nCalcContext.I = I[i3];
+        _nCalcContext.J = J[i3];
+        _nCalcContext.K = K[i3];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i4 = NextIndex();
+        _nCalcContext.A = A[i4];
+        _nCalcContext.B = B[i4];
+        _nCalcContext.C = C[i4];
+        _nCalcContext.D = D[i4];
+        _nCalcContext.E = E[i4];
+        _nCalcContext.F = F[i4];
+        _nCalcContext.G = G[i4];
+        _nCalcContext.H = H[i4];
+        _nCalcContext.I = I[i4];
+        _nCalcContext.J = J[i4];
+        _nCalcContext.K = K[i4];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i5 = NextIndex();
+        _nCalcContext.A = A[i5];
+        _nCalcContext.B = B[i5];
+        _nCalcContext.C = C[i5];
+        _nCalcContext.D = D[i5];
+        _nCalcContext.E = E[i5];
+        _nCalcContext.F = F[i5];
+        _nCalcContext.G = G[i5];
+        _nCalcContext.H = H[i5];
+        _nCalcContext.I = I[i5];
+        _nCalcContext.J = J[i5];
+        _nCalcContext.K = K[i5];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i6 = NextIndex();
+        _nCalcContext.A = A[i6];
+        _nCalcContext.B = B[i6];
+        _nCalcContext.C = C[i6];
+        _nCalcContext.D = D[i6];
+        _nCalcContext.E = E[i6];
+        _nCalcContext.F = F[i6];
+        _nCalcContext.G = G[i6];
+        _nCalcContext.H = H[i6];
+        _nCalcContext.I = I[i6];
+        _nCalcContext.J = J[i6];
+        _nCalcContext.K = K[i6];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i7 = NextIndex();
+        _nCalcContext.A = A[i7];
+        _nCalcContext.B = B[i7];
+        _nCalcContext.C = C[i7];
+        _nCalcContext.D = D[i7];
+        _nCalcContext.E = E[i7];
+        _nCalcContext.F = F[i7];
+        _nCalcContext.G = G[i7];
+        _nCalcContext.H = H[i7];
+        _nCalcContext.I = I[i7];
+        _nCalcContext.J = J[i7];
+        _nCalcContext.K = K[i7];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i8 = NextIndex();
+        _nCalcContext.A = A[i8];
+        _nCalcContext.B = B[i8];
+        _nCalcContext.C = C[i8];
+        _nCalcContext.D = D[i8];
+        _nCalcContext.E = E[i8];
+        _nCalcContext.F = F[i8];
+        _nCalcContext.G = G[i8];
+        _nCalcContext.H = H[i8];
+        _nCalcContext.I = I[i8];
+        _nCalcContext.J = J[i8];
+        _nCalcContext.K = K[i8];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i9 = NextIndex();
+        _nCalcContext.A = A[i9];
+        _nCalcContext.B = B[i9];
+        _nCalcContext.C = C[i9];
+        _nCalcContext.D = D[i9];
+        _nCalcContext.E = E[i9];
+        _nCalcContext.F = F[i9];
+        _nCalcContext.G = G[i9];
+        _nCalcContext.H = H[i9];
+        _nCalcContext.I = I[i9];
+        _nCalcContext.J = J[i9];
+        _nCalcContext.K = K[i9];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i10 = NextIndex();
+        _nCalcContext.A = A[i10];
+        _nCalcContext.B = B[i10];
+        _nCalcContext.C = C[i10];
+        _nCalcContext.D = D[i10];
+        _nCalcContext.E = E[i10];
+        _nCalcContext.F = F[i10];
+        _nCalcContext.G = G[i10];
+        _nCalcContext.H = H[i10];
+        _nCalcContext.I = I[i10];
+        _nCalcContext.J = J[i10];
+        _nCalcContext.K = K[i10];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i11 = NextIndex();
+        _nCalcContext.A = A[i11];
+        _nCalcContext.B = B[i11];
+        _nCalcContext.C = C[i11];
+        _nCalcContext.D = D[i11];
+        _nCalcContext.E = E[i11];
+        _nCalcContext.F = F[i11];
+        _nCalcContext.G = G[i11];
+        _nCalcContext.H = H[i11];
+        _nCalcContext.I = I[i11];
+        _nCalcContext.J = J[i11];
+        _nCalcContext.K = K[i11];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i12 = NextIndex();
+        _nCalcContext.A = A[i12];
+        _nCalcContext.B = B[i12];
+        _nCalcContext.C = C[i12];
+        _nCalcContext.D = D[i12];
+        _nCalcContext.E = E[i12];
+        _nCalcContext.F = F[i12];
+        _nCalcContext.G = G[i12];
+        _nCalcContext.H = H[i12];
+        _nCalcContext.I = I[i12];
+        _nCalcContext.J = J[i12];
+        _nCalcContext.K = K[i12];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i13 = NextIndex();
+        _nCalcContext.A = A[i13];
+        _nCalcContext.B = B[i13];
+        _nCalcContext.C = C[i13];
+        _nCalcContext.D = D[i13];
+        _nCalcContext.E = E[i13];
+        _nCalcContext.F = F[i13];
+        _nCalcContext.G = G[i13];
+        _nCalcContext.H = H[i13];
+        _nCalcContext.I = I[i13];
+        _nCalcContext.J = J[i13];
+        _nCalcContext.K = K[i13];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i14 = NextIndex();
+        _nCalcContext.A = A[i14];
+        _nCalcContext.B = B[i14];
+        _nCalcContext.C = C[i14];
+        _nCalcContext.D = D[i14];
+        _nCalcContext.E = E[i14];
+        _nCalcContext.F = F[i14];
+        _nCalcContext.G = G[i14];
+        _nCalcContext.H = H[i14];
+        _nCalcContext.I = I[i14];
+        _nCalcContext.J = J[i14];
+        _nCalcContext.K = K[i14];
+        sum += _nCalcLambda(_nCalcContext);
+
+        var i15 = NextIndex();
+        _nCalcContext.A = A[i15];
+        _nCalcContext.B = B[i15];
+        _nCalcContext.C = C[i15];
+        _nCalcContext.D = D[i15];
+        _nCalcContext.E = E[i15];
+        _nCalcContext.F = F[i15];
+        _nCalcContext.G = G[i15];
+        _nCalcContext.H = H[i15];
+        _nCalcContext.I = I[i15];
+        _nCalcContext.J = J[i15];
+        _nCalcContext.K = K[i15];
+        sum += _nCalcLambda(_nCalcContext);
+
+        return sum;
+    }
+
+    [Benchmark(OperationsPerInvoke = 16)]
+    public double Wist_Cil_FastInvoker_Unrolled16()
+    {
+        var sum = 0.0;
+
+        var i0 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i0], B[i0], C[i0], D[i0], E[i0], F[i0], G[i0], H[i0], I[i0], J[i0], K[i0]);
+
+        var i1 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i1], B[i1], C[i1], D[i1], E[i1], F[i1], G[i1], H[i1], I[i1], J[i1], K[i1]);
+
+        var i2 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i2], B[i2], C[i2], D[i2], E[i2], F[i2], G[i2], H[i2], I[i2], J[i2], K[i2]);
+
+        var i3 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i3], B[i3], C[i3], D[i3], E[i3], F[i3], G[i3], H[i3], I[i3], J[i3], K[i3]);
+
+        var i4 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i4], B[i4], C[i4], D[i4], E[i4], F[i4], G[i4], H[i4], I[i4], J[i4], K[i4]);
+
+        var i5 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i5], B[i5], C[i5], D[i5], E[i5], F[i5], G[i5], H[i5], I[i5], J[i5], K[i5]);
+
+        var i6 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i6], B[i6], C[i6], D[i6], E[i6], F[i6], G[i6], H[i6], I[i6], J[i6], K[i6]);
+
+        var i7 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i7], B[i7], C[i7], D[i7], E[i7], F[i7], G[i7], H[i7], I[i7], J[i7], K[i7]);
+
+        var i8 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i8], B[i8], C[i8], D[i8], E[i8], F[i8], G[i8], H[i8], I[i8], J[i8], K[i8]);
+
+        var i9 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i9], B[i9], C[i9], D[i9], E[i9], F[i9], G[i9], H[i9], I[i9], J[i9], K[i9]);
+
+        var i10 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i10], B[i10], C[i10], D[i10], E[i10], F[i10], G[i10], H[i10], I[i10], J[i10], K[i10]);
+
+        var i11 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i11], B[i11], C[i11], D[i11], E[i11], F[i11], G[i11], H[i11], I[i11], J[i11], K[i11]);
+
+        var i12 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i12], B[i12], C[i12], D[i12], E[i12], F[i12], G[i12], H[i12], I[i12], J[i12], K[i12]);
+
+        var i13 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i13], B[i13], C[i13], D[i13], E[i13], F[i13], G[i13], H[i13], I[i13], J[i13], K[i13]);
+
+        var i14 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i14], B[i14], C[i14], D[i14], E[i14], F[i14], G[i14], H[i14], I[i14], J[i14], K[i14]);
+
+        var i15 = NextIndex();
+        sum += _wistFastInvoker.Invoke(A[i15], B[i15], C[i15], D[i15], E[i15], F[i15], G[i15], H[i15], I[i15], J[i15], K[i15]);
+
+        return sum;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static double CSharp_NoInliningMethodCore(double a, double b, double c, double d, double e, double f, double g, double h, double i, double j, double k)
+        => (a + b + c + d) * (e - f + g) / (h + 1.0) + i * j - k / 3.0;
+
+    private double CSharpAt(int index)
+        => CSharp_NoInliningMethodCore(A[index], B[index], C[index], D[index], E[index], F[index], G[index], H[index], I[index], J[index], K[index]);
+
+    private double DynamicExpressoAt(int index)
+        => _dynamicExpressoDelegate(A[index], B[index], C[index], D[index], E[index], F[index], G[index], H[index], I[index], J[index], K[index]);
+
+    private double NCalcAt(int index)
+    {
+            _nCalcContext.A = A[index];
+            _nCalcContext.B = B[index];
+            _nCalcContext.C = C[index];
+            _nCalcContext.D = D[index];
+            _nCalcContext.E = E[index];
+            _nCalcContext.F = F[index];
+            _nCalcContext.G = G[index];
+            _nCalcContext.H = H[index];
+            _nCalcContext.I = I[index];
+            _nCalcContext.J = J[index];
+            _nCalcContext.K = K[index];
+        return _nCalcLambda(_nCalcContext);
+    }
+
+    private double WistAt(int index)
+        => _wistFastInvoker.Invoke(A[index], B[index], C[index], D[index], E[index], F[index], G[index], H[index], I[index], J[index], K[index]);
+}

--- a/UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/ExternalExecutionBenchmarks/Unrolled16/Tools/GenerateExternalExecutionUnrolled16Benchmarks.py
+++ b/UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/ExternalExecutionBenchmarks/Unrolled16/Tools/GenerateExternalExecutionUnrolled16Benchmarks.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+HEADER = """using System.Runtime.CompilerServices;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Order;
+using DynamicExpresso;
+using DynamicMethodCalling.Core;
+using NCalc;
+using NCalc.LambdaCompilation;
+
+namespace UniversalToolchain.Benchmarks.ExternalExecutionBenchmarks.Unrolled16;
+
+[MemoryDiagnoser]
+[SimpleJob]
+[Orderer(SummaryOrderPolicy.FastestToSlowest)]
+[RankColumn]
+"""
+
+CASES = [
+    {
+        "class": "ExternalSimple3ExecutionUnrolled16Benchmarks",
+        "context": "ExternalBenchContext3Unrolled16",
+        "arity": 3,
+        "wist": "A + B * C / 5.0",
+        "ncalc": "[A] + [B] * [C] / 5.0",
+        "dynamic": "A + B * C / 5.0",
+        "core": "a + b * c / 5.0",
+    },
+    {
+        "class": "ExternalMedium8ExecutionUnrolled16Benchmarks",
+        "context": "ExternalBenchContext8Unrolled16",
+        "arity": 8,
+        "wist": "((A + B) * (C - D) / (E + 1.0)) + F * G - H / 3.0",
+        "ncalc": "(([A] + [B]) * ([C] - [D]) / ([E] + 1.0)) + [F] * [G] - [H] / 3.0",
+        "dynamic": "((A + B) * (C - D) / (E + 1.0)) + F * G - H / 3.0",
+        "core": "((a + b) * (c - d) / (e + 1.0)) + f * g - h / 3.0",
+    },
+    {
+        "class": "ExternalDeepChain6ExecutionUnrolled16Benchmarks",
+        "context": "ExternalBenchContext6Unrolled16",
+        "arity": 6,
+        "wist": "((((A * 1.1 + B) * 1.2 + C) * 1.3 + D) * 1.4 + E) / (F + 1.0)",
+        "ncalc": "(((([A] * 1.1 + [B]) * 1.2 + [C]) * 1.3 + [D]) * 1.4 + [E]) / ([F] + 1.0)",
+        "dynamic": "((((A * 1.1 + B) * 1.2 + C) * 1.3 + D) * 1.4 + E) / (F + 1.0)",
+        "core": "((((a * 1.1 + b) * 1.2 + c) * 1.3 + d) * 1.4 + e) / (f + 1.0)",
+    },
+    {
+        "class": "ExternalRepeatedSubexpressions5ExecutionUnrolled16Benchmarks",
+        "context": "ExternalBenchContext5Unrolled16",
+        "arity": 5,
+        "wist": "((A * B) + (A * B) + (A * B) + (C * D)) / (E + 1.0)",
+        "ncalc": "(([A] * [B]) + ([A] * [B]) + ([A] * [B]) + ([C] * [D])) / ([E] + 1.0)",
+        "dynamic": "((A * B) + (A * B) + (A * B) + (C * D)) / (E + 1.0)",
+        "core": "((a * b) + (a * b) + (a * b) + (c * d)) / (e + 1.0)",
+    },
+    {
+        "class": "ExternalWideExpression11ExecutionUnrolled16Benchmarks",
+        "context": "ExternalBenchContext11Unrolled16",
+        "arity": 11,
+        "wist": "(A + B + C + D) * (E - F + G) / (H + 1.0) + I * J - K / 3.0",
+        "ncalc": "([A] + [B] + [C] + [D]) * ([E] - [F] + [G]) / ([H] + 1.0) + [I] * [J] - [K] / 3.0",
+        "dynamic": "(A + B + C + D) * (E - F + G) / (H + 1.0) + I * J - K / 3.0",
+        "core": "(a + b + c + d) * (e - f + g) / (h + 1.0) + i * j - k / 3.0",
+    },
+    {
+        "class": "ExternalConstantsHeavy6ExecutionUnrolled16Benchmarks",
+        "context": "ExternalBenchContext6Unrolled16",
+        "arity": 6,
+        "wist": "(A * 1.5 + B * 2.0 - C * 3.0 + D / 4.0 + E / 5.0) * 0.75 + F",
+        "ncalc": "([A] * 1.5 + [B] * 2.0 - [C] * 3.0 + [D] / 4.0 + [E] / 5.0) * 0.75 + [F]",
+        "dynamic": "(A * 1.5 + B * 2.0 - C * 3.0 + D / 4.0 + E / 5.0) * 0.75 + F",
+        "core": "(a * 1.5 + b * 2.0 - c * 3.0 + d / 4.0 + e / 5.0) * 0.75 + f",
+    },
+]
+
+
+def letters(arity: int):
+    return [chr(ord('A') + i) for i in range(arity)]
+
+
+def csharp_params(arity: int):
+    return ", ".join(f"double {chr(ord('a')+i)}" for i in range(arity))
+
+
+def generic_func(arity: int):
+    return "Func<" + ", ".join(["double"] * (arity + 1)) + ">"
+
+
+def dynamic_invoker(arity: int):
+    return "DynamicMethodInvoker<" + ", ".join(["double"] * (arity + 1)) + ">"
+
+
+def arg_access(names, idx='i'):
+    return ", ".join(f"{n}[{idx}]" for n in names)
+
+
+def declared_names(names):
+    return ", ".join(f'"{n}"' for n in names)
+
+
+def context_setters(context: str, names, idx='i'):
+    return "\n".join(f"            {context}.{n} = {n}[{idx}];" for n in names)
+
+
+def unrolled_lines(kind: str, names, context_name='_nCalcContext'):
+    lines = []
+    for i in range(16):
+        lines.append(f"        var i{i} = NextIndex();")
+        if kind == 'csharp':
+            args = arg_access(names, f"i{i}")
+            lines.append(f"        sum += CSharp_NoInliningMethodCore({args});")
+        elif kind == 'dynamic':
+            args = arg_access(names, f"i{i}")
+            lines.append(f"        sum += _dynamicExpressoDelegate({args});")
+        elif kind == 'wist':
+            args = arg_access(names, f"i{i}")
+            lines.append(f"        sum += _wistFastInvoker.Invoke({args});")
+        else:
+            for n in names:
+                lines.append(f"        {context_name}.{n} = {n}[i{i}];")
+            lines.append(f"        sum += _nCalcLambda({context_name});")
+        lines.append("")
+    return "\n".join(lines).rstrip()
+
+
+def render(case):
+    names = letters(case['arity'])
+    class_name = case['class']
+    context = case['context']
+    src = f"""{HEADER}public sealed class {class_name} : ExternalArithmeticExecutionUnrolled16BenchmarkEnvironmentBase
+{{
+    private const string WistFormula = \"{case['wist']}\";
+    private const string NCalcFormula = \"{case['ncalc']}\";
+    private const string DynamicExpressoFormula = \"{case['dynamic']}\";
+
+    private {context} _nCalcContext = null!;
+    private Func<{context}, double> _nCalcLambda = null!;
+    private {generic_func(case['arity'])} _dynamicExpressoDelegate = null!;
+    private {dynamic_invoker(case['arity'])} _wistFastInvoker = null!;
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {{
+        InitializeInputData();
+        CreateProviderAndHost();
+
+        var dynamicMethod = CompileWistDynamicMethod(WistFormula, [{declared_names(names)}]);
+        _wistFastInvoker = new {dynamic_invoker(case['arity'])}(dynamicMethod);
+
+        var nCalcExpression = new Expression(NCalcFormula);
+        _nCalcLambda = nCalcExpression.ToLambda<{context}, double>();
+        _nCalcContext = new {context}();
+
+        var dynamicExpressoInterpreter = new Interpreter();
+        _dynamicExpressoDelegate =
+            dynamicExpressoInterpreter.ParseAsDelegate<{generic_func(case['arity'])}>(
+                DynamicExpressoFormula,
+                {declared_names(names)});
+
+        EnsureResultParityAcrossIndexes(CSharpAt, DynamicExpressoAt, NCalcAt, WistAt);
+    }}
+
+    [Benchmark(Baseline = true, OperationsPerInvoke = 16)]
+    public double CSharp_NoInliningMethod_Unrolled16()
+    {{
+        var sum = 0.0;
+
+{unrolled_lines('csharp', names)}
+
+        return sum;
+    }}
+
+    [Benchmark(OperationsPerInvoke = 16)]
+    public double DynamicExpresso_Delegate_Unrolled16()
+    {{
+        var sum = 0.0;
+
+{unrolled_lines('dynamic', names)}
+
+        return sum;
+    }}
+
+    [Benchmark(OperationsPerInvoke = 16)]
+    public double NCalc_Lambda_Unrolled16()
+    {{
+        var sum = 0.0;
+
+{unrolled_lines('ncalc', names)}
+
+        return sum;
+    }}
+
+    [Benchmark(OperationsPerInvoke = 16)]
+    public double Wist_Cil_FastInvoker_Unrolled16()
+    {{
+        var sum = 0.0;
+
+{unrolled_lines('wist', names)}
+
+        return sum;
+    }}
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static double CSharp_NoInliningMethodCore({csharp_params(case['arity'])})
+        => {case['core']};
+
+    private double CSharpAt(int index)
+        => CSharp_NoInliningMethodCore({arg_access(names, 'index')});
+
+    private double DynamicExpressoAt(int index)
+        => _dynamicExpressoDelegate({arg_access(names, 'index')});
+
+    private double NCalcAt(int index)
+    {{
+{context_setters('_nCalcContext', names, 'index')}
+        return _nCalcLambda(_nCalcContext);
+    }}
+
+    private double WistAt(int index)
+        => _wistFastInvoker.Invoke({arg_access(names, 'index')});
+}}
+"""
+    return src
+
+
+for case in CASES:
+    path = ROOT / f"{case['class']}.cs"
+    path.write_text(render(case), encoding='utf-8')
+    print(f"generated {path}")

--- a/UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/Program.cs
+++ b/UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/Program.cs
@@ -1,6 +1,7 @@
 using BenchmarkDotNet.Running;
 using UniversalToolchain.Benchmarks;
 using UniversalToolchain.Benchmarks.ExternalExecutionBenchmarks;
+using UniversalToolchain.Benchmarks.ExternalExecutionBenchmarks.Unrolled16;
 
 BenchmarkRunner.Run<Simple3Benchmarks>();
 BenchmarkRunner.Run<Medium8Benchmarks>();
@@ -14,3 +15,10 @@ BenchmarkRunner.Run<ExternalDeepChain6ExecutionBenchmarks>();
 BenchmarkRunner.Run<ExternalRepeatedSubexpressions5ExecutionBenchmarks>();
 BenchmarkRunner.Run<ExternalWideExpression11ExecutionBenchmarks>();
 BenchmarkRunner.Run<ExternalConstantsHeavy6ExecutionBenchmarks>();
+
+BenchmarkRunner.Run<ExternalSimple3ExecutionUnrolled16Benchmarks>();
+BenchmarkRunner.Run<ExternalMedium8ExecutionUnrolled16Benchmarks>();
+BenchmarkRunner.Run<ExternalDeepChain6ExecutionUnrolled16Benchmarks>();
+BenchmarkRunner.Run<ExternalRepeatedSubexpressions5ExecutionUnrolled16Benchmarks>();
+BenchmarkRunner.Run<ExternalWideExpression11ExecutionUnrolled16Benchmarks>();
+BenchmarkRunner.Run<ExternalConstantsHeavy6ExecutionUnrolled16Benchmarks>();


### PR DESCRIPTION
### Motivation

- Add a new additive benchmark suite that measures execution speed using a small, generated unrolled block of 16 inline hot-path invocations instead of an explicit loop, preserving existing suites and runner lines.
- Keep the benchmark hot-path allocation-free and preprepared in `GlobalSetup`, with parity checks on indexes {0,1,17,255,1023,2047,4095} to ensure correctness.
- Provide a tiny deterministic generator to produce the repetitive inline code so the repo contains committed generated sources and does not require runtime code generation.

### Description

- Added a new namespace `UniversalToolchain.Benchmarks.ExternalExecutionBenchmarks.Unrolled16` and an environment base `ExternalArithmeticExecutionUnrolled16BenchmarkEnvironmentBase.cs` that mirrors the external environment setup and parity validation.
- Added unrolled bench contexts `ExternalBenchContexts.Unrolled16.cs` and six generated benchmark classes matching existing formulas: `ExternalSimple3ExecutionUnrolled16Benchmarks`, `ExternalMedium8ExecutionUnrolled16Benchmarks`, `ExternalDeepChain6ExecutionUnrolled16Benchmarks`, `ExternalRepeatedSubexpressions5ExecutionUnrolled16Benchmarks`, `ExternalWideExpression11ExecutionUnrolled16Benchmarks`, and `ExternalConstantsHeavy6ExecutionUnrolled16Benchmarks` (all committed generated .cs files).
- Each benchmark method contains exactly 16 inline prepared invocations, is loop-free, and is annotated with `[Benchmark(OperationsPerInvoke = 16)]`; compared paths are C# no-inlining baseline, Wist fast `DynamicMethodInvoker`, NCalc precompiled lambda, and Dynamic Expresso `ParseAsDelegate` as requested.
- Added a small deterministic generator script `Tools/GenerateExternalExecutionUnrolled16Benchmarks.py` (committed) and appended `BenchmarkRunner.Run<...>()` lines for the new classes to `Program.cs`.

### Testing

- Ran `dotnet restore UniversalToolchain/Wist.sln` and the command completed successfully.
- Ran `dotnet build UniversalToolchain/Wist.sln -c Release` and the solution built successfully (no errors, warnings only).
- Performed a smoke check by starting the benchmark runner for `ExternalSimple3ExecutionUnrolled16Benchmarks`; the runner started and proceeded into BenchmarkDotNet validation/build stages, confirming the new suite is discoverable and the runner begins processing (full measurement run was not completed here due to the harness timeout behavior in this environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea6855eac08324aac934c595cd937a)