### PR TITLE
Skip heavy README build/test block in markdown smoke (use ci-run=false)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -251,7 +251,7 @@ Active runtime and backend work is being verified there first, so older target f
 
 From repository root:
 
-```bash
+```bash ci-run=false
 dotnet restore UniversalToolchain/Wist.sln
 dotnet build UniversalToolchain/Wist.sln -c Release --no-restore
 dotnet test UniversalToolchain/Tests/Tests.csproj -c Release --no-build


### PR DESCRIPTION
### Motivation
- Prevent markdown smoke CI from timing out by skipping the heavy `Build and test from source` bash block while keeping the commands visible to human readers.

### Description
- Change the opening fence in `readme.md` for the `## Build and test from source` block from ```bash to ```bash ci-run=false and leave all `dotnet restore/build/test` commands and the block body unchanged, without modifying production code, IfExpression sources, test sources, the markdown runner, or CI workflow files.

### Testing
- Ran `rg -n '```bash ci-run=false' readme.md` and `rg -n 'Build and test from source' readme.md` to confirm the fence change, verified via `git diff` that `UniversalToolchain/ConditionsModule/Creators/IfExpressionNodeCreator.cs`, `UniversalToolchain/ConditionsModule/Visitors/IfExpressionVisitor.cs`, and `UniversalToolchain/UniversalToolchain.Dialects.Tests/Wist/WistDialectExecutionParityTests.cs` remain unchanged, and executed `python3 .github/scripts/run-markdown-bash-blocks.py` which moved past the README timeout point but aborted later due to `dotnet` not being available in the local environment (the README block no longer times out in markdown smoke).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee7ac030488324a2045d2b09edceb1)