### PR TITLE
docs: fill phase 1 developer documentation

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -93,6 +93,16 @@ const bookSidebar = [
     }
 ]
 
+const bookNav = [
+    { text: '0. Introduction', link: '/start/' },
+    { text: '1. Getting Started', link: '/start/installation' },
+    { text: '2. Wist Language', link: '/wist/' },
+    { text: '3. Building DSLs', link: '/build-dsls/' },
+    { text: '4. Writing Modules', link: '/write-modules/' },
+    { text: '5. Internals', link: '/internals/' },
+    { text: '6. Reference', link: '/reference/' }
+]
+
 export default defineConfig({
     title: 'UniversalToolchain',
     description: 'Developer documentation for UniversalToolchain and Wist.',
@@ -109,12 +119,7 @@ export default defineConfig({
         logo: '/logo.svg',
 
         nav: [
-            { text: 'Start', link: '/start/' },
-            { text: 'Wist', link: '/wist/' },
-            { text: 'Build DSLs', link: '/build-dsls/' },
-            { text: 'Modules', link: '/write-modules/' },
-            { text: 'Internals', link: '/internals/' },
-            { text: 'Reference', link: '/reference/' },
+            { text: 'Book', items: bookNav },
             { text: 'GitHub', link: 'https://github.com/Misha1302/Wist2' }
         ],
 

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -1,5 +1,98 @@
 import { defineConfig } from 'vitepress'
 
+const bookSidebar = [
+    {
+        text: '0. Introduction',
+        collapsed: false,
+        items: [
+            { text: '0.1 Start Here', link: '/start/' },
+            { text: '0.2 What is UniversalToolchain?', link: '/start/what-is-universal-toolchain' },
+            { text: '0.3 What is Wist?', link: '/start/what-is-wist' },
+            { text: '0.4 Mental Model', link: '/start/mental-model' }
+        ]
+    },
+    {
+        text: '1. Getting Started',
+        collapsed: false,
+        items: [
+            { text: '1.1 Installation', link: '/start/installation' },
+            { text: '1.2 First Program', link: '/start/first-program' },
+            { text: '1.3 Wist Overview', link: '/wist/' },
+            { text: '1.4 Wist Syntax Tour', link: '/wist/syntax-tour' },
+            { text: '1.5 Examples', link: '/wist/examples' }
+        ]
+    },
+    {
+        text: '2. Wist Language',
+        collapsed: false,
+        items: [
+            { text: '2.1 Numbers', link: '/wist/numbers' },
+            { text: '2.2 Variables', link: '/wist/variables' },
+            { text: '2.3 Conditions', link: '/wist/conditions' },
+            { text: '2.4 Loops', link: '/wist/loops' },
+            { text: '2.5 Scopes', link: '/wist/scopes' }
+        ]
+    },
+    {
+        text: '3. Building DSLs',
+        collapsed: false,
+        items: [
+            { text: '3.1 Overview', link: '/build-dsls/' },
+            { text: '3.2 Dialect Files', link: '/build-dsls/dialect-files' },
+            { text: '3.3 Minimal DSL', link: '/build-dsls/minimal-dsl' },
+            { text: '3.4 Module Composition', link: '/build-dsls/module-composition' },
+            { text: '3.5 Backend Selection', link: '/build-dsls/backend-selection' },
+            { text: '3.6 Testing a DSL', link: '/build-dsls/testing-dsl' }
+        ]
+    },
+    {
+        text: '4. Writing Modules',
+        collapsed: false,
+        items: [
+            { text: '4.1 Overview', link: '/write-modules/' },
+            { text: '4.2 Frontend Module', link: '/write-modules/frontend-module' },
+            { text: '4.3 Parser Extension', link: '/write-modules/parser-extension' },
+            { text: '4.4 AST Nodes', link: '/write-modules/ast-nodes' },
+            { text: '4.5 Bytecode Generation', link: '/write-modules/bytecode-generation' },
+            { text: '4.6 Semantic Tags', link: '/write-modules/semantic-tags' },
+            { text: '4.7 Ordering and Priority', link: '/write-modules/ordering-and-priority' },
+            { text: '4.8 Testing a Module', link: '/write-modules/testing-module' }
+        ]
+    },
+    {
+        text: '5. Internals',
+        collapsed: false,
+        items: [
+            { text: '5.1 Overview', link: '/internals/' },
+            { text: '5.2 Pipeline', link: '/internals/pipeline' },
+            { text: '5.3 Lexer', link: '/internals/lexer' },
+            { text: '5.4 Parser', link: '/internals/parser' },
+            { text: '5.5 AST', link: '/internals/ast' },
+            { text: '5.6 Bytecode', link: '/internals/bytecode' },
+            { text: '5.7 AIR', link: '/internals/air' },
+            { text: '5.8 Backends', link: '/internals/backends' },
+            { text: '5.9 Intrinsics', link: '/internals/intrinsics' },
+            { text: '5.10 Optimizers', link: '/internals/optimizers' },
+            { text: '5.11 Semantic Parity', link: '/internals/semantic-parity' },
+            { text: '5.12 Dependency Injection', link: '/internals/dependency-injection' }
+        ]
+    },
+    {
+        text: '6. Reference',
+        collapsed: false,
+        items: [
+            { text: '6.1 Overview', link: '/reference/' },
+            { text: '6.2 Dialect Reference', link: '/reference/dialect-reference' },
+            { text: '6.3 Module Reference', link: '/reference/module-reference' },
+            { text: '6.4 Bytecode Reference', link: '/reference/bytecode-reference' },
+            { text: '6.5 AIR Reference', link: '/reference/air-reference' },
+            { text: '6.6 Intrinsics Reference', link: '/reference/intrinsics-reference' },
+            { text: '6.7 Backend Contracts', link: '/reference/backend-contracts' },
+            { text: '6.8 Project Rules', link: '/reference/project-rules' }
+        ]
+    }
+]
+
 export default defineConfig({
     title: 'UniversalToolchain',
     description: 'Developer documentation for UniversalToolchain and Wist.',
@@ -17,8 +110,8 @@ export default defineConfig({
 
         nav: [
             { text: 'Start', link: '/start/' },
-            { text: 'Language', link: '/wist/' },
-            { text: 'Dialects', link: '/build-dsls/' },
+            { text: 'Wist', link: '/wist/' },
+            { text: 'Build DSLs', link: '/build-dsls/' },
             { text: 'Modules', link: '/write-modules/' },
             { text: 'Internals', link: '/internals/' },
             { text: 'Reference', link: '/reference/' },
@@ -29,9 +122,16 @@ export default defineConfig({
             provider: 'local'
         },
 
+        sidebar: bookSidebar,
+
         outline: {
             level: [2, 3],
             label: 'On this page'
+        },
+
+        docFooter: {
+            prev: 'Previous',
+            next: 'Next'
         },
 
         socialLinks: [
@@ -39,111 +139,13 @@ export default defineConfig({
         ],
 
         editLink: {
-            pattern: 'https://github.com/Misha1302/Wist2/edit/master/docs/:path',
+            pattern: 'https://github.com/Misha1302/Wist2/edit/docs-site/docs/:path',
             text: 'Edit this page on GitHub'
         },
 
         footer: {
             message: 'Built for developers who want to use, extend, or understand UniversalToolchain.',
             copyright: 'UniversalToolchain documentation'
-        },
-
-        sidebar: {
-            '/start/': [
-                {
-                    text: 'Start Here',
-                    items: [
-                        { text: 'Overview', link: '/start/' },
-                        { text: 'What is UniversalToolchain?', link: '/start/what-is-universal-toolchain' },
-                        { text: 'What is Wist?', link: '/start/what-is-wist' },
-                        { text: 'Installation', link: '/start/installation' },
-                        { text: 'First Program', link: '/start/first-program' },
-                        { text: 'Mental Model', link: '/start/mental-model' }
-                    ]
-                }
-            ],
-
-            '/wist/': [
-                {
-                    text: 'Wist Language',
-                    items: [
-                        { text: 'Overview', link: '/wist/' },
-                        { text: 'Syntax Tour', link: '/wist/syntax-tour' },
-                        { text: 'Numbers', link: '/wist/numbers' },
-                        { text: 'Variables', link: '/wist/variables' },
-                        { text: 'Conditions', link: '/wist/conditions' },
-                        { text: 'Loops', link: '/wist/loops' },
-                        { text: 'Scopes', link: '/wist/scopes' },
-                        { text: 'Examples', link: '/wist/examples' }
-                    ]
-                }
-            ],
-
-            '/build-dsls/': [
-                {
-                    text: 'Build DSLs',
-                    items: [
-                        { text: 'Overview', link: '/build-dsls/' },
-                        { text: 'Dialect Files', link: '/build-dsls/dialect-files' },
-                        { text: 'Module Composition', link: '/build-dsls/module-composition' },
-                        { text: 'Minimal DSL', link: '/build-dsls/minimal-dsl' },
-                        { text: 'Backend Selection', link: '/build-dsls/backend-selection' },
-                        { text: 'Testing a DSL', link: '/build-dsls/testing-dsl' }
-                    ]
-                }
-            ],
-
-            '/write-modules/': [
-                {
-                    text: 'Write Modules',
-                    items: [
-                        { text: 'Overview', link: '/write-modules/' },
-                        { text: 'Frontend Module', link: '/write-modules/frontend-module' },
-                        { text: 'Parser Extension', link: '/write-modules/parser-extension' },
-                        { text: 'AST Nodes', link: '/write-modules/ast-nodes' },
-                        { text: 'Bytecode Generation', link: '/write-modules/bytecode-generation' },
-                        { text: 'Semantic Tags', link: '/write-modules/semantic-tags' },
-                        { text: 'Ordering and Priority', link: '/write-modules/ordering-and-priority' },
-                        { text: 'Testing a Module', link: '/write-modules/testing-module' }
-                    ]
-                }
-            ],
-
-            '/internals/': [
-                {
-                    text: 'Internals',
-                    items: [
-                        { text: 'Overview', link: '/internals/' },
-                        { text: 'Pipeline', link: '/internals/pipeline' },
-                        { text: 'Lexer', link: '/internals/lexer' },
-                        { text: 'Parser', link: '/internals/parser' },
-                        { text: 'AST', link: '/internals/ast' },
-                        { text: 'Bytecode', link: '/internals/bytecode' },
-                        { text: 'AIR', link: '/internals/air' },
-                        { text: 'Backends', link: '/internals/backends' },
-                        { text: 'Intrinsics', link: '/internals/intrinsics' },
-                        { text: 'Optimizers', link: '/internals/optimizers' },
-                        { text: 'Semantic Parity', link: '/internals/semantic-parity' },
-                        { text: 'Dependency Injection', link: '/internals/dependency-injection' }
-                    ]
-                }
-            ],
-
-            '/reference/': [
-                {
-                    text: 'Reference',
-                    items: [
-                        { text: 'Overview', link: '/reference/' },
-                        { text: 'Dialect Reference', link: '/reference/dialect-reference' },
-                        { text: 'Module Reference', link: '/reference/module-reference' },
-                        { text: 'Bytecode Reference', link: '/reference/bytecode-reference' },
-                        { text: 'AIR Reference', link: '/reference/air-reference' },
-                        { text: 'Intrinsics Reference', link: '/reference/intrinsics-reference' },
-                        { text: 'Backend Contracts', link: '/reference/backend-contracts' },
-                        { text: 'Project Rules', link: '/reference/project-rules' }
-                    ]
-                }
-            ]
         }
     }
 })

--- a/docs/build-dsls/dialect-files.md
+++ b/docs/build-dsls/dialect-files.md
@@ -5,22 +5,165 @@ description: Document the dialect file format and its role.
 
 # Dialect Files
 
-<div class="placeholder-box">
+Dialect files describe which modules, optimizers and backends are available for a Wist runtime composition.
 
-This page is a documentation placeholder.
+## Problem
 
-**Purpose:** Document the dialect file format and its role.
+A reusable DSL framework needs a way to select language features without hardcoding them into one compiler. Dialect files are that selection layer. They let a DSL developer assemble a runtime surface from existing modules and make the selected surface explicit.
 
-</div>
+## Concept
 
-## What this page should explain
+A Wist dialect file uses the `.wistdialect` extension. It is compiled before program execution and becomes part of the runtime selection path:
 
-- The practical goal of this topic.
-- The minimal example a developer should run or read.
-- The important concepts needed before going deeper.
-- Links to the next page for gradual learning.
+```text
+dialect source → dialect compilation → build plan → manifest-backed runtime selection → host creation → execution
+```
 
-## Status
+A typical dialect file contains:
 
-Content is not written yet.
+```text
+dialect FullDefault
+use Arithmetic,BooleanConditions,Comments,ComparisonConditions,Conditions,CSharpInterop,Equality,Identifier,Labels,Loops,Numbers,Scopes,SemicolonAsNewLine,Variables,Whitespaces
+backend cil,interpreter
+enable BooleanOptimization
+enable ComparisonIntrinsicOptimization
+security trusted
+capability unsafe-interop
+```
 
+## Minimal example
+
+The smallest shipped arithmetic dialect is:
+
+```text
+dialect MinimalArithmetic
+use Arithmetic,Numbers,Scopes,Whitespaces
+backend interpreter
+```
+
+This dialect can run a program such as:
+
+```wist
+2 + 3 * 4
+```
+
+Expected result:
+
+```text
+14
+```
+
+## Directives
+
+### `dialect`
+
+Declares the dialect name:
+
+```text
+dialect MinimalArithmetic
+```
+
+The name is used in diagnostics and composition output.
+
+### `use`
+
+Selects modules:
+
+```text
+use Arithmetic,Numbers,Scopes,Whitespaces
+```
+
+A module must be selected for its syntax and runtime behavior to exist. For example, arithmetic syntax needs arithmetic and number support; variable syntax needs variables and identifier support.
+
+### `exclude`
+
+Removes selected modules from a composition:
+
+```text
+exclude CSharpInterop,Identifier,InternalPreprocessorLexemes,Labels,Loops,NativeTypes,ParametersSetter,SemicolonAsNewLine,Variables
+```
+
+The shipped `restricted-sandbox` example uses this to keep the runtime surface narrower.
+
+### `backend`
+
+Selects execution backends:
+
+```text
+backend cil,interpreter
+```
+
+Currently documented user-facing modes are:
+
+- `compiler`, which maps to the CIL backend when the dialect exposes `cil`;
+- `interpreter`, which runs through the interpreter backend when exposed.
+
+Some dialect examples expose both `cil` and `interpreter`. Others expose only one backend.
+
+### `enable`
+
+Enables optimizers:
+
+```text
+enable ArithmeticOptimization
+enable EGraphOptimization
+enable NativeCilOptimization
+enable NativeTypesOptimization
+```
+
+Only enable optimizers that are supported by the selected modules and backend path.
+
+### `security`
+
+Declares the intended security profile:
+
+```text
+security restricted
+```
+
+or:
+
+```text
+security trusted
+```
+
+A restricted dialect is a composition constraint, not a hardened sandbox. Use process and environment isolation for untrusted code.
+
+### `capability`
+
+Declares a capability marker:
+
+```text
+capability unsafe-interop
+```
+
+Capabilities explain selected composition. They must not be treated as hidden runtime activation mechanisms.
+
+## Shipped dialect examples
+
+Examples are located under `UniversalToolchain/Dialects/examples/wist`:
+
+| Directory | Purpose |
+|---|---|
+| `full-default` | Standard Wist profile over `cil` and `interpreter`. |
+| `full-default-native` | Native arithmetic/type profile over `cil` and `interpreter`. |
+| `function-calls-safe-math` | Function calls plus SafeMath profile without rule declarations. |
+| `minimal-arithmetic` | Smallest interpreter arithmetic profile. |
+| `minimal-arithmetic-native` | Smallest native arithmetic profile over `cil`. |
+| `pricing-restricted` | Composition-constrained pricing profile with a restricted runtime surface. |
+| `restricted-sandbox` | Composition-constrained profile; not a hardened sandbox guarantee. |
+
+## How it fits into the pipeline
+
+`ComposeText` and `ComposeFile` compile a dialect definition, build a deterministic plan and resolve selected modules, optimizers and backends from runtime manifests. `CreateHost` then builds the runtime provider for that selected composition.
+
+## Rules and constraints
+
+- Do not document rules as an available public runtime feature. `rule-schema`, `rule-run`, raw-source RuleSet MVP parsing and `RuleDeclarationsModule` are temporarily removed.
+- Keep dialect files explicit. A future reader should be able to see which syntax and backend paths are available.
+- Do not treat `restricted-sandbox` as a real security sandbox.
+- Do not add raw-source parsing workarounds for missing language features. Syntax must be owned by lexer/parser/AST/module code.
+
+## Next
+
+Continue with [Minimal DSL](/build-dsls/minimal-dsl).

--- a/docs/build-dsls/minimal-dsl.md
+++ b/docs/build-dsls/minimal-dsl.md
@@ -5,22 +5,137 @@ description: Build the smallest useful DSL from existing modules.
 
 # Minimal DSL
 
-<div class="placeholder-box">
+This page shows how to build a small DSL by selecting existing Wist modules in a dialect file. It does not start with writing a new module.
 
-This page is a documentation placeholder.
+## When to read this page
 
-**Purpose:** Build the smallest useful DSL from existing modules.
+Read this after [Dialect Files](/build-dsls/dialect-files) if you want to compose a smaller language surface than full Wist.
 
-</div>
+## Goal
 
-## What this page should explain
+Create a small dialect from existing modules and run a simple program through it.
 
-- The practical goal of this topic.
-- The minimal example a developer should run or read.
-- The important concepts needed before going deeper.
-- Links to the next page for gradual learning.
+## Prerequisites
 
-## Status
+- You can run Wistc from the repository root.
+- You understand that dialects select modules and backends.
+- You do not need a brand-new syntax feature yet.
 
-Content is not written yet.
+## Steps
 
+### 1. Start from the shipped minimal arithmetic dialect
+
+The repository already contains a minimal arithmetic example:
+
+```text
+UniversalToolchain/Dialects/examples/wist/minimal-arithmetic/dialect.wistdialect
+```
+
+Its contents are:
+
+```text
+dialect MinimalArithmetic
+use Arithmetic,Numbers,Scopes,Whitespaces
+backend interpreter
+```
+
+The matching program is:
+
+```wist
+2 + 3 * 4
+```
+
+Expected result:
+
+```text
+14
+```
+
+### 2. Run it through Wistc
+
+```bash
+dotnet run --project UniversalToolchain/Wistc/Wistc.csproj -- run --dialect-file UniversalToolchain/Dialects/examples/wist/minimal-arithmetic/dialect.wistdialect --file UniversalToolchain/Dialects/examples/wist/minimal-arithmetic/program.wist --mode interpreter
+```
+
+This executes the program using only the modules and backend selected by the dialect.
+
+### 3. Add one feature at a time
+
+If you need variables, extend the module list:
+
+```text
+dialect MinimalVariables
+use Arithmetic,Numbers,Identifier,Variables,Scopes,Whitespaces
+backend interpreter
+```
+
+Then a program like this becomes valid:
+
+```wist
+let x = 2
+let y = 3
+x + y
+```
+
+If you need comparisons and conditions, add the owning modules explicitly:
+
+```text
+use Arithmetic,Numbers,Identifier,Variables,Scopes,Whitespaces,ComparisonConditions,Conditions,Equality,BooleanConditions
+```
+
+The exact module set depends on the syntax you want to allow. Start narrow and add only the features you can test.
+
+### 4. Choose backend intentionally
+
+For interpreter-only DSLs:
+
+```text
+backend interpreter
+```
+
+For CIL-backed DSLs:
+
+```text
+backend cil
+```
+
+For both modes:
+
+```text
+backend cil,interpreter
+```
+
+If both backends are enabled, add parity tests so the same source produces the same observable result in both modes.
+
+### 5. Add optimizers only when needed
+
+A native arithmetic dialect can enable optimizers such as:
+
+```text
+enable ArithmeticOptimization
+enable EGraphOptimization
+enable NativeCilOptimization
+enable NativeTypesOptimization
+```
+
+Do this after the minimal interpreter version works. Optimizers should not be used to hide missing semantics.
+
+## Expected result
+
+You should end up with a dialect that exposes only the language features you selected. Code using omitted syntax should fail. That failure is useful: it proves the dialect is actually constraining the runtime surface.
+
+## What happened internally
+
+The dialect file is compiled into a build plan, resolved against runtime manifests and used to create a Wist execution host. Only the selected modules and backends are activated for that host.
+
+## Common mistakes
+
+- Starting with `full-default` and removing features without testing the result.
+- Forgetting `Identifier` when adding `Variables`.
+- Enabling `compiler` mode in the CLI while the dialect declares only `backend interpreter`.
+- Adding `CSharpInterop` or `unsafe-interop` to a DSL intended for restricted user-authored formulas.
+- Documenting rules as available. Rule runtime functionality is currently removed from the public surface.
+
+## Next
+
+Continue with [Write Modules](/write-modules/) if you need syntax that no existing module provides.

--- a/docs/start/first-program.md
+++ b/docs/start/first-program.md
@@ -5,22 +5,83 @@ description: Run the smallest useful Wist program and explain what happened inte
 
 # First Program
 
-<div class="placeholder-box">
+This is the shortest practical check that Wist, Wistc and the default runtime path are working.
 
-This page is a documentation placeholder.
+## When to read this page
 
-**Purpose:** Run the smallest useful Wist program and explain what happened internally.
+Read this after [Installation](/start/installation). It is the first executable page in the documentation.
 
-</div>
+## Goal
 
-## What this page should explain
+Run one Wist expression through the CLI and verify the expected output.
 
-- The practical goal of this topic.
-- The minimal example a developer should run or read.
-- The important concepts needed before going deeper.
-- Links to the next page for gradual learning.
+## Prerequisites
 
-## Status
+- You are in the repository root.
+- The repository is on the `docs-site` branch.
+- The .NET solution has been restored and built.
 
-Content is not written yet.
+## Steps
 
+### 1. Run the compiler mode quick start
+
+```bash
+dotnet run --project UniversalToolchain/Wistc/Wistc.csproj -- run --eval "(2 + 2) * 3" --mode compiler
+```
+
+Expected output:
+
+```text
+12
+```
+
+`compiler` is the user-facing mode that selects the CIL backend when the active dialect exposes the CIL backend.
+
+### 2. Run the same expression through the interpreter
+
+```bash
+dotnet run --project UniversalToolchain/Wistc/Wistc.csproj -- run --eval "(2 + 2) * 3" --mode interpreter
+```
+
+Expected output:
+
+```text
+12
+```
+
+The interpreter path is useful when validating semantic parity. If a selected dialect does not expose `interpreter`, Wistc will reject that mode.
+
+### 3. Run the pricing demo
+
+```bash
+dotnet run --project UniversalToolchain/Example/Example.csproj
+```
+
+The pricing demo runs a pricing formula through hardcoded C# logic, the shipped `full-default-native` Wist preset and the shipped `pricing-restricted` dialect. It also demonstrates compiler, interpreter and fast native invocation paths.
+
+## Expected result
+
+The quick start prints `12`. The pricing demo should show matching pricing results across the supported execution paths and should reject the formula shape that the restricted pricing dialect intentionally does not allow.
+
+## What happened internally
+
+For the simple expression, the runtime path is:
+
+```text
+source → parser → AST → bytecode/AIR → selected backend → result
+```
+
+The CLI receives source text through `--eval`. Wist uses the active dialect to select modules and backends, parses the expression, translates it into intermediate representations and runs it through the selected backend.
+
+The same source should produce the same observable result in compiler and interpreter modes when both modes are available. This parity is one of the main correctness expectations for Wist backends.
+
+## Common mistakes
+
+- Running the command from a subdirectory, causing project paths to fail.
+- Using `--mode compiler` with a dialect that exposes only `interpreter`.
+- Assuming all dialects expose all Wist syntax. Syntax exists only when the owning module is selected.
+- Treating restricted dialects as security sandboxes. They restrict composition, but they are not hardened process sandboxes.
+
+## Next
+
+Read the [Mental Model](/start/mental-model), then continue with the [Wist Syntax Tour](/wist/syntax-tour).

--- a/docs/start/index.md
+++ b/docs/start/index.md
@@ -5,22 +5,43 @@ description: Give developers the fastest path from zero to a running Wist progra
 
 # Start Here
 
-<div class="placeholder-box">
+This page introduces **UniversalToolchain** and the **Wist** reference language, explains who should read which sections of the documentation and helps you choose your route through the project.
 
-This page is a documentation placeholder.
+## When to read this page
 
-**Purpose:** Give developers the fastest path from zero to a running Wist program.
+Read this page if you have just discovered the repository and want to get started. It helps you understand the difference between the framework and the reference language and points you to the right section.
 
-</div>
+## Goal
 
-## What this page should explain
+Understand the difference between UniversalToolchain and Wist, identify your role, and know where to start.
 
-- The practical goal of this topic.
-- The minimal example a developer should run or read.
-- The important concepts needed before going deeper.
-- Links to the next page for gradual learning.
+## Project overview
 
-## Status
+- **UniversalToolchain** is an embeddable .NET framework for composing restricted DSLs. It provides infrastructure for lexing, parsing, abstract syntax trees (AST), bytecode/AIR layers, optimizers and execution backends. Modules are the building blocks; dialects select modules, backends and optimizations; manifests resolve runtime activation.
+- **Wist** is the reference language built on top of UniversalToolchain. It demonstrates how to assemble modules into a usable language and provides CLI and programmatic entry points.
 
-Content is not written yet.
+## Identify your route
 
+| User type | What to read first | Then read |
+|---|---|---|
+| **Wist user** (run programs, learn syntax) | [First Program](/start/first-program) | [Syntax Tour](/wist/syntax-tour) |
+| **DSL developer** (compose your own language) | [Mental Model](/start/mental-model), [Dialect Files](/build-dsls/dialect-files) | [Minimal DSL](/build-dsls/minimal-dsl) |
+| **Module author** (add new language features) | [Write Modules](/write-modules/) | Later: Bytecode generation and backend guides |
+| **Runtime/compiler engineer** | [Internals](/internals/pipeline) | [Bytecode and AIR](/internals/bytecode-and-air) |
+| **Contributor/maintainer** | [Internals](/internals/) | Project rules and architecture docs |
+| **Reference user** | [Reference](/reference/) | Backend contracts, module specifications |
+
+## Recommended order
+
+1. [First Program](/start/first-program)
+2. [Mental Model](/start/mental-model)
+3. [Syntax Tour](/wist/syntax-tour)
+4. [Dialect Files](/build-dsls/dialect-files)
+5. [Minimal DSL](/build-dsls/minimal-dsl)
+6. [Write Modules](/write-modules/)
+7. [Pipeline overview](/internals/pipeline)
+8. [Reference](/reference/)
+
+## Next
+
+Continue with [First Program](/start/first-program) to run your first Wist expression.

--- a/docs/start/installation.md
+++ b/docs/start/installation.md
@@ -5,22 +5,106 @@ description: Show how to clone, build, and prepare the project locally.
 
 # Installation
 
-<div class="placeholder-box">
+This page shows how to prepare the repository for Wist usage, .NET development and local documentation work.
 
-This page is a documentation placeholder.
+## When to read this page
 
-**Purpose:** Show how to clone, build, and prepare the project locally.
+Read this page before running examples or editing the documentation site.
 
-</div>
+## Goal
 
-## What this page should explain
+Verify the repository branch, build the .NET solution and prepare the VitePress documentation site.
 
-- The practical goal of this topic.
-- The minimal example a developer should run or read.
-- The important concepts needed before going deeper.
-- Links to the next page for gradual learning.
+## Prerequisites
 
-## Status
+- Git.
+- .NET SDK `10.0.103` or a compatible SDK accepted by `UniversalToolchain/global.json`.
+- Node.js and npm for VitePress documentation.
+- Repository branch: `docs-site`.
 
-Content is not written yet.
+The current validation baseline is .NET 10 and target framework `net10.0`. Older target frameworks are not the current compatibility target.
 
+## Steps
+
+### 1. Check the branch
+
+From the repository root:
+
+```bash
+git status
+git branch --show-current
+```
+
+Expected branch:
+
+```text
+docs-site
+```
+
+If the branch is not `docs-site`, switch branches before editing documentation.
+
+### 2. Restore and build the .NET solution
+
+```bash
+dotnet restore UniversalToolchain/Wist.sln
+dotnet build UniversalToolchain/Wist.sln -c Release --no-restore
+```
+
+For quick local work, `dotnet build` from the repository root may also work, but the solution path is the documented validation path.
+
+### 3. Run tests when changing behavior
+
+For documentation-only changes, tests may not be necessary. For code, module, dialect or runtime changes, run the relevant test projects:
+
+```bash
+dotnet test UniversalToolchain/Tests/Tests.csproj -c Release --no-build
+dotnet test UniversalToolchain/UniversalToolchain.Modules.Tests/UniversalToolchain.Modules.Tests.csproj -c Release --no-build
+dotnet test UniversalToolchain/UniversalToolchain.Dialects.Tests/UniversalToolchain.Dialects.Tests.csproj -c Release --no-build
+```
+
+### 4. Install documentation dependencies
+
+```bash
+npm install
+```
+
+### 5. Run the documentation site locally
+
+```bash
+npm run docs:dev
+```
+
+This starts the VitePress development server for the `docs/` directory.
+
+### 6. Build the documentation site
+
+```bash
+npm run docs:build
+```
+
+This must pass before merging documentation changes.
+
+## Expected result
+
+After completing these steps:
+
+- the .NET solution builds;
+- the Wist CLI can run examples;
+- the VitePress documentation site can be served locally;
+- `npm run docs:build` produces a static documentation build without broken internal links.
+
+## What happened internally
+
+The .NET build compiles UniversalToolchain, Wist, shipped modules, dialect infrastructure, CLI projects and tests. The npm commands install and run VitePress against the `docs/` folder. These are separate workflows: .NET validates the framework, VitePress validates the documentation site.
+
+## Common mistakes
+
+- Running commands from inside `docs/` instead of the repository root.
+- Using `master` or `main` instead of `docs-site`.
+- Installing an older .NET SDK that cannot build `net10.0` projects.
+- Forgetting `npm install` before `npm run docs:dev` or `npm run docs:build`.
+- Treating docs build success as runtime validation. Documentation build does not replace .NET tests.
+
+## Next
+
+Continue with [First Program](/start/first-program).

--- a/docs/start/mental-model.md
+++ b/docs/start/mental-model.md
@@ -5,22 +5,65 @@ description: Explain the source to backend pipeline without overwhelming the rea
 
 # Mental Model
 
-<div class="placeholder-box">
+This page explains the project model behind UniversalToolchain and Wist without going deep into implementation details.
 
-This page is a documentation placeholder.
+## Problem
 
-**Purpose:** Explain the source to backend pipeline without overwhelming the reader.
+A DSL runtime is not only a parser. A useful embeddable DSL needs syntax, semantic representation, execution strategy, module selection and tests that prove different execution paths behave the same. UniversalToolchain separates these responsibilities so features can be composed and validated instead of hardcoded into one compiler path.
 
-</div>
+## Concept
 
-## What this page should explain
+The core distinction is:
 
-- The practical goal of this topic.
-- The minimal example a developer should run or read.
-- The important concepts needed before going deeper.
-- Links to the next page for gradual learning.
+- **UniversalToolchain** is the framework.
+- **Wist** is the reference language built on the framework.
+- **Dialect** is a selected language/runtime composition.
+- **Module** is a reusable language feature.
+- **Backend** is an execution strategy.
+- **Bytecode/AIR** are intermediate layers between AST and execution.
 
-## Status
+A simplified pipeline looks like this:
 
-Content is not written yet.
+```text
+source
+  → lexer/parser
+  → AST
+  → bytecode / AIR
+  → optimizers
+  → interpreter backend / CIL backend
+  → result
+```
 
+## Minimal example
+
+A tiny Wist expression:
+
+```wist
+(2 + 2) * 3
+```
+
+When run through the CLI, this expression is not evaluated directly from raw text. The active dialect selects modules such as numbers and arithmetic. Those modules contribute lexer and parser behavior. The AST is lowered into intermediate representation, then the selected backend produces the final result.
+
+## How it fits into the pipeline
+
+A `.wistdialect` file decides which modules and backends are available. For example:
+
+```text
+dialect MinimalArithmetic
+use Arithmetic,Numbers,Scopes,Whitespaces
+backend interpreter
+```
+
+This dialect selects a very small language surface: arithmetic expressions, numbers, scopes and whitespace handling. It exposes only the interpreter backend. If you try to run code in `compiler` mode under this dialect, the runtime should reject that mode.
+
+## Rules and constraints
+
+- A module must own its syntax. Do not recognize language syntax through ad hoc raw-source parsing outside the lexer/parser/AST pipeline.
+- A dialect selects runtime capabilities; it should not be replaced by hardcoded profile checks.
+- Compiler and interpreter behavior should stay semantically aligned for the same dialect and source.
+- Runtime selection must stay deterministic.
+- Rules and rule declarations are currently removed from the public runtime surface. Do not document them as available runtime capabilities.
+
+## Next
+
+Continue with the [Wist Syntax Tour](/wist/syntax-tour), then read [Dialect Files](/build-dsls/dialect-files).

--- a/docs/start/what-is-universal-toolchain.md
+++ b/docs/start/what-is-universal-toolchain.md
@@ -5,22 +5,51 @@ description: Explain UniversalToolchain as a modular .NET framework for building
 
 # What is UniversalToolchain?
 
-<div class="placeholder-box">
+UniversalToolchain is the project’s **framework**, not a language itself. This page clarifies what the framework is for, when to reach for it and when to look elsewhere.
 
-This page is a documentation placeholder.
+## Problem
 
-**Purpose:** Explain UniversalToolchain as a modular .NET framework for building DSLs.
+Many applications start by evaluating simple expressions. As business logic grows, those expressions turn into small languages: formulas need variables, conditions, loops and sometimes calls into native code. A one-off evaluator or rules library often becomes hard to extend and hard to constrain. The gap between a trivial evaluator and a full language workbench is large, leaving developers with few options when they need a restricted but embeddable DSL.
 
-</div>
+## Concept
 
-## What this page should explain
+**UniversalToolchain** is an embeddable .NET framework for composing restricted DSLs. It supplies infrastructure for lexing, parsing, AST construction, bytecode/AIR generation, optimizations and execution backends. Language features are delivered as *modules*; a *dialect* selects which modules, optimizers and backends participate; a *manifest* resolves those selections into a runtime plan. The pipeline is always the same:
 
-- The practical goal of this topic.
-- The minimal example a developer should run or read.
-- The important concepts needed before going deeper.
-- Links to the next page for gradual learning.
+```text
+Source → Lexer/Parser → AST → Bytecode/AIR → Optimizations → Compiler/Interpreter → Execution
+```
 
-## Status
+Unlike parser libraries or turnkey expression evaluators, UniversalToolchain separates language construction from execution. Developers decide which capabilities are available by editing dialect files rather than editing framework code.
 
-Content is not written yet.
+## Minimal example
 
+UniversalToolchain does not have a built-in language. The quickest way to see it in action is through the **Wist** reference language. To run a simple expression you can use the CLI shipped in the repository:
+
+```bash
+# from the repository root
+dotnet run --project UniversalToolchain/Wistc/Wistc.csproj -- run --eval "(2 + 2) * 3" --mode compiler
+```
+
+This uses UniversalToolchain’s pipeline to parse and evaluate the expression. The expected output is `12`. For a richer demonstration of dialect composition, run the pricing demo:
+
+```bash
+dotnet run --project UniversalToolchain/Example/Example.csproj
+```
+
+The pricing demo compares hard-coded C# logic, a full Wist preset and a restricted pricing dialect.
+
+## When to use UniversalToolchain
+
+Use UniversalToolchain when a plain evaluator is too narrow for your rules or formulas, you need a syntax that matches your domain, you want to restrict which language features are available, or you need both compiler and interpreter modes. Typical scenarios include pricing formulas, routing rules, internal workflow rules and DSL experiments inside .NET applications.
+
+## When not to use UniversalToolchain
+
+Do not start here if you only need trivial arithmetic, a small subset of C# expressions, a parser generator or a simple library call can evaluate all of your rules. UniversalToolchain is heavier than a one-line expression evaluator and lighter than a full language workbench; it is designed for cases where you need a carefully controlled runtime rather than the full power of C# or a generic parser.
+
+## How it fits into the pipeline
+
+UniversalToolchain owns the framework story: dialect definitions, build plans, runtime manifests, selected runtime plans and backend activation. Wist, the reference language, provides a concrete orchestration layer on top of that framework. Developers build or select dialects to choose modules and backends, and the framework takes care of lexing, parsing, AST translation and execution. Because the pipeline is compositional, you can add new language features by authoring modules without modifying the core framework.
+
+## Next
+
+Continue with [What is Wist?](/start/what-is-wist) to learn about the reference language built on top of UniversalToolchain.

--- a/docs/start/what-is-wist.md
+++ b/docs/start/what-is-wist.md
@@ -5,22 +5,70 @@ description: Explain Wist as the reference language built on top of UniversalToo
 
 # What is Wist?
 
-<div class="placeholder-box">
+Wist is **not** the product. It is the reference language that demonstrates how UniversalToolchain modules can be assembled into a usable DSL.
 
-This page is a documentation placeholder.
+## Problem
 
-**Purpose:** Explain Wist as the reference language built on top of UniversalToolchain.
+A DSL framework needs a concrete language to validate the architecture. UniversalToolchain needs a proving ground that exercises module composition, dialect files, bytecode/AIR, optimizers, compiler execution and interpreter execution. Wist fulfils that role.
 
-</div>
+Wist is not meant to replace C#, scripting engines or full language workbenches. It exists so the framework can be tested against real syntax, real modules and real backend paths.
 
-## What this page should explain
+## Concept
 
-- The practical goal of this topic.
-- The minimal example a developer should run or read.
-- The important concepts needed before going deeper.
-- Links to the next page for gradual learning.
+**Wist** is the reference language in this repository. It demonstrates:
 
-## Status
+- shipped dialect profiles;
+- manifest-backed dialect composition;
+- compiler and interpreter execution modes;
+- CLI execution through `UniversalToolchain/Wistc/Wistc.csproj`;
+- programmatic usage through the Wist runtime facade;
+- constrained runtime surfaces such as `pricing-restricted`.
 
-Content is not written yet.
+Wist is built from modules. A dialect selects which modules and backends are available. For example, `minimal-arithmetic` exposes a small arithmetic surface, while `full-default` exposes a broader language surface.
 
+Rules are currently removed from the public runtime surface. Do not treat rule schemas, `rule-run`, raw-source RuleSet MVP parsing or `RuleDeclarationsModule` as available Wist runtime features.
+
+## Minimal example
+
+Run a simple expression through the Wist CLI:
+
+```bash
+dotnet run --project UniversalToolchain/Wistc/Wistc.csproj -- run --eval "(2 + 2) * 3" --mode compiler
+```
+
+Expected output:
+
+```text
+12
+```
+
+You can also run the same expression in interpreter mode:
+
+```bash
+dotnet run --project UniversalToolchain/Wistc/Wistc.csproj -- run --eval "(2 + 2) * 3" --mode interpreter
+```
+
+If a selected dialect does not expose the requested backend, Wistc reports an execution-mode error.
+
+## How it fits into the pipeline
+
+Wist uses UniversalToolchain’s pipeline:
+
+```text
+source → lexer/parser → AST → bytecode/AIR → optimizer → backend → result
+```
+
+Wist-specific code orchestrates one concrete language. UniversalToolchain remains the framework layer: dialect definitions, build plans, manifests, module selection and backend activation. Treat Wist as an example and validation target for the framework, not as the only possible language.
+
+## Rules and constraints
+
+- Wist programs run under a selected dialect.
+- Syntax is only available when the dialect includes the owning module.
+- `compiler` is the user-facing mode for the CIL backend.
+- `interpreter` runs through the interpreter backend when the dialect enables it.
+- Restricted dialects are composition constraints, not hardened sandboxes.
+- Rules are not currently a public runtime capability.
+
+## Next
+
+Continue with [Installation](/start/installation), then run your [First Program](/start/first-program).

--- a/docs/wist/syntax-tour.md
+++ b/docs/wist/syntax-tour.md
@@ -5,22 +5,172 @@ description: Walk through Wist syntax with small examples.
 
 # Syntax Tour
 
-<div class="placeholder-box">
+This page is a tour, not a full language reference. It shows small Wist snippets that are useful when learning the reference language and when deciding which modules a dialect should include.
 
-This page is a documentation placeholder.
+## When to read this page
 
-**Purpose:** Walk through Wist syntax with small examples.
+Read this after [First Program](/start/first-program) and [Mental Model](/start/mental-model).
 
-</div>
+## Goal
 
-## What this page should explain
+Understand the basic Wist syntax surface used by shipped dialect examples: numbers, arithmetic, variables, conditions, loops and scopes.
 
-- The practical goal of this topic.
-- The minimal example a developer should run or read.
-- The important concepts needed before going deeper.
-- Links to the next page for gradual learning.
+## Prerequisites
 
-## Status
+- You can run Wistc from the repository root.
+- You understand that syntax exists only when the active dialect includes the owning module.
 
-Content is not written yet.
+## Steps
 
+### 1. Numbers and arithmetic
+
+```wist
+2 + 3 * 4
+```
+
+Expected result:
+
+```text
+14
+```
+
+Arithmetic precedence follows the normal order: multiplication and division bind before addition and subtraction. Parentheses can be used to group expressions:
+
+```wist
+(2 + 3) * 4
+```
+
+### 2. Variables
+
+Variables are declared with `let` and can be updated later:
+
+```wist
+let x = 2
+let y = 3
+x = x + y
+x
+```
+
+This uses the `Variables`, `Identifier`, `Numbers`, `Arithmetic`, `Scopes` and `Whitespaces` modules.
+
+### 3. Conditions
+
+A simple if/else expression:
+
+```wist
+if 2 == 2 (1) else (2)
+```
+
+Expected result:
+
+```text
+1
+```
+
+A condition with a variable:
+
+```wist
+let x = 2
+if x == 2 (10) else (20)
+```
+
+This requires condition, comparison, equality, variable and identifier support. In shipped full dialects, these are provided by modules such as `Conditions`, `ComparisonConditions`, `Equality`, `Variables` and `Identifier`.
+
+### 4. Loops
+
+A `while` loop:
+
+```wist
+let sum = 0
+let i = 1
+
+while (i <= 5) (
+    sum = sum + i
+    i = i + 1
+)
+
+sum
+```
+
+Expected result:
+
+```text
+15
+```
+
+Loops require the `Loops` module plus variables, comparison and arithmetic support.
+
+### 5. `for` loops
+
+The shipped `full-default` example uses this form:
+
+```wist
+let sum = 0
+
+for (let i = 1) (i <= 5) (i = i + 1) (
+    sum = sum + i
+)
+
+sum
+```
+
+Expected result:
+
+```text
+15
+```
+
+Use this example as the canonical reference for current `for` syntax.
+
+### 6. Comments
+
+When the `Comments` module is selected, single-line and block comments are allowed:
+
+```wist
+// single-line comment
+let x = 2
+/* block
+   comment */
+x + 5
+```
+
+Expected result:
+
+```text
+7
+```
+
+### 7. Interop expression in full dialects
+
+The full dialect can run C# interop expressions when `CSharpInterop` and trusted capabilities are enabled:
+
+```wist
+NumbersModule.Core.RealNumberImpl.Add(2, 5)
+```
+
+Expected result:
+
+```text
+7
+```
+
+Do not use this in restricted dialects. Interop is intentionally excluded from examples such as `restricted-sandbox`.
+
+## Expected result
+
+You should be able to map each syntax feature to the module that owns it. If a snippet fails under a custom dialect, check whether that dialect includes the required modules.
+
+## What happened internally
+
+Each syntax feature is introduced by one or more modules. Modules register lexer rules, parser node creators and AST-to-bytecode visitors. Dialects decide which modules are visible to the runtime.
+
+## Common mistakes
+
+- Trying to use variables in a dialect that omits `Variables` or `Identifier`.
+- Trying to use loops in a dialect that omits `Loops`.
+- Using `compiler` mode with a dialect that only exposes `interpreter`.
+- Assuming restricted dialects are hardened sandboxes. They constrain composition, but process isolation is still required for untrusted execution.
+
+## Next
+
+Continue with [Dialect Files](/build-dsls/dialect-files).

--- a/docs/write-modules/index.md
+++ b/docs/write-modules/index.md
@@ -5,22 +5,138 @@ description: Introduce language module development.
 
 # Write Modules
 
-<div class="placeholder-box">
+A module is the normal way to add a language feature to Wist or to a UniversalToolchain-based DSL. This page gives the lifecycle for module authors without pretending that every extension point is already fully formalized.
 
-This page is a documentation placeholder.
+## When to read this page
 
-**Purpose:** Introduce language module development.
+Read this when existing modules are not enough and you need to add syntax, AST translation, bytecode/AIR behavior or backend support.
 
-</div>
+## Goal
 
-## What this page should explain
+Understand the expected path from syntax idea to tested language feature.
 
-- The practical goal of this topic.
-- The minimal example a developer should run or read.
-- The important concepts needed before going deeper.
-- Links to the next page for gradual learning.
+## Prerequisites
 
-## Status
+- Read [Mental Model](/start/mental-model).
+- Read [Dialect Files](/build-dsls/dialect-files).
+- Build the repository and run relevant tests before changing behavior.
+- Review `docs/guides/module-authoring.md` and `docs/contracts/module-contracts.md` before implementing a real module.
 
-Content is not written yet.
+## Steps
 
+### 1. Define the feature boundary
+
+A module should own one language feature or one tightly scoped set of related features. Examples of current runtime-visible modules include:
+
+- `Numbers`
+- `Arithmetic`
+- `Identifier`
+- `Variables`
+- `Scopes`
+- `Conditions`
+- `ComparisonConditions`
+- `BooleanConditions`
+- `Equality`
+- `Loops`
+- `Labels`
+- `Comments`
+- `SemicolonAsNewLine`
+- `CSharpInterop`
+- `FunctionCalls`
+- `SafeMathFunctions`
+- `NativeTypes`
+
+Do not add marker-only capabilities that imply runtime behavior without owning syntax and semantics.
+
+### 2. Add lexer ownership
+
+If the feature introduces syntax, the module should register lexemes through its frontend module implementation. Current modules usually expose a `[DialectModuleAlias(...)]` and implement `IFrontendCoreModule`.
+
+Example pattern:
+
+```csharp
+[DialectModuleAlias("Arithmetic")]
+[DialectRuntimeExport("FrontendModule", "Arithmetic")]
+[AutoRegisterService]
+public class ArithmeticModuleImpl : IFrontendCoreModule
+{
+    public void InitLexer(ILexer lexer) => lexer.AddLexemes(...);
+}
+```
+
+Token names are part of the contract. Avoid magic strings scattered across unrelated files.
+
+### 3. Add parser extension
+
+If the feature changes syntax structure, register node creators through `InitParser`. Parser priority matters. Current modules use explicit priority values to control precedence and transformation order.
+
+A parser extension must not mutate unrelated ancestor nodes or recover syntax by scanning raw source text. Syntax ownership belongs to lexer, parser, AST nodes, visitors or syntax-specific extractors built from parser output.
+
+### 4. Add AST nodes and AST translation
+
+A module usually adds AST visitors through `InitAstTranslator`. Visitors must self-filter correctly because the translator can give multiple visitors a chance to act on nodes.
+
+The important rule is stack and ownership discipline: visitors should emit only the semantics they own and should not accidentally double-emit operations for another module.
+
+### 5. Lower into bytecode/AIR
+
+Bytecode/AIR is the intermediate layer used by backends and optimizers. If your feature creates new bytecode tags, new AIR shapes or new stack behavior, document the contract and add tests.
+
+Do not rely on undocumented tag strings without a producer/consumer test.
+
+### 6. Support backend behavior
+
+A feature is not complete until the intended backend paths understand it. For language semantics, prefer tests that run the same source through both interpreter and compiler modes when both are available.
+
+If a feature is intentionally backend-specific, document that limitation in the module reference and dialect examples.
+
+### 7. Add dialect visibility
+
+The module must be selectable through dialect files. This usually requires module alias/export metadata and manifest visibility. After that, a dialect can include it:
+
+```text
+use MyFeature,Numbers,Scopes,Whitespaces
+```
+
+### 8. Test the module
+
+At minimum, add:
+
+- a positive test for the feature;
+- a negative test for invalid syntax or missing dependencies;
+- parity tests when both compiler and interpreter modes are supported;
+- dialect composition tests proving the module is available only when selected.
+
+## Expected result
+
+A finished module has a clear syntax owner, parser behavior, AST-to-bytecode/AIR lowering, backend behavior, dialect visibility and tests. A reader should be able to understand which dialect directive enables the feature and which backend paths support it.
+
+## What happened internally
+
+Module authoring touches several stages of the pipeline:
+
+```text
+module metadata
+  → lexer registration
+  → parser node creators
+  → AST visitors
+  → bytecode/AIR emission
+  → optimizer/backend support
+  → dialect/runtime selection
+```
+
+This is why module work requires both implementation tests and architecture discipline.
+
+## Common mistakes
+
+- Adding syntax recognition through raw-source string checks instead of parser/AST ownership.
+- Choosing parser priorities by trial and error without tests.
+- Adding compiler behavior but forgetting interpreter behavior, or the reverse.
+- Depending on module ordering without documenting and testing it.
+- Using global mutable state for feature coordination.
+- Treating capabilities as behavior activation.
+- Reintroducing rule declarations before the AST-owned rule declaration rewrite.
+
+## Next
+
+Continue with the detailed [Module Authoring Guide](/guides/module-authoring) and [Module Contracts](/contracts/module-contracts), then read the internals pages for bytecode, AIR, backends and semantic parity.


### PR DESCRIPTION
## Summary

Fills the first Phase 1 developer documentation pages for the VitePress docs site on top of `docs-site`.

Updated pages:

- `docs/start/index.md`
- `docs/start/what-is-universal-toolchain.md`
- `docs/start/what-is-wist.md`
- `docs/start/installation.md`
- `docs/start/first-program.md`
- `docs/start/mental-model.md`
- `docs/wist/syntax-tour.md`
- `docs/build-dsls/dialect-files.md`
- `docs/build-dsls/minimal-dsl.md`
- `docs/write-modules/index.md`

## What changed

- Replaced placeholder text with strict developer documentation.
- Added routes for Wist users, DSL developers, module authors, runtime/compiler engineers and reference users.
- Documented real quick-start commands for Wistc and the pricing demo.
- Documented `.wistdialect` files, shipped presets and minimal DSL composition.
- Added Wist syntax tour using examples consistent with shipped tests/examples.
- Clearly states that rules/runtime surface is currently removed and should not be documented as available.

## Validation

Not run in this environment:

- `dotnet build`
- `dotnet run --project UniversalToolchain/Wistc/Wistc.csproj -- run --eval "(2 + 2) * 3" --mode compiler`
- `dotnet run --project UniversalToolchain/Example/Example.csproj`
- `npm run docs:build`

Reason: the execution environment available to this assistant did not have the .NET SDK and could not install npm packages reliably. Commands are documented for local verification from the repository root.