### PR TITLE
Fix pricing demo fast invoker argument contract

### DIFF
--- a/UniversalToolchain/Example/Scenarios/DslPricingCalculator.cs
+++ b/UniversalToolchain/Example/Scenarios/DslPricingCalculator.cs
@@ -60,7 +60,7 @@ public sealed class DslPricingCalculator : IDisposable
     public double CalculateWithFastInvoker(string formula, double price, double fee)
     {
         var compiledArtifact = CompileWithCompiler(formula);
-        var environment = CreateExecutionEnvironment(compiledArtifact, price, fee);
+        var environment = CreateRuntimeCallEnvironment(compiledArtifact);
         var fastNativeInvoker = new DynamicMethodInvoker<IExecutionEnvironment, double, double, double>(compiledArtifact.CompilationOutput);
 
         return fastNativeInvoker.Invoke(environment, price, fee);
@@ -107,26 +107,11 @@ public sealed class DslPricingCalculator : IDisposable
             ["fee"] = typeof(double)
         };
 
-    private static IExecutionEnvironment CreateExecutionEnvironment(ICompiledArtifact compiledArtifact, double price, double fee)
+    private static IExecutionEnvironment CreateRuntimeCallEnvironment(ICompiledArtifact compiledArtifact)
     {
         compiledArtifact = compiledArtifact.ArgNotNull();
 
-        var environment = new ExecutionEnvironment(compiledArtifact.DeclaredBindings);
-        environment.SetExternalValue(GetRequiredSlot(compiledArtifact, "price"), price);
-        environment.SetExternalValue(GetRequiredSlot(compiledArtifact, "fee"), fee);
-
-        return environment;
-    }
-
-    private static int GetRequiredSlot(ICompiledArtifact compiledArtifact, string name)
-    {
-        compiledArtifact = compiledArtifact.ArgNotNull();
-        name = name.ArgNotNull();
-
-        if (!compiledArtifact.SlotsByName.TryGetValue(name, out var slot))
-            Thrower.Argument(nameof(name), $"Unknown argument name '{name}'.");
-
-        return slot;
+        return new ExecutionEnvironment(compiledArtifact.DeclaredBindings);
     }
 
     private ICompiledArtifact<DynamicMethod> CompileWithCompiler(string formula)


### PR DESCRIPTION
## Summary

Fixes the pricing demo fast-invoker path so it no longer duplicates runtime argument values in two places.

Before this change, `CalculateWithFastInvoker` created an `ExecutionEnvironment`, wrote `price` and `fee` into it, and also passed `price` and `fee` as native `DynamicMethod` arguments. That made the invocation contract confusing:

- `IExecutionEnvironment` was used both as runtime-call context and as argument storage;
- `price`/`fee` were also passed as direct compiled method parameters.

After this change:

- `IExecutionEnvironment` is used only as runtime-call/provider context;
- `price` and `fee` are passed only as direct compiled method parameters;
- the normal compiler path still uses `CreateSession()`.

## Validation

Not run locally in this environment. CI should cover the README pricing demo through Markdown smoke checks.