### PR TITLE
Move Wist rule runtime mappings into provider-owned bindings

### DIFF
--- a/UniversalToolchain/ConditionsModule/BooleanCapabilityProvider.cs
+++ b/UniversalToolchain/ConditionsModule/BooleanCapabilityProvider.cs
@@ -1,10 +1,13 @@
 using UniversalToolchain.Capabilities.Abstractions;
+using UniversalToolchain.Rules.Abstractions;
 
 namespace ConditionsModule;
 
-public sealed class BooleanCapabilityProvider : ILanguageFeatureDescriptorProvider
+public sealed class BooleanCapabilityProvider : ILanguageFeatureDescriptorProvider, IRuleRuntimeTypeBindingProvider
 {
     private static readonly LanguageFeatureId FeatureId = new("BooleanConditions");
+    private static readonly RuleTypeDescriptor BoolRuleType = new("bool");
+    private static readonly IRuleRuntimeValueConverter BoolConverter = new BooleanRuleRuntimeValueConverter();
 
     public IReadOnlyList<LanguageFeatureDescriptor> GetLanguageFeatures()
     {
@@ -25,6 +28,14 @@ public sealed class BooleanCapabilityProvider : ILanguageFeatureDescriptorProvid
                 ],
                 ["cil", "interpreter"],
                 "Provides boolean literals and boolean operators.")
+        ];
+    }
+
+    public IReadOnlyList<RuleRuntimeTypeBinding> GetRuleRuntimeTypeBindings()
+    {
+        return
+        [
+            new RuleRuntimeTypeBinding(BoolRuleType, typeof(bool), BoolConverter)
         ];
     }
 }

--- a/UniversalToolchain/ConditionsModule/BooleanRuleRuntimeValueConverter.cs
+++ b/UniversalToolchain/ConditionsModule/BooleanRuleRuntimeValueConverter.cs
@@ -1,0 +1,52 @@
+using UniversalToolchain.Diagnostics.Abstractions;
+using UniversalToolchain.Rules.Abstractions;
+
+namespace ConditionsModule;
+
+public sealed class BooleanRuleRuntimeValueConverter : IRuleRuntimeValueConverter
+{
+    public bool TryConvert(
+        object? value,
+        out object? runtimeValue,
+        out ToolchainDiagnostic? diagnostic,
+        string argumentName,
+        string ruleName,
+        RuleTypeDescriptor expectedType)
+    {
+        argumentName = argumentName.ArgNotNull();
+        ruleName = ruleName.ArgNotNull();
+        expectedType = expectedType.ArgNotNull();
+
+        runtimeValue = null;
+        diagnostic = null;
+
+        if (value == null)
+        {
+            diagnostic = CreateDiagnostic(
+                ToolchainDiagnosticCodes.RuleArgumentNull,
+                $"Argument '{argumentName}' for rule '{ruleName}' must not be null.");
+            return false;
+        }
+
+        if (value is bool booleanValue)
+        {
+            runtimeValue = booleanValue;
+            return true;
+        }
+
+        diagnostic = CreateDiagnostic(
+            ToolchainDiagnosticCodes.RuleArgumentTypeMismatch,
+            $"Argument '{argumentName}' for rule '{ruleName}' must have type '{expectedType.Name}'. Actual runtime type: '{value.GetType().FullName}'.");
+        return false;
+    }
+
+    private static ToolchainDiagnostic CreateDiagnostic(string code, string message)
+    {
+        return new ToolchainDiagnostic(
+            code,
+            ToolchainDiagnosticSeverity.Error,
+            message,
+            null,
+            []);
+    }
+}

--- a/UniversalToolchain/ConditionsModule/ConditionsModule.csproj
+++ b/UniversalToolchain/ConditionsModule/ConditionsModule.csproj
@@ -17,6 +17,8 @@
         <ProjectReference Include="..\ObjectExtensions\ObjectExtensions.csproj"/>
         <ProjectReference Include="..\UniversalIntermediateRepresentation\UniversalIntermediateRepresentation.csproj"/>
         <ProjectReference Include="..\ExceptionsManager\ExceptionsManager.csproj"/>
+        <ProjectReference Include="..\UniversalToolchain.Diagnostics.Abstractions\UniversalToolchain.Diagnostics.Abstractions.csproj"/>
+        <ProjectReference Include="..\UniversalToolchain.Rules.Abstractions\UniversalToolchain.Rules.Abstractions.csproj"/>
         <ProjectReference Include="..\UniversalToolchain.Dialects.Integration\UniversalToolchain.Dialects.Integration.csproj"/>
     </ItemGroup>
 

--- a/UniversalToolchain/NumbersModule/NumberRuleRuntimeValueConverter.cs
+++ b/UniversalToolchain/NumbersModule/NumberRuleRuntimeValueConverter.cs
@@ -1,0 +1,89 @@
+using UniversalToolchain.Diagnostics.Abstractions;
+using UniversalToolchain.Rules.Abstractions;
+
+namespace NumbersModule;
+
+public sealed class NumberRuleRuntimeValueConverter : IRuleRuntimeValueConverter
+{
+    public bool TryConvert(
+        object? value,
+        out object? runtimeValue,
+        out ToolchainDiagnostic? diagnostic,
+        string argumentName,
+        string ruleName,
+        RuleTypeDescriptor expectedType)
+    {
+        argumentName = argumentName.ArgNotNull();
+        ruleName = ruleName.ArgNotNull();
+        expectedType = expectedType.ArgNotNull();
+
+        runtimeValue = null;
+        diagnostic = null;
+
+        if (value == null)
+        {
+            diagnostic = CreateDiagnostic(
+                ToolchainDiagnosticCodes.RuleArgumentNull,
+                $"Argument '{argumentName}' for rule '{ruleName}' must not be null.");
+            return false;
+        }
+
+        if (value is RealNumberImpl realNumber)
+        {
+            runtimeValue = realNumber;
+            return true;
+        }
+
+        if (TryConvertToDouble(value, out var doubleValue))
+        {
+            runtimeValue = new RealNumberImpl(doubleValue);
+            return true;
+        }
+
+        diagnostic = CreateDiagnostic(
+            ToolchainDiagnosticCodes.RuleArgumentTypeMismatch,
+            $"Argument '{argumentName}' for rule '{ruleName}' must have type '{expectedType.Name}'. Actual runtime type: '{value.GetType().FullName}'.");
+        return false;
+    }
+
+    private static bool TryConvertToDouble(object value, out double result)
+    {
+        switch (value)
+        {
+            case double doubleValue:
+                result = doubleValue;
+                return true;
+            case float floatValue:
+                result = floatValue;
+                return true;
+            case decimal decimalValue:
+                result = (double)decimalValue;
+                return true;
+            case int intValue:
+                result = intValue;
+                return true;
+            case long longValue:
+                result = longValue;
+                return true;
+            case short shortValue:
+                result = shortValue;
+                return true;
+            case byte byteValue:
+                result = byteValue;
+                return true;
+            default:
+                result = default;
+                return false;
+        }
+    }
+
+    private static ToolchainDiagnostic CreateDiagnostic(string code, string message)
+    {
+        return new ToolchainDiagnostic(
+            code,
+            ToolchainDiagnosticSeverity.Error,
+            message,
+            null,
+            []);
+    }
+}

--- a/UniversalToolchain/NumbersModule/NumbersCapabilityProvider.cs
+++ b/UniversalToolchain/NumbersModule/NumbersCapabilityProvider.cs
@@ -1,10 +1,13 @@
 using UniversalToolchain.Capabilities.Abstractions;
+using UniversalToolchain.Rules.Abstractions;
 
 namespace NumbersModule;
 
-public sealed class NumbersCapabilityProvider : ILanguageFeatureDescriptorProvider
+public sealed class NumbersCapabilityProvider : ILanguageFeatureDescriptorProvider, IRuleRuntimeTypeBindingProvider
 {
     private static readonly LanguageFeatureId FeatureId = new("NumericLiterals");
+    private static readonly RuleTypeDescriptor NumberRuleType = new("number");
+    private static readonly IRuleRuntimeValueConverter NumberConverter = new NumberRuleRuntimeValueConverter();
 
     public IReadOnlyList<LanguageFeatureDescriptor> GetLanguageFeatures()
     {
@@ -21,6 +24,14 @@ public sealed class NumbersCapabilityProvider : ILanguageFeatureDescriptorProvid
                 ],
                 ["cil", "interpreter"],
                 "Provides numeric literal parsing for Wist expressions.")
+        ];
+    }
+
+    public IReadOnlyList<RuleRuntimeTypeBinding> GetRuleRuntimeTypeBindings()
+    {
+        return
+        [
+            new RuleRuntimeTypeBinding(NumberRuleType, typeof(RealNumberImpl), NumberConverter)
         ];
     }
 }

--- a/UniversalToolchain/NumbersModule/NumbersModule.csproj
+++ b/UniversalToolchain/NumbersModule/NumbersModule.csproj
@@ -16,6 +16,8 @@
         <ProjectReference Include="..\GenericMath\GenericMath.csproj"/>
         <ProjectReference Include="..\UniversalIntermediateRepresentation\UniversalIntermediateRepresentation.csproj"/>
         <ProjectReference Include="..\ExceptionsManager\ExceptionsManager.csproj"/>
+        <ProjectReference Include="..\UniversalToolchain.Diagnostics.Abstractions\UniversalToolchain.Diagnostics.Abstractions.csproj"/>
+        <ProjectReference Include="..\UniversalToolchain.Rules.Abstractions\UniversalToolchain.Rules.Abstractions.csproj"/>
         <ProjectReference Include="..\UniversalToolchain.Dialects.Integration\UniversalToolchain.Dialects.Integration.csproj"/>
     </ItemGroup>
 

--- a/UniversalToolchain/UniversalToolchain.Capabilities.Core/CapabilityCatalog.cs
+++ b/UniversalToolchain/UniversalToolchain.Capabilities.Core/CapabilityCatalog.cs
@@ -3,6 +3,7 @@ using UniversalToolchain.Capabilities.Abstractions;
 using UniversalToolchain.Diagnostics.Abstractions;
 using UniversalToolchain.ExpressionTyping.Abstractions;
 using UniversalToolchain.Functions.Abstractions;
+using UniversalToolchain.Rules.Abstractions;
 
 namespace UniversalToolchain.Capabilities.Core;
 
@@ -15,6 +16,7 @@ public sealed class CapabilityCatalog
     private readonly IReadOnlyDictionary<LanguageFeatureId, CapabilityProviderDescriptor> _featureOwnersById;
     private readonly ReadOnlyCollection<LanguageFeatureDescriptor> _languageFeatures;
     private readonly ReadOnlyCollection<CapabilityProviderDescriptor> _providers;
+    private readonly ReadOnlyCollection<RuleRuntimeTypeBinding> _ruleRuntimeTypeBindings;
 
     public CapabilityCatalog(
         IEnumerable<CapabilityProviderDescriptor> providers,
@@ -22,6 +24,7 @@ public sealed class CapabilityCatalog
         IEnumerable<BuiltinFunctionDescriptor> builtinFunctionDescriptors,
         IEnumerable<BuiltinFunctionRuntimeBinding> builtinFunctionRuntimeBindings,
         IEnumerable<IExpressionTypeRule> expressionTypeRules,
+        IEnumerable<RuleRuntimeTypeBinding> ruleRuntimeTypeBindings,
         IEnumerable<ToolchainDiagnostic> diagnostics,
         IReadOnlyDictionary<LanguageFeatureId, CapabilityProviderDescriptor>? featureOwnersById = null)
     {
@@ -30,6 +33,7 @@ public sealed class CapabilityCatalog
         ArgumentNullException.ThrowIfNull(builtinFunctionDescriptors);
         ArgumentNullException.ThrowIfNull(builtinFunctionRuntimeBindings);
         ArgumentNullException.ThrowIfNull(expressionTypeRules);
+        ArgumentNullException.ThrowIfNull(ruleRuntimeTypeBindings);
         ArgumentNullException.ThrowIfNull(diagnostics);
 
         _providers = new ReadOnlyCollection<CapabilityProviderDescriptor>(providers
@@ -53,6 +57,10 @@ public sealed class CapabilityCatalog
         _expressionTypeRules = new ReadOnlyCollection<IExpressionTypeRule>(expressionTypeRules
             .OrderBy(static x => CapabilityProviderTypeResolver.GetTypeName(x.GetType()), StringComparer.Ordinal)
             .ToList());
+        _ruleRuntimeTypeBindings = new ReadOnlyCollection<RuleRuntimeTypeBinding>(ruleRuntimeTypeBindings
+            .OrderBy(static x => x.RuleType.Name, StringComparer.Ordinal)
+            .ThenBy(static x => x.RuntimeType.FullName ?? x.RuntimeType.Name, StringComparer.Ordinal)
+            .ToList());
         _diagnostics = new ReadOnlyCollection<ToolchainDiagnostic>(diagnostics
             .OrderBy(static x => x.Code, StringComparer.Ordinal)
             .ThenBy(static x => x.Message, StringComparer.Ordinal)
@@ -69,6 +77,8 @@ public sealed class CapabilityCatalog
     public IReadOnlyList<BuiltinFunctionRuntimeBinding> BuiltinFunctionRuntimeBindings => _builtinFunctionRuntimeBindings;
 
     public IReadOnlyList<IExpressionTypeRule> ExpressionTypeRules => _expressionTypeRules;
+
+    public IReadOnlyList<RuleRuntimeTypeBinding> RuleRuntimeTypeBindings => _ruleRuntimeTypeBindings;
 
     public IReadOnlyList<ToolchainDiagnostic> Diagnostics => _diagnostics;
 
@@ -101,6 +111,7 @@ public sealed class CapabilityCatalog
         var expressionTypeRules = new List<IExpressionTypeRule>();
         var diagnostics = new List<ToolchainDiagnostic>(discovery.Diagnostics);
         var featureOwnersById = new Dictionary<LanguageFeatureId, CapabilityProviderDescriptor>();
+        var ruleRuntimeTypeBindings = new List<RuleRuntimeTypeBinding>();
 
         foreach (var descriptor in discovery.ProviderDescriptors)
         {
@@ -131,6 +142,9 @@ public sealed class CapabilityCatalog
 
             if (provider is IExpressionTypeRuleProvider expressionTypeRuleProvider)
                 expressionTypeRules.AddRange(expressionTypeRuleProvider.GetRules() ?? []);
+
+            if (provider is IRuleRuntimeTypeBindingProvider ruleRuntimeTypeBindingProvider)
+                ruleRuntimeTypeBindings.AddRange(ruleRuntimeTypeBindingProvider.GetRuleRuntimeTypeBindings() ?? []);
         }
 
         return new CapabilityCatalog(
@@ -139,6 +153,7 @@ public sealed class CapabilityCatalog
             functions,
             runtimeBindings,
             expressionTypeRules,
+            ruleRuntimeTypeBindings,
             diagnostics,
             featureOwnersById);
     }

--- a/UniversalToolchain/UniversalToolchain.Capabilities.Core/CapabilityProviderTypeResolver.cs
+++ b/UniversalToolchain/UniversalToolchain.Capabilities.Core/CapabilityProviderTypeResolver.cs
@@ -2,6 +2,7 @@ using UniversalToolchain.Capabilities.Abstractions;
 using UniversalToolchain.Diagnostics.Abstractions;
 using UniversalToolchain.ExpressionTyping.Abstractions;
 using UniversalToolchain.Functions.Abstractions;
+using UniversalToolchain.Rules.Abstractions;
 
 namespace UniversalToolchain.Capabilities.Core;
 
@@ -54,7 +55,8 @@ public sealed class CapabilityProviderTypeResolver
         return typeof(ILanguageFeatureDescriptorProvider).IsAssignableFrom(providerType) ||
                typeof(IBuiltinFunctionDescriptorProvider).IsAssignableFrom(providerType) ||
                typeof(IBuiltinFunctionRuntimeBindingProvider).IsAssignableFrom(providerType) ||
-               typeof(IExpressionTypeRuleProvider).IsAssignableFrom(providerType);
+               typeof(IExpressionTypeRuleProvider).IsAssignableFrom(providerType) ||
+               typeof(IRuleRuntimeTypeBindingProvider).IsAssignableFrom(providerType);
     }
 
     internal static ToolchainDiagnostic CreateInvalidProviderDiagnostic(

--- a/UniversalToolchain/UniversalToolchain.Capabilities.Core/UniversalToolchain.Capabilities.Core.csproj
+++ b/UniversalToolchain/UniversalToolchain.Capabilities.Core/UniversalToolchain.Capabilities.Core.csproj
@@ -11,6 +11,7 @@
     <ProjectReference Include="..\UniversalToolchain.Functions.Abstractions\UniversalToolchain.Functions.Abstractions.csproj"/>
     <ProjectReference Include="..\UniversalToolchain.ExpressionTyping.Abstractions\UniversalToolchain.ExpressionTyping.Abstractions.csproj"/>
     <ProjectReference Include="..\UniversalToolchain.Diagnostics.Abstractions\UniversalToolchain.Diagnostics.Abstractions.csproj"/>
+    <ProjectReference Include="..\UniversalToolchain.Rules.Abstractions\UniversalToolchain.Rules.Abstractions.csproj"/>
     <ProjectReference Include="..\UniversalToolchain.Dialects.Integration\UniversalToolchain.Dialects.Integration.csproj"/>
   </ItemGroup>
 </Project>

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/Architecture/WistRuleRuntimeDependencyGuardrailTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/Architecture/WistRuleRuntimeDependencyGuardrailTests.cs
@@ -1,0 +1,48 @@
+namespace UniversalToolchain.Dialects.Tests.Architecture;
+
+public sealed class WistRuleRuntimeDependencyGuardrailTests
+{
+    [Test]
+    public void WistRulesLayer_MustNotDependOnNumbersModuleImplementationDetails()
+    {
+        var root = ResolveRepositoryRoot();
+        var ruleRoot = Path.Combine(root, "UniversalToolchain", "UniversalToolchain.Dialects.Wist", "Rules");
+        var files = Directory.GetFiles(ruleRoot, "*.cs", SearchOption.AllDirectories)
+            .OrderBy(static x => x, StringComparer.Ordinal)
+            .ToList();
+
+        var forbiddenPatterns = new[]
+        {
+            "NumbersModule.Core",
+            "RealNumberImpl"
+        };
+
+        var violations = new List<string>();
+        foreach (var file in files)
+        {
+            var content = File.ReadAllText(file);
+            foreach (var pattern in forbiddenPatterns)
+            {
+                if (content.Contains(pattern, StringComparison.Ordinal))
+                    violations.Add($"{Path.GetRelativePath(root, file)} contains forbidden pattern '{pattern}'.");
+            }
+        }
+
+        Assert.That(violations, Is.Empty);
+    }
+
+    private static string ResolveRepositoryRoot()
+    {
+        var current = new DirectoryInfo(TestContext.CurrentContext.TestDirectory);
+
+        while (current != null)
+        {
+            if (File.Exists(Path.Combine(current.FullName, "AGENTS.md")))
+                return current.FullName;
+
+            current = current.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Repository root with AGENTS.md was not found.");
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/Rules/WistRuleRuntimeBindingTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/Rules/WistRuleRuntimeBindingTests.cs
@@ -1,0 +1,117 @@
+using NumbersModule.Core;
+using NumbersModule.Module;
+using UniversalToolchain.Capabilities.Core;
+using UniversalToolchain.Diagnostics.Abstractions;
+using UniversalToolchain.Dialects.Wist.Rules;
+using UniversalToolchain.Rules.Abstractions;
+
+namespace UniversalToolchain.Dialects.Tests.Rules;
+
+public sealed class WistRuleRuntimeBindingTests
+{
+    [Test]
+    public void RuntimeTypeResolver_UsesProvidedBindings()
+    {
+        var resolver = new WistRuleRuntimeTypeResolver(
+        [
+            new RuleRuntimeTypeBinding(
+                new RuleTypeDescriptor("custom"),
+                typeof(string),
+                new PassThroughConverter())
+        ]);
+
+        var resolved = resolver.TryResolve(new RuleTypeDescriptor("custom"), out var runtimeType);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(resolved, Is.True);
+            Assert.That(runtimeType, Is.EqualTo(typeof(string)));
+        });
+    }
+
+    [Test]
+    public void RuleArgumentBinder_DelegatesRuntimeConversionToBindingConverter()
+    {
+        var converter = new TrackingConverter("adapted-value");
+        var resolver = new WistRuleRuntimeTypeResolver(
+        [
+            new RuleRuntimeTypeBinding(
+                new RuleTypeDescriptor("custom"),
+                typeof(string),
+                converter)
+        ]);
+        var adapter = new WistRuleRuntimeValueAdapter(resolver);
+        var binder = new WistRuleArgumentBinder(adapter);
+
+        var descriptor = new CompiledRuleDescriptor(
+            "CustomRule",
+            [new RuleParameterDescriptor("input", new RuleTypeDescriptor("custom"))],
+            new RuleTypeDescriptor("custom"));
+
+        var result = binder.Bind(
+            descriptor,
+            new Dictionary<string, object?>
+            {
+                ["input"] = 123
+            });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(converter.WasCalled, Is.True);
+            Assert.That(result.RuntimeArguments["input"], Is.EqualTo("adapted-value"));
+        });
+    }
+
+    [Test]
+    public void SelectedCapabilityCatalog_ContainsNumberRuleRuntimeBinding()
+    {
+        var catalog = new SelectedCapabilityCatalogBuilder().Build([typeof(NumbersModuleImpl)]);
+
+        var binding = catalog.RuleRuntimeTypeBindings.Single(static x => x.RuleType.Name == "number");
+
+        Assert.That(binding.RuntimeType, Is.EqualTo(typeof(RealNumberImpl)));
+    }
+
+    private sealed class PassThroughConverter : IRuleRuntimeValueConverter
+    {
+        public bool TryConvert(
+            object? value,
+            out object? runtimeValue,
+            out ToolchainDiagnostic? diagnostic,
+            string argumentName,
+            string ruleName,
+            RuleTypeDescriptor expectedType)
+        {
+            runtimeValue = value;
+            diagnostic = null;
+            return true;
+        }
+    }
+
+    private sealed class TrackingConverter : IRuleRuntimeValueConverter
+    {
+        private readonly object _result;
+
+        public TrackingConverter(object result)
+        {
+            _result = result;
+        }
+
+        public bool WasCalled { get; private set; }
+
+        public bool TryConvert(
+            object? value,
+            out object? runtimeValue,
+            out ToolchainDiagnostic? diagnostic,
+            string argumentName,
+            string ruleName,
+            RuleTypeDescriptor expectedType)
+        {
+            WasCalled = true;
+            runtimeValue = _result;
+            diagnostic = null;
+            return true;
+        }
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/Facade/WistRuntimeFacadeBuilder.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/Facade/WistRuntimeFacadeBuilder.cs
@@ -3,6 +3,7 @@ using BasicCore.Compilation;
 using IntermediateRepresentationAbstractions;
 using ExceptionsManager;
 using Microsoft.Extensions.DependencyInjection;
+using UniversalToolchain.Capabilities.Core;
 using UniversalToolchain.Dialects.Integration;
 using UniversalToolchain.Dialects.Wist.Presets;
 using UniversalToolchain.Dialects.Wist.Rules;
@@ -70,6 +71,12 @@ public sealed class WistRuntimeFacadeBuilder
             Thrower.InvalidOpEx(DialectCompositionExplanationFormatter.FormatDeterministic(DialectCompositionExplanationProjector.Project(composition)));
 
         var host = workflow.CreateHost(composition);
+        var selectedRuntimePlan = composition.RuntimeSelection as SelectedRuntimePlan
+                                  ?? Thrower.InvalidOpEx<SelectedRuntimePlan>("Wist facade requires selected runtime plan for rule runtime binding resolution.");
+        var runtimeComponentTypeLoader = provider.GetRequiredService<IRuntimeComponentTypeLoader>();
+        var selectedCapabilityCatalog = new SelectedCapabilityCatalogBuilder(runtimeComponentTypeLoader).Build(selectedRuntimePlan);
+        var ruleRuntimeTypeBindings = selectedCapabilityCatalog.RuleRuntimeTypeBindings;
+
         var ruleSetCompiler = new WistRuleSetCompiler((source, declaredBindings, mode) =>
         {
             if (!host.Configuration.TryResolveKnownBackendId(mode, out var backendId))
@@ -82,7 +89,7 @@ public sealed class WistRuntimeFacadeBuilder
                 return host.GetArtifactCompiler<DynamicMethod>(mode).Compile(source, declaredBindings);
 
             return Thrower.InvalidOpEx<ICompiledArtifact>($"Unsupported Wist facade backend '{mode}'.");
-        });
+        }, ruleRuntimeTypeBindings);
 
         return new WistRuntimeFacade(host, composition, ruleSetCompiler);
     }

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/Rules/WistRuleArgumentBinder.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/Rules/WistRuleArgumentBinder.cs
@@ -27,7 +27,12 @@ public sealed record RuleArgumentBindingResult(
 
 public sealed class WistRuleArgumentBinder : IWistRuleArgumentBinder
 {
-    private readonly WistRuleRuntimeValueAdapter _runtimeValueAdapter = new();
+    private readonly WistRuleRuntimeValueAdapter _runtimeValueAdapter;
+
+    public WistRuleArgumentBinder(WistRuleRuntimeValueAdapter runtimeValueAdapter)
+    {
+        _runtimeValueAdapter = runtimeValueAdapter.ArgNotNull();
+    }
 
     public RuleArgumentBindingResult Bind(CompiledRuleDescriptor descriptor, IReadOnlyDictionary<string, object?> arguments)
     {

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/Rules/WistRuleRuntimeTypeResolver.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/Rules/WistRuleRuntimeTypeResolver.cs
@@ -1,20 +1,48 @@
 using ExceptionsManager;
-using NumbersModule.Core;
 using UniversalToolchain.Rules.Abstractions;
 
 namespace UniversalToolchain.Dialects.Wist.Rules;
 
 public sealed class WistRuleRuntimeTypeResolver
 {
-    private static readonly IReadOnlyDictionary<string, Type> _runtimeTypes = new Dictionary<string, Type>(StringComparer.Ordinal)
+    private readonly IReadOnlyDictionary<string, RuleRuntimeTypeBinding> _bindings;
+
+    public WistRuleRuntimeTypeResolver(IEnumerable<RuleRuntimeTypeBinding> bindings)
     {
-        ["number"] = typeof(RealNumberImpl),
-        ["bool"] = typeof(bool)
-    };
+        bindings = bindings.ArgNotNull();
+
+        var orderedBindings = bindings
+            .OrderBy(static x => x.RuleType.Name, StringComparer.Ordinal)
+            .ThenBy(static x => x.RuntimeType.FullName ?? x.RuntimeType.Name, StringComparer.Ordinal)
+            .ToList();
+
+        var map = new Dictionary<string, RuleRuntimeTypeBinding>(StringComparer.Ordinal);
+        foreach (var binding in orderedBindings)
+        {
+            if (!map.TryAdd(binding.RuleType.Name, binding))
+                Thrower.InvalidOpEx($"Duplicate rule runtime type binding for rule type '{binding.RuleType.Name}'.");
+        }
+
+        _bindings = map;
+    }
 
     public bool TryResolve(RuleTypeDescriptor type, out Type runtimeType)
     {
         type = type.ArgNotNull();
-        return _runtimeTypes.TryGetValue(type.Name, out runtimeType!);
+
+        if (TryGetBinding(type, out var binding))
+        {
+            runtimeType = binding.RuntimeType;
+            return true;
+        }
+
+        runtimeType = null!;
+        return false;
+    }
+
+    public bool TryGetBinding(RuleTypeDescriptor type, out RuleRuntimeTypeBinding binding)
+    {
+        type = type.ArgNotNull();
+        return _bindings.TryGetValue(type.Name, out binding!);
     }
 }

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/Rules/WistRuleRuntimeValueAdapter.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/Rules/WistRuleRuntimeValueAdapter.cs
@@ -1,5 +1,4 @@
 using ExceptionsManager;
-using NumbersModule.Core;
 using UniversalToolchain.Diagnostics.Abstractions;
 using UniversalToolchain.Rules.Abstractions;
 
@@ -7,6 +6,13 @@ namespace UniversalToolchain.Dialects.Wist.Rules;
 
 public sealed class WistRuleRuntimeValueAdapter
 {
+    private readonly WistRuleRuntimeTypeResolver _typeResolver;
+
+    public WistRuleRuntimeValueAdapter(WistRuleRuntimeTypeResolver typeResolver)
+    {
+        _typeResolver = typeResolver.ArgNotNull();
+    }
+
     public bool TryConvert(
         RuleTypeDescriptor type,
         object? value,
@@ -19,102 +25,22 @@ public sealed class WistRuleRuntimeValueAdapter
         argumentName = argumentName.ArgNotNull();
         ruleName = ruleName.ArgNotNull();
 
-        runtimeValue = null;
-        diagnostic = null;
-
-        if (value == null)
+        if (!_typeResolver.TryGetBinding(type, out var binding))
         {
+            runtimeValue = null;
             diagnostic = CreateDiagnostic(
-                ToolchainDiagnosticCodes.RuleArgumentNull,
-                $"Argument '{argumentName}' for rule '{ruleName}' must not be null.");
+                ToolchainDiagnosticCodes.RuleArgumentTypeMismatch,
+                $"Unsupported rule type '{type.Name}'.");
             return false;
         }
 
-        if (type.Name == "number")
-            return TryConvertNumber(value, out runtimeValue, out diagnostic, argumentName, ruleName);
-
-        if (type.Name == "bool")
-        {
-            if (value is bool)
-            {
-                runtimeValue = value;
-                return true;
-            }
-
-            diagnostic = CreateTypeMismatch(type, value, argumentName, ruleName);
-            return false;
-        }
-
-        diagnostic = CreateTypeMismatch(type, value, argumentName, ruleName);
-        return false;
-    }
-
-    private static bool TryConvertNumber(
-        object value,
-        out object runtimeValue,
-        out ToolchainDiagnostic? diagnostic,
-        string argumentName,
-        string ruleName)
-    {
-        diagnostic = null;
-
-        if (value is RealNumberImpl)
-        {
-            runtimeValue = value;
-            return true;
-        }
-
-        if (TryConvertToDouble(value, out var doubleValue))
-        {
-            runtimeValue = new RealNumberImpl(doubleValue);
-            return true;
-        }
-
-        runtimeValue = null!;
-        diagnostic = CreateTypeMismatch(new RuleTypeDescriptor("number"), value, argumentName, ruleName);
-        return false;
-    }
-
-    private static bool TryConvertToDouble(object value, out double result)
-    {
-        switch (value)
-        {
-            case double doubleValue:
-                result = doubleValue;
-                return true;
-            case float floatValue:
-                result = floatValue;
-                return true;
-            case decimal decimalValue:
-                result = (double)decimalValue;
-                return true;
-            case int intValue:
-                result = intValue;
-                return true;
-            case long longValue:
-                result = longValue;
-                return true;
-            case short shortValue:
-                result = shortValue;
-                return true;
-            case byte byteValue:
-                result = byteValue;
-                return true;
-            default:
-                result = default;
-                return false;
-        }
-    }
-
-    private static ToolchainDiagnostic CreateTypeMismatch(
-        RuleTypeDescriptor type,
-        object value,
-        string argumentName,
-        string ruleName)
-    {
-        return CreateDiagnostic(
-            ToolchainDiagnosticCodes.RuleArgumentTypeMismatch,
-            $"Argument '{argumentName}' for rule '{ruleName}' must have type '{type.Name}'. Actual runtime type: '{value.GetType().FullName}'.");
+        return binding.Converter.TryConvert(
+            value,
+            out runtimeValue,
+            out diagnostic,
+            argumentName,
+            ruleName,
+            type);
     }
 
     private static ToolchainDiagnostic CreateDiagnostic(string code, string message)

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/Rules/WistRuleSetCompiler.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/Rules/WistRuleSetCompiler.cs
@@ -18,13 +18,21 @@ public sealed class WistRuleSetCompiler : IWistRuleSetCompiler
     private readonly WistRuleDeclarationExtractor _extractor;
     private readonly WistRuleRuntimeTypeResolver _typeResolver;
 
-    public WistRuleSetCompiler(Func<string, OrderedDictionary<string, Type>, string, ICompiledArtifact> artifactCompiler)
+    public WistRuleSetCompiler(
+        Func<string, OrderedDictionary<string, Type>, string, ICompiledArtifact> artifactCompiler,
+        IReadOnlyList<RuleRuntimeTypeBinding> ruleRuntimeTypeBindings)
     {
         _artifactCompiler = artifactCompiler.ArgNotNull();
+        ruleRuntimeTypeBindings = ruleRuntimeTypeBindings.ArgNotNull();
+
         _extractor = new WistRuleDeclarationExtractor();
         _validator = new WistRuleBodyValidator();
-        _typeResolver = new WistRuleRuntimeTypeResolver();
-        _argumentBinder = new WistRuleArgumentBinder();
+
+        var typeResolver = new WistRuleRuntimeTypeResolver(ruleRuntimeTypeBindings);
+        var valueAdapter = new WistRuleRuntimeValueAdapter(typeResolver);
+
+        _typeResolver = typeResolver;
+        _argumentBinder = new WistRuleArgumentBinder(valueAdapter);
     }
 
     public RuleSetCompileResult Compile(string source, string mode)

--- a/UniversalToolchain/UniversalToolchain.Rules.Abstractions/RuleRuntimeContracts.cs
+++ b/UniversalToolchain/UniversalToolchain.Rules.Abstractions/RuleRuntimeContracts.cs
@@ -1,0 +1,24 @@
+using UniversalToolchain.Diagnostics.Abstractions;
+
+namespace UniversalToolchain.Rules.Abstractions;
+
+public sealed record RuleRuntimeTypeBinding(
+    RuleTypeDescriptor RuleType,
+    Type RuntimeType,
+    IRuleRuntimeValueConverter Converter);
+
+public interface IRuleRuntimeValueConverter
+{
+    bool TryConvert(
+        object? value,
+        out object? runtimeValue,
+        out ToolchainDiagnostic? diagnostic,
+        string argumentName,
+        string ruleName,
+        RuleTypeDescriptor expectedType);
+}
+
+public interface IRuleRuntimeTypeBindingProvider
+{
+    IReadOnlyList<RuleRuntimeTypeBinding> GetRuleRuntimeTypeBindings();
+}


### PR DESCRIPTION
### Motivation
- Remove hardcoded rule runtime type mapping and value conversion from the Wist rules layer so the Wist dialect does not depend on `NumbersModule.Core` or `RealNumberImpl` and to satisfy the anti-hardcode guard. 
- Make runtime type mapping and conversion provider-owned and discoverable through the capability/catalog plumbing so rule types are extensible and deterministic. 

### Description
- Added generic rule runtime binding contracts in `UniversalToolchain.Rules.Abstractions` (`RuleRuntimeTypeBinding`, `IRuleRuntimeValueConverter`, `IRuleRuntimeTypeBindingProvider`).
- Extended capability discovery/catalog (`CapabilityProviderTypeResolver`, `CapabilityCatalog`) to recognize `IRuleRuntimeTypeBindingProvider`, collect `RuleRuntimeTypeBinding`s and expose `CapabilityCatalog.RuleRuntimeTypeBindings` deterministically.
- Implemented module-owned bindings and converters: `NumbersModule` now provides `RuleRuntimeTypeBinding("number") -> typeof(RealNumberImpl)` with `NumberRuleRuntimeValueConverter`, and `ConditionsModule` provides `RuleRuntimeTypeBinding("bool") -> typeof(bool)` with `BooleanRuleRuntimeValueConverter`.
- Refactored Wist runtime plumbing so the Wist rules layer is binding-driven: `WistRuleRuntimeTypeResolver` accepts injected `RuleRuntimeTypeBinding`s and validates duplicates, `WistRuleRuntimeValueAdapter` delegates conversions to provider converters, `WistRuleArgumentBinder` is constructor-injected with the adapter, `WistRuleSetCompiler` accepts selected bindings and wires resolver/adapter/binder, and `WistRuntimeFacadeBuilder` resolves selected capability catalog from the selected runtime plan and passes its `RuleRuntimeTypeBindings` into the compiler.
- Added tests validating resolver/provider-driven bindings, binder conversion delegation, presence of the `number` binding in the selected catalog, and an architecture guardrail test that the Wist rules sources do not reference `NumbersModule.Core` or `RealNumberImpl`.

### Testing
- Ran `dotnet test UniversalToolchain/Wist.sln -c Release` and the full test suite (Wist/Modules/Dialects/Tests) completed with all tests passing (no failures).
- Verified the anti-hardcode guard with `rg "RealNumberImpl|NumbersModule\.Core|Addition|Multiplication|GreaterOrEqual|LessOrEqual" UniversalToolchain -g "*.cs" -g "!**/*Tests*/**" -g "!**/ArithmeticModule/**" -g "!**/NativeMathModule/**" -g "!**/ConditionsModule/**" -g "!**/NumbersModule/**" -g "!**/Intrinsics/**" -g "!**/BasicStdLib/**"` which returned no matches.
- Verified Wist rules folder contains no references to `NumbersModule.Core`/`RealNumberImpl` with `rg "NumbersModule\.Core|RealNumberImpl" UniversalToolchain/UniversalToolchain.Dialects.Wist/Rules -g "*.cs"` which returned no matches.
- New unit tests `WistRuleRuntimeBindingTests` and `WistRuleRuntimeDependencyGuardrailTests` were added and executed as part of the test run and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee7f8814708324ac87d096c965daff)