### PR TITLE
Fix IfExpression range consumption and make lowering deterministic

### DIFF
--- a/UniversalToolchain/ConditionsModule/Creators/IfExpressionNodeCreator.cs
+++ b/UniversalToolchain/ConditionsModule/Creators/IfExpressionNodeCreator.cs
@@ -26,10 +26,10 @@ public sealed class IfExpressionNodeCreator : IAstNodeCreator
 
         var condition = ReadSingleExpression(scope, childIndex + 1, thenIndex, "if-expression condition");
         var trueExpression = ReadSingleExpression(scope, thenIndex + 1, elseIndex, "if-expression true branch");
-        var falseExpression = ReadSingleExpression(scope, elseIndex + 1, scope.Children.Count, "if-expression false branch");
+        var falseExpression = ReadSingleExpression(scope, elseIndex + 1, elseIndex + 2, "if-expression false branch");
 
         var ifExpression = new AstNode(AstNodeType, ifToken.LexemeValue, [condition, trueExpression, falseExpression]);
-        var removeCount = scope.Children.Count - childIndex;
+        var removeCount = (elseIndex + 1) - childIndex + 1;
         scope.Children.RemoveRange(childIndex, removeCount);
         scope.Children.Insert(childIndex, ifExpression);
         return true;

--- a/UniversalToolchain/ConditionsModule/Visitors/IfExpressionVisitor.cs
+++ b/UniversalToolchain/ConditionsModule/Visitors/IfExpressionVisitor.cs
@@ -3,6 +3,7 @@ namespace ConditionsModule.Visitors;
 public sealed class IfExpressionVisitor : IAstVisitor
 {
     private static readonly ExtensibleEnum<AstNodeTag> IfExpressionNodeType = ExtensibleEnum<AstNodeTag>.CreateOrGet("IfExpression");
+    private int _ifExpressionSequence;
 
     public void TryVisit(BytecodeVisitorData data)
     {
@@ -14,12 +15,16 @@ public sealed class IfExpressionVisitor : IAstVisitor
         if (data.Node.Children.Count != 3)
             Thrower.InvalidOpEx("IfExpression node must contain condition, true branch, and false branch.");
 
-        var falseLabel = Guid.NewGuid();
-        var endLabel = Guid.NewGuid();
-        var resultLocalName = $"__if_expression_result_{Guid.NewGuid():N}";
+        var sequence = _ifExpressionSequence++;
+        var falseLabel = CreateDeterministicLabel(sequence, 1);
+        var endLabel = CreateDeterministicLabel(sequence, 2);
+        var resultLocalName = $"__if_expression_result_{sequence}";
         var resultType = default(Type);
 
         data.AstToBytecodeTranslator.Translate(data.Node.Children[0]);
+        data.Bytecode.Instructions.Add(new BytecodeInstruction(new AbstractMethodImpl(
+            $"IfExpression_RequireBooleanCondition_{sequence}",
+            (_, context) => RequireBooleanCondition(context))));
         data.Bytecode.Instructions.Add(new BytecodeInstruction(new AbstractMethodImpl(
             $"IfExpression_JmpIfNot_{falseLabel}",
             (il, _) => il.JmpIfNot(falseLabel))));
@@ -46,6 +51,25 @@ public sealed class IfExpressionVisitor : IAstVisitor
         data.Bytecode.Instructions.Add(new BytecodeInstruction(new AbstractMethodImpl(
             $"IfExpression_LoadResult_{resultLocalName}",
             (il, _) => il.LdLoc(resultLocalName, resultType.NotNull()))));
+    }
+
+    private static Guid CreateDeterministicLabel(int sequence, byte marker)
+    {
+        var bytes = new byte[16];
+        BitConverter.GetBytes(sequence).CopyTo(bytes, 0);
+        bytes[15] = marker;
+        return new Guid(bytes);
+    }
+
+    private static void RequireBooleanCondition(IAbstractMethodConvertable.Context context)
+    {
+        if (context.Stack.Count == 0)
+            Thrower.InvalidOpEx("IfExpression condition must leave a value on the stack.");
+
+        var conditionType = context.Stack[^1];
+        if (conditionType != typeof(bool))
+            Thrower.InvalidOpEx(
+                $"IfExpression condition must be boolean. Actual type: '{conditionType.FullName}'.");
     }
 
     private static void StoreBranchResult(

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/Wist/WistDialectExecutionParityTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/Wist/WistDialectExecutionParityTests.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using ExceptionsManager;
 using Microsoft.Extensions.DependencyInjection;
 using NumbersModule.Core;
 using UniversalToolchain.Dialects.Wist;
@@ -30,6 +31,21 @@ public class WistDialectExecutionParityTests
     [Test]
     public void InterpreterAndCompiler_ShouldMatch_ForIfExpression_WithIntermediateResultLocal()
         => AssertParity(CreateFullDialect(), "let result = 255.0\nif result < 0.0 then 0.0 else result", 255d);
+
+    [Test]
+    public void IfExpression_WhenConditionIsNotBool_ReturnsOrThrowsClearDiagnostic()
+    {
+        using var host = ComposeAndCreateHost(CreateFullDialect());
+
+        var interpreterException = Assert.Throws<InvalidOperationException>(() => host.Run("if 1.0 then 10.0 else 20.0", "interpreter"));
+        var compilerException = Assert.Throws<InvalidOperationException>(() => host.Run("if 1.0 then 10.0 else 20.0", "compiler"));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(interpreterException!.Message, Does.Contain("condition must be boolean"));
+            Assert.That(compilerException!.Message, Does.Contain("condition must be boolean"));
+        });
+    }
 
     [Test]
     public void InterpreterAndCompiler_ShouldMatch_ForVariablesAndScopesDialect()
@@ -93,7 +109,7 @@ public class WistDialectExecutionParityTests
         var workflow = provider.GetRequiredService<WistDialectExecutionWorkflow>();
         var composition = workflow.ComposeText(dialect, "inline-dialect");
         if (!composition.IsSuccess)
-            throw new InvalidOperationException(DialectCompositionExplanationFormatter.FormatDeterministic(DialectCompositionExplanationProjector.Project(composition)));
+            Thrower.InvalidOpEx(DialectCompositionExplanationFormatter.FormatDeterministic(DialectCompositionExplanationProjector.Project(composition)));
 
         return workflow.CreateHost(composition);
     }


### PR DESCRIPTION
### Motivation
- The `IfExpression` creator was removing the rest of the scope after consuming an `if ... then ... else ...` segment, which broke following siblings and program structure.
- Lowering used nondeterministic `Guid.NewGuid()` values for labels and local names, causing non-deterministic artifacts and failing parity/diagnostic expectations.
- The parser/lowering lacked an explicit check that the `if` condition leaves a boolean on the stack, producing unclear runtime failures for malformed conditions.

### Description
- Restrict `IfExpressionNodeCreator` to consume exactly the `if condition then trueExpr else falseExpr` range so following siblings remain intact by adjusting the removed range calculation and the false-branch extraction indices in `UniversalToolchain/ConditionsModule/Creators/IfExpressionNodeCreator.cs`.
- Replace nondeterministic GUID generation in lowering with a per-visitor sequence and deterministic label construction, and use sequence-based result-local names instead of `Guid.NewGuid()` in `UniversalToolchain/ConditionsModule/Visitors/IfExpressionVisitor.cs`.
- Add an explicit boolean-condition check during lowering that emits a clear `Thrower.InvalidOpEx` when the condition does not leave a `bool` on the stack in `IfExpressionVisitor`.
- Add a focused regression test for non-boolean `if` conditions and adjust a test utility to use `Thrower.InvalidOpEx` in `UniversalToolchain/UniversalToolchain.Dialects.Tests/Wist/WistDialectExecutionParityTests.cs`.

### Testing
- Restored the solution with `dotnet restore UniversalToolchain/Wist.sln` using .NET 10 and built with `dotnet build UniversalToolchain/Wist.sln -c Release --no-restore` which completed successfully.
- Ran the full test suite with `dotnet test UniversalToolchain/Wist.sln -c Release --no-build` and observed all tests passing in the affected test assemblies (no failing tests after the change).
- Executed the dialect tests specifically via `dotnet test UniversalToolchain/UniversalToolchain.Dialects.Tests/UniversalToolchain.Dialects.Tests.csproj -c Release --no-restore` which passed, and reproduced repository anti-hardcode checks (`rg` commands) from CI which returned no violations for the relevant guardrails.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee66aec738832484447099287a7ca5)