### PR TITLE
Document interpreter call-only intrinsic policy

### DIFF
--- a/UniversalToolchain/BasicInterpreter/InterpreterIntrinsicExecutor.cs
+++ b/UniversalToolchain/BasicInterpreter/InterpreterIntrinsicExecutor.cs
@@ -4,6 +4,11 @@ namespace BasicInterpreter;
 
 internal sealed class InterpreterIntrinsicExecutor
 {
+    // The interpreter is the reference universal-call backend.
+    // Keep this executor intentionally minimal.
+    // Only "call C#" and "call C# ctor" are allowed here.
+    // Feature-specific or optimization-specific intrinsics must be handled by
+    // backend-capability-gated optimizers and must not be added to the interpreter.
     public void Execute(Instruction instruction, InterpreterState state)
     {
         var normalizedInstruction = IntrinsicInstructionNormalizer.NormalizeOrThrow(instruction);

--- a/docs/ARCHITECTURE_RULES.md
+++ b/docs/ARCHITECTURE_RULES.md
@@ -73,6 +73,29 @@ Correct direction:
 
 See `docs/SYNTAX_OWNERSHIP_RULES.md` for the full mandatory policy.
 
+## 3.2 Interpreter intrinsic policy
+
+The interpreter is the reference universal-call backend.
+
+It must execute only:
+
+- core AIR opcodes: `Nop`, `Push`, `Drop`, `Jmp`, `JmpIf`, `JmpIfNot`, `Label`, and `Annotate`;
+- the universal `call C#` intrinsic;
+- the universal `call C# ctor` intrinsic.
+
+The interpreter must not implement feature-specific or optimization-specific intrinsics, including but not limited to:
+
+- local storage intrinsics: `load_local`, `store_local`, `load_local_ref`;
+- external binding intrinsics: `load_external`, `store_external`;
+- native arithmetic and comparison intrinsics: `load_*`, `add_*`, `sub_*`, `mul_*`, `div_*`, `cmp_*`;
+- boolean intrinsics: `load_bool`, `boolean_and`, `boolean_or`, `boolean_not`.
+
+If a feature must work in the interpreter, it must lower to ordinary C# runtime calls before interpretation.
+
+If a feature is optimized into intrinsics, that optimization must be backend-capability gated and must not run for the interpreter unless this policy is explicitly changed.
+
+Do not add interpreter intrinsic branches to make tests pass. Fix lowering or optimizer capability gating instead.
+
 ## 4. Controlled reflection policy
 
 Reflection is allowed and recommended when it reduces compile-time coupling between generic framework layers and concrete modules.

--- a/docs/CURRENT_ARCHITECTURE_STATUS.md
+++ b/docs/CURRENT_ARCHITECTURE_STATUS.md
@@ -50,6 +50,19 @@ Forbidden shortcuts:
 - raw-source local binding scanners;
 - restoring rule-local validation tests without first restoring an explicit rules architecture task.
 
+## Interpreter runtime path
+
+Status: reference universal-call backend.
+
+Current policy:
+
+- the interpreter executes core AIR control-flow/data opcodes and the two universal C# call intrinsics only: `call C#` and `call C# ctor`;
+- the interpreter must not implement feature-specific or optimization-specific intrinsics;
+- if a feature must work in the interpreter, it must lower to ordinary C# runtime calls before interpretation;
+- backend-optimized intrinsics belong to backends that explicitly support them, such as CIL.
+
+Forbidden interpreter intrinsics include `load_local`, `store_local`, `load_local_ref`, `load_external`, `store_external`, `load_*`, `add_*`, `sub_*`, `mul_*`, `div_*`, `cmp_*`, `load_bool`, and boolean operation intrinsics.
+
 ## Local variables runtime path
 
 Status: migrated to execution-scoped C# runtime calls.
@@ -61,10 +74,17 @@ Current behavior:
 - `VariablesContainer<T>` static storage is removed from the production runtime path;
 - `LocalVariablesOptimization` is removed from the current runtime path.
 
+Interpreter path:
+
+- the interpreter executes local variables through the canonical execution-scoped C# runtime calls;
+- the interpreter must not receive `load_local`, `store_local`, or `load_local_ref`;
+- local-variable intrinsics are reserved for backend-capability-gated optimized paths, such as CIL.
+
 Future direction:
 
 - any local-variable optimization must operate on generated C# runtime call patterns;
-- do not reintroduce local-variable intrinsics or static/global variable storage.
+- such optimization may compress runtime-call patterns to local intrinsics only for backends that explicitly support those intrinsics;
+- do not reintroduce local-variable intrinsics into the interpreter or static/global variable storage.
 
 ## Documentation policy
 


### PR DESCRIPTION
## Summary

- Document the interpreter as the reference universal-call backend.
- State that the interpreter must execute only core AIR opcodes plus `call C#` and `call C# ctor`.
- Clarify that feature-specific and optimization-specific intrinsics must be backend-capability gated and must not be added to the interpreter.
- Add a guard comment near `InterpreterIntrinsicExecutor.Execute` to prevent future accidental intrinsic additions.

## Notes

This PR intentionally documents and guards the policy only. It does not yet remove the existing interpreter intrinsic branches; that should be a separate implementation PR with tests and optimizer/lowering fixes.