### PR TITLE
docs: fix VitePress dead links

### DIFF
--- a/docs/reviews/technical-due-diligence.md
+++ b/docs/reviews/technical-due-diligence.md
@@ -10,7 +10,7 @@ This document belongs under `docs/reviews/` because it is a review and due-dilig
 
 Use it together with these canonical documents:
 
-- Project entry point: [readme.md](../../readme.md)
+- Project entry point: [Documentation index](../index.md)
 - Public positioning and wording: [Project positioning](../project-positioning.md)
 - Known limitations and wording boundaries: [Current limitations](../limitations.md)
 - Runtime pipeline: [Current canonical runtime pipeline](../current-canonical-runtime-pipeline.md)

--- a/docs/start/index.md
+++ b/docs/start/index.md
@@ -27,7 +27,7 @@ Understand the difference between UniversalToolchain and Wist, identify your rol
 | **Wist user** (run programs, learn syntax) | [First Program](/start/first-program) | [Syntax Tour](/wist/syntax-tour) |
 | **DSL developer** (compose your own language) | [Mental Model](/start/mental-model), [Dialect Files](/build-dsls/dialect-files) | [Minimal DSL](/build-dsls/minimal-dsl) |
 | **Module author** (add new language features) | [Write Modules](/write-modules/) | Later: Bytecode generation and backend guides |
-| **Runtime/compiler engineer** | [Internals](/internals/pipeline) | [Bytecode and AIR](/internals/bytecode-and-air) |
+| **Runtime/compiler engineer** | [Internals](/internals/pipeline) | [Bytecode and AIR](/architecture/bytecode-and-air) |
 | **Contributor/maintainer** | [Internals](/internals/) | Project rules and architecture docs |
 | **Reference user** | [Reference](/reference/) | Backend contracts, module specifications |
 


### PR DESCRIPTION
## Summary

Fixes the two VitePress dead links reported by `npm run docs:build`:

```text
(!) Found dead link /internals/bytecode-and-air in file start/index.md
(!) Found dead link ./../../readme in file reviews/technical-due-diligence.md
```

## Changes

- `docs/start/index.md`
  - `/internals/bytecode-and-air` -> `/architecture/bytecode-and-air`
- `docs/reviews/technical-due-diligence.md`
  - `../../readme.md` -> `../index.md`

## Notes

The `wist` syntax-highlighting warnings are non-fatal and do not break the build. This PR only addresses the fatal dead-link errors.

## Validation

Not rerun in this environment. The changes directly match the two dead links reported by VitePress.