### PR TITLE
Unseal BenchmarkDotNet benchmark classes in external benchmarks

### DIFF
--- a/UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/ExternalExecutionBenchmarks/ExternalConstantsHeavy6ExecutionBenchmarks.cs
+++ b/UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/ExternalExecutionBenchmarks/ExternalConstantsHeavy6ExecutionBenchmarks.cs
@@ -13,7 +13,7 @@ namespace UniversalToolchain.Benchmarks.ExternalExecutionBenchmarks;
 [SimpleJob]
 [Orderer(SummaryOrderPolicy.FastestToSlowest)]
 [RankColumn]
-public sealed class ExternalConstantsHeavy6ExecutionBenchmarks : ExternalArithmeticExecutionBenchmarkEnvironmentBase
+public class ExternalConstantsHeavy6ExecutionBenchmarks : ExternalArithmeticExecutionBenchmarkEnvironmentBase
 {
     private const string WistFormula = "(A * 1.5 + B * 2.0 - C * 3.0 + D / 4.0 + E / 5.0) * 0.75 + F";
     private const string NCalcFormula = "([A] * 1.5 + [B] * 2.0 - [C] * 3.0 + [D] / 4.0 + [E] / 5.0) * 0.75 + [F]";

--- a/UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/ExternalExecutionBenchmarks/ExternalDeepChain6ExecutionBenchmarks.cs
+++ b/UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/ExternalExecutionBenchmarks/ExternalDeepChain6ExecutionBenchmarks.cs
@@ -13,7 +13,7 @@ namespace UniversalToolchain.Benchmarks.ExternalExecutionBenchmarks;
 [SimpleJob]
 [Orderer(SummaryOrderPolicy.FastestToSlowest)]
 [RankColumn]
-public sealed class ExternalDeepChain6ExecutionBenchmarks : ExternalArithmeticExecutionBenchmarkEnvironmentBase
+public class ExternalDeepChain6ExecutionBenchmarks : ExternalArithmeticExecutionBenchmarkEnvironmentBase
 {
     private const string WistFormula = "((((A * 1.1 + B) * 1.2 + C) * 1.3 + D) * 1.4 + E) / (F + 1.0)";
     private const string NCalcFormula = "(((([A] * 1.1 + [B]) * 1.2 + [C]) * 1.3 + [D]) * 1.4 + [E]) / ([F] + 1.0)";

--- a/UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/ExternalExecutionBenchmarks/ExternalMedium8ExecutionBenchmarks.cs
+++ b/UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/ExternalExecutionBenchmarks/ExternalMedium8ExecutionBenchmarks.cs
@@ -13,7 +13,7 @@ namespace UniversalToolchain.Benchmarks.ExternalExecutionBenchmarks;
 [SimpleJob]
 [Orderer(SummaryOrderPolicy.FastestToSlowest)]
 [RankColumn]
-public sealed class ExternalMedium8ExecutionBenchmarks : ExternalArithmeticExecutionBenchmarkEnvironmentBase
+public class ExternalMedium8ExecutionBenchmarks : ExternalArithmeticExecutionBenchmarkEnvironmentBase
 {
     private const string WistFormula = "((A + B) * (C - D) / (E + 1.0)) + F * G - H / 3.0";
     private const string NCalcFormula = "(([A] + [B]) * ([C] - [D]) / ([E] + 1.0)) + [F] * [G] - [H] / 3.0";

--- a/UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/ExternalExecutionBenchmarks/ExternalRepeatedSubexpressions5ExecutionBenchmarks.cs
+++ b/UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/ExternalExecutionBenchmarks/ExternalRepeatedSubexpressions5ExecutionBenchmarks.cs
@@ -13,7 +13,7 @@ namespace UniversalToolchain.Benchmarks.ExternalExecutionBenchmarks;
 [SimpleJob]
 [Orderer(SummaryOrderPolicy.FastestToSlowest)]
 [RankColumn]
-public sealed class ExternalRepeatedSubexpressions5ExecutionBenchmarks : ExternalArithmeticExecutionBenchmarkEnvironmentBase
+public class ExternalRepeatedSubexpressions5ExecutionBenchmarks : ExternalArithmeticExecutionBenchmarkEnvironmentBase
 {
     private const string WistFormula = "((A * B) + (A * B) + (A * B) + (C * D)) / (E + 1.0)";
     private const string NCalcFormula = "(([A] * [B]) + ([A] * [B]) + ([A] * [B]) + ([C] * [D])) / ([E] + 1.0)";

--- a/UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/ExternalExecutionBenchmarks/ExternalSimple3ExecutionBenchmarks.cs
+++ b/UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/ExternalExecutionBenchmarks/ExternalSimple3ExecutionBenchmarks.cs
@@ -13,7 +13,7 @@ namespace UniversalToolchain.Benchmarks.ExternalExecutionBenchmarks;
 [SimpleJob]
 [Orderer(SummaryOrderPolicy.FastestToSlowest)]
 [RankColumn]
-public sealed class ExternalSimple3ExecutionBenchmarks : ExternalArithmeticExecutionBenchmarkEnvironmentBase
+public class ExternalSimple3ExecutionBenchmarks : ExternalArithmeticExecutionBenchmarkEnvironmentBase
 {
     private const string WistFormula = "A + B * C / 5.0";
     private const string NCalcFormula = "[A] + [B] * [C] / 5.0";

--- a/UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/ExternalExecutionBenchmarks/ExternalWideExpression11ExecutionBenchmarks.cs
+++ b/UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/ExternalExecutionBenchmarks/ExternalWideExpression11ExecutionBenchmarks.cs
@@ -13,7 +13,7 @@ namespace UniversalToolchain.Benchmarks.ExternalExecutionBenchmarks;
 [SimpleJob]
 [Orderer(SummaryOrderPolicy.FastestToSlowest)]
 [RankColumn]
-public sealed class ExternalWideExpression11ExecutionBenchmarks : ExternalArithmeticExecutionBenchmarkEnvironmentBase
+public class ExternalWideExpression11ExecutionBenchmarks : ExternalArithmeticExecutionBenchmarkEnvironmentBase
 {
     private const string WistFormula = "(A + B + C + D) * (E - F + G) / (H + 1.0) + I * J - K / 3.0";
     private const string NCalcFormula = "([A] + [B] + [C] + [D]) * ([E] - [F] + [G]) / ([H] + 1.0) + [I] * [J] - [K] / 3.0";


### PR DESCRIPTION
### Motivation

- BenchmarkDotNet rejects benchmark classes declared `sealed` with the error `Declaring type must be unsealed`, so benchmark classes containing `[Benchmark]` must be made unsealed.  
- Apply a minimal, targeted fix that only removes the `sealed` modifier from benchmark classes and changes nothing else.  

### Description

- Removed the `sealed` modifier from the following external benchmark classes (only the class modifier was changed): `ExternalSimple3ExecutionBenchmarks`, `ExternalMedium8ExecutionBenchmarks`, `ExternalDeepChain6ExecutionBenchmarks`, `ExternalRepeatedSubexpressions5ExecutionBenchmarks`, `ExternalWideExpression11ExecutionBenchmarks`, and `ExternalConstantsHeavy6ExecutionBenchmarks`.  
- Files modified (only one-line change per file: `public sealed class ...` → `public class ...`):  
  - `UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/ExternalExecutionBenchmarks/ExternalSimple3ExecutionBenchmarks.cs`  
  - `UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/ExternalExecutionBenchmarks/ExternalMedium8ExecutionBenchmarks.cs`  
  - `UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/ExternalExecutionBenchmarks/ExternalDeepChain6ExecutionBenchmarks.cs`  
  - `UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/ExternalExecutionBenchmarks/ExternalRepeatedSubexpressions5ExecutionBenchmarks.cs`  
  - `UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/ExternalExecutionBenchmarks/ExternalWideExpression11ExecutionBenchmarks.cs`  
  - `UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/ExternalExecutionBenchmarks/ExternalConstantsHeavy6ExecutionBenchmarks.cs`  
- No other code, attributes, method signatures, logic, comments, formatting, namespaces, or production code were changed.  

### Testing

- Installed required SDK with `bash /tmp/dotnet-install.sh --version 10.0.103 --install-dir $HOME/.dotnet` and verified with `dotnet --version`.  
- Built the benchmark project with `dotnet build UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/UniversalToolchain.Benchmarks.csproj -c Release`, and the build succeeded.  
- Launched a short BenchmarkDotNet run with `dotnet run --project UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/UniversalToolchain.Benchmarks.csproj -c Release -- --filter "*ExternalSimple3ExecutionBenchmarks*" --job short --warmupCount 1 --iterationCount 1`; the previous `Declaring type must be unsealed` validation error did not occur, but the run hit an external environment timeout while BenchmarkDotNet was building/running its generated project (timeout unrelated to the sealed-class validation).  
- Performed an automated scan (`python`/`rg`) to verify no source files still declare benchmark classes with `sealed` while containing `[Benchmark]`, result: none found.  

All changes are deliberately minimal and limited to removing `sealed` from the benchmark class declarations to satisfy BenchmarkDotNet validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea797a5184832492a6c517c9e63929)