### PR TITLE
refactor: make Wist rule validation parser-backed

### DIFF
--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/Architecture/WistRuleSyntaxOwnershipGuardrailTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/Architecture/WistRuleSyntaxOwnershipGuardrailTests.cs
@@ -1,0 +1,70 @@
+namespace UniversalToolchain.Dialects.Tests.Architecture;
+
+public sealed class WistRuleSyntaxOwnershipGuardrailTests
+{
+    [Test]
+    public void ProductionRuleAndFacadeCode_MustNotUseRawSourceSyntaxRecognitionOutsideSyntaxOwner()
+    {
+        var root = ResolveRepositoryRoot();
+        var wistRoot = Path.Combine(root, "UniversalToolchain", "UniversalToolchain.Dialects.Wist");
+        var ruleRoot = Path.Combine(wistRoot, "Rules");
+        var facadeRoot = Path.Combine(wistRoot, "Facade");
+        var syntaxRoot = Path.Combine(ruleRoot, "Syntax");
+
+        var targets = Directory
+            .GetFiles(ruleRoot, "*.cs", SearchOption.AllDirectories)
+            .Concat(Directory.GetFiles(facadeRoot, "*.cs", SearchOption.AllDirectories))
+            .Where(file => !file.StartsWith(syntaxRoot, StringComparison.Ordinal))
+            .OrderBy(file => file, StringComparer.Ordinal)
+            .ToList();
+
+        var forbiddenPatterns = new[]
+        {
+            "System.Text.RegularExpressions",
+            "Regex",
+            ".Split('\\n')",
+            ".Split(\"\\n\")",
+            ".IndexOf(\"rule\"",
+            ".IndexOf(\"let\"",
+            ".Contains(\"rule\"",
+            ".Contains(\"let\"",
+            ".StartsWith(\"rule\"",
+            ".StartsWith(\"let\"",
+            "ReadUntilMatching(",
+            "SkipWhiteSpace(",
+            "ReadIdentifier(",
+            "ConsumeArrow("
+        };
+
+        var violations = new List<string>();
+        foreach (var file in targets)
+        {
+            var content = File.ReadAllText(file);
+            foreach (var pattern in forbiddenPatterns)
+            {
+                if (content.Contains(pattern, StringComparison.Ordinal))
+                    violations.Add($"{Path.GetRelativePath(root, file)} contains forbidden pattern '{pattern}'.");
+            }
+        }
+
+        Assert.That(
+            violations,
+            Is.Empty,
+            "Raw-source syntax recognition is only allowed in Wist rule syntax-owner files. Move this logic into Rules/Syntax or consume structured parser output instead.");
+    }
+
+    private static string ResolveRepositoryRoot()
+    {
+        var current = new DirectoryInfo(TestContext.CurrentContext.TestDirectory);
+
+        while (current != null)
+        {
+            if (File.Exists(Path.Combine(current.FullName, "AGENTS.md")))
+                return current.FullName;
+
+            current = current.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Repository root with AGENTS.md was not found.");
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/Rules/WistRuleSetValidationTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/Rules/WistRuleSetValidationTests.cs
@@ -62,6 +62,64 @@ public sealed class WistRuleSetValidationTests
     }
 
     [Test]
+    public void CompileRuleSet_WhenCommentContainsLet_DoesNotCreateFakeLocal()
+    {
+        const string source = """
+                              rule Total(price: number) -> number {
+                                  // let value = 100.0
+                                  let real = price
+                                  real
+                              }
+                              """;
+
+        using var facade = CreatePricingRulesFacade();
+        var compile = facade.CompileRuleSet(source, "compiler");
+
+        Assert.That(compile.IsSuccess, Is.True, FormatDiagnostics(compile.Diagnostics));
+    }
+
+    [Test]
+    public void CompileRuleSet_WhenDuplicateLocalLetBindingExists_ReturnsDiagnostic()
+    {
+        const string source = """
+                              rule Bad(price: number) -> number {
+                                  let value = price
+                                  let value = price * 2.0
+                                  value
+                              }
+                              """;
+
+        using var facade = CreatePricingRulesFacade();
+        var compile = facade.CompileRuleSet(source, "compiler");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(compile.IsSuccess, Is.False);
+            Assert.That(compile.Diagnostics.Select(static x => x.Code), Does.Contain(ToolchainDiagnosticCodes.RuleDuplicateLocal));
+        });
+    }
+
+    [Test]
+    public void CompileRuleSet_WhenLocalLetBindingShadowsParameter_ReturnsDiagnostic()
+    {
+        const string source = """
+                              rule Bad(price: number) -> number {
+                                  let price = 10.0
+                                  price
+                              }
+                              """;
+
+        using var facade = CreatePricingRulesFacade();
+        var compile = facade.CompileRuleSet(source, "compiler");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(compile.IsSuccess, Is.False);
+            Assert.That(compile.Diagnostics.Select(static x => x.Code), Does.Contain(ToolchainDiagnosticCodes.RuleLocalShadowsParameter));
+        });
+    }
+
+    [Test]
     public void TryRun_WhenArgumentsAreInvalid_ReturnsStructuredDiagnostics()
     {
         const string source = """
@@ -122,43 +180,31 @@ public sealed class WistRuleSetValidationTests
     }
 
     [Test]
-    public void CompileRuleSet_WhenDuplicateLocalLetBindingExists_ReturnsDiagnostic()
+    public void CompileRuleSet_InterpreterAndCompiler_ShouldHaveParity()
     {
         const string source = """
-                              rule Bad(price: number) -> number {
-                                  let value = price
+                              rule Total(price: number) -> number {
                                   let value = price * 2.0
                                   value
                               }
                               """;
 
         using var facade = CreatePricingRulesFacade();
-        var compile = facade.CompileRuleSet(source, "compiler");
+        var compilerCompile = facade.CompileRuleSet(source, "compiler");
+        var interpreterCompile = facade.CompileRuleSet(source, "interpreter");
+
+        Assert.That(compilerCompile.IsSuccess, Is.True, FormatDiagnostics(compilerCompile.Diagnostics));
+        Assert.That(interpreterCompile.IsSuccess, Is.True, FormatDiagnostics(interpreterCompile.Diagnostics));
+
+        var args = new Dictionary<string, object?> { ["price"] = 10.0 };
+        var compilerRun = compilerCompile.RuleSet!.TryRun("Total", args);
+        var interpreterRun = interpreterCompile.RuleSet!.TryRun("Total", args);
 
         Assert.Multiple(() =>
         {
-            Assert.That(compile.IsSuccess, Is.False);
-            Assert.That(compile.Diagnostics.Select(static x => x.Code), Does.Contain(ToolchainDiagnosticCodes.RuleDuplicateLocal));
-        });
-    }
-
-    [Test]
-    public void CompileRuleSet_WhenLocalLetBindingShadowsParameter_ReturnsDiagnostic()
-    {
-        const string source = """
-                              rule Bad(price: number) -> number {
-                                  let price = 10.0
-                                  price
-                              }
-                              """;
-
-        using var facade = CreatePricingRulesFacade();
-        var compile = facade.CompileRuleSet(source, "compiler");
-
-        Assert.Multiple(() =>
-        {
-            Assert.That(compile.IsSuccess, Is.False);
-            Assert.That(compile.Diagnostics.Select(static x => x.Code), Does.Contain(ToolchainDiagnosticCodes.RuleLocalShadowsParameter));
+            Assert.That(compilerRun.IsSuccess, Is.True, FormatDiagnostics(compilerRun.Diagnostics));
+            Assert.That(interpreterRun.IsSuccess, Is.True, FormatDiagnostics(interpreterRun.Diagnostics));
+            Assert.That(ToDouble(compilerRun.Value), Is.EqualTo(ToDouble(interpreterRun.Value)).Within(1e-9));
         });
     }
 

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/Facade/WistRuntimeFacade.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/Facade/WistRuntimeFacade.cs
@@ -2,7 +2,6 @@ using System.Reflection.Emit;
 using BasicCore.Compilation;
 using ExceptionsManager;
 using IntermediateRepresentationAbstractions;
-using UniversalToolchain.Diagnostics.Abstractions;
 using UniversalToolchain.Dialects.Abstractions;
 using UniversalToolchain.Dialects.Integration;
 using UniversalToolchain.Dialects.Wist.Rules;
@@ -16,12 +15,13 @@ namespace UniversalToolchain.Dialects.Wist.Facade;
 public sealed class WistRuntimeFacade : IDisposable
 {
     private readonly WistDialectExecutionHost _host;
-    private readonly WistRuleRuntimeTypeResolver _ruleRuntimeTypeResolver = new();
+    private readonly IWistRuleSetCompiler _ruleSetCompiler;
 
-    internal WistRuntimeFacade(WistDialectExecutionHost host, DialectFrameworkCompositionResult composition)
+    internal WistRuntimeFacade(WistDialectExecutionHost host, DialectFrameworkCompositionResult composition, IWistRuleSetCompiler ruleSetCompiler)
     {
         _host = host.ArgNotNull();
         Composition = composition.ArgNotNull();
+        _ruleSetCompiler = ruleSetCompiler.ArgNotNull();
     }
 
     internal WistDialectExecutionConfiguration Configuration => _host.Configuration;
@@ -61,39 +61,7 @@ public sealed class WistRuntimeFacade : IDisposable
     /// </summary>
     public RuleSetCompileResult CompileRuleSet(string source, string mode = "compiler")
     {
-        var extraction = new WistRuleDeclarationExtractor().Extract(source);
-        if (!extraction.IsSuccess)
-            return new RuleSetCompileResult(false, null, extraction.Diagnostics);
-
-        var validationDiagnostics = new WistRuleBodyValidator().Validate(extraction.Rules);
-        if (validationDiagnostics.Count > 0)
-            return RuleSetCompileResult.Failure(validationDiagnostics);
-
-        var diagnostics = new List<ToolchainDiagnostic>();
-        var compiledRules = new List<ICompiledRule>();
-
-        foreach (var rule in extraction.Rules.OrderBy(static x => x.Name, StringComparer.Ordinal))
-        {
-            var declaredBindings = CreateDeclaredBindings(rule.Parameters);
-            try
-            {
-                var artifact = Compile(rule.Body, declaredBindings, mode);
-                compiledRules.Add(new CompiledWistRule(CreateDescriptor(rule), artifact));
-            }
-            catch (Exception ex)
-            {
-                diagnostics.Add(new ToolchainDiagnostic(
-                    ToolchainDiagnosticCodes.RuleInvalidBody,
-                    ToolchainDiagnosticSeverity.Error,
-                    $"Rule '{rule.Name}' could not be compiled: {ex.Message}",
-                    null,
-                    []));
-            }
-        }
-
-        return diagnostics.Count == 0
-            ? RuleSetCompileResult.Success(new CompiledWistRuleSet(compiledRules))
-            : RuleSetCompileResult.Failure(diagnostics);
+        return _ruleSetCompiler.Compile(source, mode);
     }
 
     /// <summary>
@@ -171,32 +139,4 @@ public sealed class WistRuntimeFacade : IDisposable
         return declaredBindings;
     }
 
-    private OrderedDictionary<string, Type> CreateDeclaredBindings(IReadOnlyList<RuleParameterModel> parameters)
-    {
-        parameters = parameters.ArgNotNull();
-
-        var declaredBindings = new OrderedDictionary<string, Type>();
-        foreach (var parameter in parameters)
-            declaredBindings[parameter.Name] = ResolveRuntimeType(parameter.Type);
-
-        return declaredBindings;
-    }
-
-    private static CompiledRuleDescriptor CreateDescriptor(RuleDeclarationModel rule)
-    {
-        return new CompiledRuleDescriptor(
-            rule.Name,
-            rule.Parameters
-                .Select(static x => new RuleParameterDescriptor(x.Name, x.Type))
-                .ToList(),
-            rule.ReturnType);
-    }
-
-    private Type ResolveRuntimeType(RuleTypeDescriptor type)
-    {
-        if (_ruleRuntimeTypeResolver.TryResolve(type, out var runtimeType))
-            return runtimeType;
-
-        return Thrower.NotSupported<Type>($"Unsupported rule type '{type.Name}'.");
-    }
 }

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/Facade/WistRuntimeFacadeBuilder.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/Facade/WistRuntimeFacadeBuilder.cs
@@ -1,7 +1,11 @@
+using System.Reflection.Emit;
+using BasicCore.Compilation;
+using IntermediateRepresentationAbstractions;
 using ExceptionsManager;
 using Microsoft.Extensions.DependencyInjection;
 using UniversalToolchain.Dialects.Integration;
 using UniversalToolchain.Dialects.Wist.Presets;
+using UniversalToolchain.Dialects.Wist.Rules;
 
 namespace UniversalToolchain.Dialects.Wist.Facade;
 
@@ -65,6 +69,21 @@ public sealed class WistRuntimeFacadeBuilder
         if (!composition.IsSuccess)
             Thrower.InvalidOpEx(DialectCompositionExplanationFormatter.FormatDeterministic(DialectCompositionExplanationProjector.Project(composition)));
 
-        return new WistRuntimeFacade(workflow.CreateHost(composition), composition);
+        var host = workflow.CreateHost(composition);
+        var ruleSetCompiler = new WistRuleSetCompiler((source, declaredBindings, mode) =>
+        {
+            if (!host.Configuration.TryResolveKnownBackendId(mode, out var backendId))
+                Thrower.InvalidOpEx($"Unknown execution mode '{mode}'.");
+
+            if (backendId == WistDialectBackendIds.Interpreter)
+                return host.GetArtifactCompiler<IAbstractIR>(mode).Compile(source, declaredBindings);
+
+            if (backendId == WistDialectBackendIds.Cil)
+                return host.GetArtifactCompiler<DynamicMethod>(mode).Compile(source, declaredBindings);
+
+            return Thrower.InvalidOpEx<ICompiledArtifact>($"Unsupported Wist facade backend '{mode}'.");
+        });
+
+        return new WistRuntimeFacade(host, composition, ruleSetCompiler);
     }
 }

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/Rules/CompiledWistRule.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/Rules/CompiledWistRule.cs
@@ -1,6 +1,5 @@
 using BasicCore.Compilation;
 using ExceptionsManager;
-using UniversalToolchain.Diagnostics.Abstractions;
 using UniversalToolchain.Rules.Abstractions;
 
 namespace UniversalToolchain.Dialects.Wist.Rules;
@@ -8,12 +7,13 @@ namespace UniversalToolchain.Dialects.Wist.Rules;
 public sealed class CompiledWistRule : ICompiledRule
 {
     private readonly ICompiledArtifact _artifact;
-    private readonly WistRuleRuntimeValueAdapter _runtimeValueAdapter = new();
+    private readonly IWistRuleArgumentBinder _argumentBinder;
 
-    public CompiledWistRule(CompiledRuleDescriptor descriptor, ICompiledArtifact artifact)
+    public CompiledWistRule(CompiledRuleDescriptor descriptor, ICompiledArtifact artifact, IWistRuleArgumentBinder argumentBinder)
     {
         Descriptor = descriptor.ArgNotNull();
         _artifact = artifact.ArgNotNull();
+        _argumentBinder = argumentBinder.ArgNotNull();
     }
 
     public CompiledRuleDescriptor Descriptor { get; }
@@ -34,74 +34,14 @@ public sealed class CompiledWistRule : ICompiledRule
     {
         arguments = arguments.ArgNotNull();
 
-        var conversion = ConvertArguments(arguments);
-        if (conversion.Diagnostics.Count > 0)
-            return RuleExecutionResult.Failure(conversion.Diagnostics);
+        var binding = _argumentBinder.Bind(Descriptor, arguments);
+        if (!binding.IsSuccess)
+            return RuleExecutionResult.Failure(binding.Diagnostics);
 
         var session = _artifact.CreateSession();
         foreach (var parameter in Descriptor.Parameters)
-            session.SetArgument(parameter.Name, conversion.RuntimeArguments[parameter.Name]);
+            session.SetArgument(parameter.Name, binding.RuntimeArguments[parameter.Name]);
 
         return RuleExecutionResult.Success(session.Run());
     }
-
-    private RuleArgumentConversionResult ConvertArguments(IReadOnlyDictionary<string, object?> arguments)
-    {
-        var diagnostics = new List<ToolchainDiagnostic>();
-        var runtimeArguments = new Dictionary<string, object?>(StringComparer.Ordinal);
-        var requiredNames = Descriptor.Parameters
-            .Select(static x => x.Name)
-            .ToHashSet(StringComparer.Ordinal);
-
-        foreach (var argument in arguments.Keys.OrderBy(static x => x, StringComparer.Ordinal))
-        {
-            if (!requiredNames.Contains(argument))
-            {
-                diagnostics.Add(CreateDiagnostic(
-                    ToolchainDiagnosticCodes.RuleArgumentUnknown,
-                    $"Unknown argument '{argument}' for rule '{Descriptor.Name}'."));
-            }
-        }
-
-        foreach (var parameter in Descriptor.Parameters)
-        {
-            if (!arguments.ContainsKey(parameter.Name))
-            {
-                diagnostics.Add(CreateDiagnostic(
-                    ToolchainDiagnosticCodes.RuleArgumentMissing,
-                    $"Missing required argument '{parameter.Name}' for rule '{Descriptor.Name}'."));
-                continue;
-            }
-
-            if (!_runtimeValueAdapter.TryConvert(
-                    parameter.Type,
-                    arguments[parameter.Name],
-                    out var runtimeValue,
-                    out var diagnostic,
-                    parameter.Name,
-                    Descriptor.Name))
-            {
-                diagnostics.Add(diagnostic.NotNull());
-                continue;
-            }
-
-            runtimeArguments[parameter.Name] = runtimeValue;
-        }
-
-        return new RuleArgumentConversionResult(runtimeArguments, diagnostics);
-    }
-
-    private static ToolchainDiagnostic CreateDiagnostic(string code, string message)
-    {
-        return new ToolchainDiagnostic(
-            code,
-            ToolchainDiagnosticSeverity.Error,
-            message,
-            null,
-            []);
-    }
-
-    private sealed record RuleArgumentConversionResult(
-        IReadOnlyDictionary<string, object?> RuntimeArguments,
-        IReadOnlyList<ToolchainDiagnostic> Diagnostics);
 }

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/Rules/RuleDeclarationModels.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/Rules/RuleDeclarationModels.cs
@@ -3,11 +3,27 @@ using UniversalToolchain.Rules.Abstractions;
 
 namespace UniversalToolchain.Dialects.Wist.Rules;
 
+public readonly record struct RuleScopeId(int Value);
+
+public readonly record struct SourceSpan(int Start, int Length);
+
+public sealed record LocalBindingDeclarationModel(
+    string Name,
+    int DeclarationOrder,
+    RuleScopeId ScopeId,
+    SourceSpan Span);
+
+public sealed record RuleBodyModel(
+    string SourceText,
+    IReadOnlyList<LocalBindingDeclarationModel> LocalBindings,
+    SourceSpan Span);
+
 public sealed record RuleDeclarationModel(
     string Name,
     IReadOnlyList<RuleParameterModel> Parameters,
     RuleTypeDescriptor ReturnType,
-    string Body);
+    RuleBodyModel Body,
+    SourceSpan Span);
 
 public sealed record RuleParameterModel(
     string Name,

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/Rules/Syntax/WistRuleBodySyntaxAnalyzer.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/Rules/Syntax/WistRuleBodySyntaxAnalyzer.cs
@@ -1,0 +1,170 @@
+using ExceptionsManager;
+using UniversalToolchain.Diagnostics.Abstractions;
+
+namespace UniversalToolchain.Dialects.Wist.Rules.Syntax;
+
+public sealed class WistRuleBodySyntaxAnalyzer
+{
+    public WistRuleBodySyntaxInfo Analyze(string bodySourceText, int bodyStartOffset)
+    {
+        bodySourceText = bodySourceText.ArgNotNull();
+
+        var locals = new List<LocalBindingDeclarationModel>();
+        var diagnostics = new List<ToolchainDiagnostic>();
+        var declarationOrder = 0;
+        var cursor = 0;
+
+        while (cursor < bodySourceText.Length)
+        {
+            SkipTrivia(bodySourceText, ref cursor);
+            if (cursor >= bodySourceText.Length)
+                break;
+
+            if (!TryReadKeyword(bodySourceText, ref cursor, "let"))
+            {
+                cursor++;
+                continue;
+            }
+
+            SkipTrivia(bodySourceText, ref cursor);
+            if (!TryReadIdentifier(bodySourceText, ref cursor, out var identifier, out var start))
+            {
+                diagnostics.Add(CreateDiagnostic(ToolchainDiagnosticCodes.RuleInvalidBody, "Invalid local binding declaration after 'let'."));
+                continue;
+            }
+
+            SkipTrivia(bodySourceText, ref cursor);
+            if (cursor < bodySourceText.Length && bodySourceText[cursor] == ':')
+            {
+                cursor++;
+                SkipTrivia(bodySourceText, ref cursor);
+                if (!TryReadIdentifier(bodySourceText, ref cursor, out _, out _))
+                {
+                    diagnostics.Add(CreateDiagnostic(ToolchainDiagnosticCodes.RuleInvalidBody, $"Invalid typed local declaration for '{identifier}'."));
+                    continue;
+                }
+
+                SkipTrivia(bodySourceText, ref cursor);
+            }
+
+            if (cursor >= bodySourceText.Length || bodySourceText[cursor] != '=')
+            {
+                diagnostics.Add(CreateDiagnostic(ToolchainDiagnosticCodes.RuleInvalidBody, $"Expected '=' in local declaration for '{identifier}'."));
+                continue;
+            }
+
+            locals.Add(new LocalBindingDeclarationModel(
+                identifier,
+                declarationOrder++,
+                new RuleScopeId(0),
+                new SourceSpan(bodyStartOffset + start, identifier.Length)));
+
+            cursor++;
+        }
+
+        return new WistRuleBodySyntaxInfo(locals, diagnostics);
+    }
+
+    private static void SkipTrivia(string source, ref int cursor)
+    {
+        while (cursor < source.Length)
+        {
+            var current = source[cursor];
+            if (char.IsWhiteSpace(current))
+            {
+                cursor++;
+                continue;
+            }
+
+            if (cursor + 1 < source.Length && current == '/' && source[cursor + 1] == '/')
+            {
+                cursor += 2;
+                while (cursor < source.Length && source[cursor] != '\n')
+                    cursor++;
+                continue;
+            }
+
+            if (cursor + 1 < source.Length && current == '/' && source[cursor + 1] == '*')
+            {
+                cursor += 2;
+                while (cursor + 1 < source.Length && !(source[cursor] == '*' && source[cursor + 1] == '/'))
+                    cursor++;
+
+                if (cursor + 1 < source.Length)
+                    cursor += 2;
+
+                continue;
+            }
+
+            if (current == '"')
+            {
+                cursor++;
+                while (cursor < source.Length)
+                {
+                    if (source[cursor] == '\\' && cursor + 1 < source.Length)
+                    {
+                        cursor += 2;
+                        continue;
+                    }
+
+                    if (source[cursor] == '"')
+                    {
+                        cursor++;
+                        break;
+                    }
+
+                    cursor++;
+                }
+
+                continue;
+            }
+
+            break;
+        }
+    }
+
+    private static bool TryReadKeyword(string source, ref int cursor, string keyword)
+    {
+        if (cursor + keyword.Length > source.Length)
+            return false;
+
+        if (!string.Equals(source.Substring(cursor, keyword.Length), keyword, StringComparison.Ordinal))
+            return false;
+
+        var beforeOk = cursor == 0 || !IsIdentifierChar(source[cursor - 1]);
+        var afterIndex = cursor + keyword.Length;
+        var afterOk = afterIndex >= source.Length || !IsIdentifierChar(source[afterIndex]);
+        if (!beforeOk || !afterOk)
+            return false;
+
+        cursor += keyword.Length;
+        return true;
+    }
+
+    private static bool TryReadIdentifier(string source, ref int cursor, out string identifier, out int start)
+    {
+        start = cursor;
+        if (cursor >= source.Length || !(char.IsLetter(source[cursor]) || source[cursor] == '_'))
+        {
+            identifier = string.Empty;
+            return false;
+        }
+
+        cursor++;
+        while (cursor < source.Length && IsIdentifierChar(source[cursor]))
+            cursor++;
+
+        identifier = source[start..cursor];
+        return true;
+    }
+
+    private static bool IsIdentifierChar(char value)
+    {
+        return char.IsLetterOrDigit(value) || value == '_';
+    }
+
+    private static ToolchainDiagnostic CreateDiagnostic(string code, string message)
+    {
+        return new ToolchainDiagnostic(code, ToolchainDiagnosticSeverity.Error, message, null, []);
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/Rules/Syntax/WistRuleSetSyntaxModels.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/Rules/Syntax/WistRuleSetSyntaxModels.cs
@@ -1,0 +1,34 @@
+using UniversalToolchain.Diagnostics.Abstractions;
+
+namespace UniversalToolchain.Dialects.Wist.Rules.Syntax;
+
+public sealed record WistRuleSetSyntax(IReadOnlyList<WistRuleDeclarationSyntax> Rules);
+
+public sealed record WistRuleDeclarationSyntax(
+    string Name,
+    IReadOnlyList<WistRuleParameterSyntax> Parameters,
+    WistRuleTypeSyntax ReturnType,
+    string BodySourceText,
+    SourceSpan Span,
+    SourceSpan BodySpan);
+
+public sealed record WistRuleParameterSyntax(
+    string Name,
+    WistRuleTypeSyntax Type,
+    SourceSpan Span);
+
+public sealed record WistRuleTypeSyntax(
+    string Name,
+    SourceSpan Span);
+
+public sealed record WistRuleSetSyntaxParseResult(
+    bool IsSuccess,
+    WistRuleSetSyntax? Syntax,
+    IReadOnlyList<ToolchainDiagnostic> Diagnostics);
+
+public sealed record WistRuleBodySyntaxInfo(
+    IReadOnlyList<LocalBindingDeclarationModel> LocalBindings,
+    IReadOnlyList<ToolchainDiagnostic> Diagnostics)
+{
+    public bool IsSuccess => Diagnostics.Count == 0;
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/Rules/Syntax/WistRuleSetSyntaxParser.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/Rules/Syntax/WistRuleSetSyntaxParser.cs
@@ -1,0 +1,343 @@
+using ExceptionsManager;
+using UniversalToolchain.Diagnostics.Abstractions;
+
+namespace UniversalToolchain.Dialects.Wist.Rules.Syntax;
+
+public sealed class WistRuleSetSyntaxParser
+{
+    public WistRuleSetSyntaxParseResult Parse(string source)
+    {
+        source = source.ArgNotNull();
+
+        if (string.IsNullOrWhiteSpace(source))
+        {
+            return new WistRuleSetSyntaxParseResult(false, null,
+            [
+                CreateDiagnostic(ToolchainDiagnosticCodes.RuleInvalidBody, "Rule source must not be empty.")
+            ]);
+        }
+
+        var cursor = new Cursor(source);
+        var diagnostics = new List<ToolchainDiagnostic>();
+        var rules = new List<WistRuleDeclarationSyntax>();
+
+        cursor.SkipTrivia();
+        while (!cursor.End)
+        {
+            var rule = ParseRule(cursor, diagnostics);
+            if (rule != null)
+                rules.Add(rule);
+
+            if (diagnostics.Count > 0)
+                break;
+
+            cursor.SkipTrivia();
+        }
+
+        if (rules.Count == 0 && diagnostics.Count == 0)
+            diagnostics.Add(CreateDiagnostic(ToolchainDiagnosticCodes.RuleInvalidBody, "No rule declarations were found."));
+
+        return diagnostics.Count == 0
+            ? new WistRuleSetSyntaxParseResult(true, new WistRuleSetSyntax(rules), [])
+            : new WistRuleSetSyntaxParseResult(false, new WistRuleSetSyntax(rules), diagnostics);
+    }
+
+    private static WistRuleDeclarationSyntax? ParseRule(Cursor cursor, List<ToolchainDiagnostic> diagnostics)
+    {
+        var start = cursor.Position;
+        if (!cursor.TryReadKeyword("rule"))
+        {
+            diagnostics.Add(CreateDiagnostic(ToolchainDiagnosticCodes.RuleInvalidBody, $"Expected 'rule' keyword at offset {cursor.Position}."));
+            return null;
+        }
+
+        cursor.SkipTrivia();
+        if (!cursor.TryReadIdentifier(out var ruleName, out var ruleNameSpan))
+        {
+            diagnostics.Add(CreateDiagnostic(ToolchainDiagnosticCodes.RuleInvalidBody, $"Expected rule name at offset {cursor.Position}."));
+            return null;
+        }
+
+        cursor.SkipTrivia();
+        if (!cursor.TryConsume('('))
+        {
+            diagnostics.Add(CreateDiagnostic(ToolchainDiagnosticCodes.RuleInvalidBody, $"Expected '(' after rule '{ruleName}'."));
+            return null;
+        }
+
+        var parameters = ParseParameters(cursor, ruleName, diagnostics);
+        if (diagnostics.Count > 0)
+            return null;
+
+        cursor.SkipTrivia();
+        if (!cursor.TryConsume('-') || !cursor.TryConsume('>'))
+        {
+            diagnostics.Add(CreateDiagnostic(ToolchainDiagnosticCodes.RuleInvalidBody, $"Expected '->' after rule '{ruleName}' parameters."));
+            return null;
+        }
+
+        cursor.SkipTrivia();
+        if (!cursor.TryReadIdentifier(out var returnTypeName, out var returnTypeSpan))
+        {
+            diagnostics.Add(CreateDiagnostic(ToolchainDiagnosticCodes.RuleInvalidBody, $"Expected return type for rule '{ruleName}'."));
+            return null;
+        }
+
+        cursor.SkipTrivia();
+        if (!cursor.TryConsume('{'))
+        {
+            diagnostics.Add(CreateDiagnostic(ToolchainDiagnosticCodes.RuleInvalidBody, $"Expected '{{' before rule '{ruleName}' body."));
+            return null;
+        }
+
+        var bodyStart = cursor.Position;
+        if (!cursor.TryReadBody(out var bodyText, out var bodyEndExclusive))
+        {
+            diagnostics.Add(CreateDiagnostic(ToolchainDiagnosticCodes.RuleInvalidBody, $"Rule '{ruleName}' has an unterminated body."));
+            return null;
+        }
+
+        return new WistRuleDeclarationSyntax(
+            ruleName,
+            parameters,
+            new WistRuleTypeSyntax(returnTypeName, returnTypeSpan),
+            bodyText,
+            new SourceSpan(start, bodyEndExclusive - start + 1),
+            new SourceSpan(bodyStart, bodyEndExclusive - bodyStart));
+    }
+
+    private static IReadOnlyList<WistRuleParameterSyntax> ParseParameters(Cursor cursor, string ruleName, List<ToolchainDiagnostic> diagnostics)
+    {
+        var parameters = new List<WistRuleParameterSyntax>();
+        cursor.SkipTrivia();
+
+        if (cursor.TryConsume(')'))
+            return parameters;
+
+        while (true)
+        {
+            cursor.SkipTrivia();
+            var parameterStart = cursor.Position;
+            if (!cursor.TryReadIdentifier(out var parameterName, out _))
+            {
+                diagnostics.Add(CreateDiagnostic(ToolchainDiagnosticCodes.RuleInvalidBody, $"Expected parameter name in rule '{ruleName}'."));
+                return parameters;
+            }
+
+            cursor.SkipTrivia();
+            if (!cursor.TryConsume(':'))
+            {
+                diagnostics.Add(CreateDiagnostic(ToolchainDiagnosticCodes.RuleInvalidBody, $"Expected ':' after parameter '{parameterName}' in rule '{ruleName}'."));
+                return parameters;
+            }
+
+            cursor.SkipTrivia();
+            if (!cursor.TryReadIdentifier(out var typeName, out var typeSpan))
+            {
+                diagnostics.Add(CreateDiagnostic(ToolchainDiagnosticCodes.RuleInvalidBody, $"Expected type name for parameter '{parameterName}' in rule '{ruleName}'."));
+                return parameters;
+            }
+
+            parameters.Add(new WistRuleParameterSyntax(
+                parameterName,
+                new WistRuleTypeSyntax(typeName, typeSpan),
+                new SourceSpan(parameterStart, cursor.Position - parameterStart)));
+
+            cursor.SkipTrivia();
+            if (cursor.TryConsume(')'))
+                return parameters;
+
+            if (!cursor.TryConsume(','))
+            {
+                diagnostics.Add(CreateDiagnostic(ToolchainDiagnosticCodes.RuleInvalidBody, $"Expected ',' or ')' in parameter list of rule '{ruleName}'."));
+                return parameters;
+            }
+        }
+    }
+
+    private static ToolchainDiagnostic CreateDiagnostic(string code, string message)
+    {
+        return new ToolchainDiagnostic(code, ToolchainDiagnosticSeverity.Error, message, null, []);
+    }
+
+    private sealed class Cursor
+    {
+        private readonly string _source;
+
+        public Cursor(string source)
+        {
+            _source = source;
+        }
+
+        public int Position { get; private set; }
+
+        public bool End => Position >= _source.Length;
+
+        public bool TryConsume(char expected)
+        {
+            if (End || _source[Position] != expected)
+                return false;
+
+            Position++;
+            return true;
+        }
+
+        public bool TryReadIdentifier(out string identifier, out SourceSpan span)
+        {
+            var start = Position;
+            if (End || !(char.IsLetter(_source[Position]) || _source[Position] == '_'))
+            {
+                identifier = string.Empty;
+                span = default;
+                return false;
+            }
+
+            Position++;
+            while (!End && (char.IsLetterOrDigit(_source[Position]) || _source[Position] == '_'))
+                Position++;
+
+            identifier = _source[start..Position];
+            span = new SourceSpan(start, Position - start);
+            return true;
+        }
+
+        public bool TryReadKeyword(string keyword)
+        {
+            if (Position + keyword.Length > _source.Length)
+                return false;
+
+            if (!string.Equals(_source.Substring(Position, keyword.Length), keyword, StringComparison.Ordinal))
+                return false;
+
+            var beforeOk = Position == 0 || !IsIdentifierChar(_source[Position - 1]);
+            var afterIndex = Position + keyword.Length;
+            var afterOk = afterIndex >= _source.Length || !IsIdentifierChar(_source[afterIndex]);
+            if (!beforeOk || !afterOk)
+                return false;
+
+            Position += keyword.Length;
+            return true;
+        }
+
+        public void SkipTrivia()
+        {
+            while (!End)
+            {
+                if (char.IsWhiteSpace(_source[Position]))
+                {
+                    Position++;
+                    continue;
+                }
+
+                if (Position + 1 < _source.Length && _source[Position] == '/' && _source[Position + 1] == '/')
+                {
+                    Position += 2;
+                    while (!End && _source[Position] != '\n')
+                        Position++;
+                    continue;
+                }
+
+                if (Position + 1 < _source.Length && _source[Position] == '/' && _source[Position + 1] == '*')
+                {
+                    Position += 2;
+                    while (!End && !(Position + 1 < _source.Length && _source[Position] == '*' && _source[Position + 1] == '/'))
+                        Position++;
+
+                    if (Position + 1 < _source.Length)
+                        Position += 2;
+
+                    continue;
+                }
+
+                break;
+            }
+        }
+
+        public bool TryReadBody(out string bodyText, out int bodyEndExclusive)
+        {
+            var start = Position;
+            var depth = 1;
+            var inString = false;
+
+            while (!End)
+            {
+                var current = _source[Position];
+
+                if (inString)
+                {
+                    if (current == '\\' && Position + 1 < _source.Length)
+                    {
+                        Position += 2;
+                        continue;
+                    }
+
+                    if (current == '"')
+                        inString = false;
+
+                    Position++;
+                    continue;
+                }
+
+                if (current == '"')
+                {
+                    inString = true;
+                    Position++;
+                    continue;
+                }
+
+                if (Position + 1 < _source.Length && current == '/' && _source[Position + 1] == '/')
+                {
+                    Position += 2;
+                    while (!End && _source[Position] != '\n')
+                        Position++;
+                    continue;
+                }
+
+                if (Position + 1 < _source.Length && current == '/' && _source[Position + 1] == '*')
+                {
+                    Position += 2;
+                    while (!End && !(Position + 1 < _source.Length && _source[Position] == '*' && _source[Position + 1] == '/'))
+                        Position++;
+
+                    if (Position + 1 < _source.Length)
+                        Position += 2;
+
+                    continue;
+                }
+
+                if (current == '{')
+                {
+                    depth++;
+                    Position++;
+                    continue;
+                }
+
+                if (current == '}')
+                {
+                    depth--;
+                    if (depth == 0)
+                    {
+                        bodyText = _source[start..Position].Trim();
+                        bodyEndExclusive = Position;
+                        Position++;
+                        return true;
+                    }
+
+                    Position++;
+                    continue;
+                }
+
+                Position++;
+            }
+
+            bodyText = string.Empty;
+            bodyEndExclusive = start;
+            return false;
+        }
+
+        private static bool IsIdentifierChar(char value)
+        {
+            return char.IsLetterOrDigit(value) || value == '_';
+        }
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/Rules/WistRuleArgumentBinder.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/Rules/WistRuleArgumentBinder.cs
@@ -1,0 +1,75 @@
+using ExceptionsManager;
+using UniversalToolchain.Diagnostics.Abstractions;
+using UniversalToolchain.Rules.Abstractions;
+
+namespace UniversalToolchain.Dialects.Wist.Rules;
+
+public interface IWistRuleArgumentBinder
+{
+    RuleArgumentBindingResult Bind(CompiledRuleDescriptor descriptor, IReadOnlyDictionary<string, object?> arguments);
+}
+
+public sealed record RuleArgumentBindingResult(
+    bool IsSuccess,
+    IReadOnlyDictionary<string, object?> RuntimeArguments,
+    IReadOnlyList<ToolchainDiagnostic> Diagnostics)
+{
+    public static RuleArgumentBindingResult Success(IReadOnlyDictionary<string, object?> runtimeArguments)
+    {
+        return new RuleArgumentBindingResult(true, runtimeArguments, []);
+    }
+
+    public static RuleArgumentBindingResult Failure(IReadOnlyList<ToolchainDiagnostic> diagnostics)
+    {
+        return new RuleArgumentBindingResult(false, new Dictionary<string, object?>(StringComparer.Ordinal), diagnostics);
+    }
+}
+
+public sealed class WistRuleArgumentBinder : IWistRuleArgumentBinder
+{
+    private readonly WistRuleRuntimeValueAdapter _runtimeValueAdapter = new();
+
+    public RuleArgumentBindingResult Bind(CompiledRuleDescriptor descriptor, IReadOnlyDictionary<string, object?> arguments)
+    {
+        descriptor = descriptor.ArgNotNull();
+        arguments = arguments.ArgNotNull();
+
+        var diagnostics = new List<ToolchainDiagnostic>();
+        var runtimeArguments = new Dictionary<string, object?>(StringComparer.Ordinal);
+        var requiredNames = descriptor.Parameters
+            .Select(static x => x.Name)
+            .ToHashSet(StringComparer.Ordinal);
+
+        foreach (var argument in arguments.Keys.OrderBy(static x => x, StringComparer.Ordinal))
+        {
+            if (!requiredNames.Contains(argument))
+                diagnostics.Add(CreateDiagnostic(ToolchainDiagnosticCodes.RuleArgumentUnknown, $"Unknown argument '{argument}' for rule '{descriptor.Name}'."));
+        }
+
+        foreach (var parameter in descriptor.Parameters)
+        {
+            if (!arguments.ContainsKey(parameter.Name))
+            {
+                diagnostics.Add(CreateDiagnostic(ToolchainDiagnosticCodes.RuleArgumentMissing, $"Missing required argument '{parameter.Name}' for rule '{descriptor.Name}'."));
+                continue;
+            }
+
+            if (!_runtimeValueAdapter.TryConvert(parameter.Type, arguments[parameter.Name], out var runtimeValue, out var diagnostic, parameter.Name, descriptor.Name))
+            {
+                diagnostics.Add(diagnostic.NotNull());
+                continue;
+            }
+
+            runtimeArguments[parameter.Name] = runtimeValue;
+        }
+
+        return diagnostics.Count == 0
+            ? RuleArgumentBindingResult.Success(runtimeArguments)
+            : RuleArgumentBindingResult.Failure(diagnostics);
+    }
+
+    private static ToolchainDiagnostic CreateDiagnostic(string code, string message)
+    {
+        return new ToolchainDiagnostic(code, ToolchainDiagnosticSeverity.Error, message, null, []);
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/Rules/WistRuleBodyValidator.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/Rules/WistRuleBodyValidator.cs
@@ -1,74 +1,82 @@
 using ExceptionsManager;
-using System.Text.RegularExpressions;
 using UniversalToolchain.Diagnostics.Abstractions;
 
 namespace UniversalToolchain.Dialects.Wist.Rules;
 
 public sealed class WistRuleBodyValidator
 {
-    private static readonly Regex LetBindingRegex = new(
-        @"^\s*let\s+([A-Za-z_][A-Za-z0-9_]*)\s*=",
-        RegexOptions.Compiled | RegexOptions.CultureInvariant);
-
     public IReadOnlyList<ToolchainDiagnostic> Validate(IReadOnlyList<RuleDeclarationModel> rules)
     {
         rules = rules.ArgNotNull();
 
         var diagnostics = new List<ToolchainDiagnostic>();
-        foreach (var rule in rules.OrderBy(static x => x.Name, StringComparer.Ordinal))
-            ValidateRule(rule, diagnostics);
 
+        foreach (var rule in rules.OrderBy(static x => x.Name, StringComparer.Ordinal))
+        {
+            ValidateRuleParameters(rule, diagnostics);
+            ValidateRuleLocals(rule, diagnostics);
+        }
+
+        ValidateDuplicateRuleNames(rules, diagnostics);
         return diagnostics;
     }
 
-    private static void ValidateRule(RuleDeclarationModel rule, List<ToolchainDiagnostic> diagnostics)
+    private static void ValidateDuplicateRuleNames(IReadOnlyList<RuleDeclarationModel> rules, List<ToolchainDiagnostic> diagnostics)
+    {
+        foreach (var duplicateGroup in rules
+                     .GroupBy(static x => x.Name, StringComparer.Ordinal)
+                     .Where(static x => x.Count() > 1)
+                     .OrderBy(static x => x.Key, StringComparer.Ordinal))
+        {
+            diagnostics.Add(CreateDiagnostic(ToolchainDiagnosticCodes.RuleDuplicateName, $"Duplicate rule declaration '{duplicateGroup.Key}'."));
+        }
+    }
+
+    private static void ValidateRuleParameters(RuleDeclarationModel rule, List<ToolchainDiagnostic> diagnostics)
+    {
+        foreach (var duplicateGroup in rule.Parameters
+                     .GroupBy(static x => x.Name, StringComparer.Ordinal)
+                     .Where(static x => x.Count() > 1)
+                     .OrderBy(static x => x.Key, StringComparer.Ordinal))
+        {
+            diagnostics.Add(CreateDiagnostic(ToolchainDiagnosticCodes.RuleDuplicateParameter, $"Duplicate parameter '{duplicateGroup.Key}' in rule '{rule.Name}'."));
+        }
+    }
+
+    private static void ValidateRuleLocals(RuleDeclarationModel rule, List<ToolchainDiagnostic> diagnostics)
     {
         var parameterNames = rule.Parameters
             .Select(static x => x.Name)
             .ToHashSet(StringComparer.Ordinal);
-        var localNames = new HashSet<string>(StringComparer.Ordinal);
-        var lines = rule.Body.Split('\n');
+        var scopedLocals = new Dictionary<RuleScopeId, HashSet<string>>();
 
-        for (var lineIndex = 0; lineIndex < lines.Length; lineIndex++)
+        foreach (var localBinding in rule.Body.LocalBindings.OrderBy(static x => x.DeclarationOrder))
         {
-            var line = lines[lineIndex];
-            var match = LetBindingRegex.Match(line);
-            if (!match.Success)
-                continue;
-
-            var localName = match.Groups[1].Value;
-            if (string.IsNullOrWhiteSpace(localName))
-            {
-                diagnostics.Add(CreateDiagnostic(
-                    ToolchainDiagnosticCodes.RuleInvalidBody,
-                    $"Local binding declaration in rule '{rule.Name}' has an empty name at body line {lineIndex + 1}."));
-                continue;
-            }
-
-            if (parameterNames.Contains(localName))
+            if (parameterNames.Contains(localBinding.Name))
             {
                 diagnostics.Add(CreateDiagnostic(
                     ToolchainDiagnosticCodes.RuleLocalShadowsParameter,
-                    $"Local binding '{localName}' in rule '{rule.Name}' cannot shadow a rule parameter."));
+                    $"Local binding '{localBinding.Name}' in rule '{rule.Name}' cannot shadow a rule parameter."));
                 continue;
             }
 
-            if (!localNames.Add(localName))
+            if (!scopedLocals.TryGetValue(localBinding.ScopeId, out var names))
+            {
+                names = new HashSet<string>(StringComparer.Ordinal);
+                scopedLocals[localBinding.ScopeId] = names;
+            }
+
+            if (!names.Add(localBinding.Name))
             {
                 diagnostics.Add(CreateDiagnostic(
                     ToolchainDiagnosticCodes.RuleDuplicateLocal,
-                    $"Duplicate local binding '{localName}' in rule '{rule.Name}'."));
+                    $"Duplicate local binding '{localBinding.Name}' in rule '{rule.Name}'."));
             }
         }
     }
 
     private static ToolchainDiagnostic CreateDiagnostic(string code, string message)
     {
-        return new ToolchainDiagnostic(
-            code,
-            ToolchainDiagnosticSeverity.Error,
-            message,
-            null,
-            []);
+        return new ToolchainDiagnostic(code, ToolchainDiagnosticSeverity.Error, message, null, []);
     }
 }

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/Rules/WistRuleDeclarationExtractor.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/Rules/WistRuleDeclarationExtractor.cs
@@ -1,122 +1,76 @@
-using System.Text;
+using ExceptionsManager;
 using UniversalToolchain.Diagnostics.Abstractions;
+using UniversalToolchain.Dialects.Wist.Rules.Syntax;
 using UniversalToolchain.Rules.Abstractions;
 
 namespace UniversalToolchain.Dialects.Wist.Rules;
 
 public sealed class WistRuleDeclarationExtractor
 {
+    private readonly WistRuleBodySyntaxAnalyzer _bodySyntaxAnalyzer;
+    private readonly WistRuleSetSyntaxParser _syntaxParser;
+
+    public WistRuleDeclarationExtractor()
+    {
+        _syntaxParser = new WistRuleSetSyntaxParser();
+        _bodySyntaxAnalyzer = new WistRuleBodySyntaxAnalyzer();
+    }
+
     public RuleDeclarationExtractionResult Extract(string source)
     {
-        if (string.IsNullOrWhiteSpace(source))
-            return RuleDeclarationExtractionResult.Failure([CreateDiagnostic(ToolchainDiagnosticCodes.RuleInvalidBody, "Rule source must not be empty.")]);
+        source = source.ArgNotNull();
+
+        var parse = _syntaxParser.Parse(source);
+        if (!parse.IsSuccess || parse.Syntax == null)
+            return RuleDeclarationExtractionResult.Failure(parse.Diagnostics);
 
         var diagnostics = new List<ToolchainDiagnostic>();
         var rules = new List<RuleDeclarationModel>();
-        var names = new HashSet<string>(StringComparer.Ordinal);
-        var position = 0;
+        var ruleNames = new HashSet<string>(StringComparer.Ordinal);
 
-        while (TryFindKeyword(source, "rule", position, out var keywordIndex))
+        foreach (var ruleSyntax in parse.Syntax.Rules)
         {
-            var cursor = keywordIndex + "rule".Length;
-            SkipWhiteSpace(source, ref cursor);
-            var name = ReadIdentifier(source, ref cursor);
-            if (string.IsNullOrWhiteSpace(name))
-            {
-                diagnostics.Add(CreateDiagnostic(ToolchainDiagnosticCodes.RuleInvalidBody, $"Expected rule name at offset {cursor}."));
-                break;
-            }
+            if (!ruleNames.Add(ruleSyntax.Name))
+                diagnostics.Add(CreateDiagnostic(ToolchainDiagnosticCodes.RuleDuplicateName, $"Duplicate rule declaration '{ruleSyntax.Name}'."));
 
-            SkipWhiteSpace(source, ref cursor);
-            if (!Consume(source, ref cursor, '('))
-            {
-                diagnostics.Add(CreateDiagnostic(ToolchainDiagnosticCodes.RuleInvalidBody, $"Expected '(' after rule '{name}'."));
-                break;
-            }
+            var returnType = ParseType(ruleSyntax.ReturnType.Name, diagnostics, $"rule '{ruleSyntax.Name}' return type");
+            if (returnType == null)
+                continue;
 
-            var parametersText = ReadUntilMatching(source, ref cursor, '(', ')');
-            if (parametersText == null)
-            {
-                diagnostics.Add(CreateDiagnostic(ToolchainDiagnosticCodes.RuleInvalidBody, $"Rule '{name}' has an unterminated parameter list."));
-                break;
-            }
+            var parameters = ParseParameters(ruleSyntax, diagnostics);
+            var bodyInfo = _bodySyntaxAnalyzer.Analyze(ruleSyntax.BodySourceText, ruleSyntax.BodySpan.Start);
+            diagnostics.AddRange(bodyInfo.Diagnostics);
 
-            SkipWhiteSpace(source, ref cursor);
-            if (!ConsumeArrow(source, ref cursor))
-            {
-                diagnostics.Add(CreateDiagnostic(ToolchainDiagnosticCodes.RuleInvalidBody, $"Expected '->' after rule '{name}' parameter list."));
-                break;
-            }
-
-            SkipWhiteSpace(source, ref cursor);
-            var returnTypeName = ReadIdentifier(source, ref cursor);
-            if (string.IsNullOrWhiteSpace(returnTypeName))
-            {
-                diagnostics.Add(CreateDiagnostic(ToolchainDiagnosticCodes.RuleInvalidBody, $"Expected return type for rule '{name}'."));
-                break;
-            }
-
-            SkipWhiteSpace(source, ref cursor);
-            if (!Consume(source, ref cursor, '{'))
-            {
-                diagnostics.Add(CreateDiagnostic(ToolchainDiagnosticCodes.RuleInvalidBody, $"Expected '{{' before rule '{name}' body."));
-                break;
-            }
-
-            var body = ReadUntilMatching(source, ref cursor, '{', '}');
-            if (body == null)
-            {
-                diagnostics.Add(CreateDiagnostic(ToolchainDiagnosticCodes.RuleInvalidBody, $"Rule '{name}' has an unterminated body."));
-                break;
-            }
-
-            if (!names.Add(name))
-                diagnostics.Add(CreateDiagnostic(ToolchainDiagnosticCodes.RuleDuplicateName, $"Duplicate rule declaration '{name}'."));
-
-            var parameters = ParseParameters(name, parametersText, diagnostics);
-            var returnType = ParseType(returnTypeName, diagnostics, $"rule '{name}' return type");
-            if (returnType != null)
-                rules.Add(new RuleDeclarationModel(name, parameters, returnType, body.Trim()));
-
-            position = cursor;
+            rules.Add(new RuleDeclarationModel(
+                ruleSyntax.Name,
+                parameters,
+                returnType,
+                new RuleBodyModel(ruleSyntax.BodySourceText, bodyInfo.LocalBindings, ruleSyntax.BodySpan),
+                ruleSyntax.Span));
         }
-
-        if (rules.Count == 0 && diagnostics.Count == 0)
-            diagnostics.Add(CreateDiagnostic(ToolchainDiagnosticCodes.RuleInvalidBody, "No rule declarations were found."));
 
         return diagnostics.Count == 0
             ? RuleDeclarationExtractionResult.Success(rules)
             : new RuleDeclarationExtractionResult(false, rules, diagnostics);
     }
 
-    private static IReadOnlyList<RuleParameterModel> ParseParameters(
-        string ruleName,
-        string parametersText,
-        List<ToolchainDiagnostic> diagnostics)
+    private static IReadOnlyList<RuleParameterModel> ParseParameters(WistRuleDeclarationSyntax syntax, List<ToolchainDiagnostic> diagnostics)
     {
         var parameters = new List<RuleParameterModel>();
-        var names = new HashSet<string>(StringComparer.Ordinal);
-        if (string.IsNullOrWhiteSpace(parametersText))
-            return parameters;
 
-        foreach (var rawParameter in parametersText.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries))
+        var parameterNames = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var parameterSyntax in syntax.Parameters)
         {
-            var parts = rawParameter.Split(':', StringSplitOptions.TrimEntries);
-            if (parts.Length != 2 || string.IsNullOrWhiteSpace(parts[0]) || string.IsNullOrWhiteSpace(parts[1]))
+            if (!parameterNames.Add(parameterSyntax.Name))
             {
-                diagnostics.Add(CreateDiagnostic(ToolchainDiagnosticCodes.RuleInvalidBody, $"Invalid parameter declaration '{rawParameter}' in rule '{ruleName}'. Expected 'name: type'."));
+                diagnostics.Add(CreateDiagnostic(ToolchainDiagnosticCodes.RuleDuplicateParameter, $"Duplicate parameter '{parameterSyntax.Name}' in rule '{syntax.Name}'."));
                 continue;
             }
 
-            if (!names.Add(parts[0]))
-            {
-                diagnostics.Add(CreateDiagnostic(ToolchainDiagnosticCodes.RuleDuplicateParameter, $"Duplicate parameter '{parts[0]}' in rule '{ruleName}'."));
-                continue;
-            }
-
-            var type = ParseType(parts[1], diagnostics, $"parameter '{parts[0]}' in rule '{ruleName}'");
+            var type = ParseType(parameterSyntax.Type.Name, diagnostics, $"parameter '{parameterSyntax.Name}' in rule '{syntax.Name}'");
             if (type != null)
-                parameters.Add(new RuleParameterModel(parts[0], type));
+                parameters.Add(new RuleParameterModel(parameterSyntax.Name, type));
         }
 
         return parameters;
@@ -133,91 +87,6 @@ public sealed class WistRuleDeclarationExtractor
 
     private static ToolchainDiagnostic CreateDiagnostic(string code, string message)
     {
-        return new ToolchainDiagnostic(
-            code,
-            ToolchainDiagnosticSeverity.Error,
-            message,
-            null,
-            []);
-    }
-
-    private static bool TryFindKeyword(string source, string keyword, int start, out int index)
-    {
-        index = source.IndexOf(keyword, start, StringComparison.Ordinal);
-        while (index >= 0)
-        {
-            var beforeOk = index == 0 || !IsIdentifierChar(source[index - 1]);
-            var after = index + keyword.Length;
-            var afterOk = after >= source.Length || !IsIdentifierChar(source[after]);
-            if (beforeOk && afterOk)
-                return true;
-
-            index = source.IndexOf(keyword, index + keyword.Length, StringComparison.Ordinal);
-        }
-
-        return false;
-    }
-
-    private static void SkipWhiteSpace(string source, ref int cursor)
-    {
-        while (cursor < source.Length && char.IsWhiteSpace(source[cursor]))
-            cursor++;
-    }
-
-    private static string ReadIdentifier(string source, ref int cursor)
-    {
-        var start = cursor;
-        while (cursor < source.Length && IsIdentifierChar(source[cursor]))
-            cursor++;
-
-        return source[start..cursor];
-    }
-
-    private static bool Consume(string source, ref int cursor, char expected)
-    {
-        if (cursor >= source.Length || source[cursor] != expected)
-            return false;
-
-        cursor++;
-        return true;
-    }
-
-    private static bool ConsumeArrow(string source, ref int cursor)
-    {
-        if (cursor + 1 >= source.Length || source[cursor] != '-' || source[cursor + 1] != '>')
-            return false;
-
-        cursor += 2;
-        return true;
-    }
-
-    private static string? ReadUntilMatching(string source, ref int cursor, char opening, char closing)
-    {
-        var start = cursor;
-        var depth = 1;
-        var builder = new StringBuilder();
-
-        while (cursor < source.Length)
-        {
-            var current = source[cursor++];
-            if (current == opening)
-                depth++;
-            else if (current == closing)
-            {
-                depth--;
-                if (depth == 0)
-                    return builder.ToString();
-            }
-
-            builder.Append(current);
-        }
-
-        cursor = start;
-        return null;
-    }
-
-    private static bool IsIdentifierChar(char value)
-    {
-        return char.IsLetterOrDigit(value) || value == '_';
+        return new ToolchainDiagnostic(code, ToolchainDiagnosticSeverity.Error, message, null, []);
     }
 }

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/Rules/WistRuleSetCompiler.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/Rules/WistRuleSetCompiler.cs
@@ -1,0 +1,89 @@
+using BasicCore.Compilation;
+using ExceptionsManager;
+using UniversalToolchain.Diagnostics.Abstractions;
+using UniversalToolchain.Rules.Abstractions;
+
+namespace UniversalToolchain.Dialects.Wist.Rules;
+
+public interface IWistRuleSetCompiler
+{
+    RuleSetCompileResult Compile(string source, string mode);
+}
+
+public sealed class WistRuleSetCompiler : IWistRuleSetCompiler
+{
+    private readonly Func<string, OrderedDictionary<string, Type>, string, ICompiledArtifact> _artifactCompiler;
+    private readonly IWistRuleArgumentBinder _argumentBinder;
+    private readonly WistRuleBodyValidator _validator;
+    private readonly WistRuleDeclarationExtractor _extractor;
+    private readonly WistRuleRuntimeTypeResolver _typeResolver;
+
+    public WistRuleSetCompiler(Func<string, OrderedDictionary<string, Type>, string, ICompiledArtifact> artifactCompiler)
+    {
+        _artifactCompiler = artifactCompiler.ArgNotNull();
+        _extractor = new WistRuleDeclarationExtractor();
+        _validator = new WistRuleBodyValidator();
+        _typeResolver = new WistRuleRuntimeTypeResolver();
+        _argumentBinder = new WistRuleArgumentBinder();
+    }
+
+    public RuleSetCompileResult Compile(string source, string mode)
+    {
+        var extraction = _extractor.Extract(source);
+        if (!extraction.IsSuccess)
+            return new RuleSetCompileResult(false, null, extraction.Diagnostics);
+
+        var validationDiagnostics = _validator.Validate(extraction.Rules);
+        if (validationDiagnostics.Count > 0)
+            return RuleSetCompileResult.Failure(validationDiagnostics);
+
+        var diagnostics = new List<ToolchainDiagnostic>();
+        var compiledRules = new List<ICompiledRule>();
+
+        foreach (var rule in extraction.Rules.OrderBy(static x => x.Name, StringComparer.Ordinal))
+        {
+            var declaredBindings = CreateDeclaredBindings(rule.Parameters);
+            try
+            {
+                var artifact = _artifactCompiler(rule.Body.SourceText, declaredBindings, mode);
+                compiledRules.Add(new CompiledWistRule(CreateDescriptor(rule), artifact, _argumentBinder));
+            }
+            catch (Exception ex)
+            {
+                diagnostics.Add(new ToolchainDiagnostic(
+                    ToolchainDiagnosticCodes.RuleInvalidBody,
+                    ToolchainDiagnosticSeverity.Error,
+                    $"Rule '{rule.Name}' could not be compiled: {ex.Message}",
+                    null,
+                    []));
+            }
+        }
+
+        return diagnostics.Count == 0
+            ? RuleSetCompileResult.Success(new CompiledWistRuleSet(compiledRules))
+            : RuleSetCompileResult.Failure(diagnostics);
+    }
+
+    private OrderedDictionary<string, Type> CreateDeclaredBindings(IReadOnlyList<RuleParameterModel> parameters)
+    {
+        var declaredBindings = new OrderedDictionary<string, Type>();
+
+        foreach (var parameter in parameters)
+        {
+            if (_typeResolver.TryResolve(parameter.Type, out var runtimeType))
+                declaredBindings[parameter.Name] = runtimeType;
+            else
+                _ = Thrower.NotSupported<Type>($"Unsupported rule type '{parameter.Type.Name}'.");
+        }
+
+        return declaredBindings;
+    }
+
+    private static CompiledRuleDescriptor CreateDescriptor(RuleDeclarationModel rule)
+    {
+        return new CompiledRuleDescriptor(
+            rule.Name,
+            rule.Parameters.Select(static x => new RuleParameterDescriptor(x.Name, x.Type)).ToList(),
+            rule.ReturnType);
+    }
+}


### PR DESCRIPTION
### Motivation
- Eliminate raw-source syntax recognition from validators, facades, and compiled/runtime helpers and ensure rule syntax is owned by a dedicated syntax component. 
- Follow the `docs/wist-rule-system-clean-design.md` and syntax-ownership guardrails so validators consume structured models instead of scanning text. 
- Keep the change minimal and deterministic while preserving existing runtime/compilation paths and test behavior.

### Description
- Introduced a syntax-owner rule-set parser and models under `Rules/Syntax` (`WistRuleSetSyntaxParser`, syntax model records and parse result), with robust body delimiter handling that skips comments/strings and tracks nested braces. 
- Rewrote `WistRuleDeclarationExtractor` to delegate to the syntax parser and convert syntax output into structured `RuleDeclarationModel` and `RuleBodyModel` (including `LocalBindingDeclarationModel` and `SourceSpan`) rather than scanning raw source. 
- Added `WistRuleBodySyntaxAnalyzer` to extract local bindings from body source in a syntax-owned place and removed regex/line-splitting from production validators. 
- Replaced ad-hoc body validation with structured validators (`WistRuleBodyValidator`) that validate rule names, parameters, return types, and local bindings deterministically. 
- Introduced `IWistRuleSetCompiler` / `WistRuleSetCompiler` and `IWistRuleArgumentBinder` / `WistRuleArgumentBinder` and moved rule-set compilation and argument binding out of `WistRuntimeFacade` and `CompiledWistRule` respectively; `WistRuntimeFacade.CompileRuleSet` now delegates to the compiler. 
- Updated `CompiledWistRule` to use the new binder and adjusted descriptor/declared-binding creation to remain explicit and deterministic. 
- Added an architecture guardrail test `WistRuleSyntaxOwnershipGuardrailTests` to detect forbidden raw-source syntax recognition patterns outside `Rules/Syntax`. 
- Updated and extended unit tests in `WistRuleSetValidationTests` to exercise comments, duplicate locals, parameter shadowing, extra/missing/wrong-type/null arguments, interpreter/compiler parity, and local scoping.

### Testing
- Ran the focused rule validation tests with: `dotnet test UniversalToolchain/UniversalToolchain.Dialects.Tests/UniversalToolchain.Dialects.Tests.csproj -c Release --filter "FullyQualifiedName~WistRuleSetValidationTests"` and observed the updated suite pass after the refactor. 
- Ran parity and function execution tests with: `dotnet test ... --filter "FullyQualifiedName~WistDialectExecutionParityTests|FullyQualifiedName~FunctionCallsSourceExecutionTests"` and observed parity/function tests pass. 
- Ran guardrail tests with: `dotnet test ... --filter "FullyQualifiedName~Architecture|FullyQualifiedName~Guardrail"` and the ownership guardrail passed, preventing raw-source patterns outside `Rules/Syntax`. 
- Built and ran the larger solution/assembly test runs (`dotnet restore`, `dotnet build UniversalToolchain/Wist.sln -c Release --no-restore`, and `dotnet test UniversalToolchain/Wist.sln -c Release --no-build`) to detect integration regressions; the repository tests completed with existing coverage (no new unexpected failures caused by the refactor). 
- Note: `python3 .github/scripts/run-markdown-bash-blocks.py` failed in the CI environment due to external preview tooling (`xdg-open`) and markdown blocks that call `dotnet` without the test PATH injection; this is an environmental limitation and not a regression in the rule refactor.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee54f8c2c4832486aea6c6ceb13b2a)