### PR TITLE
Restrict interpreter to universal C# call intrinsics (call C# / call C# ctor)

### DIFF
--- a/UniversalToolchain/AbstractIrExtensions/AbstractIrExtensions.cs
+++ b/UniversalToolchain/AbstractIrExtensions/AbstractIrExtensions.cs
@@ -24,12 +24,18 @@ public static class AbstractIrExtensions
 
     public static void LdExternal<TIdentifier>(this IGenericAbstractIR<TIdentifier> air, int slot, Type valueType)
     {
-        air.Intrinsic("load_external", slot, valueType);
+        valueType = valueType.ArgNotNull();
+        air.CallCSharp(ExternalRuntimeMethodDescriptors.LoadEnvironmentDescriptor);
+        air.Push(slot);
+        air.CallCSharp(ExternalRuntimeMethodDescriptors.CreateLoadExternalMethod(valueType));
     }
 
     public static void StExternal<TIdentifier>(this IGenericAbstractIR<TIdentifier> air, int slot, Type valueType)
     {
-        air.Intrinsic("store_external", slot, valueType);
+        valueType = valueType.ArgNotNull();
+        air.Push(slot);
+        air.CallCSharp(ExternalRuntimeMethodDescriptors.LoadEnvironmentDescriptor);
+        air.CallCSharp(ExternalRuntimeMethodDescriptors.CreateStoreExternalMethod(valueType));
     }
 
 }

--- a/UniversalToolchain/BasicCore/Execution/ExecutionEnvironment.cs
+++ b/UniversalToolchain/BasicCore/Execution/ExecutionEnvironment.cs
@@ -68,6 +68,8 @@ public sealed class ExecutionEnvironment : IExecutionEnvironment, IExternalBindi
             var parameters = constructor.GetParameters();
             if (parameters.Length == 1 && parameters[0].ParameterType == typeof(IRuntimeContextStore))
                 return constructor.Invoke([this]).NotNull();
+            if (parameters.Length == 1 && parameters[0].ParameterType == typeof(IExecutionEnvironment))
+                return constructor.Invoke([this]).NotNull();
         }
 
         var parameterless = providerType.GetConstructor(Type.EmptyTypes);

--- a/UniversalToolchain/BasicCore/Execution/ExternalRuntimeCallProvider.cs
+++ b/UniversalToolchain/BasicCore/Execution/ExternalRuntimeCallProvider.cs
@@ -1,0 +1,16 @@
+namespace BasicCore.Execution;
+
+public sealed class ExternalRuntimeCallProvider
+{
+    private readonly IExecutionEnvironment _environment;
+
+    public ExternalRuntimeCallProvider(IExecutionEnvironment environment)
+    {
+        _environment = environment.ArgNotNull();
+    }
+
+    public IExecutionEnvironment LoadEnvironment()
+    {
+        return _environment;
+    }
+}

--- a/UniversalToolchain/BasicCore/Execution/ExternalRuntimeCalls.cs
+++ b/UniversalToolchain/BasicCore/Execution/ExternalRuntimeCalls.cs
@@ -1,0 +1,21 @@
+namespace BasicCore.Execution;
+
+public static class ExternalRuntimeCalls
+{
+    public static T LoadExternal<T>(IExecutionEnvironment environment, int slot)
+    {
+        environment = environment.ArgNotNull();
+        var value = environment.GetExternalValue(slot);
+
+        if (value is T typed)
+            return typed;
+
+        return (T)Convert.ChangeType(value.NotNull(), typeof(T));
+    }
+
+    public static void StoreExternal<T>(T value, int slot, IExecutionEnvironment environment)
+    {
+        environment = environment.ArgNotNull();
+        environment.SetExternalValue(slot, value);
+    }
+}

--- a/UniversalToolchain/BasicCore/Execution/ExternalRuntimeMethodDescriptors.cs
+++ b/UniversalToolchain/BasicCore/Execution/ExternalRuntimeMethodDescriptors.cs
@@ -1,0 +1,31 @@
+using System.Reflection;
+using BasicCore.Core;
+
+namespace BasicCore.Execution;
+
+public static class ExternalRuntimeMethodDescriptors
+{
+    private static readonly MethodInfo LoadExternalDefinition = typeof(ExternalRuntimeCalls)
+        .GetMethod(nameof(ExternalRuntimeCalls.LoadExternal))
+        .NotNull();
+
+    private static readonly MethodInfo StoreExternalDefinition = typeof(ExternalRuntimeCalls)
+        .GetMethod(nameof(ExternalRuntimeCalls.StoreExternal))
+        .NotNull();
+
+    public static CSharpCallDescriptor LoadEnvironmentDescriptor { get; } = new(
+        typeof(ExternalRuntimeCallProvider).GetMethod(nameof(ExternalRuntimeCallProvider.LoadEnvironment)).NotNull(),
+        new CSharpCallReceiver.ExecutionScopedProvider(typeof(ExternalRuntimeCallProvider)));
+
+    public static MethodInfo CreateLoadExternalMethod(Type valueType)
+    {
+        valueType = valueType.ArgNotNull();
+        return LoadExternalDefinition.MakeGenericMethod(valueType);
+    }
+
+    public static MethodInfo CreateStoreExternalMethod(Type valueType)
+    {
+        valueType = valueType.ArgNotNull();
+        return StoreExternalDefinition.MakeGenericMethod(valueType);
+    }
+}

--- a/UniversalToolchain/BasicInterpreter/InterpreterImpl.cs
+++ b/UniversalToolchain/BasicInterpreter/InterpreterImpl.cs
@@ -8,8 +8,7 @@ public class InterpreterImpl : IExecutor<IAbstractIR>
     {
         var state = new InterpreterState
         {
-            ExecutionEnvironment = environment,
-            ExternalBindingsLayout = (environment as IExternalBindingsLayoutProvider)?.ExternalBindingsLayout
+            ExecutionEnvironment = environment
         };
         state.BuildLabelPositions(air.Instructions);
         return ExecuteInstructions(air.Instructions, state);

--- a/UniversalToolchain/BasicInterpreter/InterpreterIntrinsicExecutor.cs
+++ b/UniversalToolchain/BasicInterpreter/InterpreterIntrinsicExecutor.cs
@@ -4,6 +4,9 @@ namespace BasicInterpreter;
 
 internal sealed class InterpreterIntrinsicExecutor
 {
+    // Keep this executor intentionally minimal.
+    // Do not add feature-specific intrinsics here.
+    // Lower features to C# calls for interpreter, or implement backend-specific optimization for CIL.
     public void Execute(Instruction instruction, InterpreterState state)
     {
         var normalizedInstruction = IntrinsicInstructionNormalizer.NormalizeOrThrow(instruction);
@@ -21,82 +24,8 @@ internal sealed class InterpreterIntrinsicExecutor
             return;
         }
 
-        if (intrinsicName == "load_bool")
-        {
-            ExecuteLoadBool(normalizedInstruction, state);
-            return;
-        }
-
-        if (intrinsicName == "boolean_and")
-        {
-            ExecuteBooleanAnd(state);
-            return;
-        }
-
-        if (intrinsicName == "boolean_or")
-        {
-            ExecuteBooleanOr(state);
-            return;
-        }
-
-        if (intrinsicName == "boolean_not")
-        {
-            ExecuteBooleanNot(state);
-            return;
-        }
-
-        if (intrinsicName == "load_external")
-        {
-            ExecuteLoadExternal(normalizedInstruction, state);
-            return;
-        }
-
-        if (intrinsicName == "store_external")
-        {
-            ExecuteStoreExternal(normalizedInstruction, state);
-            return;
-        }
-
-        if (intrinsicName == "load_local")
-        {
-            ExecuteLoadLocal(normalizedInstruction, state);
-            return;
-        }
-
-        if (intrinsicName == "store_local")
-        {
-            ExecuteStoreLocal(normalizedInstruction, state);
-            return;
-        }
-
-        if (intrinsicName == "load_local_ref")
-        {
-            ExecuteLoadLocalRef(normalizedInstruction, state);
-            return;
-        }
-
-        if (intrinsicName.StartsWith("load_", StringComparison.Ordinal))
-        {
-            ExecuteLoadNativeNumber(normalizedInstruction, state);
-            return;
-        }
-
-        if (intrinsicName.StartsWith("add_", StringComparison.Ordinal)
-            || intrinsicName.StartsWith("sub_", StringComparison.Ordinal)
-            || intrinsicName.StartsWith("mul_", StringComparison.Ordinal)
-            || intrinsicName.StartsWith("div_", StringComparison.Ordinal))
-        {
-            ExecuteArithmeticIntrinsic(normalizedInstruction, state);
-            return;
-        }
-
-        if (intrinsicName.StartsWith("cmp_", StringComparison.Ordinal))
-        {
-            ExecuteComparisonIntrinsic(normalizedInstruction, state);
-            return;
-        }
-
-        Thrower.InvalidOpEx($"Unknown intrinsic call: {intrinsicName}.");
+        Thrower.InvalidOpEx(
+            $"Interpreter backend supports only 'call C#' and 'call C# ctor' intrinsics. Unsupported intrinsic: '{intrinsicName}'.");
     }
 
     private void ExecuteCallCSharp(Instruction instruction, InterpreterState state)
@@ -107,8 +36,6 @@ internal sealed class InterpreterIntrinsicExecutor
         var parameters = method.GetParameters();
         var args = new object?[parameters.Length];
         var argTypes = new Type[parameters.Length];
-        var byRefTargets = new Dictionary<int, LocalReference>();
-
         for (var i = parameters.Length - 1; i >= 0; i--)
         {
             if (state.ValueStack.Count == 0)
@@ -117,16 +44,7 @@ internal sealed class InterpreterIntrinsicExecutor
             var value = state.ValueStack.Pop();
             if (parameters[i].ParameterType.IsByRef)
             {
-                if (value is not LocalReference localReference)
-                {
-                    Thrower.InvalidOpEx("By-ref call requires local reference operand.");
-                    return;
-                }
-
-                var byRefType = parameters[i].ParameterType.GetElementType().NotNull();
-                args[i] = state.GetLocalValue(localReference.Name, byRefType);
-                argTypes[i] = byRefType;
-                byRefTargets[i] = localReference;
+                Thrower.InvalidOpEx("By-ref call is not supported by the interpreter intrinsic surface.");
                 continue;
             }
 
@@ -170,9 +88,6 @@ internal sealed class InterpreterIntrinsicExecutor
             }
         }
 
-        foreach (var (index, localReference) in byRefTargets)
-            state.SetLocalValue(localReference.Name, args[index]);
-
         if (method.ReturnType != typeof(void))
             state.ValueStack.Push(result.NotNull());
     }
@@ -207,161 +122,4 @@ internal sealed class InterpreterIntrinsicExecutor
         state.ValueStack.Push(instance.NotNull());
     }
 
-    private static void ExecuteLoadBool(Instruction instruction, InterpreterState state)
-    {
-        state.ValueStack.Push(instruction.Operands[1].Get<bool>());
-    }
-
-    private static void ExecuteLoadNativeNumber(Instruction instruction, InterpreterState state)
-    {
-        state.ValueStack.Push(instruction.Operands[1]);
-    }
-
-    private static void ExecuteBooleanAnd(InterpreterState state)
-    {
-        var right = Pop<bool>(state);
-        var left = Pop<bool>(state);
-        state.ValueStack.Push(left && right);
-    }
-
-    private static void ExecuteBooleanOr(InterpreterState state)
-    {
-        var right = Pop<bool>(state);
-        var left = Pop<bool>(state);
-        state.ValueStack.Push(left || right);
-    }
-
-    private static void ExecuteBooleanNot(InterpreterState state)
-    {
-        state.ValueStack.Push(!Pop<bool>(state));
-    }
-
-    private static void ExecuteArithmeticIntrinsic(Instruction instruction, InterpreterState state)
-    {
-        var name = instruction.Operands[0].Get<string>();
-        var operation = name.Split('_')[0];
-
-        if (name.EndsWith("_decimal", StringComparison.Ordinal))
-        {
-            var rightDecimal = Pop<decimal>(state);
-            var leftDecimal = Pop<decimal>(state);
-            var decimalResult = operation switch
-            {
-                "add" => decimal.Add(leftDecimal, rightDecimal),
-                "sub" => decimal.Subtract(leftDecimal, rightDecimal),
-                "mul" => decimal.Multiply(leftDecimal, rightDecimal),
-                "div" => decimal.Divide(leftDecimal, rightDecimal),
-                _ => Thrower.InvalidOpEx<decimal>($"Unknown arithmetic intrinsic '{name}'.")
-            };
-            state.ValueStack.Push(decimalResult);
-            return;
-        }
-
-        var numericType = GetNumericType(name);
-        var rightValue = Convert.ChangeType(state.ValueStack.Pop(), numericType);
-        var leftValue = Convert.ChangeType(state.ValueStack.Pop(), numericType);
-
-        dynamic right = rightValue.NotNull();
-        dynamic left = leftValue.NotNull();
-
-        object result = operation switch
-        {
-            "add" => left + right,
-            "sub" => left - right,
-            "mul" => left * right,
-            "div" => left / right,
-            _ => Thrower.InvalidOpEx<object>($"Unknown arithmetic intrinsic '{name}'.")
-        };
-
-        state.ValueStack.Push(result);
-    }
-
-    private static void ExecuteComparisonIntrinsic(Instruction instruction, InterpreterState state)
-    {
-        var name = instruction.Operands[0].Get<string>();
-        var operation = name.Split('_')[1];
-
-        var operandType = GetNumericType(name);
-        dynamic right = Convert.ChangeType(state.ValueStack.Pop(), operandType).NotNull();
-        dynamic left = Convert.ChangeType(state.ValueStack.Pop(), operandType).NotNull();
-
-        var result = operation switch
-        {
-            "eq" => left == right,
-            "ne" => left != right,
-            "gt" => left > right,
-            "ge" => left >= right,
-            "lt" => left < right,
-            "le" => left <= right,
-            _ => Thrower.InvalidOpEx<bool>($"Unknown comparison intrinsic '{name}'.")
-        };
-
-        state.ValueStack.Push(result);
-    }
-
-    private static Type GetNumericType(string intrinsicName)
-    {
-        if (intrinsicName.EndsWith("_i32", StringComparison.Ordinal))
-            return typeof(int);
-        if (intrinsicName.EndsWith("_i64", StringComparison.Ordinal))
-            return typeof(long);
-        if (intrinsicName.EndsWith("_f32", StringComparison.Ordinal))
-            return typeof(float);
-        if (intrinsicName.EndsWith("_f64", StringComparison.Ordinal))
-            return typeof(double);
-        if (intrinsicName.EndsWith("_decimal", StringComparison.Ordinal))
-            return typeof(decimal);
-
-        return Thrower.InvalidOpEx<Type>($"Unknown intrinsic numeric type in '{intrinsicName}'.");
-    }
-
-    private static void ExecuteLoadExternal(Instruction instruction, InterpreterState state)
-    {
-        var slot = instruction.Operands[1].Get<int>();
-        var value = state.ExecutionEnvironment.NotNull().GetExternalValue(slot);
-        state.ValueStack.Push(value.NotNull());
-    }
-
-    private static void ExecuteStoreExternal(Instruction instruction, InterpreterState state)
-    {
-        var slot = instruction.Operands[1].Get<int>();
-        var value = state.ValueStack.Pop();
-        state.ExecutionEnvironment.NotNull().SetExternalValue(slot, value);
-    }
-
-    private static void ExecuteLoadLocal(Instruction instruction, InterpreterState state)
-    {
-        var name = instruction.Operands[1].Get<string>();
-        var type = instruction.Operands[2].Get<Type>();
-        state.ValueStack.Push(state.GetLocalValue(name, type));
-    }
-
-    private static void ExecuteStoreLocal(Instruction instruction, InterpreterState state)
-    {
-        var name = instruction.Operands[1].Get<string>();
-        var value = state.ValueStack.Pop();
-        state.SetLocalValue(name, value);
-    }
-
-    private static void ExecuteLoadLocalRef(Instruction instruction, InterpreterState state)
-    {
-        var name = instruction.Operands[1].Get<string>();
-        var type = instruction.Operands[2].Get<Type>();
-        state.GetLocalValue(name, type);
-        state.ValueStack.Push(new LocalReference(name, type));
-    }
-
-    private static T Pop<T>(InterpreterState state)
-    {
-        if (state.ValueStack.Count == 0)
-            Thrower.InvalidOpEx("Interpreter stack is empty.");
-
-        return state.ValueStack.Pop().Get<T>();
-    }
-
-    private sealed class LocalReference(string name, Type type)
-    {
-        public string Name { get; } = name;
-        public Type Type { get; } = type;
-    }
 }

--- a/UniversalToolchain/BasicInterpreter/InterpreterState.cs
+++ b/UniversalToolchain/BasicInterpreter/InterpreterState.cs
@@ -3,16 +3,8 @@ namespace BasicInterpreter;
 public class InterpreterState
 {
     private readonly Dictionary<Guid, int> _labelPositions = new();
-    private readonly Dictionary<string, object?> _locals = new(StringComparer.Ordinal);
     private bool _labelsBuilt;
     public Stack<object> ValueStack { get; } = new();
-
-    /// <summary>
-    ///     Compile-time binding layout used to resolve declared external symbols at runtime.
-    ///     Symbol class (local vs external) must be determined before interpreter execution.
-    ///     Runtime state is not allowed to infer or redefine symbol class from observed calls.
-    /// </summary>
-    public ExternalBindingsLayout? ExternalBindingsLayout { get; set; }
 
     public int InstructionPointer { get; set; }
     public IExecutionEnvironment? ExecutionEnvironment { get; set; }
@@ -41,27 +33,5 @@ public class InterpreterState
             Thrower.InvalidOpEx($"Label with id '{labelId}' was not found in the instruction stream.");
 
         return position;
-    }
-
-    public object GetLocalValue(string name, Type runtimeType)
-    {
-        if (_locals.TryGetValue(name, out var value) && value != null)
-            return value;
-
-        var defaultValue = runtimeType.IsValueType
-            ? Activator.CreateInstance(runtimeType)
-            : null;
-
-        _locals[name] = defaultValue;
-
-        if (defaultValue == null)
-            Thrower.InvalidOpEx($"Local '{name}' is null and cannot be loaded.");
-
-        return defaultValue;
-    }
-
-    public void SetLocalValue(string name, object? value)
-    {
-        _locals[name] = value;
     }
 }

--- a/UniversalToolchain/Tests/Backends/InterpreterBackendIrExecutionTests.cs
+++ b/UniversalToolchain/Tests/Backends/InterpreterBackendIrExecutionTests.cs
@@ -1,4 +1,3 @@
-using BasicCore.Builtins;
 using SettableGettableModule.Core;
 using Tests.Infrastructure;
 
@@ -7,24 +6,6 @@ namespace Tests.Backends;
 [TestFixture]
 public class InterpreterBackendIrExecutionTests
 {
-    private static class RefInteropSamples
-    {
-        public static void Increment(ref int value)
-        {
-            value++;
-        }
-
-        public static void Set42(out int value)
-        {
-            value = 42;
-        }
-
-        public static void AddTen(ref int value)
-        {
-            value += 10;
-        }
-    }
-
     [Test]
     public void ConditionalJump_PreservesExpectedStackState()
     {
@@ -130,7 +111,7 @@ public class InterpreterBackendIrExecutionTests
 
         var exception = Assert.Throws<RuntimeExecutionException>(() => ExecuteInInterpreter(ir));
 
-        Assert.That(exception!.Message, Does.Contain("unknown intrinsic"));
+        Assert.That(exception!.Message, Does.Contain("Unsupported intrinsic instruction payload"));
     }
 
     [Test]
@@ -170,171 +151,10 @@ public class InterpreterBackendIrExecutionTests
     }
 
 
-    [Test]
-    public void TypedArithmeticIntrinsicI32_OnCoreInterpreterPath_ExecutesSuccessfully()
-    {
-        var ir = BuildIr(
-            new Instruction(UOpCode.Push, [20]),
-            new Instruction(UOpCode.Push, [22]),
-            CreateTypedIntrinsic(BuiltinIntrinsicSymbols.Arithmetic.Add, [IntrinsicTypeArgument.From(typeof(int))])
-        );
-
-        var result = ExecuteInInterpreter(ir);
-
-        Assert.That(result, Is.EqualTo(42));
-    }
-
-    [Test]
-    public void TypedBooleanNotIntrinsic_OnCoreInterpreterPath_ExecutesSuccessfully()
-    {
-        var ir = BuildIr(
-            new Instruction(UOpCode.Push, [true]),
-            CreateTypedIntrinsic(BuiltinIntrinsicSymbols.Boolean.Not)
-        );
-
-        var result = ExecuteInInterpreter(ir);
-
-        Assert.That(result, Is.EqualTo(false));
-    }
-
-    [Test]
-    public void InterpreterAndCil_StoreLocalThenLoadLocal_ReturnSameValue()
-    {
-        var air = Air(
-            Intrinsic("load_i32", 123),
-            Intrinsic("store_local", "x", typeof(int)),
-            Intrinsic("load_local", "x", typeof(int))
-        );
-
-        var interpreterResult = ExecuteWithInterpreter(air);
-        var cilResult = ExecuteWithCil(air);
-
-        Assert.Multiple(() =>
-        {
-            Assert.That(interpreterResult, Is.EqualTo(123));
-            Assert.That(cilResult, Is.EqualTo(123));
-        });
-    }
-
-    [Test]
-    public void InterpreterAndCil_LoadLocalRef_CallRefMethod_MutatesLocal()
-    {
-        var method = typeof(RefInteropSamples)
-            .GetMethod(nameof(RefInteropSamples.Increment), BindingFlags.Public | BindingFlags.Static)!;
-
-        var air = Air(
-            Intrinsic("load_i32", 10),
-            Intrinsic("store_local", "x", typeof(int)),
-            Intrinsic("load_local_ref", "x", typeof(int)),
-            Intrinsic("call C#", method),
-            Intrinsic("load_local", "x", typeof(int))
-        );
-
-        var interpreterResult = ExecuteWithInterpreter(air);
-        var cilResult = ExecuteWithCil(air);
-
-        Assert.Multiple(() =>
-        {
-            Assert.That(interpreterResult, Is.EqualTo(11));
-            Assert.That(cilResult, Is.EqualTo(11));
-        });
-    }
-
-    [Test]
-    public void InterpreterAndCil_LoadLocalRef_CallOutMethod_AssignsLocal()
-    {
-        var method = typeof(RefInteropSamples)
-            .GetMethod(nameof(RefInteropSamples.Set42), BindingFlags.Public | BindingFlags.Static)!;
-
-        var air = Air(
-            Intrinsic("load_i32", 0),
-            Intrinsic("store_local", "x", typeof(int)),
-            Intrinsic("load_local_ref", "x", typeof(int)),
-            Intrinsic("call C#", method),
-            Intrinsic("load_local", "x", typeof(int))
-        );
-
-        var interpreterResult = ExecuteWithInterpreter(air);
-        var cilResult = ExecuteWithCil(air);
-
-        Assert.Multiple(() =>
-        {
-            Assert.That(interpreterResult, Is.EqualTo(42));
-            Assert.That(cilResult, Is.EqualTo(42));
-        });
-    }
-
-    [Test]
-    public void InterpreterAndCil_LoadLocalRef_MutatesOnlyTargetLocal()
-    {
-        var method = typeof(RefInteropSamples)
-            .GetMethod(nameof(RefInteropSamples.Increment), BindingFlags.Public | BindingFlags.Static)!;
-
-        var air = Air(
-            Intrinsic("load_i32", 10),
-            Intrinsic("store_local", "x", typeof(int)),
-            Intrinsic("load_i32", 20),
-            Intrinsic("store_local", "y", typeof(int)),
-            Intrinsic("load_local_ref", "y", typeof(int)),
-            Intrinsic("call C#", method),
-            Intrinsic("load_local", "x", typeof(int)),
-            Intrinsic("load_local", "y", typeof(int)),
-            Intrinsic("add_i32")
-        );
-
-        var interpreterResult = ExecuteWithInterpreter(air);
-        var cilResult = ExecuteWithCil(air);
-
-        Assert.Multiple(() =>
-        {
-            Assert.That(interpreterResult, Is.EqualTo(31));
-            Assert.That(cilResult, Is.EqualTo(31));
-        });
-    }
-
-    [Test]
-    public void InterpreterAndCil_RepeatedRefMutation_KeepsLatestLocalValue()
-    {
-        var method = typeof(RefInteropSamples)
-            .GetMethod(nameof(RefInteropSamples.AddTen), BindingFlags.Public | BindingFlags.Static)!;
-
-        var air = Air(
-            Intrinsic("load_i32", 5),
-            Intrinsic("store_local", "x", typeof(int)),
-            Intrinsic("load_local_ref", "x", typeof(int)),
-            Intrinsic("call C#", method),
-            Intrinsic("load_local_ref", "x", typeof(int)),
-            Intrinsic("call C#", method),
-            Intrinsic("load_local", "x", typeof(int))
-        );
-
-        var interpreterResult = ExecuteWithInterpreter(air);
-        var cilResult = ExecuteWithCil(air);
-
-        Assert.Multiple(() =>
-        {
-            Assert.That(interpreterResult, Is.EqualTo(25));
-            Assert.That(cilResult, Is.EqualTo(25));
-        });
-    }
-
     private static int CombineDigits(int acc, int nextDigit) => acc * 10 + nextDigit;
 
     private static T Echo<T>(T value) => value;
 
-
-    private static Instruction CreateTypedIntrinsic(
-        IntrinsicSymbol symbol,
-        IReadOnlyList<IntrinsicTypeArgument>? typeArguments = null,
-        IReadOnlyList<object?>? dataOperands = null)
-    {
-        var invocation = new IntrinsicInvocation(
-            symbol,
-            typeArguments ?? [],
-            dataOperands ?? []);
-
-        return new Instruction(UOpCode.Intrinsic, [invocation]);
-    }
 
     private static object? ExecuteInInterpreter(IAbstractIR ir)
     {
@@ -347,32 +167,6 @@ public class InterpreterBackendIrExecutionTests
         var interpreter = new InterpreterImpl();
         return interpreter.Execute(ir, environment);
     }
-
-    private static object? ExecuteWithInterpreter(IAbstractIR air)
-    {
-        var interpreter = new InterpreterImpl();
-        return interpreter.Execute(air, new ExecutionEnvironment([]));
-    }
-
-    private static object ExecuteWithCil(IAbstractIR air)
-    {
-        var compiler = new AbstractMethodsCompilerImpl();
-        var dynamicMethod = compiler.Compile(air, new CompilationInput { SourceText = string.Empty });
-
-        var executor = new DynamicMethodExecutor();
-        return executor.Execute(dynamicMethod, new ExecutionEnvironment([]));
-    }
-
-    private static Instruction Intrinsic(string name, params object?[] args)
-    {
-        var operands = new List<object>(args.Length + 1) { name };
-        for (var i = 0; i < args.Length; i++)
-            operands.Add(args[i]!);
-
-        return new Instruction(UOpCode.Intrinsic, operands);
-    }
-
-    private static IAbstractIR Air(params Instruction[] instructions) => BuildIr(instructions);
 
     private static IAbstractIR BuildIr(params Instruction[] instructions)
     {

--- a/UniversalToolchain/Tests/Backends/InterpreterBackendOptimizerIntrinsicSurfaceTests.cs
+++ b/UniversalToolchain/Tests/Backends/InterpreterBackendOptimizerIntrinsicSurfaceTests.cs
@@ -33,25 +33,7 @@ public sealed class InterpreterBackendOptimizerIntrinsicSurfaceTests
 
     private static bool IsSupportedInterpreterIntrinsic(string intrinsicName)
     {
-        if (intrinsicName == "call C#"
-            || intrinsicName == "call C# ctor"
-            || intrinsicName == "load_external"
-            || intrinsicName == "store_external"
-            || intrinsicName == "store_local"
-            || intrinsicName == "load_local"
-            || intrinsicName == "load_local_ref"
-            || intrinsicName == "load_bool"
-            || intrinsicName == "boolean_and"
-            || intrinsicName == "boolean_or"
-            || intrinsicName == "boolean_not")
-            return true;
-
-        return intrinsicName.StartsWith("load_", StringComparison.Ordinal)
-               || intrinsicName.StartsWith("add_", StringComparison.Ordinal)
-               || intrinsicName.StartsWith("sub_", StringComparison.Ordinal)
-               || intrinsicName.StartsWith("mul_", StringComparison.Ordinal)
-               || intrinsicName.StartsWith("div_", StringComparison.Ordinal)
-               || intrinsicName.StartsWith("cmp_", StringComparison.Ordinal);
+        return intrinsicName == "call C#" || intrinsicName == "call C# ctor";
     }
 
     private static IEnumerable<string> CollectIntrinsicNames(IAbstractIR air)

--- a/UniversalToolchain/Tests/Backends/InterpreterIntrinsicSurfaceTests.cs
+++ b/UniversalToolchain/Tests/Backends/InterpreterIntrinsicSurfaceTests.cs
@@ -1,0 +1,171 @@
+using UniversalToolchain.Dialects.Tests;
+
+namespace Tests.Backends;
+
+[TestFixture]
+public sealed class InterpreterIntrinsicSurfaceTests
+{
+    private static readonly string[] ForbiddenIntrinsics =
+    [
+        "load_bool",
+        "boolean_and",
+        "boolean_or",
+        "boolean_not",
+        "load_external",
+        "store_external",
+        "load_local",
+        "store_local",
+        "load_local_ref",
+        "load_i32",
+        "load_i64",
+        "load_f32",
+        "load_f64",
+        "load_decimal",
+        "add_i32",
+        "sub_i32",
+        "mul_i32",
+        "div_i32",
+        "cmp_eq_i32",
+        "cmp_gt_i32"
+    ];
+
+    [Test]
+    public void Interpreter_Allows_CallCSharp()
+    {
+        var abs = typeof(Math).GetMethod(nameof(Math.Abs), [typeof(int)])!;
+        var ir = BuildIr(
+            new Instruction(UOpCode.Push, [-12]),
+            new Instruction(UOpCode.Intrinsic, ["call C#", abs]));
+
+        var result = ExecuteInInterpreter(ir);
+
+        Assert.That(result, Is.EqualTo(12));
+    }
+
+    [Test]
+    public void Interpreter_Allows_CallCSharpCtor()
+    {
+        var ctor = typeof(Version).GetConstructor([typeof(int), typeof(int)])!;
+        var ir = BuildIr(
+            new Instruction(UOpCode.Push, [1]),
+            new Instruction(UOpCode.Push, [2]),
+            new Instruction(UOpCode.Intrinsic, ["call C# ctor", ctor]));
+
+        var result = ExecuteInInterpreter(ir);
+
+        Assert.That(result, Is.TypeOf<Version>());
+        Assert.That(((Version)result!).ToString(), Is.EqualTo("1.2"));
+    }
+
+    [TestCase("load_local", "x", typeof(int))]
+    [TestCase("store_local", "x", typeof(int))]
+    [TestCase("load_local_ref", "x", typeof(int))]
+    public void Interpreter_Rejects_LocalIntrinsics(string intrinsicName, object arg1, object arg2)
+    {
+        var ir = BuildIr(new Instruction(UOpCode.Intrinsic, [intrinsicName, arg1, arg2]));
+
+        var ex = Assert.Throws<RuntimeExecutionException>(() => ExecuteInInterpreter(ir));
+
+        Assert.That(ex!.Message, Does.Contain("supports only 'call C#' and 'call C# ctor'"));
+        Assert.That(ex.Message, Does.Contain(intrinsicName));
+    }
+
+    [TestCase("load_i32", 7)]
+    [TestCase("add_i32")]
+    [TestCase("cmp_gt_i32")]
+    [TestCase("load_bool", true)]
+    [TestCase("boolean_and")]
+    public void Interpreter_Rejects_ArithmeticAndComparisonIntrinsics(string intrinsicName, params object[] args)
+    {
+        var operands = new List<object> { intrinsicName };
+        operands.AddRange(args);
+        var ir = BuildIr(new Instruction(UOpCode.Intrinsic, operands));
+
+        var ex = Assert.Throws<RuntimeExecutionException>(() => ExecuteInInterpreter(ir));
+
+        Assert.That(ex!.Message, Does.Contain("supports only 'call C#' and 'call C# ctor'"));
+        Assert.That(ex.Message, Does.Contain(intrinsicName));
+    }
+
+    [TestCase("load_external", 0, typeof(int))]
+    [TestCase("store_external", 0, typeof(int))]
+    public void Interpreter_Rejects_ExternalIntrinsics(string intrinsicName, object arg1, object arg2)
+    {
+        var ir = BuildIr(new Instruction(UOpCode.Intrinsic, [intrinsicName, arg1, arg2]));
+
+        var ex = Assert.Throws<RuntimeExecutionException>(() => ExecuteInInterpreter(ir));
+
+        Assert.That(ex!.Message, Does.Contain("supports only 'call C#' and 'call C# ctor'"));
+        Assert.That(ex.Message, Does.Contain(intrinsicName));
+    }
+
+    [Test]
+    public void Interpreter_Guardrail_RejectsAllForbiddenIntrinsicSamples()
+    {
+        foreach (var intrinsicName in ForbiddenIntrinsics)
+        {
+            var operands = intrinsicName switch
+            {
+                "load_bool" => new List<object> { intrinsicName, true },
+                "load_i32" or "load_i64" or "load_f32" or "load_f64" or "load_decimal" => new List<object> { intrinsicName, 1 },
+                "load_external" or "store_external" => new List<object> { intrinsicName, 0, typeof(int) },
+                "load_local" or "store_local" or "load_local_ref" => new List<object> { intrinsicName, "x", typeof(int) },
+                _ => new List<object> { intrinsicName }
+            };
+
+            var ir = BuildIr(new Instruction(UOpCode.Intrinsic, operands));
+            var ex = Assert.Throws<RuntimeExecutionException>(() => ExecuteInInterpreter(ir), intrinsicName);
+            Assert.That(ex!.Message, Does.Contain("supports only 'call C#' and 'call C# ctor'"), intrinsicName);
+        }
+    }
+
+    [Test]
+    public void InterpreterPipeline_WithOptimizersEnabled_ContainsOnlyUniversalCallIntrinsics()
+    {
+        var dialect = """
+                      dialect Tiny
+                      use NativeTypes, BooleanConditions, ComparisonConditions, Conditions, Numbers, Scopes, Variables, Whitespaces
+                      backend interpreter
+                      enable ArithmeticOptimization
+                      enable BooleanOptimization
+                      enable ComparisonIntrinsicOptimization
+                      enable NativeCilOptimization
+                      enable EGraphOptimization
+                      """;
+
+        using var host = DialectTestHostInfrastructure.CreateInterpreterHost(dialect);
+        var compiler = host.GetArtifactCompiler<IAbstractIR>("interpreter");
+        var artifact = compiler.Compile("(1 + 2) > 0 and true");
+
+        var intrinsics = CollectIntrinsicNames(artifact.CompilationOutput).Distinct(StringComparer.Ordinal).ToArray();
+
+        Assert.That(intrinsics, Is.Not.Empty);
+        Assert.That(intrinsics, Is.SubsetOf(new[] { "call C#", "call C# ctor" }));
+        Assert.That(intrinsics, Has.None.Matches<string>(name => ForbiddenIntrinsics.Contains(name, StringComparer.Ordinal)));
+    }
+
+    private static IEnumerable<string> CollectIntrinsicNames(IAbstractIR air)
+    {
+        foreach (var instruction in air.Instructions)
+        {
+            if (instruction.UOpCode != UOpCode.Intrinsic)
+                continue;
+
+            var normalized = IntrinsicInstructionNormalizer.NormalizeOrThrow(instruction);
+            yield return (string)normalized.Operands[0];
+        }
+    }
+
+    private static object? ExecuteInInterpreter(IAbstractIR ir)
+    {
+        var interpreter = new InterpreterImpl();
+        return interpreter.Execute(ir, new ExecutionEnvironment([]));
+    }
+
+    private static IAbstractIR BuildIr(params Instruction[] instructions)
+    {
+        var ir = new AbstractIR();
+        ir.AppendInstructions(instructions);
+        return ir;
+    }
+}

--- a/docs/CURRENT_ARCHITECTURE_STATUS.md
+++ b/docs/CURRENT_ARCHITECTURE_STATUS.md
@@ -66,6 +66,22 @@ Future direction:
 - any local-variable optimization must operate on generated C# runtime call patterns;
 - do not reintroduce local-variable intrinsics or static/global variable storage.
 
+## Interpreter intrinsic surface
+
+Status: intentionally minimal reference backend.
+
+Current behavior:
+
+- the interpreter executes core AIR opcodes (`Nop`, `Push`, `Drop`, `Jmp`, `JmpIf`, `JmpIfNot`, `Label`, `Annotate`);
+- the interpreter executes only two intrinsics: `call C#` and `call C# ctor`;
+- feature-specific or backend-optimized intrinsics (`load_*`, arithmetic, comparison, boolean, local/external storage intrinsics) are rejected by interpreter execution.
+
+Required optimization policy:
+
+- optimizers that produce non-call intrinsics must be backend-capability gated;
+- optimized intrinsic IR may be produced for backends that explicitly support it (for example CIL);
+- interpreter execution must remain a universal reference path and must not be used as a high-performance intrinsic backend.
+
 ## Documentation policy
 
 `docs/DOCUMENTATION_RULES.md` defines how agents must handle stale Markdown examples and architecture documents.


### PR DESCRIPTION
### Motivation

- Make the BasicInterpreter a strict, minimal reference backend that executes only core AIR opcodes and the universal `call C#` / `call C# ctor` intrinsics.
- Remove feature-specific, optimization-specific, or backend-performance intrinsics from interpreter implementation to preserve correctness-first semantics and avoid duplicating CIL optimizations.
- Ensure optimizer-produced non-call intrinsics are gated by backend capabilities so only backends that explicitly support them (e.g., CIL) receive them.

### Description

- Reduced `InterpreterIntrinsicExecutor` to accept only `"call C#"` and `"call C# ctor"` and emit a clear error for any other intrinsic; removed interpreter-side implementations for boolean, arithmetic, comparison, native loads, local, and external intrinsics and removed by-ref local machinery from the intrinsic executor.
- Removed local-storage plumbing from `InterpreterState` (no interpreter-local `_locals` map) and kept core AIR opcode handling (`Nop`, `Push`, `Drop`, `Jmp`, `JmpIf`, `JmpIfNot`, `Label`, `Annotate`) unchanged in `InterpreterImpl`.
- Lowered external access to execution-scoped C# calls by changing `AbstractIrExtensions` to emit `call C#` flows for externals and added `ExternalRuntimeCallProvider`, `ExternalRuntimeCalls`, and `ExternalRuntimeMethodDescriptors` so external loads/stores are performed via ordinary C# runtime calls.
- Extended `ExecutionEnvironment` provider activation so runtime providers can expose constructors accepting `IExecutionEnvironment` (used by the new external runtime provider glue).
- Added `InterpreterIntrinsicSurfaceTests` to assert approved intrinsics and to guard against forbidden intrinsics; updated interpreter optimizer-surface and IR execution tests to match the new interpreter policy.
- Updated `docs/CURRENT_ARCHITECTURE_STATUS.md` with an explicit interpreter intrinsic-surface rule and reminder that optimizers must be capability-gated.

### Testing

- Ran `dotnet restore UniversalToolchain/Wist.sln`, `dotnet build UniversalToolchain/Wist.sln -c Release --no-restore` and `dotnet test UniversalToolchain/Wist.sln -c Release --no-build` with success reported for the solution build and test suites.
- Ran targeted tests: `dotnet test UniversalToolchain/Tests/Tests.csproj -c Release --filter InterpreterIntrinsicSurfaceTests`, `dotnet test UniversalToolchain/UniversalToolchain.Dialects.Tests/UniversalToolchain.Dialects.Tests.csproj -c Release --filter WistDialectExecutionParityTests`, and `dotnet test UniversalToolchain/UniversalToolchain.Modules.Tests/UniversalToolchain.Modules.Tests.csproj -c Release`; these passed.
- Performed grep checks confirming no removed interpreter intrinsic handlers remain, e.g. checks for `ExecuteLoadLocal`, `ExecuteStoreLocal`, `ExecuteLoadLocalRef`, `ExecuteArithmeticIntrinsic`, `ExecuteComparisonIntrinsic`, `ExecuteLoadNativeNumber`, `ExecuteLoadBool` returned no matches in the BasicInterpreter sources.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0b9e92ca88324b7954d1d8a561bd3)