### PR TITLE
Fix VitePress documentation publication

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -33,10 +33,9 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 22
-          cache: npm
 
       - name: Install dependencies
-        run: npm ci || npm install
+        run: npm install --no-audit --no-fund
 
       - name: Build documentation
         run: npm run docs:build

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -1,0 +1,42 @@
+name: Docs Check
+
+on:
+  pull_request:
+    paths:
+      - 'docs/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/docs-check.yml'
+      - '.github/workflows/deploy-docs.yml'
+  push:
+    branches:
+      - master
+      - main
+    paths:
+      - 'docs/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/docs-check.yml'
+      - '.github/workflows/deploy-docs.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: npm install --no-audit --no-fund
+
+      - name: Build documentation
+        run: npm run docs:build

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -1,108 +1,5 @@
 import { defineConfig } from 'vitepress'
 
-const bookSidebar = [
-    {
-        text: '0. Introduction',
-        collapsed: false,
-        items: [
-            { text: '0.1 Start Here', link: '/start/' },
-            { text: '0.2 What is UniversalToolchain?', link: '/start/what-is-universal-toolchain' },
-            { text: '0.3 What is Wist?', link: '/start/what-is-wist' },
-            { text: '0.4 Mental Model', link: '/start/mental-model' }
-        ]
-    },
-    {
-        text: '1. Getting Started',
-        collapsed: false,
-        items: [
-            { text: '1.1 Installation', link: '/start/installation' },
-            { text: '1.2 First Program', link: '/start/first-program' },
-            { text: '1.3 Wist Overview', link: '/wist/' },
-            { text: '1.4 Wist Syntax Tour', link: '/wist/syntax-tour' },
-            { text: '1.5 Examples', link: '/wist/examples' }
-        ]
-    },
-    {
-        text: '2. Wist Language',
-        collapsed: false,
-        items: [
-            { text: '2.1 Numbers', link: '/wist/numbers' },
-            { text: '2.2 Variables', link: '/wist/variables' },
-            { text: '2.3 Conditions', link: '/wist/conditions' },
-            { text: '2.4 Loops', link: '/wist/loops' },
-            { text: '2.5 Scopes', link: '/wist/scopes' }
-        ]
-    },
-    {
-        text: '3. Building DSLs',
-        collapsed: false,
-        items: [
-            { text: '3.1 Overview', link: '/build-dsls/' },
-            { text: '3.2 Dialect Files', link: '/build-dsls/dialect-files' },
-            { text: '3.3 Minimal DSL', link: '/build-dsls/minimal-dsl' },
-            { text: '3.4 Module Composition', link: '/build-dsls/module-composition' },
-            { text: '3.5 Backend Selection', link: '/build-dsls/backend-selection' },
-            { text: '3.6 Testing a DSL', link: '/build-dsls/testing-dsl' }
-        ]
-    },
-    {
-        text: '4. Writing Modules',
-        collapsed: false,
-        items: [
-            { text: '4.1 Overview', link: '/write-modules/' },
-            { text: '4.2 Frontend Module', link: '/write-modules/frontend-module' },
-            { text: '4.3 Parser Extension', link: '/write-modules/parser-extension' },
-            { text: '4.4 AST Nodes', link: '/write-modules/ast-nodes' },
-            { text: '4.5 Bytecode Generation', link: '/write-modules/bytecode-generation' },
-            { text: '4.6 Semantic Tags', link: '/write-modules/semantic-tags' },
-            { text: '4.7 Ordering and Priority', link: '/write-modules/ordering-and-priority' },
-            { text: '4.8 Testing a Module', link: '/write-modules/testing-module' }
-        ]
-    },
-    {
-        text: '5. Internals',
-        collapsed: false,
-        items: [
-            { text: '5.1 Overview', link: '/internals/' },
-            { text: '5.2 Pipeline', link: '/internals/pipeline' },
-            { text: '5.3 Lexer', link: '/internals/lexer' },
-            { text: '5.4 Parser', link: '/internals/parser' },
-            { text: '5.5 AST', link: '/internals/ast' },
-            { text: '5.6 Bytecode', link: '/internals/bytecode' },
-            { text: '5.7 AIR', link: '/internals/air' },
-            { text: '5.8 Backends', link: '/internals/backends' },
-            { text: '5.9 Intrinsics', link: '/internals/intrinsics' },
-            { text: '5.10 Optimizers', link: '/internals/optimizers' },
-            { text: '5.11 Semantic Parity', link: '/internals/semantic-parity' },
-            { text: '5.12 Dependency Injection', link: '/internals/dependency-injection' }
-        ]
-    },
-    {
-        text: '6. Reference',
-        collapsed: false,
-        items: [
-            { text: '6.1 Overview', link: '/reference/' },
-            { text: '6.2 Dialect Reference', link: '/reference/dialect-reference' },
-            { text: '6.3 Module Reference', link: '/reference/module-reference' },
-            { text: '6.4 Bytecode Reference', link: '/reference/bytecode-reference' },
-            { text: '6.5 AIR Reference', link: '/reference/air-reference' },
-            { text: '6.6 Intrinsics Reference', link: '/reference/intrinsics-reference' },
-            { text: '6.7 Backend Contracts', link: '/reference/backend-contracts' },
-            { text: '6.8 Project Rules', link: '/reference/project-rules' }
-        ]
-    }
-]
-
-const bookNav = [
-    { text: '0. Introduction', link: '/start/' },
-    { text: '1. Getting Started', link: '/start/installation' },
-    { text: '2. Wist Language', link: '/wist/' },
-    { text: '3. Building DSLs', link: '/build-dsls/' },
-    { text: '4. Writing Modules', link: '/write-modules/' },
-    { text: '5. Internals', link: '/internals/' },
-    { text: '6. Reference', link: '/reference/' }
-]
-
 export default defineConfig({
     title: 'UniversalToolchain',
     description: 'Developer documentation for UniversalToolchain and Wist.',
@@ -110,47 +7,17 @@ export default defineConfig({
     cleanUrls: true,
     lastUpdated: true,
 
-    head: [
-        ['meta', { name: 'theme-color', content: '#0f172a' }],
-        ['link', { rel: 'icon', type: 'image/svg+xml', href: '/Wist2/logo.svg' }]
-    ],
-
     themeConfig: {
-        logo: '/logo.svg',
-
         nav: [
-            { text: 'Book', items: bookNav },
+            { text: 'Start', link: '/start/' },
             { text: 'GitHub', link: 'https://github.com/Misha1302/Wist2' }
         ],
-
         search: {
             provider: 'local'
         },
-
-        sidebar: bookSidebar,
-
-        outline: {
-            level: [2, 3],
-            label: 'On this page'
-        },
-
-        docFooter: {
-            prev: 'Previous',
-            next: 'Next'
-        },
-
-        socialLinks: [
-            { icon: 'github', link: 'https://github.com/Misha1302/Wist2' }
-        ],
-
         editLink: {
-            pattern: 'https://github.com/Misha1302/Wist2/edit/docs-site/docs/:path',
+            pattern: 'https://github.com/Misha1302/Wist2/edit/master/docs/:path',
             text: 'Edit this page on GitHub'
-        },
-
-        footer: {
-            message: 'Built for developers who want to use, extend, or understand UniversalToolchain.',
-            copyright: 'UniversalToolchain documentation'
         }
     }
 })

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -1,5 +1,108 @@
 import { defineConfig } from 'vitepress'
 
+const bookSidebar = [
+    {
+        text: '0. Introduction',
+        collapsed: false,
+        items: [
+            { text: '0.1 Start Here', link: '/start/' },
+            { text: '0.2 What is UniversalToolchain?', link: '/start/what-is-universal-toolchain' },
+            { text: '0.3 What is Wist?', link: '/start/what-is-wist' },
+            { text: '0.4 Mental Model', link: '/start/mental-model' }
+        ]
+    },
+    {
+        text: '1. Getting Started',
+        collapsed: false,
+        items: [
+            { text: '1.1 Installation', link: '/start/installation' },
+            { text: '1.2 First Program', link: '/start/first-program' },
+            { text: '1.3 Wist Overview', link: '/wist/' },
+            { text: '1.4 Wist Syntax Tour', link: '/wist/syntax-tour' },
+            { text: '1.5 Examples', link: '/wist/examples' }
+        ]
+    },
+    {
+        text: '2. Wist Language',
+        collapsed: false,
+        items: [
+            { text: '2.1 Numbers', link: '/wist/numbers' },
+            { text: '2.2 Variables', link: '/wist/variables' },
+            { text: '2.3 Conditions', link: '/wist/conditions' },
+            { text: '2.4 Loops', link: '/wist/loops' },
+            { text: '2.5 Scopes', link: '/wist/scopes' }
+        ]
+    },
+    {
+        text: '3. Building DSLs',
+        collapsed: false,
+        items: [
+            { text: '3.1 Overview', link: '/build-dsls/' },
+            { text: '3.2 Dialect Files', link: '/build-dsls/dialect-files' },
+            { text: '3.3 Minimal DSL', link: '/build-dsls/minimal-dsl' },
+            { text: '3.4 Module Composition', link: '/build-dsls/module-composition' },
+            { text: '3.5 Backend Selection', link: '/build-dsls/backend-selection' },
+            { text: '3.6 Testing a DSL', link: '/build-dsls/testing-dsl' }
+        ]
+    },
+    {
+        text: '4. Writing Modules',
+        collapsed: false,
+        items: [
+            { text: '4.1 Overview', link: '/write-modules/' },
+            { text: '4.2 Frontend Module', link: '/write-modules/frontend-module' },
+            { text: '4.3 Parser Extension', link: '/write-modules/parser-extension' },
+            { text: '4.4 AST Nodes', link: '/write-modules/ast-nodes' },
+            { text: '4.5 Bytecode Generation', link: '/write-modules/bytecode-generation' },
+            { text: '4.6 Semantic Tags', link: '/write-modules/semantic-tags' },
+            { text: '4.7 Ordering and Priority', link: '/write-modules/ordering-and-priority' },
+            { text: '4.8 Testing a Module', link: '/write-modules/testing-module' }
+        ]
+    },
+    {
+        text: '5. Internals',
+        collapsed: false,
+        items: [
+            { text: '5.1 Overview', link: '/internals/' },
+            { text: '5.2 Pipeline', link: '/internals/pipeline' },
+            { text: '5.3 Lexer', link: '/internals/lexer' },
+            { text: '5.4 Parser', link: '/internals/parser' },
+            { text: '5.5 AST', link: '/internals/ast' },
+            { text: '5.6 Bytecode', link: '/internals/bytecode' },
+            { text: '5.7 AIR', link: '/internals/air' },
+            { text: '5.8 Backends', link: '/internals/backends' },
+            { text: '5.9 Intrinsics', link: '/internals/intrinsics' },
+            { text: '5.10 Optimizers', link: '/internals/optimizers' },
+            { text: '5.11 Semantic Parity', link: '/internals/semantic-parity' },
+            { text: '5.12 Dependency Injection', link: '/internals/dependency-injection' }
+        ]
+    },
+    {
+        text: '6. Reference',
+        collapsed: false,
+        items: [
+            { text: '6.1 Overview', link: '/reference/' },
+            { text: '6.2 Dialect Reference', link: '/reference/dialect-reference' },
+            { text: '6.3 Module Reference', link: '/reference/module-reference' },
+            { text: '6.4 Bytecode Reference', link: '/reference/bytecode-reference' },
+            { text: '6.5 AIR Reference', link: '/reference/air-reference' },
+            { text: '6.6 Intrinsics Reference', link: '/reference/intrinsics-reference' },
+            { text: '6.7 Backend Contracts', link: '/reference/backend-contracts' },
+            { text: '6.8 Project Rules', link: '/reference/project-rules' }
+        ]
+    }
+]
+
+const bookNav = [
+    { text: '0. Introduction', link: '/start/' },
+    { text: '1. Getting Started', link: '/start/installation' },
+    { text: '2. Wist Language', link: '/wist/' },
+    { text: '3. Building DSLs', link: '/build-dsls/' },
+    { text: '4. Writing Modules', link: '/write-modules/' },
+    { text: '5. Internals', link: '/internals/' },
+    { text: '6. Reference', link: '/reference/' }
+]
+
 export default defineConfig({
     title: 'UniversalToolchain',
     description: 'Developer documentation for UniversalToolchain and Wist.',
@@ -7,17 +110,47 @@ export default defineConfig({
     cleanUrls: true,
     lastUpdated: true,
 
+    head: [
+        ['meta', { name: 'theme-color', content: '#0f172a' }],
+        ['link', { rel: 'icon', type: 'image/svg+xml', href: '/Wist2/logo.svg' }]
+    ],
+
     themeConfig: {
+        logo: '/logo.svg',
+
         nav: [
-            { text: 'Start', link: '/start/' },
+            { text: 'Book', items: bookNav },
             { text: 'GitHub', link: 'https://github.com/Misha1302/Wist2' }
         ],
+
         search: {
             provider: 'local'
         },
+
+        sidebar: bookSidebar,
+
+        outline: {
+            level: [2, 3],
+            label: 'On this page'
+        },
+
+        docFooter: {
+            prev: 'Previous',
+            next: 'Next'
+        },
+
+        socialLinks: [
+            { icon: 'github', link: 'https://github.com/Misha1302/Wist2' }
+        ],
+
         editLink: {
             pattern: 'https://github.com/Misha1302/Wist2/edit/master/docs/:path',
             text: 'Edit this page on GitHub'
+        },
+
+        footer: {
+            message: 'Built for developers who want to use, extend, or understand UniversalToolchain.',
+            copyright: 'UniversalToolchain documentation'
         }
     }
 })


### PR DESCRIPTION
## Summary

This PR fixes the documentation publication path so the public Wist2 site is treated as a VitePress developer manual rather than as raw GitHub Pages markdown.

Changes:

- restores the full VitePress book sidebar after fixing the public edit link target;
- changes `editLink` from the temporary `docs-site` branch to `master`;
- keeps the Pages deploy workflow focused on publishing `docs/.vitepress/dist`;
- removes the lockfile cache dependency from the deploy workflow because the repository currently does not contain `package-lock.json`;
- adds a separate `Docs Check` workflow for PR/push validation of the VitePress build.

## Required repository setting after merge

GitHub Pages must be switched to Actions deployment:

`Settings → Pages → Build and deployment → Source → GitHub Actions`

If Pages stays on `Deploy from a branch`, GitHub will keep serving raw `docs/` markdown and `/Wist2/start/` will remain visually broken.

## Verification

After merge and deployment:

- `https://misha1302.github.io/Wist2/` should open the VitePress documentation home.
- `https://misha1302.github.io/Wist2/start/` should have the same VitePress layout as local `npm run docs:preview`.
- Sidebar, search, theme, and `Edit this page on GitHub` should work against `master`.