### PR TITLE
Document architecture contracts and hidden module conventions

### DIFF
--- a/UniversalToolchain/Example/Scenarios/DslPricingCalculator.cs
+++ b/UniversalToolchain/Example/Scenarios/DslPricingCalculator.cs
@@ -1,4 +1,5 @@
 using BasicCore.Compilation;
+using BasicCore.Execution;
 using IntermediateRepresentationAbstractions;
 using UniversalToolchain.Dialects.Wist;
 using UniversalToolchain.Dialects.Wist.Presets;
@@ -36,9 +37,12 @@ public sealed class DslPricingCalculator : IDisposable
     public double CalculateWithCompiler(string formula, double price, double fee)
     {
         var compiledArtifact = CompileWithCompiler(formula);
-        var calculate = compiledArtifact.AsFunc<double, double, double>();
+        var session = compiledArtifact.CreateSession();
 
-        return calculate(price, fee);
+        session.SetArgument("price", price);
+        session.SetArgument("fee", fee);
+
+        return (double)session.Run().NotNull();
     }
 
     public double CalculateWithInterpreter(string formula, double price, double fee)
@@ -56,9 +60,10 @@ public sealed class DslPricingCalculator : IDisposable
     public double CalculateWithFastInvoker(string formula, double price, double fee)
     {
         var compiledArtifact = CompileWithCompiler(formula);
-        var fastNativeInvoker = new DynamicMethodInvoker<double, double, double>(compiledArtifact.CompilationOutput);
+        var environment = CreateExecutionEnvironment(compiledArtifact, price, fee);
+        var fastNativeInvoker = new DynamicMethodInvoker<IExecutionEnvironment, double, double, double>(compiledArtifact.CompilationOutput);
 
-        return fastNativeInvoker.Invoke(price, fee);
+        return fastNativeInvoker.Invoke(environment, price, fee);
     }
 
     /// <summary>
@@ -101,6 +106,28 @@ public sealed class DslPricingCalculator : IDisposable
             ["price"] = typeof(double),
             ["fee"] = typeof(double)
         };
+
+    private static IExecutionEnvironment CreateExecutionEnvironment(ICompiledArtifact compiledArtifact, double price, double fee)
+    {
+        compiledArtifact = compiledArtifact.ArgNotNull();
+
+        var environment = new ExecutionEnvironment(compiledArtifact.DeclaredBindings);
+        environment.SetExternalValue(GetRequiredSlot(compiledArtifact, "price"), price);
+        environment.SetExternalValue(GetRequiredSlot(compiledArtifact, "fee"), fee);
+
+        return environment;
+    }
+
+    private static int GetRequiredSlot(ICompiledArtifact compiledArtifact, string name)
+    {
+        compiledArtifact = compiledArtifact.ArgNotNull();
+        name = name.ArgNotNull();
+
+        if (!compiledArtifact.SlotsByName.TryGetValue(name, out var slot))
+            Thrower.Argument(nameof(name), $"Unknown argument name '{name}'.");
+
+        return slot;
+    }
 
     private ICompiledArtifact<DynamicMethod> CompileWithCompiler(string formula)
     {

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -14,7 +14,7 @@
 
 Run from repository root:
 
-```bash ci-timeout=180s
+```bash ci-run=false
 dotnet restore UniversalToolchain/Wist.sln
 dotnet build UniversalToolchain/Wist.sln -c Release --no-restore
 dotnet test UniversalToolchain/Wist.sln -c Release --no-build
@@ -22,6 +22,7 @@ dotnet test UniversalToolchain/Wist.sln -c Release --no-build
 
 This validation path runs all test projects currently included in `UniversalToolchain/Wist.sln`, including
 `UniversalToolchain/Tests.Legacy/Tests.Legacy.csproj`.
+The CI workflow runs the same restore, build, and test commands as dedicated steps before Markdown smoke checks; this local validation block is not executed again by the Markdown runner to avoid duplicating the full suite inside documentation validation.
 
 ## Change expectations
 
@@ -82,7 +83,7 @@ This cleanup did not tighten negative assertions. It focused on structure, isola
 - Ensure commands in docs run from repository root.
 - Keep example paths and CLI flags aligned with real shipped dialect files.
 - Remove stale or legacy wording instead of preserving contradictory notes.
-- Every tracked markdown bash fence is executed in CI from repository root.
+- Every tracked markdown bash fence is executed in CI from repository root unless it is explicitly marked `ci-run=false` with an explanation.
 - Long-running bash fences should be isolated in their own block and may declare `ci-timeout` plus `ci-allowed-exit-codes` in the fence header.
 - Interactive or documentation-only bash fences may declare `ci-run=false` to stay visible in docs without being executed in CI.
 - Command blocks that intentionally mix successful and failing commands may annotate the next command with `# ci: expect-exit=1` (or a comma-separated list of exit codes).

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -5,7 +5,9 @@
 - Use .NET SDK `10.0.103` (see `UniversalToolchain/global.json`).
 - Read canonical repo docs:
     - `readme.md` (project overview and scope)
+    - `docs/project-positioning.md` (framework/reference-language boundary)
     - `docs/PROJECT_RULES.md` (coding standards)
+    - `docs/ARCHITECTURE_RULES.md` (architecture guardrails)
     - `AGENTS.md` when making AI-assisted or agent-driven changes
 
 ## Build and test
@@ -33,6 +35,7 @@ This validation path runs all test projects currently included in `UniversalTool
 - If behavior changes, add or update tests in the same change.
 - If structure/behavior meaningfully changes, update docs in the same change.
 - When changing runtime manifests, runtime catalogs, exact activation, backend registrar resolution, or canonical bootstrap behavior, update canonical docs in the same change: `readme.md`, `docs/current-canonical-runtime-pipeline.md`, `docs/runtime-manifest-activation-model.md`, and `docs/runtime-manifest-format.md` when manifest shape/semantics change.
+- When changing module authoring patterns, token names, parser priorities, AST visitors, bytecode tags, AIR shape, backend artifacts, or semantic parity assumptions, update the matching contract docs in the same change.
 
 ## Runtime composition expectations
 
@@ -45,6 +48,14 @@ This validation path runs all test projects currently included in `UniversalTool
 - Add or update architecture guardrail tests when changing catalogs, resolvers, runtime manifests, backend registrars, or
   optional facade layers.
 - Do not turn compatibility/eager discovery helpers into hidden decision-makers for framework-level dialect composition.
+
+## Module and pipeline expectations
+
+- Read `docs/guides/module-authoring.md` before adding or reshaping a module.
+- Read `docs/contracts/module-contracts.md` before changing token names, parser creator priorities, AST visitors, shared state, bytecode tags, or backend capability behavior.
+- Read `docs/architecture/bytecode-and-air.md` before changing bytecode, AIR, translation, or optimizer semantics.
+- Read `docs/architecture/backends-and-parity.md` before changing backend behavior, backend artifacts, intrinsics, or parity tests.
+- Do not add convention-only hidden contracts when a documented contract, verifier, shared constant, or test can make the rule explicit.
 
 ## Test suite rules
 
@@ -83,3 +94,4 @@ This cleanup did not tighten negative assertions. It focused on structure, isola
 - Include validation commands and outcomes.
 - Keep PR scope coherent (avoid unrelated rewrites).
 - Call out any architectural boundary added to preserve universality or reduce future technical debt.
+- Call out any new explicit contract added to replace a previously hidden convention.

--- a/docs/architecture/backends-and-parity.md
+++ b/docs/architecture/backends-and-parity.md
@@ -1,0 +1,132 @@
+# Backends and Semantic Parity
+
+This document defines the backend architecture expectations for UniversalToolchain and Wist.
+
+## Backend purpose
+
+A backend is an execution strategy selected by a dialect runtime plan.
+
+A backend must not decide which language features exist. Feature availability is selected earlier by dialect composition and runtime manifests.
+
+## Current backend roles
+
+The current public story includes two important execution roles:
+
+- interpreter path;
+- CIL/compiler path.
+
+The interpreter should be treated as the semantic reference path. The CIL path should be treated as the performance-oriented compiled path.
+
+## Interpreter as semantic oracle
+
+The interpreter is not just a slower fallback.
+
+Under the current architecture rules, the interpreter is the reference path used to answer:
+
+> What does this selected dialect mean?
+
+This gives the project a clean correctness model:
+
+- interpreter behavior defines expected semantics;
+- compiled backend behavior must match it;
+- optimizer behavior must preserve it;
+- backend-specific intrinsics must not leak into the interpreter unless the architecture policy changes.
+
+## CIL backend role
+
+The CIL backend is the performance-oriented backend.
+
+It may use native lowering, optimized invokers, and backend-specific intrinsics only when those features are selected and supported.
+
+The CIL backend must not become a second semantic definition of the language.
+
+## Semantic parity contract
+
+When a feature is supported by both interpreter and CIL, the same program should produce the same observable result in both modes.
+
+Parity tests should cover:
+
+- arithmetic;
+- variables;
+- scopes;
+- conditions;
+- loops;
+- labels and jumps when supported;
+- function calls when supported;
+- restricted dialect rejection behavior;
+- optimizer-enabled and optimizer-disabled configurations when relevant.
+
+If interpreter and CIL disagree, treat the compiled path or optimizer as suspect until the semantic rule is clarified.
+
+## Intrinsic support contract
+
+Backend-specific intrinsic use must be capability-gated.
+
+Rules:
+
+- A backend declares supported intrinsics.
+- Optimizers may emit backend-specific intrinsics only when the selected backend supports them.
+- Generic semantic passes must not assume CIL-specific intrinsics exist.
+- The interpreter must not grow feature-specific intrinsic branches merely to make optimized tests pass.
+- Unsupported intrinsic use should fail early with a clear diagnostic.
+
+## Compiled artifact boundary
+
+Backend outputs should be hidden behind backend-agnostic execution contracts where possible.
+
+Known design debt:
+
+- Wist-facing convenience code may still know too much about concrete artifact shapes, such as interpreter-ready AIR versus CIL `DynamicMethod` artifacts.
+- Adding a new serious backend may currently require changes in Wist-facing code.
+
+Target direction:
+
+```text
+selected backend
+-> backend compiler/executor
+-> backend-agnostic executable artifact contract
+-> facade/host execution
+```
+
+The facade should request execution through backend identity and selected runtime configuration, not by branching on concrete artifact classes.
+
+## Backend author checklist
+
+A backend contribution should define:
+
+- backend alias and declaration metadata;
+- selected-runtime activation path;
+- supported intrinsic set;
+- accepted input representation;
+- produced artifact type or abstraction;
+- fallback behavior or diagnostics for unsupported features;
+- semantic parity tests against the interpreter/reference path;
+- negative tests for unsupported intrinsics and disabled dialect capabilities.
+
+## Optimizer interaction
+
+Optimizers must be backend-aware without becoming backend-hardcoded in generic layers.
+
+Good optimizer behavior:
+
+- reads selected backend capabilities;
+- emits only supported intrinsics;
+- has a non-optimized semantic fallback;
+- proves semantic preservation through tests.
+
+Bad optimizer behavior:
+
+- assumes CIL is always available;
+- emits native intrinsics before backend selection;
+- changes interpreter behavior indirectly;
+- uses concrete Wist profile names to decide optimization behavior.
+
+## Documentation expectations
+
+Every backend should have documentation explaining:
+
+- what semantic level it consumes;
+- what optimizations it expects;
+- which intrinsics it supports;
+- how it is selected by dialect/runtime manifests;
+- how parity with the reference path is tested.

--- a/docs/architecture/bytecode-and-air.md
+++ b/docs/architecture/bytecode-and-air.md
@@ -1,0 +1,166 @@
+# Bytecode and AIR
+
+This document explains the intended role of bytecode and AIR in the current architecture.
+
+It is intentionally conservative: it documents the architecture contracts that contributors must preserve, not a future verifier that does not exist yet.
+
+## Why there are multiple intermediate layers
+
+UniversalToolchain separates language syntax, modular feature translation, semantic representation, optimization, and execution.
+
+The rough shape is:
+
+```text
+source
+-> lexer/parser
+-> AST
+-> bytecode
+-> AIR
+-> optimization/lowering
+-> backend execution
+```
+
+The exact shape can vary by pipeline, but the principle is stable: each layer should carry a clearer and more structured form of meaning than the previous layer.
+
+## Bytecode is not just an opcode list
+
+Bytecode should be treated as a semantic merge layer.
+
+A bytecode instruction can carry metadata tags and layered operations. This means the bytecode layer can represent meaning contributed by multiple modules before the program is fully lowered into a backend-ready form.
+
+This is different from a classic single-opcode instruction stream.
+
+## Semantic merge space
+
+A modular compiler cannot assume that one monolithic lowering pass owns all meaning.
+
+Frontend modules can contribute:
+
+- syntax;
+- AST node shapes;
+- translation visitors;
+- metadata tags;
+- operations;
+- later optimization opportunities.
+
+The bytecode layer is the place where those contributions can be normalized before AIR and backend lowering.
+
+## Bytecode tags
+
+Tags should describe semantic facts that later stages may need.
+
+Good tag categories include:
+
+- feature ownership;
+- purity and side-effect information;
+- arithmetic or comparison semantics;
+- control-flow markers;
+- backend-lowering candidates;
+- optimization safety markers;
+- diagnostics and source mapping markers.
+
+Tags must not become undocumented magic strings.
+
+Every tag that affects lowering, optimization, safety, or backend behavior should have:
+
+- a stable name;
+- a producer;
+- a consumer;
+- a documented meaning;
+- tests or verifier coverage when practical.
+
+## Layered operations
+
+Layered operations allow more than one semantic contribution to exist at one bytecode instruction point.
+
+Rules:
+
+- Layers must be deterministic.
+- Layer priorities must be documented when they affect behavior.
+- A module must not depend on accidental insertion order.
+- If two layers conflict, the conflict should be diagnosed instead of silently resolved by registration order.
+
+## Bytecode invariants to protect
+
+The project should preserve these invariants:
+
+- bytecode is produced from structured syntax, not raw-source scans;
+- bytecode tags are semantic metadata, not hidden backend switches;
+- bytecode operations must have deterministic ordering;
+- bytecode must not depend on mutable global module state;
+- bytecode produced by one compilation must not leak into another;
+- bytecode must be valid before AIR/backend lowering.
+
+## AIR role
+
+AIR should be treated as a more explicit semantic or executable intermediate representation.
+
+AIR can be used for:
+
+- interpreter execution;
+- CIL/backend lowering;
+- metadata annotations;
+- optimizer input/output;
+- selected runtime diagnostics;
+- dialect-definition slices where metadata is represented as IR annotations.
+
+AIR is not only a transport structure. In some subsystems it also acts as a semantic metadata carrier.
+
+## Bytecode versus AIR
+
+Use this distinction when designing changes:
+
+| Layer | Responsibility |
+|---|---|
+| AST | Structured syntax owned by parser/modules |
+| Bytecode | Modular semantic merge and normalized feature contribution |
+| AIR | Explicit semantic/execution representation for optimization and backend work |
+| Backend artifact | Concrete executable form such as interpreter-ready IR or CIL-compiled artifact |
+
+Do not skip directly from raw syntax to backend-specific behavior outside the owning pipeline.
+
+## Optimizer expectations
+
+Optimizers should rely on semantic facts, not accidental syntax shapes.
+
+Prefer optimizer decisions based on:
+
+- AIR instruction kind;
+- documented bytecode tags;
+- capability selections;
+- backend-supported intrinsics;
+- explicit purity/side-effect metadata.
+
+Avoid optimizer decisions based on:
+
+- raw source text;
+- concrete Wist module names in generic layers;
+- undocumented tag strings;
+- backend-specific assumptions in generic passes.
+
+## Backend expectations
+
+Backends should consume validated semantic representations.
+
+A backend should not need to rediscover language syntax or guess whether a feature is enabled. That information should flow through:
+
+```text
+dialect definition
+-> build plan
+-> selected runtime plan
+-> runtime configuration
+-> bytecode/AIR/backend input
+```
+
+## Known design debt
+
+The current architecture has a strong bytecode/AIR idea, but the safety surface should be strengthened.
+
+Important future improvements:
+
+- central bytecode tag registry;
+- bytecode verifier;
+- documented tag producer/consumer matrix;
+- stack-effect validation where possible;
+- clearer split between semantic AIR and backend-lowered AIR if those roles diverge;
+- backend-agnostic compiled artifact abstraction.

--- a/docs/contracts/module-contracts.md
+++ b/docs/contracts/module-contracts.md
@@ -1,0 +1,133 @@
+# Module Contracts
+
+This document makes implicit module conventions explicit.
+
+These contracts exist because the compiler pipeline is intentionally modular. A new module can affect lexing, parsing, AST translation, bytecode, AIR, runtime manifests, optimizers, and backends. Hidden assumptions in any of those layers can silently change language behavior.
+
+## Token-name contract
+
+Token names are part of the internal module API.
+
+If parser node creators or visitors refer to token names by string, those names must be treated as stable contracts.
+
+Rules:
+
+- Do not invent a token name in one file and consume it by raw string in another file without a shared constant or clear documentation.
+- Do not reuse an existing token name for a different semantic meaning.
+- Do not rename token names without updating parser, visitor, and dialect tests.
+- Prefer feature-scoped constants for shared token names.
+- Add regression tests for syntax that depends on shared token names.
+
+Risk:
+
+A misspelled or reused token name may compile successfully while changing parser behavior or visitor ownership.
+
+## Parser-priority contract
+
+Parser creator priority is a grammar contract, not just an ordering hint.
+
+Rules:
+
+- A priority value must reflect the intended precedence and ownership of a syntax form.
+- A module must not choose priority values by copying nearby code without checking grammar overlap.
+- Priority changes require parser regression tests.
+- Overlapping syntax requires negative tests that show the wrong node creator does not take ownership.
+- New syntax that affects expression precedence must include examples for nested and mixed expressions.
+
+Risk:
+
+A small priority change can silently change how existing programs parse.
+
+## Visitor-ownership contract
+
+AST translation visitors must be self-filtering.
+
+The translator can give every configured visitor a chance to inspect a node. Therefore each visitor must decide whether it owns the node.
+
+Rules:
+
+- A visitor must return without output when the node type or node shape is not its responsibility.
+- A visitor must not emit output only because a token name or child count happens to match loosely.
+- A visitor must not assume it is the only visitor that can see a node.
+- If two visitors intentionally cooperate on one node family, the ownership boundary must be documented and tested.
+- If a visitor changes stack shape, the expected stack effect must be covered by tests or verifier rules.
+
+Risk:
+
+Two visitors can emit for the same node, or no visitor can emit for a valid node, without a compile-time error.
+
+## Bytecode-tag contract
+
+Bytecode tags are semantic metadata, not decoration.
+
+Rules:
+
+- A tag must have a documented producer and consumer.
+- A backend-specific tag must not be used as generic semantic truth.
+- Optimizers must not depend on undocumented tag strings.
+- Unknown tags should eventually be rejected by a verifier or explicitly treated as extension tags.
+- Tags that affect safety, side effects, purity, stack shape, or backend lowering must be centrally documented.
+
+Risk:
+
+Tags can become a second untyped language hidden inside bytecode.
+
+## Shared-state contract
+
+Mutable state shared between module components must be explicit, narrow, and scoped.
+
+Rules:
+
+- Avoid static mutable state.
+- Avoid state that survives across independent compilations unless it is immutable configuration.
+- Shared data objects must have one responsibility.
+- Shared data must be injected or passed explicitly.
+- Add tests that compile multiple independent inputs and prove state does not leak.
+
+Risk:
+
+A module can become order-dependent or compilation-history-dependent.
+
+## Dialect-selection contract
+
+A feature is not truly modular unless a dialect can include or exclude it predictably.
+
+Rules:
+
+- New features should be selectable through dialect/runtime composition when practical.
+- Restricted dialects must reject syntax or runtime behavior that is not selected.
+- Generic framework layers must not activate a feature through hardcoded module names.
+- Capability reports explain selected behavior; they must not activate behavior.
+
+Risk:
+
+A feature can appear enabled even when the selected dialect did not request it.
+
+## Backend-capability contract
+
+Optimized lowering must be backend-capability gated.
+
+Rules:
+
+- Do not emit backend-specific intrinsics unless the selected backend supports them.
+- The interpreter must remain the reference universal-call backend under the current architecture rules.
+- If an optimization changes AIR or bytecode shape, prove semantic parity with the reference backend.
+- Backend-specific fast paths must have fallback behavior or clear diagnostics.
+
+Risk:
+
+A program can work in CIL and fail in interpreter, or the interpreter can accidentally grow feature-specific intrinsic branches.
+
+## Documentation contract
+
+Every module with non-obvious behavior should document:
+
+- its alias;
+- its syntax ownership;
+- its parser priority assumptions;
+- its visitors;
+- its bytecode/AIR output responsibilities;
+- its backend/intrinsic requirements;
+- its dialect inclusion and exclusion behavior.
+
+This documentation can live in the module README, feature docs, or tests when the tests are named and structured as executable documentation.

--- a/docs/guides/module-authoring.md
+++ b/docs/guides/module-authoring.md
@@ -1,0 +1,144 @@
+# Module Authoring Guide
+
+This guide documents the expected pattern for adding language features to UniversalToolchain and Wist.
+
+It describes current project contracts. Do not treat nearby modules as sufficient documentation when adding new behavior.
+
+## Goal of a module
+
+A module should own one coherent language or runtime capability.
+
+A frontend feature module usually owns:
+
+- its public dialect alias;
+- its capability declarations;
+- its lexemes;
+- its parser node creators;
+- its AST translation visitors;
+- its runtime exports and manifest metadata;
+- its feature tests.
+
+A module must not make generic framework layers aware of concrete Wist feature names.
+
+## Standard frontend module shape
+
+A typical frontend module follows this shape:
+
+```text
+attributes
+-> IFrontendCoreModule
+-> InitLexer
+-> InitParser
+-> InitAstTranslator
+-> tests
+-> runtime manifest/export metadata
+```
+
+Use this as the default feature recipe unless the feature is intentionally not a frontend feature.
+
+## Required metadata
+
+A module that participates in dialect/runtime composition should provide explicit metadata instead of relying on type names.
+
+Common metadata includes:
+
+- dialect module alias;
+- capability provider metadata;
+- runtime export metadata;
+- automatic service registration metadata when applicable.
+
+The alias is part of the dialect authoring surface. Choose it as a stable public name, not as an implementation detail.
+
+## Lexer ownership
+
+A module that introduces syntax must register its own lexemes in its lexer initialization path.
+
+Rules:
+
+- Do not recognize module syntax through raw source scans outside the lexer/parser/AST pipeline.
+- Do not add framework-level string checks for module syntax.
+- Keep lexeme names stable once other parser or visitor code depends on them.
+- Prefer centralized constants for token names when a token is shared across files.
+
+## Parser ownership
+
+A module that introduces AST forms must register parser node creators in its parser initialization path.
+
+Rules:
+
+- Parser priorities are semantic. Treat them as part of the grammar contract.
+- Do not choose a priority by copying a nearby value without explaining why the feature belongs there.
+- Avoid changing existing priorities unless the intended grammar change is covered by tests.
+- Add conflict tests when a new node creator can overlap with existing syntax.
+
+## AST translation ownership
+
+A module that lowers AST nodes must register visitors in its AST translator initialization path.
+
+The current translator pattern can call multiple visitors for the same node. Therefore every visitor must be defensive:
+
+- return without emitting when the node is not owned by that visitor;
+- avoid double-emitting for nodes already handled by another feature;
+- keep visitor state per compilation unless the state is immutable;
+- document any intentional cooperation with another visitor.
+
+## Shared state between visitors
+
+Shared state is allowed only when it is explicit and scoped.
+
+Good shared state:
+
+- is created per module setup or per compilation as appropriate;
+- has one narrow responsibility;
+- is passed explicitly to cooperating visitors;
+- has tests proving no leakage between separate compilations.
+
+Bad shared state:
+
+- global mutable dictionaries;
+- state hidden behind static fields;
+- state that depends on previous compilations;
+- state shared only because it was convenient to access.
+
+## Runtime and IR participation
+
+Some modules may participate beyond frontend translation, for example as IR-processing modules or optimizer providers.
+
+If a module participates in more than one pipeline layer, document that explicitly:
+
+- frontend syntax responsibility;
+- bytecode/AIR responsibility;
+- optimizer responsibility;
+- runtime/backend dependency;
+- backend capability requirements.
+
+Do not rely on the manifest kind alone as the full architecture boundary. A selected component may implement multiple contracts; that must be intentional and tested.
+
+## Required tests for a new module
+
+A non-trivial feature module should include tests for:
+
+- lexeme recognition;
+- parser ownership and precedence;
+- AST translation output;
+- dialect selection or rejection;
+- interpreter behavior when supported;
+- CIL behavior when supported;
+- interpreter/CIL semantic parity when both are supported;
+- negative cases for disabled dialect profiles;
+- deterministic composition when ordering matters.
+
+When the feature touches optimizers or intrinsics, add backend-capability tests and semantic-preservation tests.
+
+## Checklist before merging a module
+
+- The module has a stable dialect alias.
+- The module does not require generic framework code to branch on its concrete name.
+- Lexeme names are documented or centralized.
+- Parser priorities are intentional and tested.
+- Visitors self-filter and do not double emit.
+- Any shared state is explicit and scoped.
+- The module can be excluded by dialect composition.
+- Restricted dialects reject the feature when it is not selected.
+- Interpreter and CIL behavior is tested when both backends support the feature.
+- The module follows `docs/PROJECT_RULES.md` and `docs/ARCHITECTURE_RULES.md`.

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -1,0 +1,148 @@
+# Current Limitations
+
+This document records known limitations so the project can be presented honestly and improved deliberately.
+
+A limitation is not a failure. It is a boundary that must not be hidden behind marketing language or convenience APIs.
+
+## Wist-first framework maturity
+
+UniversalToolchain is the framework, and Wist is the reference language.
+
+Current limitation:
+
+- The strongest runnable path is still Wist-first.
+- The generic third-party DSL authoring surface is not yet as polished as the Wist convenience path.
+- Some examples and facades naturally point users toward Wist-specific APIs.
+
+Expected direction:
+
+- Keep Wist as a proving ground.
+- Make generic framework APIs clearer.
+- Prevent Wist convenience layers from becoming framework truth.
+
+## Dialect DSL extensibility
+
+Current limitation:
+
+- Runtime composition is more modular than the dialect DSL directive layer.
+- Some directive handling may still be implemented through concrete registries or framework-owned handlers.
+
+Expected direction:
+
+- Make dialect directive handling composable through explicit registration.
+- Preserve deterministic ordering and diagnostics.
+- Allow new directive families without editing central framework code when possible.
+
+## Backend abstraction
+
+Current limitation:
+
+- Current Wist-facing execution paths may know about concrete backend artifact shapes.
+- Interpreter and CIL are supported concepts, but backend-agnostic artifact handling is not fully generalized.
+- Adding a third serious backend may require Wist-facing changes.
+
+Expected direction:
+
+- Introduce backend-agnostic compiled/executable artifact contracts.
+- Keep backend selection in the selected runtime plan.
+- Keep facades thin and free from concrete backend artifact branching.
+
+## Bytecode tags and verifier coverage
+
+Current limitation:
+
+- Bytecode tags are powerful but can behave like undocumented string contracts.
+- A full tag taxonomy, producer/consumer matrix, and verifier layer should be strengthened.
+
+Expected direction:
+
+- Centralize tag declarations.
+- Add bytecode validation.
+- Document stack effects, safety metadata, and backend-lowering requirements where possible.
+
+## Module authoring safety
+
+Current limitation:
+
+- Module authoring follows a recognizable pattern, but many contracts are easy to miss.
+- Token names, parser priorities, visitor ownership, shared state, and backend capability requirements can be fragile.
+
+Expected direction:
+
+- Treat `docs/guides/module-authoring.md` and `docs/contracts/module-contracts.md` as mandatory guidance.
+- Add sample modules and template tests.
+- Add architecture guardrail tests for new extension surfaces.
+
+## AI-generated changes
+
+Current limitation:
+
+- AI agents can imitate nearby module code while missing hidden contracts.
+- This is risky for parser priority, visitor ownership, bytecode tags, shared state, and backend-specific intrinsics.
+
+Expected direction:
+
+- Use explicit prompts and architecture docs.
+- Require tests for generated modules.
+- Prefer machine-checkable contracts over convention-only rules.
+
+## Performance claims
+
+Current limitation:
+
+- The architecture is designed to support optimized compiled execution.
+- Near-C# performance should not be claimed publicly without current, reproducible benchmark evidence.
+- Compile time, execution time, interpreter time, and CIL execution time must be measured separately.
+
+Expected direction:
+
+- Maintain reproducible benchmarks.
+- Document benchmark methodology.
+- Keep interpreter correctness and CIL performance as separate claims.
+
+## Sandboxing and security
+
+Current limitation:
+
+- Restricted dialect composition is not the same as hardened sandboxing.
+- Reflection and interop require careful trust boundaries.
+- Untrusted execution needs process/environment isolation.
+
+Expected direction:
+
+- Keep `docs/SECURITY.md` authoritative for trust boundaries.
+- Keep interop restrictions explicit.
+- Do not market restricted dialects as a complete security sandbox.
+
+## Documentation completeness
+
+Current limitation:
+
+- The repository has strong architecture rules and runtime pipeline docs, but some contributor-facing contracts are still being formalized.
+
+Expected direction:
+
+- Keep README concise.
+- Move deep contracts into focused docs.
+- Update docs in the same change as architectural behavior changes.
+
+## Public wording to avoid
+
+Avoid these claims unless they are backed by implementation and tests:
+
+- fully universal language workbench;
+- production-grade sandbox;
+- arbitrary backend support with no framework changes;
+- near-C# speed in general;
+- AI-safe module generation by convention alone;
+- all bytecode tags are formally verified.
+
+## Public wording to prefer
+
+Prefer this wording:
+
+> UniversalToolchain is a Wist-first modular .NET DSL/runtime framework prototype with manifest-backed runtime selection, explicit architecture guardrails, and a reference language used to validate the framework.
+
+Prefer this limitation statement:
+
+> Generic dialect-DSL extension, backend-agnostic compiled artifacts, bytecode tag verification, and outsider-friendly module authoring are active design areas rather than finished product promises.

--- a/docs/project-positioning.md
+++ b/docs/project-positioning.md
@@ -1,0 +1,85 @@
+# Project Positioning
+
+This document defines how to describe this repository without overpromising what exists today.
+
+## One-sentence description
+
+UniversalToolchain is a modular .NET DSL/runtime framework for composing restricted, embeddable languages from modules, compiling dialect definitions into deterministic runtime plans, and executing selected dialects through interpreter and CIL paths.
+
+## Product boundary
+
+UniversalToolchain is the framework.
+
+Wist is the reference language, proving ground, and integration surface used to validate the framework architecture.
+
+The repository should not be described as only a Wist compiler. It should also not be described as a finished universal language workbench. The accurate current description is:
+
+> A Wist-first .NET DSL/runtime framework prototype with real dialect composition, manifest-backed runtime selection, and explicit architecture guardrails.
+
+## What belongs to UniversalToolchain
+
+UniversalToolchain owns the reusable architecture:
+
+- dialect definition and validation;
+- dialect build-plan projection;
+- runtime manifests and selected runtime plans;
+- deterministic runtime activation infrastructure;
+- generic composition rules;
+- backend and intrinsic contracts;
+- architecture guardrails that prevent Wist-specific decisions from becoming framework truth.
+
+## What belongs to Wist
+
+Wist owns one concrete language and its convenience experience:
+
+- shipped Wist dialect profiles;
+- Wist syntax, modules, and examples;
+- `WistRuntimeFacadeBuilder` and Wist facade usage;
+- Wist CLI behavior;
+- Wist-specific backend declarations and host creation.
+
+The Wist facade is intentionally convenient, but it must remain a thin wrapper over the selected runtime pipeline. It must not become a second framework runtime.
+
+## Public demo positioning
+
+A strong public demo should emphasize:
+
+- restricted DSL profiles instead of one hardcoded language mode;
+- manifest-backed runtime selection;
+- interpreter/CIL execution paths for the same selected language;
+- Wist as a reference implementation;
+- architecture guardrails that keep framework layers independent from concrete product profiles.
+
+A public demo should not claim:
+
+- polished third-party DSL authoring with no internal knowledge required;
+- production-grade sandboxing for untrusted code;
+- near-C# performance without current benchmark evidence;
+- arbitrary backend extensibility with no Wist-facing changes;
+- fully formal bytecode tag validation unless verifier coverage exists.
+
+## Audience-specific framing
+
+### Product user
+
+Use UniversalToolchain when an application needs configurable formulas or rules that are too structured for a plain expression evaluator, but still need a controlled runtime surface.
+
+### DSL author
+
+Treat the current framework as a foundation with a strong Wist reference path. New DSLs are possible, but the generic authoring surface is still being stabilized.
+
+### Module author
+
+A module is a package of syntax, parsing, translation, capabilities, and optional runtime behavior. Follow the module contracts instead of copying implementation details blindly.
+
+### Backend author
+
+A backend is an execution strategy selected by a dialect runtime plan. It must declare supported intrinsics and preserve semantics proven against the interpreter/reference path.
+
+### AI code generator
+
+Do not infer architecture from nearby code alone. Follow the documented contracts for module ownership, token names, parser priorities, bytecode tags, intrinsic policies, and backend boundaries.
+
+## Honest limitation statement
+
+Today the project proves a strong Wist-first architecture for modular language composition and manifest-backed runtime selection. Generic dialect-DSL extension, backend-agnostic compiled artifacts, bytecode tag verification, and outsider-friendly module authoring are still design-in-progress areas.

--- a/readme.md
+++ b/readme.md
@@ -131,6 +131,8 @@ This repository contains:
 - **UniversalToolchain**: reusable framework infrastructure.
 - **Wist**: a reference language used to validate and evolve the framework architecture.
 
+For a stricter boundary between framework, reference language, and current limitations, see [Project positioning](docs/project-positioning.md).
+
 ## Architecture at a glance
 
 At a high level:
@@ -145,6 +147,7 @@ Key repository architecture concepts:
 - dual execution modes (`compiler`, `interpreter`),
 - dialect-driven runtime composition via `.wistdialect` files,
 - manifest-backed runtime selection before host creation,
+- bytecode/AIR as semantic pipeline layers,
 - CLI and programmatic entry points for validation and integration.
 
 ## Canonical Wist runtime path
@@ -177,6 +180,8 @@ For example, a frontend module can participate in several stages:
 - AST post-processing,
 - bytecode post-processing,
 - AST-to-bytecode translator initialization.
+
+Module authoring is convention-heavy. Before adding or changing modules, read [Module authoring guide](docs/guides/module-authoring.md) and [Module contracts](docs/contracts/module-contracts.md).
 
 ## CLI usage (`Wistc`)
 
@@ -277,14 +282,25 @@ This repository is actively evolving, and some areas are intentionally treated a
 - some bootstrap/runtime wiring is still concrete rather than fully descriptor-driven,
 - reflection-based interop/discovery helpers still exist for compatibility and bootstrap scenarios,
 - constrained dialect composition is not equivalent to hardened sandboxing,
+- bytecode tags and module authoring contracts are being formalized,
+- backend-agnostic artifact handling is still an active architecture area,
 - the reference language Wist is still the main proving ground for framework decisions.
+
+See [Current limitations](docs/limitations.md) for the explicit limitation and wording guide.
 
 ## Canonical documentation map
 
 - Project overview: [readme.md](readme.md)
+- Project positioning and public wording: [docs/project-positioning.md](docs/project-positioning.md)
+- Current limitations: [docs/limitations.md](docs/limitations.md)
 - Current runtime pipeline: [docs/current-canonical-runtime-pipeline.md](docs/current-canonical-runtime-pipeline.md)
 - Runtime manifest activation model: [docs/runtime-manifest-activation-model.md](docs/runtime-manifest-activation-model.md)
 - Runtime manifest format: [docs/runtime-manifest-format.md](docs/runtime-manifest-format.md)
+- Bytecode and AIR architecture: [docs/architecture/bytecode-and-air.md](docs/architecture/bytecode-and-air.md)
+- Backend and semantic parity contracts: [docs/architecture/backends-and-parity.md](docs/architecture/backends-and-parity.md)
+- Module authoring guide: [docs/guides/module-authoring.md](docs/guides/module-authoring.md)
+- Module hidden contracts: [docs/contracts/module-contracts.md](docs/contracts/module-contracts.md)
+- Architecture guardrails: [docs/ARCHITECTURE_RULES.md](docs/ARCHITECTURE_RULES.md)
 - Why this exists: [docs/why-this-exists.md](docs/why-this-exists.md)
 - Nearby alternatives: [docs/alternatives.md](docs/alternatives.md)
 - Coding standards: [docs/PROJECT_RULES.md](docs/PROJECT_RULES.md)


### PR DESCRIPTION
## Summary

This PR adds explicit documentation for the architecture contracts that were previously easy to infer only by reading implementation details.

Added docs:

- `docs/project-positioning.md` — clarifies UniversalToolchain vs Wist, public wording, and current maturity boundaries.
- `docs/guides/module-authoring.md` — documents the expected module authoring pattern.
- `docs/contracts/module-contracts.md` — makes hidden token, parser priority, visitor ownership, bytecode tag, shared state, dialect selection, and backend capability contracts explicit.
- `docs/architecture/bytecode-and-air.md` — explains bytecode as a semantic merge layer and AIR as a semantic/execution representation.
- `docs/architecture/backends-and-parity.md` — documents interpreter-as-oracle, CIL as performance backend, intrinsic gating, and parity expectations.
- `docs/limitations.md` — adds an honest limitations and wording guide.

Updated docs:

- `readme.md` now links the new architecture/contract docs and expands known limitations.
- `docs/CONTRIBUTING.md` now requires contributors to update matching contract docs when changing hidden module/pipeline/backend assumptions.

## Why

The project already has strong architecture rules and a real manifest-driven runtime path, but several important conventions were implicit:

- token names as internal API;
- parser priorities as grammar contracts;
- AST visitors needing self-filtering;
- bytecode tags as semantic metadata;
- backend-specific intrinsic gating;
- Wist facade staying separate from framework truth.

This PR turns those conventions into reviewable documentation so future human and AI-assisted changes are harder to make incorrectly.

## Validation

Documentation-only change. I did not run the .NET test suite in this environment.