### PR TITLE
Harden IfExpression parsing and add regression + diagnostic tests

### DIFF
--- a/UniversalToolchain/ConditionsModule/Creators/IfExpressionNodeCreator.cs
+++ b/UniversalToolchain/ConditionsModule/Creators/IfExpressionNodeCreator.cs
@@ -48,6 +48,11 @@ public sealed class IfExpressionNodeCreator : IAstNodeCreator
 
     private static AstNode ReadSingleExpression(AstNode scope, int startIndex, int endIndex, string segmentName)
     {
+        scope = scope.ArgNotNull();
+
+        if (startIndex < 0 || endIndex > scope.Children.Count || startIndex >= endIndex)
+            Thrower.InvalidOpEx($"Expected exactly one expression in {segmentName}.");
+
         var count = endIndex - startIndex;
         if (count != 1)
             Thrower.InvalidOpEx($"Expected exactly one expression in {segmentName}.");

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/Wist/WistDialectExecutionParityTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/Wist/WistDialectExecutionParityTests.cs
@@ -1,4 +1,7 @@
 using System.Globalization;
+using BasicCore.ParserWrapper;
+using BasicTypesExtensions;
+using ConditionsModule.Creators;
 using ExceptionsManager;
 using Microsoft.Extensions.DependencyInjection;
 using NumbersModule.Core;
@@ -31,6 +34,68 @@ public class WistDialectExecutionParityTests
     [Test]
     public void InterpreterAndCompiler_ShouldMatch_ForIfExpression_WithIntermediateResultLocal()
         => AssertParity(CreateFullDialect(), "let result = 255.0\nif result < 0.0 then 0.0 else result", 255d);
+
+    [Test]
+    public void IfExpressionNodeCreator_ShouldPreserveSiblingsAfterIfExpression()
+    {
+        var ifNodeType = ExtensibleEnum<AstNodeTag>.CreateOrGet("If");
+        var thenNodeType = ExtensibleEnum<AstNodeTag>.CreateOrGet("Then");
+        var elseNodeType = ExtensibleEnum<AstNodeTag>.CreateOrGet("Else");
+        var expressionNodeType = ExtensibleEnum<AstNodeTag>.CreateOrGet("Expression");
+        var statementNodeType = ExtensibleEnum<AstNodeTag>.CreateOrGet("Statement");
+        var scopeNodeType = ExtensibleEnum<AstNodeTag>.CreateOrGet("Scope");
+
+        var condition = new AstNode(expressionNodeType, null, []);
+        var trueBranch = new AstNode(expressionNodeType, null, []);
+        var falseBranch = new AstNode(expressionNodeType, null, []);
+        var sibling1 = new AstNode(statementNodeType, null, []);
+        var sibling2 = new AstNode(statementNodeType, null, []);
+
+        var scope = new AstNode(
+            scopeNodeType,
+            null,
+            [
+                new AstNode(ifNodeType, null, []),
+                condition,
+                new AstNode(thenNodeType, null, []),
+                trueBranch,
+                new AstNode(elseNodeType, null, []),
+                falseBranch,
+                sibling1,
+                sibling2
+            ]);
+
+        var creator = new IfExpressionNodeCreator();
+        var wasCreated = creator.TryCreateNode(scope, 0);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(wasCreated, Is.True);
+            Assert.That(scope.Children.Count, Is.EqualTo(3));
+            Assert.That(scope.Children[1], Is.SameAs(sibling1));
+            Assert.That(scope.Children[2], Is.SameAs(sibling2));
+        });
+    }
+
+    [Test]
+    public void IfExpression_WhenFalseBranchIsMissing_ThrowsClearDiagnostic()
+    {
+        using var host = ComposeAndCreateHost(CreateFullDialect());
+
+        var interpreterException = Assert.Throws<InvalidOperationException>(
+            () => host.Run("if 1.0 < 2.0 then 10.0 else", "interpreter"));
+
+        var compilerException = Assert.Throws<InvalidOperationException>(
+            () => host.Run("if 1.0 < 2.0 then 10.0 else", "compiler"));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(interpreterException, Is.Not.Null);
+            Assert.That(compilerException, Is.Not.Null);
+            Assert.That(interpreterException?.Message, Does.Contain("if-expression false branch"));
+            Assert.That(compilerException?.Message, Does.Contain("if-expression false branch"));
+        });
+    }
 
     [Test]
     public void IfExpression_WhenConditionIsNotBool_ReturnsOrThrowsClearDiagnostic()


### PR DESCRIPTION
### Motivation
- Prevent index-out-of-range crashes when a malformed `if ... then ... else` sequence is parsed so frontend failures surface as clear diagnostics instead of runtime exceptions.
- Add a regression test proving `IfExpressionNodeCreator` does not consume following sibling statements when it collapses `if ... then ... else` into an `IfExpression` node.
- Ensure a missing false branch in an `if-expression` produces a clear diagnostic that mentions `if-expression false branch` for both interpreter and compiler paths.

### Description
- Hardened `ReadSingleExpression` in `UniversalToolchain/ConditionsModule/Creators/IfExpressionNodeCreator.cs` by adding `scope = scope.ArgNotNull()` and explicit index/bounds validation (`startIndex < 0 || endIndex > scope.Children.Count || startIndex >= endIndex`) before reading `scope.Children[startIndex]` so malformed segments raise a deterministic `InvalidOperationException` diagnostic.
- Added `IfExpressionNodeCreator_ShouldPreserveSiblingsAfterIfExpression` unit test to `UniversalToolchain/UniversalToolchain.Dialects.Tests/Wist/WistDialectExecutionParityTests.cs` to validate sibling preservation after the node rewrite.
- Added `IfExpression_WhenFalseBranchIsMissing_ThrowsClearDiagnostic` negative test to the same test file to assert both interpreter and compiler produce `InvalidOperationException` messages containing `if-expression false branch`.
- Added necessary test imports (`BasicCore.ParserWrapper`, `BasicTypesExtensions`, `ConditionsModule.Creators`) used by the regression test and verified no changes to `IfExpressionVisitor` deterministic naming or use of `Guid.NewGuid()` were introduced.

### Testing
- Performed `dotnet restore` and `dotnet build` for the solution with SDK `10.0.103` (install steps used `dotnet-install.sh`).
- Ran targeted tests with `dotnet test` for the newly added tests and related condition tests (filtering by name); all targeted tests passed.
- Ran the full dialect tests with `dotnet test UniversalToolchain/UniversalToolchain.Dialects.Tests/UniversalToolchain.Dialects.Tests.csproj -c Release --no-restore` and the full `Wist.sln` test runs; the test suites passed (no failures in the run reported: all tests passed).
- Confirmed `IfExpressionVisitor` contains no `Guid.NewGuid()` with `rg "Guid\.NewGuid" UniversalToolchain/ConditionsModule/Visitors/IfExpressionVisitor.cs` (no matches).
- Verified the existing non-bool condition test still passes after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee6de88b5c8324b22d6e1dad9db619)