### PR TITLE
docs: fill Build DSLs documentation

### DIFF
--- a/docs/build-dsls/backend-selection.md
+++ b/docs/build-dsls/backend-selection.md
@@ -5,22 +5,160 @@ description: Explain interpreter, CIL, and backend choice.
 
 # Backend Selection
 
-<div class="placeholder-box">
+Backends decide how a composed DSL program is executed after parsing and lowering.
 
-This page is a documentation placeholder.
+Wist currently exposes two user-facing execution modes:
 
-**Purpose:** Explain interpreter, CIL, and backend choice.
+- `interpreter`
+- `compiler`
 
-</div>
+The `compiler` mode selects the CIL backend when the active dialect exposes the `cil` backend. The `interpreter` mode selects the interpreter backend when the active dialect exposes `interpreter`.
 
-## What this page should explain
+## When to read this page
 
-- The practical goal of this topic.
-- The minimal example a developer should run or read.
-- The important concepts needed before going deeper.
-- Links to the next page for gradual learning.
+Read this page when you are deciding whether a dialect should run through the interpreter, through generated CIL, or through both.
 
-## Status
+## Goal
 
-Content is not written yet.
+Choose a backend intentionally and understand what must be tested when multiple backends are enabled.
 
+## Backend modes
+
+### Interpreter
+
+Use interpreter mode when you want:
+
+- simpler debugging;
+- a smaller first implementation path;
+- easier semantic validation;
+- a backend that is useful before native/CIL-specific optimization is introduced.
+
+Dialect example:
+
+```text
+dialect MinimalArithmetic
+use Arithmetic,Numbers,Scopes,Whitespaces
+backend interpreter
+```
+
+Run example:
+
+```bash
+dotnet run --project UniversalToolchain/Wistc/Wistc.csproj -- run --dialect-file UniversalToolchain/Dialects/examples/wist/minimal-arithmetic/dialect.wistdialect --file UniversalToolchain/Dialects/examples/wist/minimal-arithmetic/program.wist --mode interpreter
+```
+
+### CIL compiler
+
+Use compiler mode when you want:
+
+- faster repeated execution;
+- native .NET execution paths;
+- optimized arithmetic or type-aware runtime behavior;
+- integration with compiled artifacts.
+
+Dialect example:
+
+```text
+dialect MinimalArithmeticNative
+use Arithmetic,Numbers,Scopes,Whitespaces,NativeTypes
+backend cil
+enable ArithmeticOptimization
+enable NativeCilOptimization
+enable NativeTypesOptimization
+```
+
+Run example:
+
+```bash
+dotnet run --project UniversalToolchain/Wistc/Wistc.csproj -- run --dialect-file UniversalToolchain/Dialects/examples/wist/minimal-arithmetic-native/dialect.wistdialect --file UniversalToolchain/Dialects/examples/wist/minimal-arithmetic-native/program.wist --mode compiler
+```
+
+### Both backends
+
+Use both backends when you need:
+
+- semantic parity checks;
+- debugging through the interpreter and production execution through CIL;
+- confidence that optimizations do not change program meaning.
+
+Dialect example:
+
+```text
+backend cil,interpreter
+```
+
+When both are enabled, tests should run the same source through both modes and compare observable results.
+
+## Choosing the right backend
+
+| Scenario | Recommended backend |
+|---|---|
+| First prototype of a narrow DSL | `interpreter` |
+| Debugging parser/AST/lowering behavior | `interpreter` |
+| Performance-sensitive formula execution | `compiler`, after parity tests |
+| Documentation examples for semantics | both, when available |
+| Restricted user-authored formulas | usually `compiler` or `interpreter`, but only with a narrow module set |
+| Backend feature development | both, with explicit parity and negative tests |
+
+The backend choice is not a substitute for language restriction. A CIL-backed DSL can still be too broad if the dialect selects unsafe or unnecessary modules.
+
+## Programmatic entry point
+
+First-contact users can build a Wist runtime facade instead of wiring services manually:
+
+```csharp
+using UniversalToolchain.Dialects.Wist.Facade;
+
+using var runtime = WistRuntimeFacadeBuilder
+    .CreateDefault()
+    .WithShippedDialectPreset("pricing-restricted")
+    .Build();
+
+var result = runtime.Run(
+    "price + fee * 2",
+    new Dictionary<string, object?>
+    {
+        ["price"] = 100,
+        ["fee"] = 5
+    },
+    mode: "compiler");
+```
+
+The facade still uses the composed dialect runtime. It should not be treated as a separate language implementation.
+
+## Failure modes
+
+A backend selection should fail when:
+
+- the CLI asks for `compiler`, but the dialect exposes only `interpreter`;
+- the CLI asks for `interpreter`, but the dialect exposes only `cil`;
+- a selected module emits semantics the backend cannot execute;
+- an optimizer lowers to backend-specific intrinsics that the backend does not support.
+
+These failures are useful. They show that the dialect/backend boundary is enforced instead of silently falling back to an unintended path.
+
+## Backend parity
+
+Backend parity means that the same dialect and source program produce the same observable result across supported backends.
+
+Parity matters most when:
+
+- adding a new module;
+- changing AST-to-bytecode/AIR lowering;
+- introducing an optimizer;
+- modifying interpreter execution;
+- modifying CIL emission.
+
+Parity does not mean every backend must support every dialect. A dialect may intentionally expose only one backend. In that case, document the limitation and test that unsupported modes are rejected.
+
+## Common mistakes
+
+- Documenting `compiler` as available for a dialect that exposes only `interpreter`.
+- Enabling CIL-specific optimizers without proving base semantics first.
+- Treating the interpreter as a fallback when the selected backend fails.
+- Adding backend-specific intrinsics to a general interpreter surface.
+- Comparing benchmark numbers before separating compilation time from execution time.
+
+## Next
+
+Continue with [Testing a DSL](/build-dsls/testing-dsl).

--- a/docs/build-dsls/index.md
+++ b/docs/build-dsls/index.md
@@ -5,22 +5,132 @@ description: Show how to compose existing modules into a new dialect.
 
 # Build DSLs
 
-<div class="placeholder-box">
+UniversalToolchain is designed for building small, explicit DSL runtimes instead of hardcoding every rule, formula or workflow directly into application code.
 
-This page is a documentation placeholder.
+This section explains how to assemble a DSL from existing Wist modules before writing new syntax or backend code.
 
-**Purpose:** Show how to compose existing modules into a new dialect.
+## When to read this section
 
-</div>
+Read this section when you want to:
 
-## What this page should explain
+- create a smaller language surface than full Wist;
+- expose formulas or rules to application users;
+- restrict which syntax and runtime features are available;
+- choose between interpreter and CIL execution;
+- test that a dialect accepts only the intended programs.
 
-- The practical goal of this topic.
-- The minimal example a developer should run or read.
-- The important concepts needed before going deeper.
-- Links to the next page for gradual learning.
+If you need to add a brand-new syntax feature, read this section first and then continue with [Writing Modules](/write-modules/).
 
-## Status
+## The core idea
 
-Content is not written yet.
+A UniversalToolchain-based DSL is assembled from capabilities:
 
+- frontend modules that contribute lexemes and parser behavior;
+- AST translation and bytecode/AIR lowering;
+- optimizers;
+- execution backends;
+- dialect files that select the allowed surface.
+
+The important distinction is that a dialect does not merely choose a display name. It selects what the runtime can actually recognize and execute.
+
+```text
+dialect file
+  -> selected modules
+  -> selected optimizers
+  -> selected backends
+  -> composed runtime host
+  -> executable DSL program
+```
+
+## Minimal example
+
+The smallest useful path is to start from a shipped arithmetic dialect:
+
+```text
+dialect MinimalArithmetic
+use Arithmetic,Numbers,Scopes,Whitespaces
+backend interpreter
+```
+
+This dialect is intentionally narrow. It can run arithmetic expressions such as:
+
+```wist
+2 + 3 * 4
+```
+
+Expected result:
+
+```text
+14
+```
+
+It should not accept syntax whose owning modules are not selected. For example, variables require `Identifier` and `Variables`; loops require loop-related modules; C# interop requires an explicit unsafe/trusted runtime surface.
+
+## What you usually build
+
+Most useful DSLs fall into one of three shapes.
+
+### Formula DSL
+
+Use this for pricing, scoring, limits, thresholds or other numeric expressions.
+
+Typical properties:
+
+- narrow module set;
+- no unsafe interop;
+- deterministic input bindings;
+- compiler mode only when performance matters and CIL support is available;
+- negative tests for syntax that must remain unavailable.
+
+### Workflow DSL
+
+Use this for small procedural scripts with variables, branches or loops.
+
+Typical properties:
+
+- variables and identifiers;
+- conditions and comparisons;
+- loops only when they are truly needed;
+- stronger tests for control flow and backend parity.
+
+### Reference language profile
+
+Use this when demonstrating Wist itself rather than restricting it for a production application.
+
+Typical properties:
+
+- broad module set;
+- both interpreter and compiler backends;
+- examples that show how UniversalToolchain composes a language;
+- not suitable as the default surface for untrusted end-user formulas.
+
+## Development order
+
+Build a DSL in this order:
+
+1. Start from a shipped dialect.
+2. Remove everything you do not need.
+3. Add one module group at a time.
+4. Run a positive example after every change.
+5. Add a negative example for syntax that must stay unavailable.
+6. Enable the second backend only after the first one works.
+7. Add backend parity tests when both modes are exposed.
+8. Enable optimizers last.
+
+This order keeps composition errors visible. It also prevents optimizers or backend-specific behavior from hiding missing semantics.
+
+## Important boundaries
+
+- A restricted dialect is a composition boundary, not a hardened sandbox.
+- A capability marker should describe selected behavior, not secretly activate behavior.
+- A backend must not change the observable meaning of a program.
+- A module should own the syntax and semantics it introduces.
+- Do not document removed or internal rule-declaration behavior as public runtime functionality.
+
+## Pages in this section
+
+- [Dialect Files](/build-dsls/dialect-files) explains the `.wistdialect` format.
+- [Minimal DSL](/build-dsls/minimal-dsl) walks through a small arithmetic DSL.
+- [Module Composition](/build-dsls/module-composition) explains how selected modules form a language surface.
+- [Backend Selection](/build-dsls/backend-selection) explains interpreter, CIL and mode choice.
+- [Testing a DSL](/build-dsls/testing-dsl) explains positive, negative and backend parity tests.

--- a/docs/build-dsls/module-composition.md
+++ b/docs/build-dsls/module-composition.md
@@ -5,22 +5,149 @@ description: Explain how modules combine into a language.
 
 # Module Composition
 
-<div class="placeholder-box">
+Module composition is the mechanism that turns selected language features into a runnable DSL.
 
-This page is a documentation placeholder.
+A module is not just a label in a dialect file. A real module may contribute lexer rules, parser nodes, AST visitors, bytecode/AIR lowering, optimizer support or backend behavior. A dialect selects the modules that are allowed to participate in a specific runtime host.
 
-**Purpose:** Explain how modules combine into a language.
+## When to read this page
 
-</div>
+Read this page after [Dialect Files](/build-dsls/dialect-files) and [Minimal DSL](/build-dsls/minimal-dsl) when you want to understand why adding or removing one module changes what the language can parse and execute.
 
-## What this page should explain
+## Goal
 
-- The practical goal of this topic.
-- The minimal example a developer should run or read.
-- The important concepts needed before going deeper.
-- Links to the next page for gradual learning.
+Understand how modules combine into a language surface and which mistakes break modularity.
 
-## Status
+## Composition model
 
-Content is not written yet.
+A simplified composition flow looks like this:
 
+```text
+.wistdialect
+  -> dialect compiler
+  -> selected module aliases
+  -> manifest/runtime resolution
+  -> deterministic module order
+  -> frontend/core/backend services
+  -> execution host
+```
+
+The dialect file is the user-facing selection layer. Runtime manifests and DI registration resolve the selected aliases to implementation types. The final host should be deterministic: the same dialect and repository state should produce the same runtime composition.
+
+## What a module can own
+
+A module may own one or more of these responsibilities:
+
+| Responsibility | Example |
+|---|---|
+| Lexemes | numeric literals, operators, keywords |
+| Parser behavior | expression nodes, loop syntax, condition syntax |
+| AST nodes | typed representation of a syntax construct |
+| AST translation | conversion from AST to bytecode/AIR |
+| Bytecode/AIR shape | semantic tags, stack operations, intermediate instructions |
+| Optimizer support | arithmetic folding, native lowering, backend-specific transformations |
+| Backend behavior | interpreter execution or CIL emission for the owned semantics |
+
+The boundary matters. If arithmetic owns arithmetic operators, another module should not parse arithmetic syntax by scanning raw source text. If variables own variable binding, backend code should not silently reinterpret unrelated identifiers as runtime arguments.
+
+## Minimal example
+
+This dialect:
+
+```text
+dialect MinimalArithmetic
+use Arithmetic,Numbers,Scopes,Whitespaces
+backend interpreter
+```
+
+is a composition of four capabilities:
+
+- `Numbers` provides numeric values.
+- `Arithmetic` provides arithmetic operations.
+- `Scopes` provides expression/block structure needed by the parser/runtime path.
+- `Whitespaces` keeps lexical handling usable for normal source text.
+
+It can run:
+
+```wist
+2 + 3 * 4
+```
+
+but it should not accept:
+
+```wist
+let x = 2
+x + 1
+```
+
+unless `Identifier` and `Variables` are also selected.
+
+## Dependency discipline
+
+Some modules are meaningful only with related modules. For example:
+
+- `Variables` usually requires `Identifier`.
+- conditional syntax usually requires comparison/equality/boolean support, depending on the exact program shape;
+- native/CIL-oriented optimizations require backend support;
+- unsafe interop should not appear in a restricted user-facing formula DSL.
+
+The documentation should not pretend that module composition is magic. A dialect author is responsible for selecting a coherent set of capabilities and testing it.
+
+## Deterministic ordering
+
+Composition must be deterministic because parser priority, AST visitors, optimizers and backend services can depend on order.
+
+Good composition behavior:
+
+- aliases resolve to the same implementation types every time;
+- parser priorities are explicit;
+- module ordering is either declared, derived deterministically or tested;
+- tests fail when an unexpected module appears in the runtime surface.
+
+Bad composition behavior:
+
+- relying on reflection enumeration order;
+- adding a hardcoded special case for a module instead of fixing composition;
+- treating backend IDs or module aliases as magic strings scattered across unrelated files;
+- using global mutable registries that change between test runs.
+
+## Composition vs. security
+
+A restricted dialect reduces the available language surface. That is useful, but it is not the same thing as process isolation.
+
+Use restricted dialects to say:
+
+```text
+This formula language does not include variables, loops or unsafe interop.
+```
+
+Do not use restricted dialects alone to say:
+
+```text
+This is safe for arbitrary untrusted third-party code in the same process.
+```
+
+For untrusted third-party code, combine dialect restriction with process, environment and resource isolation.
+
+## Common mistakes
+
+- Adding a module because a test passes, without documenting what syntax it enables.
+- Starting from `full-default` for a production formula DSL and forgetting to remove unnecessary features.
+- Enabling an optimizer before the unoptimized path is correct.
+- Depending on one backend while documenting the dialect as backend-neutral.
+- Adding marker-only capabilities that imply behavior without implementation ownership.
+- Hiding missing module dependencies behind fallback parser behavior.
+
+## Practical checklist
+
+Before accepting a dialect composition, verify:
+
+- the dialect file lists only intended modules;
+- omitted syntax is rejected;
+- selected backends match the intended runtime modes;
+- compiler and interpreter results match when both are enabled;
+- unsafe interop is absent from user-authored restricted DSLs;
+- optimizer support is tested separately from base semantics.
+
+## Next
+
+Continue with [Backend Selection](/build-dsls/backend-selection).

--- a/docs/build-dsls/testing-dsl.md
+++ b/docs/build-dsls/testing-dsl.md
@@ -5,22 +5,162 @@ description: Show how to test dialect behavior and backend parity.
 
 # Testing a DSL
 
-<div class="placeholder-box">
+Testing a DSL is not only checking that one valid program runs. A useful DSL test suite proves that the selected dialect accepts intended syntax, rejects omitted syntax and produces the same result across supported backends.
 
-This page is a documentation placeholder.
+## When to read this page
 
-**Purpose:** Show how to test dialect behavior and backend parity.
+Read this page when you have created or modified a dialect file, added a module, enabled an optimizer or exposed a second backend.
 
-</div>
+## Goal
 
-## What this page should explain
+Build a test set that protects the DSL surface and prevents backend drift.
 
-- The practical goal of this topic.
-- The minimal example a developer should run or read.
-- The important concepts needed before going deeper.
-- Links to the next page for gradual learning.
+## What to test
 
-## Status
+At minimum, a dialect should have these test categories:
 
-Content is not written yet.
+| Test category | What it proves |
+|---|---|
+| Positive execution | intended programs run |
+| Negative syntax | omitted syntax is rejected |
+| Backend availability | unsupported modes fail |
+| Backend parity | interpreter and compiler agree when both are exposed |
+| Optimizer safety | optimizers do not change observable results |
+| Runtime surface | unsafe or unrelated modules are not accidentally selected |
 
+## 1. Positive execution test
+
+Start with the smallest valid program for the dialect.
+
+For a minimal arithmetic dialect:
+
+```wist
+2 + 3 * 4
+```
+
+Expected result:
+
+```text
+14
+```
+
+This proves that the selected modules are sufficient for the intended core use case.
+
+## 2. Negative syntax test
+
+A restricted dialect should reject syntax that belongs to omitted modules.
+
+For example, an arithmetic-only dialect should reject:
+
+```wist
+let x = 2
+x + 1
+```
+
+unless it explicitly selects `Identifier` and `Variables`.
+
+Negative tests are as important as positive tests. Without them, a “restricted” dialect may silently grow into full Wist.
+
+## 3. Backend availability test
+
+If a dialect declares:
+
+```text
+backend interpreter
+```
+
+then asking for compiler mode should fail.
+
+If a dialect declares:
+
+```text
+backend cil
+```
+
+then asking for interpreter mode should fail.
+
+The failure should be explicit. Do not silently fall back to another backend, because fallback hides composition mistakes.
+
+## 4. Backend parity test
+
+When a dialect exposes both:
+
+```text
+backend cil,interpreter
+```
+
+run the same source through both modes and compare the result.
+
+Example parity cases:
+
+```wist
+(2 + 2) * 3
+```
+
+```wist
+price + fee * 2
+```
+
+```wist
+if price > 100 then price - 10 else price
+```
+
+Use only examples supported by the selected modules. If a dialect does not include conditions, do not use a conditional example in its parity suite.
+
+## 5. Optimizer safety test
+
+Optimizers should improve or normalize execution without changing program meaning.
+
+Test optimizer-sensitive programs in two ways:
+
+1. without the optimizer, if the dialect/profile supports that path;
+2. with the optimizer enabled.
+
+Compare observable results. For backend-specific optimizers, also verify that unsupported backends do not receive backend-specific intrinsics.
+
+## 6. Runtime surface test
+
+A DSL intended for end-user formulas should not accidentally expose broad runtime features.
+
+For a pricing formula dialect, test that these are unavailable unless intentionally selected:
+
+- unsafe C# interop;
+- loops;
+- labels;
+- broad native/runtime functionality;
+- removed rule-declaration paths.
+
+This is not only a security concern. It also keeps the product behavior predictable.
+
+## Example test matrix
+
+| Dialect | Valid program | Invalid program | Backends |
+|---|---|---|---|
+| `minimal-arithmetic` | `2 + 3 * 4` | `let x = 2` | `interpreter` |
+| `minimal-arithmetic-native` | `2 + 3 * 4` | unsupported non-arithmetic syntax | `compiler` |
+| `pricing-restricted` | pricing expression with declared inputs | unsafe interop or unrelated syntax | selected restricted backend path |
+| `full-default` | broad Wist examples | invalid syntax only | `compiler`, `interpreter` |
+
+## What not to test as a shortcut
+
+Do not test only the final demo application. Demo success does not prove the dialect surface is correct.
+
+Do not test only compiler mode. Interpreter/compiler drift is one of the easiest ways to make the project look correct while breaking semantic guarantees.
+
+Do not treat benchmark success as correctness. A fast wrong backend is still wrong.
+
+## Practical checklist
+
+Before documenting a dialect as stable, verify:
+
+- at least one positive source example passes;
+- at least one omitted feature is rejected;
+- declared backend modes match the dialect file;
+- unsupported backend modes fail explicitly;
+- parity tests exist when both compiler and interpreter are enabled;
+- optimizer behavior is tested separately from base semantics;
+- restricted dialects do not expose unsafe or unrelated modules.
+
+## Next
+
+Continue with [Writing Modules](/write-modules/) if the DSL needs syntax that existing modules do not provide, or with [Internals](/internals/) if you need to understand the execution pipeline in more detail.


### PR DESCRIPTION
## Summary

This PR replaces the remaining placeholder content in the `Build DSLs` documentation section with practical developer documentation.

Updated pages:

- `docs/build-dsls/index.md`
- `docs/build-dsls/module-composition.md`
- `docs/build-dsls/backend-selection.md`
- `docs/build-dsls/testing-dsl.md`

## What changed

- Explains how to build DSLs from existing modules before writing new syntax.
- Documents module composition boundaries and deterministic ordering risks.
- Clarifies interpreter vs CIL backend selection and unsupported-mode failures.
- Adds DSL testing guidance for positive cases, negative syntax, backend availability, parity, optimizer safety, and runtime surface checks.

## Notes

This is a documentation-only change. It intentionally avoids changing VitePress config, visual theme, runtime code, or architecture.

The branch was created from the latest documentation commit visible through the GitHub connector. Please run the VitePress docs build in CI or locally before merging.