### PR TITLE
docs: fill Wist language documentation

### DIFF
--- a/docs/wist/conditions.md
+++ b/docs/wist/conditions.md
@@ -5,22 +5,127 @@ description: Document if/else and boolean conditions.
 
 # Conditions
 
-<div class="placeholder-box">
+Conditions let Wist programs choose one of two result expressions.
 
-This page is a documentation placeholder.
+Condition support is dialect-dependent. A program can use `if` only when the active dialect includes the modules that own condition syntax and the comparison or equality operators used by the condition expression.
 
-**Purpose:** Document if/else and boolean conditions.
+## When to read this page
 
-</div>
+Read this page when you want to write `if` / `else` expressions or when a custom dialect needs conditional logic.
 
-## What this page should explain
+## Goal
 
-- The practical goal of this topic.
-- The minimal example a developer should run or read.
-- The important concepts needed before going deeper.
-- Links to the next page for gradual learning.
+Understand the current `if` syntax, result selection behavior and module dependencies.
 
-## Status
+## Minimal if/else
 
-Content is not written yet.
+```wist
+if 2 == 2 (1) else (2)
+```
 
+Expected result:
+
+```text
+1
+```
+
+If the condition is not satisfied, Wist returns the alternative expression:
+
+```wist
+if 2 == 3 (1) else (2)
+```
+
+Expected result:
+
+```text
+2
+```
+
+## Syntax shape
+
+The current documented shape is:
+
+```wist
+if condition (thenExpression) else (elseExpression)
+```
+
+The result expressions are grouped with parentheses. Multi-line grouped expressions are possible when the selected modules support the required inner syntax.
+
+## Conditions with variables
+
+```wist
+let x = 2
+if x == 2 (10) else (20)
+```
+
+Expected result:
+
+```text
+10
+```
+
+This requires variable and identifier support in addition to condition and equality support.
+
+## Nested conditions
+
+```wist
+if 2 == 2 (
+    if 3 == 3 (9) else (8)
+) else (7)
+```
+
+Expected result:
+
+```text
+9
+```
+
+Nested conditions are useful in tests because they prove that grouped conditional expressions are parsed and lowered consistently.
+
+## Required modules
+
+Depending on the expression, a conditional dialect may need modules such as:
+
+```text
+use Conditions,ComparisonConditions,Equality,BooleanConditions,Arithmetic,Numbers,Identifier,Variables,Scopes,Whitespaces
+```
+
+The exact set depends on the condition expression and result contents:
+
+- `Conditions` owns conditional syntax.
+- `Equality` is needed for `==`-style equality checks.
+- `ComparisonConditions` is needed for comparison operators such as `<`, `<=`, `>` or `>=`.
+- `BooleanConditions` is needed for boolean composition when used.
+- `Variables` and `Identifier` are needed when conditions read named values.
+
+## Conditions in formula DSLs
+
+A pricing or scoring DSL may use conditions to express thresholds:
+
+```wist
+if price > 100 (price - 10) else (price)
+```
+
+This can be useful, but it also broadens the DSL surface. Add it only when conditional logic is part of the product requirement and test both outcomes.
+
+## What to test
+
+For every dialect that enables conditions, test:
+
+- satisfied condition result;
+- unsatisfied condition result;
+- variable-based conditions if variables are allowed;
+- invalid condition syntax;
+- compiler/interpreter parity when both backends are exposed.
+
+## Common mistakes
+
+- Adding `Conditions` but forgetting equality or comparison modules required by the condition expression.
+- Assuming `if` syntax works in minimal arithmetic dialects.
+- Testing only one outcome.
+- Documenting conditions as general statement syntax when the examples use expression-like result values.
+- Letting compiler and interpreter disagree on nested condition lowering.
+
+## Next
+
+Continue with [Loops](/wist/loops) for repeated execution.

--- a/docs/wist/examples.md
+++ b/docs/wist/examples.md
@@ -5,22 +5,246 @@ description: Collect complete Wist programs.
 
 # Examples
 
-<div class="placeholder-box">
+This page collects complete Wist programs and shows which dialect shape they belong to.
 
-This page is a documentation placeholder.
+Use these examples as small executable references, not as a full language specification.
 
-**Purpose:** Collect complete Wist programs.
+## When to read this page
 
-</div>
+Read this page after the [Syntax Tour](/wist/syntax-tour) when you want complete snippets that can be copied into examples, tests or dialect documentation.
 
-## What this page should explain
+## Goal
 
-- The practical goal of this topic.
-- The minimal example a developer should run or read.
-- The important concepts needed before going deeper.
-- Links to the next page for gradual learning.
+Connect Wist syntax examples to the dialects and modules that make them valid.
 
-## Status
+## Minimal arithmetic
 
-Content is not written yet.
+Program:
 
+```wist
+2 + 3 * 4
+```
+
+Expected result:
+
+```text
+14
+```
+
+Typical dialect:
+
+```text
+dialect MinimalArithmetic
+use Arithmetic,Numbers,Scopes,Whitespaces
+backend interpreter
+```
+
+This is the best first example because it proves that the basic parser, arithmetic modules and interpreter path are working.
+
+## Grouped arithmetic
+
+Program:
+
+```wist
+(2 + 3) * 4
+```
+
+Expected result:
+
+```text
+20
+```
+
+Use this when documenting precedence and grouping.
+
+## Variables and reassignment
+
+Program:
+
+```wist
+let x = 5
+x = x + 1
+x
+```
+
+Expected result:
+
+```text
+6
+```
+
+Typical modules:
+
+```text
+use Arithmetic,Numbers,Identifier,Variables,Scopes,Whitespaces
+```
+
+This example proves that declaration, lookup and reassignment work together.
+
+## Variable-based formula
+
+Program:
+
+```wist
+price + fee * 2
+```
+
+With inputs:
+
+```text
+price = 100
+fee = 5
+```
+
+Expected result:
+
+```text
+110
+```
+
+This is useful for pricing-style DSLs. Keep the dialect narrow and avoid enabling unrelated runtime features.
+
+## Conditional expression
+
+Program:
+
+```wist
+let x = 2
+if x == 2 (10) else (20)
+```
+
+Expected result:
+
+```text
+10
+```
+
+Typical modules:
+
+```text
+use Conditions,Equality,Arithmetic,Numbers,Identifier,Variables,Scopes,Whitespaces
+```
+
+Add `ComparisonConditions` when using operators such as `<`, `<=`, `>` or `>=`.
+
+## While loop accumulator
+
+Program:
+
+```wist
+let sum = 0
+let i = 1
+
+while (i <= 5) (
+    sum = sum + i
+    i = i + 1
+)
+
+sum
+```
+
+Expected result:
+
+```text
+15
+```
+
+Typical modules:
+
+```text
+use Loops,Variables,Identifier,Arithmetic,Numbers,ComparisonConditions,Scopes,Whitespaces
+```
+
+Use this to test loop execution, variable mutation and backend parity.
+
+## Full default `for` example
+
+Program:
+
+```wist
+let sum = 0
+
+for (let i = 1) (i <= 5) (i = i + 1) (
+    sum = sum + i
+)
+
+sum
+```
+
+Expected result:
+
+```text
+15
+```
+
+This is the shipped `full-default` example shape. It is useful for validating a broader Wist dialect over both interpreter and compiler modes.
+
+## Nested loop aggregate
+
+Program:
+
+```wist
+let total = 0
+let outer = 1
+
+while (outer <= 3) (
+    let inner = 1
+    while (inner <= 2) (
+        total = total + (outer * inner)
+        inner = inner + 1
+    )
+    outer = outer + 1
+)
+
+total
+```
+
+Expected result:
+
+```text
+18
+```
+
+Use this only for dialects that intentionally allow nested loops, local declarations and mutation.
+
+## Interop expression in trusted profiles
+
+Program:
+
+```wist
+NumbersModule.Core.RealNumberImpl.Add(2, 5)
+```
+
+Expected result:
+
+```text
+7
+```
+
+This belongs to trusted full profiles that include `CSharpInterop`. Do not use this example for restricted formula dialects.
+
+## Choosing examples for documentation
+
+Use the smallest example that proves the concept:
+
+| Concept | Recommended example |
+|---|---|
+| First run | `2 + 3 * 4` |
+| Grouping | `(2 + 3) * 4` |
+| Variables | `let x = 5; x = x + 1; x` |
+| Conditions | `if x == 2 (10) else (20)` |
+| Loops | sum from 1 to 5 |
+| Backend parity | same arithmetic/loop source in both modes |
+| Restricted formula DSL | `price + fee * 2` |
+
+## Common mistakes
+
+- Using a broad full-default example to document a restricted DSL.
+- Showing interop in user-facing formula documentation.
+- Using loop examples before explaining variables and comparisons.
+- Forgetting to mention which dialect or modules make an example valid.
+- Treating examples as complete language specification.
+
+## Next
+
+Continue with [Build DSLs](/build-dsls/) to turn these examples into explicit dialect profiles.

--- a/docs/wist/index.md
+++ b/docs/wist/index.md
@@ -5,22 +5,110 @@ description: Introduce Wist as a practical language used to demonstrate Universa
 
 # Wist Overview
 
-<div class="placeholder-box">
+Wist is the reference language built on top of UniversalToolchain.
 
-This page is a documentation placeholder.
+It is not meant to be a separate monolithic compiler competing with general-purpose languages. Its main role is to demonstrate how a language can be assembled from modules, constrained through dialect files and executed through different backend paths.
 
-**Purpose:** Introduce Wist as a practical language used to demonstrate UniversalToolchain.
+## When to read this section
 
-</div>
+Read this section when you want to:
 
-## What this page should explain
+- run existing Wist programs;
+- understand the syntax used in shipped dialect examples;
+- decide which modules a custom DSL needs;
+- compare full Wist with restricted dialects;
+- understand which language features belong to which modules.
 
-- The practical goal of this topic.
-- The minimal example a developer should run or read.
-- The important concepts needed before going deeper.
-- Links to the next page for gradual learning.
+If you want to build your own DSL, read this section first, then continue with [Build DSLs](/build-dsls/).
 
-## Status
+## What Wist demonstrates
 
-Content is not written yet.
+Wist demonstrates several UniversalToolchain ideas in one concrete language:
 
+- syntax is contributed by modules;
+- dialect files select which syntax and runtime features are available;
+- the same source can run through interpreter and compiler modes when both are exposed;
+- restricted dialects can intentionally remove features from the language surface;
+- module and backend choices must be tested instead of assumed.
+
+## Minimal example
+
+The smallest useful Wist program is an arithmetic expression:
+
+```wist
+2 + 3 * 4
+```
+
+Expected result:
+
+```text
+14
+```
+
+This works under the shipped `minimal-arithmetic` dialect because that dialect selects arithmetic, numbers, scopes and whitespace handling.
+
+## Full language example
+
+The shipped `full-default` example computes the sum from 1 to 5:
+
+```wist
+let sum = 0
+
+for (let i = 1) (i <= 5) (i = i + 1) (
+    sum = sum + i
+)
+
+sum
+```
+
+Expected result:
+
+```text
+15
+```
+
+This requires a broader module set: variables, identifiers, arithmetic, comparisons, loops, scopes and whitespace handling.
+
+## Language features in this section
+
+| Page | What it explains |
+|---|---|
+| [Syntax Tour](/wist/syntax-tour) | short examples across the language surface |
+| [Numbers](/wist/numbers) | numeric literals and arithmetic expressions |
+| [Variables](/wist/variables) | `let`, assignment and lookup |
+| [Conditions](/wist/conditions) | `if` / `else`, equality and comparisons |
+| [Loops](/wist/loops) | `while` and `for` examples |
+| [Scopes](/wist/scopes) | block-like expression grouping and variable visibility notes |
+| [Examples](/wist/examples) | complete runnable programs and matching dialects |
+
+## Important boundary
+
+A Wist feature exists only when the active dialect selects the owning module or module group.
+
+For example, this program needs variable support:
+
+```wist
+let x = 10
+x + 5
+```
+
+It should not be expected to work under a dialect that selects only arithmetic and numbers.
+
+## Wist vs. UniversalToolchain
+
+Use this mental split:
+
+- **UniversalToolchain** is the framework for composing DSL runtimes.
+- **Wist** is the reference language that proves the framework can compose a usable language.
+- **Dialect files** are the selection layer that controls which Wist features are visible in a specific runtime.
+
+## Common mistakes
+
+- Treating Wist as one fixed language surface. In practice, the active dialect matters.
+- Assuming `full-default` is the right profile for end-user formulas. Restricted profiles are usually better for that.
+- Assuming compiler and interpreter modes are always both available. The dialect decides which backends are exposed.
+- Adding syntax examples without checking which modules own that syntax.
+
+## Next
+
+Start with the [Syntax Tour](/wist/syntax-tour), then continue to [Numbers](/wist/numbers) and [Variables](/wist/variables).

--- a/docs/wist/loops.md
+++ b/docs/wist/loops.md
@@ -5,22 +5,134 @@ description: Document loop constructs and common examples.
 
 # Loops
 
-<div class="placeholder-box">
+Loops let Wist programs repeat a grouped body while updating local state.
 
-This page is a documentation placeholder.
+Loop support is dialect-dependent. A dialect must select the module that owns loop syntax and the modules required by the loop condition and body.
 
-**Purpose:** Document loop constructs and common examples.
+## When to read this page
 
-</div>
+Read this page when you want to use `while` or `for` constructs, or when you are deciding whether a DSL should allow repeated execution at all.
 
-## What this page should explain
+## Goal
 
-- The practical goal of this topic.
-- The minimal example a developer should run or read.
-- The important concepts needed before going deeper.
-- Links to the next page for gradual learning.
+Understand the current loop syntax, typical accumulator examples and the modules needed for loop programs.
 
-## Status
+## `while` loop
 
-Content is not written yet.
+A `while` loop repeats while its condition remains satisfied:
 
+```wist
+let sum = 0
+let i = 1
+
+while (i <= 5) (
+    sum = sum + i
+    i = i + 1
+)
+
+sum
+```
+
+Expected result:
+
+```text
+15
+```
+
+This program sums numbers from 1 to 5.
+
+## Zero-iteration loop
+
+If the condition is not satisfied initially, the body is not executed:
+
+```wist
+let marker = 17
+let i = 10
+
+while (i < 10) (
+    marker = marker + 100
+    i = i + 1
+)
+
+marker
+```
+
+Expected result:
+
+```text
+17
+```
+
+This is an important test case because it proves that loop entry logic is correct.
+
+## `for` loop
+
+The shipped `full-default` example uses this form:
+
+```wist
+let sum = 0
+
+for (let i = 1) (i <= 5) (i = i + 1) (
+    sum = sum + i
+)
+
+sum
+```
+
+Expected result:
+
+```text
+15
+```
+
+The `for` loop groups initialization, condition, update and body:
+
+```text
+for (initialization) (condition) (update) (body)
+```
+
+Use this as the canonical documented shape for current Wist `for` syntax.
+
+## Required modules
+
+Loop programs usually need a broader module set than arithmetic-only programs:
+
+```text
+use Loops,Variables,Identifier,Arithmetic,Numbers,ComparisonConditions,Scopes,Whitespaces
+```
+
+Depending on the condition expression, equality or boolean modules may also be needed.
+
+## Loops and restricted DSLs
+
+Loops are powerful, but they broaden the runtime surface. A formula DSL for pricing, scoring or simple validation often does not need loops.
+
+Before adding loops to a user-facing DSL, check:
+
+- whether a loop is part of the actual product requirement;
+- whether repeated execution should be bounded externally;
+- whether both compiler and interpreter paths handle the loop consistently;
+- whether a simpler expression or aggregate input would be safer and easier to test.
+
+## What to test
+
+For a dialect that enables loops, test:
+
+- normal loop execution;
+- zero iterations;
+- mutation of a loop variable;
+- nested loops if they are supported by the intended dialect;
+- malformed loop syntax;
+- compiler/interpreter parity when both backends are exposed.
+
+## Common mistakes
+
+- Adding `Loops` without the variable and comparison modules required by the loop body.
+- Forgetting to update the loop variable.
+- Using loops in a restricted formula DSL when a simpler expression would be enough.
+- Testing only the happy path and missing zero-iteration behavior.
+- Assuming `while` and `for` are available under every Wist dialect.
+
+## Next
+
+Continue with [Scopes](/wist/scopes) to understand grouped expressions and variable visibility notes.

--- a/docs/wist/numbers.md
+++ b/docs/wist/numbers.md
@@ -5,22 +5,135 @@ description: Document numeric literals and arithmetic behavior.
 
 # Numbers
 
-<div class="placeholder-box">
+Numbers are the smallest useful Wist values. They are used by arithmetic expressions, comparisons, conditions, loops and most shipped examples.
 
-This page is a documentation placeholder.
+## When to read this page
 
-**Purpose:** Document numeric literals and arithmetic behavior.
+Read this page when you want to understand the numeric examples used by Wist dialects or when you are deciding whether a custom DSL needs only arithmetic or a broader language surface.
 
-</div>
+## Goal
 
-## What this page should explain
+Understand numeric literals, arithmetic operators and the modules needed to run numeric expressions.
 
-- The practical goal of this topic.
-- The minimal example a developer should run or read.
-- The important concepts needed before going deeper.
-- Links to the next page for gradual learning.
+## Minimal example
 
-## Status
+```wist
+2 + 3 * 4
+```
 
-Content is not written yet.
+Expected result:
 
+```text
+14
+```
+
+Multiplication binds before addition. Use parentheses when the intended order should be explicit:
+
+```wist
+(2 + 3) * 4
+```
+
+Expected result:
+
+```text
+20
+```
+
+## Required modules
+
+A minimal arithmetic dialect uses:
+
+```text
+use Arithmetic,Numbers,Scopes,Whitespaces
+```
+
+These modules cover numeric values, arithmetic operators, grouping and ordinary whitespace handling.
+
+## Arithmetic operators
+
+The common arithmetic operators are:
+
+| Operator | Meaning |
+|---|---|
+| `+` | addition |
+| `-` | subtraction |
+| `*` | multiplication |
+| `/` | division |
+
+The exact runtime numeric representation depends on the selected dialect and backend path. Native profiles may also enable native type and CIL-oriented optimizations.
+
+## Grouping
+
+Parentheses group expressions:
+
+```wist
+(10 - 2) * (3 + 1)
+```
+
+Expected result:
+
+```text
+32
+```
+
+Grouping is important in DSL examples because it makes intent readable even when precedence already defines the same result.
+
+## Numbers in larger programs
+
+Numbers can be stored in variables when the active dialect includes variable support:
+
+```wist
+let price = 100
+let fee = 5
+price + fee * 2
+```
+
+Expected result:
+
+```text
+110
+```
+
+This example is no longer arithmetic-only. It also needs `Identifier` and `Variables`.
+
+## Numbers in conditions
+
+Numbers can participate in equality and comparison checks when the active dialect includes condition/comparison modules:
+
+```wist
+if 2 == 2 (1) else (0)
+```
+
+Expected result:
+
+```text
+1
+```
+
+This requires more than `Numbers` and `Arithmetic`; it also needs condition and equality support.
+
+## Optimized numeric profiles
+
+Some shipped dialects include native-oriented modules and optimizers. These are useful for performance-sensitive arithmetic, but they should be enabled after the basic semantics are already correct.
+
+A native arithmetic profile may include optimizer flags such as:
+
+```text
+enable ArithmeticOptimization
+enable NativeCilOptimization
+enable NativeTypesOptimization
+```
+
+Do not use optimizers to hide missing language semantics. First make the unoptimized or simpler path correct, then optimize.
+
+## Common mistakes
+
+- Assuming arithmetic implies variables. It does not.
+- Assuming arithmetic implies conditions. It does not.
+- Using `compiler` mode with an interpreter-only arithmetic dialect.
+- Enabling native optimizers before testing the base expression behavior.
+- Treating benchmark output as a substitute for semantic tests.
+
+## Next
+
+Continue with [Variables](/wist/variables) to use numeric values in named bindings.

--- a/docs/wist/scopes.md
+++ b/docs/wist/scopes.md
@@ -5,22 +5,152 @@ description: Explain block scopes and variable visibility.
 
 # Scopes
 
-<div class="placeholder-box">
+Scopes and grouped expressions help Wist organize nested syntax such as conditions and loops.
 
-This page is a documentation placeholder.
+In current Wist examples, parentheses are used heavily for grouping: arithmetic precedence, conditional result expressions, loop conditions and loop bodies.
 
-**Purpose:** Explain block scopes and variable visibility.
+## When to read this page
 
-</div>
+Read this page when you want to understand why many Wist constructs use parenthesized groups and how grouped bodies interact with variables.
 
-## What this page should explain
+## Goal
 
-- The practical goal of this topic.
-- The minimal example a developer should run or read.
-- The important concepts needed before going deeper.
-- Links to the next page for gradual learning.
+Understand grouping syntax, variable visibility expectations and why scope behavior must be tested together with variables, conditions and loops.
 
-## Status
+## Arithmetic grouping
 
-Content is not written yet.
+Parentheses can group arithmetic expressions:
 
+```wist
+(2 + 3) * 4
+```
+
+Expected result:
+
+```text
+20
+```
+
+Without parentheses, multiplication binds before addition:
+
+```wist
+2 + 3 * 4
+```
+
+Expected result:
+
+```text
+14
+```
+
+## Grouped conditional results
+
+Conditional result expressions are grouped with parentheses:
+
+```wist
+if 2 == 2 (1) else (2)
+```
+
+Nested grouped expressions are also possible:
+
+```wist
+if 2 == 2 (
+    if 3 == 3 (9) else (8)
+) else (7)
+```
+
+Expected result:
+
+```text
+9
+```
+
+## Grouped loop bodies
+
+Loop bodies are grouped with parentheses:
+
+```wist
+let sum = 0
+let i = 1
+
+while (i <= 5) (
+    sum = sum + i
+    i = i + 1
+)
+
+sum
+```
+
+Expected result:
+
+```text
+15
+```
+
+The grouped body contains multiple operations: update the accumulator and update the loop variable.
+
+## Variables and grouped bodies
+
+A grouped body often reads and writes variables declared before the body:
+
+```wist
+let total = 0
+let outer = 1
+
+while (outer <= 3) (
+    let inner = 1
+    while (inner <= 2) (
+        total = total + (outer * inner)
+        inner = inner + 1
+    )
+    outer = outer + 1
+)
+
+total
+```
+
+Expected result:
+
+```text
+18
+```
+
+This kind of example is useful for testing that nested groups, local declarations and mutation behave consistently across backends.
+
+## Required modules
+
+Grouping appears in many features, but grouping alone is not a complete language surface. Depending on the program, a dialect may also need:
+
+```text
+use Scopes,Whitespaces,Numbers,Arithmetic,Identifier,Variables,Conditions,ComparisonConditions,Equality,Loops
+```
+
+Select only the modules required by the syntax you actually want to allow.
+
+## What scopes are not
+
+Do not use this page as a full formal specification of lexical scope rules. The project documentation should stay honest: current examples and tests demonstrate practical grouped execution behavior, while deeper implementation details belong in internals and contract pages.
+
+For module authors, the important rule is ownership: grouped syntax should be represented through parser/AST structures, not recovered later by scanning raw source text.
+
+## What to test
+
+When changing scope-related behavior, test:
+
+- arithmetic grouping;
+- grouped conditional expressions;
+- loop bodies with multiple operations;
+- nested loops or nested conditional groups;
+- variable declarations inside grouped bodies;
+- compiler/interpreter parity.
+
+## Common mistakes
+
+- Treating parentheses as plain text delimiters outside the parser/AST pipeline.
+- Assuming grouped loop bodies work without `Loops`, `Variables` and comparison modules.
+- Testing only flat expressions and missing nested grouped behavior.
+- Documenting stronger scope guarantees than the current tests prove.
+
+## Next
+
+Continue with [Examples](/wist/examples) for complete runnable programs.

--- a/docs/wist/variables.md
+++ b/docs/wist/variables.md
@@ -5,22 +5,149 @@ description: Document variable declarations, assignments, and lookup rules.
 
 # Variables
 
-<div class="placeholder-box">
+Variables let Wist programs name intermediate values and reuse them later.
 
-This page is a documentation placeholder.
+Variable support is not part of the smallest arithmetic dialect. A dialect must select the modules that own identifiers and variable behavior.
 
-**Purpose:** Document variable declarations, assignments, and lookup rules.
+## When to read this page
 
-</div>
+Read this page when you want to write Wist programs with `let`, update values or pass named inputs into formula-like programs.
 
-## What this page should explain
+## Goal
 
-- The practical goal of this topic.
-- The minimal example a developer should run or read.
-- The important concepts needed before going deeper.
-- Links to the next page for gradual learning.
+Understand declaration, lookup, reassignment and the module dependencies behind variable syntax.
 
-## Status
+## Minimal declaration
 
-Content is not written yet.
+```wist
+let x = 10
+x
+```
 
+Expected result:
+
+```text
+10
+```
+
+The first line declares a variable. The final expression returns its value.
+
+## Variable in an expression
+
+```wist
+let x = 10
+x + 5
+```
+
+Expected result:
+
+```text
+15
+```
+
+This requires arithmetic, numbers, identifiers and variables.
+
+## Reassignment
+
+A variable can be updated after declaration:
+
+```wist
+let x = 5
+x = x + 1
+x
+```
+
+Expected result:
+
+```text
+6
+```
+
+Reassignment is useful in loops and accumulator-style programs.
+
+## Declaration depending on another variable
+
+```wist
+let x = 2
+let y = x + 3
+y
+```
+
+Expected result:
+
+```text
+5
+```
+
+The second declaration reads the value created by the first declaration.
+
+## Required modules
+
+A dialect with variables usually needs at least:
+
+```text
+use Arithmetic,Numbers,Identifier,Variables,Scopes,Whitespaces
+```
+
+`Identifier` is important because variable names are not just numeric literals. If a dialect includes `Variables` but not the necessary identifier support, variable syntax should not be expected to work correctly.
+
+## Runtime inputs
+
+Programmatic execution may provide named runtime inputs. For example, a pricing expression may use names such as `price` and `fee`:
+
+```wist
+price + fee * 2
+```
+
+The runtime host must keep declared runtime inputs separate from local variables declared inside the program. Local variables should not be accidentally overwritten by unrelated external argument values.
+
+This boundary is important for formula DSLs. Runtime bindings are part of the host boundary; `let` declarations are part of the program semantics.
+
+## Use before declaration
+
+This is invalid in normal variable usage:
+
+```wist
+x
+let x = 1
+```
+
+The variable is read before it is declared.
+
+A good dialect test suite should cover this kind of failure in both compiler and interpreter modes when both are enabled.
+
+## Variables in loops
+
+Variables are commonly used as loop counters and accumulators:
+
+```wist
+let sum = 0
+let i = 1
+
+while (i <= 5) (
+    sum = sum + i
+    i = i + 1
+)
+
+sum
+```
+
+Expected result:
+
+```text
+15
+```
+
+This requires variables plus loop and comparison support.
+
+## Common mistakes
+
+- Adding `Variables` but forgetting `Identifier`.
+- Using variables in a minimal arithmetic dialect.
+- Treating runtime arguments and local variables as the same storage concept.
+- Testing only variable declaration but not reassignment.
+- Testing compiler mode but forgetting interpreter/compiler parity for variable mutation.
+
+## Next
+
+Continue with [Conditions](/wist/conditions) to use variables in branches.


### PR DESCRIPTION
## Summary

This PR replaces placeholder content in the `Wist Language` documentation section with practical developer documentation.

Updated pages:

- `docs/wist/index.md`
- `docs/wist/numbers.md`
- `docs/wist/variables.md`
- `docs/wist/conditions.md`
- `docs/wist/loops.md`
- `docs/wist/scopes.md`
- `docs/wist/examples.md`

## What changed

- Introduces Wist as the reference language for UniversalToolchain rather than a standalone monolithic compiler.
- Documents numbers, variables, conditions, loops, grouping/scopes, and complete examples.
- Connects syntax examples to module/dialect requirements.
- Uses current shipped examples and existing test-covered syntax shapes such as minimal arithmetic, `if ... else`, `while`, and the `full-default` `for` loop example.
- Keeps restricted DSL guidance explicit: examples should not imply that full Wist or interop belongs in user-facing formula DSLs.

## Notes

Documentation-only change. No runtime code, VitePress config, theme, sidebar, or architecture changes.