### PR TITLE
docs: fill module authoring documentation

### DIFF
--- a/docs/write-modules/ast-nodes.md
+++ b/docs/write-modules/ast-nodes.md
@@ -5,22 +5,131 @@ description: Explain AST node design and ownership.
 
 # AST Nodes
 
-<div class="placeholder-box">
+AST nodes are the structured representation of parsed syntax.
 
-This page is a documentation placeholder.
+A module that introduces a language feature should make that feature visible as a clear AST shape before it is lowered into bytecode or AIR. AST structure is the point where syntax becomes owned semantics.
 
-**Purpose:** Explain AST node design and ownership.
+## When to read this page
 
-</div>
+Read this page after [Parser Extension](/write-modules/parser-extension) when a feature needs a new node shape or a new visitor path.
 
-## What this page should explain
+## Goal
 
-- The practical goal of this topic.
-- The minimal example a developer should run or read.
-- The important concepts needed before going deeper.
-- Links to the next page for gradual learning.
+Understand how AST ownership protects modularity and prevents later pipeline stages from guessing source syntax.
 
-## Status
+## Why AST ownership matters
 
-Content is not written yet.
+A parser node creator should produce AST nodes that represent the feature explicitly.
 
+Good pipeline:
+
+```text
+source syntax
+  -> lexemes
+  -> parser node creator
+  -> AST node with a stable tag/shape
+  -> AST visitor
+  -> bytecode/AIR
+```
+
+Bad pipeline:
+
+```text
+source syntax
+  -> partial generic AST
+  -> later visitor scans text or child layout heuristically
+  -> bytecode emitted by guesswork
+```
+
+The second path makes dialect composition fragile because semantics are no longer owned by the feature module.
+
+## Node tags and shape
+
+Current modules commonly identify AST nodes through tags and lexeme-derived structure. For example, arithmetic visitors check whether a node belongs to arithmetic operation tags before emitting bytecode.
+
+A module should define or reuse AST tags intentionally:
+
+- one tag should mean one stable semantic category;
+- tags should not be overloaded for unrelated features;
+- visitor code should self-filter by tag/shape;
+- tests should fail when a malformed shape reaches translation.
+
+## Children are part of the contract
+
+The order and meaning of child nodes matters.
+
+For a binary operation, children usually represent left and right operands. For a loop, children may represent condition and body. For a conditional expression, children represent condition and result expressions.
+
+Document the expected shape in the module's developer documentation or tests when it is not obvious.
+
+## Visitor self-filtering
+
+AST visitors must not assume that every node belongs to them.
+
+A safe visitor pattern is:
+
+```csharp
+public void TryVisit(BytecodeVisitorData data)
+{
+    if (!IsOwnedNode(data.Node))
+        return;
+
+    // translate children and emit owned semantics
+}
+```
+
+This matters because multiple visitors may see the same AST node. A visitor that does not self-filter can double-emit instructions or consume another module's syntax.
+
+## Translation boundaries
+
+An AST visitor should emit only semantics owned by its module.
+
+For example:
+
+- an arithmetic visitor may translate operands and emit arithmetic operation bytecode;
+- a variable visitor may emit declaration, lookup or assignment behavior;
+- a loop visitor may emit loop control structure;
+- a condition visitor may emit conditional control behavior.
+
+A visitor should not repair missing parser output by searching raw source text or by assuming unrelated child layouts.
+
+## Shared AST state
+
+Shared state between visitors is allowed only when explicit and scoped.
+
+Good shared state:
+
+- created per compilation or per translator setup;
+- passed explicitly to cooperating visitors;
+- narrow in responsibility;
+- covered by tests proving no leakage between compilations.
+
+Bad shared state:
+
+- static mutable dictionaries storing compile-specific information;
+- state that depends on previous runs;
+- hidden coupling between unrelated visitors;
+- state used to bypass dialect selection.
+
+## What to test
+
+For AST node work, test:
+
+- valid syntax creates executable semantics;
+- malformed syntax fails before incorrect bytecode is emitted;
+- visitor self-filtering does not double-emit;
+- nested constructs preserve shape;
+- disabled dialects reject the feature;
+- compiler/interpreter parity when both backends support the feature.
+
+## Common mistakes
+
+- Treating AST nodes as disposable parser artifacts rather than semantic contracts.
+- Encoding feature meaning only in child indexes without tests.
+- Letting visitors infer syntax from raw text.
+- Reusing a tag for unrelated syntax because it is convenient.
+- Adding AST behavior without matching negative tests.
+
+## Next
+
+Continue with [Bytecode Generation](/write-modules/bytecode-generation).

--- a/docs/write-modules/bytecode-generation.md
+++ b/docs/write-modules/bytecode-generation.md
@@ -5,22 +5,161 @@ description: Show how a feature lowers into bytecode.
 
 # Bytecode Generation
 
-<div class="placeholder-box">
+Bytecode generation is where an AST feature becomes executable semantics.
 
-This page is a documentation placeholder.
+For module authors, the most important rule is stack and ownership discipline: emit only the operations your feature owns, in the order expected by the backend pipeline.
 
-**Purpose:** Show how a feature lowers into bytecode.
+## When to read this page
 
-</div>
+Read this page after [AST Nodes](/write-modules/ast-nodes) when a feature already has parser/AST ownership and now needs runtime behavior.
 
-## What this page should explain
+## Goal
 
-- The practical goal of this topic.
-- The minimal example a developer should run or read.
-- The important concepts needed before going deeper.
-- Links to the next page for gradual learning.
+Understand how AST visitors lower feature-owned nodes into bytecode without leaking syntax assumptions into later stages.
 
-## Status
+## Where bytecode is produced
 
-Content is not written yet.
+Frontend modules usually register AST visitors through `InitAstTranslator`:
 
+```csharp
+public void InitAstTranslator(IAstToBytecodeTranslator translator) =>
+    translator.AddVisitors(...);
+```
+
+A visitor receives a node and decides whether it owns that node. If it does, it translates children and emits bytecode instructions.
+
+A simplified lowering path looks like this:
+
+```text
+AST node
+  -> owning visitor
+  -> translate child nodes
+  -> emit feature-owned bytecode instructions
+  -> bytecode post-processing
+  -> AIR/backend path
+```
+
+## Example: arithmetic lowering
+
+Arithmetic lowering follows a simple shape:
+
+1. Check whether the AST node is an arithmetic operation.
+2. Translate child nodes first.
+3. Emit the arithmetic operation instruction.
+
+Conceptually:
+
+```text
+left operand
+right operand
+operation
+```
+
+This stack-oriented order matters. If children are translated in the wrong order, or if the operation is emitted too early, interpreter and compiler behavior can diverge.
+
+## Visitor self-filtering
+
+A bytecode visitor must return without emitting when it does not own the node:
+
+```csharp
+if (!IsOwnedNode(data.Node))
+    return;
+```
+
+This is not optional. Translators may invoke multiple visitors, and a visitor that emits for unrelated nodes can create duplicate or invalid bytecode.
+
+## Stack discipline
+
+Bytecode generation should respect the expected stack behavior of the feature.
+
+For expression-like features:
+
+- child expressions usually push values;
+- the parent operation consumes those values;
+- the parent operation pushes the result or produces a documented control-flow effect.
+
+For statement-like or control-flow features:
+
+- define what values remain on the stack;
+- document whether a body result is preserved or discarded;
+- test both interpreter and compiler paths.
+
+Never rely on accidental stack cleanup by a later backend.
+
+## Bytecode post-processing
+
+`IFrontendCoreModule` includes a `ProcessBytecode` hook:
+
+```csharp
+Bytecode ProcessBytecode(Bytecode current) => current;
+```
+
+Use this only when the module genuinely owns a bytecode-level transformation. Do not use post-processing as a workaround for missing parser or AST ownership.
+
+Good use:
+
+- normalize feature-owned bytecode;
+- validate feature-owned instruction shape;
+- apply a documented transformation with tests.
+
+Bad use:
+
+- scan instructions to guess missing syntax;
+- rewrite unrelated module instructions;
+- hide backend incompatibilities;
+- depend on previous compilations or global mutable state.
+
+## Backend awareness
+
+Bytecode is consumed by backend paths. A feature is not complete until intended backends understand the emitted semantics.
+
+When both compiler and interpreter are enabled, add parity tests:
+
+```text
+same source
+  -> interpreter result
+  -> compiler result
+  -> compare observable behavior
+```
+
+If a feature is intentionally supported by only one backend, document that limitation and test that unsupported modes fail explicitly.
+
+## Optimizers are not semantics
+
+Optimizers may improve or normalize bytecode/AIR, but they must not be required to make basic semantics correct.
+
+Build in this order:
+
+1. parser/AST ownership;
+2. unoptimized bytecode semantics;
+3. backend execution;
+4. parity tests;
+5. optimizers.
+
+If a program works only after an optimizer is enabled, the base feature is probably incomplete.
+
+## What to test
+
+For bytecode generation, test:
+
+- simple valid source;
+- nested source;
+- malformed source;
+- disabled dialect behavior;
+- interpreter execution when supported;
+- compiler execution when supported;
+- parity when both backends are supported;
+- optimizer safety when optimizers touch the feature.
+
+## Common mistakes
+
+- Emitting bytecode for nodes not owned by the visitor.
+- Depending on child order without a test.
+- Leaving unexpected values on the stack.
+- Fixing parser mistakes in bytecode post-processing.
+- Adding compiler behavior but forgetting interpreter behavior.
+- Using optimizers as required semantic lowering.
+
+## Next
+
+Continue with [Semantic Tags](/write-modules/semantic-tags).

--- a/docs/write-modules/frontend-module.md
+++ b/docs/write-modules/frontend-module.md
@@ -5,22 +5,153 @@ description: Explain frontend module responsibilities.
 
 # Frontend Module
 
-<div class="placeholder-box">
+A frontend module is the normal entry point for adding a language feature to Wist or to a UniversalToolchain-based DSL.
 
-This page is a documentation placeholder.
+It should own the feature's public dialect name, lexemes, parser registration and AST-to-bytecode translator registration. It should not rely on generic framework code knowing the concrete feature name.
 
-**Purpose:** Explain frontend module responsibilities.
+## When to read this page
 
-</div>
+Read this page when you are adding syntax or enabling a feature through a `.wistdialect` file.
 
-## What this page should explain
+## Goal
 
-- The practical goal of this topic.
-- The minimal example a developer should run or read.
-- The important concepts needed before going deeper.
-- Links to the next page for gradual learning.
+Understand what a frontend module is responsible for before going deeper into parser nodes, AST nodes or bytecode generation.
 
-## Status
+## Current interface shape
 
-Content is not written yet.
+The core frontend module contract is `IFrontendCoreModule`. It has hooks for several stages of the pipeline:
 
+```csharp
+public interface IFrontendCoreModule
+{
+    void InitLexer(ILexer lexer) { }
+    void InitParser(IParser parser) { }
+    string ProcessText(string curCode) => curCode;
+    List<LexemeValue> ProcessLexemes(List<LexemeValue> current) => current;
+    AstNode ProcessAst(AstNode astRoot) => astRoot;
+    Bytecode ProcessBytecode(Bytecode current) => current;
+    void InitAstTranslator(IAstToBytecodeTranslator translator) { }
+    void InitAstTranslator(IAstToBytecodeTranslator translator, IReadOnlyList<IFrontendCoreModule> selectedModules)
+        => InitAstTranslator(translator);
+}
+```
+
+Most feature modules use only a subset of these hooks. That is fine. A module should implement the hooks it actually owns.
+
+## Typical module shape
+
+A normal Wist feature module follows this shape:
+
+```text
+metadata attributes
+  -> IFrontendCoreModule
+  -> InitLexer
+  -> InitParser
+  -> InitAstTranslator
+  -> dialect/runtime export metadata
+  -> tests
+```
+
+For example, the arithmetic module exposes a dialect alias, registers arithmetic lexemes, registers parser node creators and registers AST visitors:
+
+```csharp
+[DialectModuleAlias("Arithmetic")]
+[DialectCapabilityProvider(typeof(global::ArithmeticModule.ArithmeticCapabilityProvider))]
+[DialectRuntimeExport("FrontendModule", "Arithmetic")]
+[AutoRegisterService]
+public class ArithmeticModuleImpl : IFrontendCoreModule
+{
+    public void InitLexer(ILexer lexer) => lexer.AddLexemes(...);
+    public void InitParser(IParser parser) => parser.AddNodeCreators(...);
+    public void InitAstTranslator(IAstToBytecodeTranslator translator) =>
+        translator.AddVisitors(...);
+}
+```
+
+The exact implementation changes from module to module, but the ownership model should stay the same.
+
+## Public dialect alias
+
+The dialect alias is part of the user-facing API:
+
+```text
+use Arithmetic,Numbers,Scopes,Whitespaces
+```
+
+Choose aliases as stable feature names. Do not choose names that expose internal implementation details or temporary class names.
+
+A dialect author should be able to understand what a module enables from the alias and the module documentation.
+
+## Lexer registration
+
+If the feature introduces new source syntax, the module should register its own lexemes in `InitLexer`.
+
+Examples:
+
+- `Arithmetic` registers operator lexemes such as addition and multiplication.
+- `Variables` registers `let`.
+- `Loops` registers `while` and `for`.
+
+Rules:
+
+- keep token names stable once parser code depends on them;
+- keep regex/token definitions close to the owning module;
+- avoid raw source scans for syntax that should be tokenized;
+- prefer constants or centralized collections when token names are reused.
+
+## Parser registration
+
+If the feature creates AST structure, the module should register parser node creators in `InitParser`.
+
+Parser registration is not just plumbing. Node creator priority affects grammar behavior and conflict resolution.
+
+Rules:
+
+- use explicit priorities;
+- document why the priority belongs near existing grammar constructs;
+- test conflicts with nearby syntax;
+- do not copy a priority only because it makes one example pass.
+
+## Translator registration
+
+If the feature produces executable semantics, the module usually registers AST visitors in `InitAstTranslator`.
+
+A visitor must self-filter. The translator may give multiple visitors a chance to see a node, so a visitor should return without emitting anything when the node is not owned by that visitor.
+
+## Context-aware translator registration
+
+`IFrontendCoreModule` also has this overload:
+
+```csharp
+void InitAstTranslator(
+    IAstToBytecodeTranslator translator,
+    IReadOnlyList<IFrontendCoreModule> selectedModules)
+```
+
+Use it only when translator setup genuinely depends on the selected module set. Keep this dependency explicit and tested. Do not use it to hide hardcoded composition shortcuts.
+
+## What a frontend module must not do
+
+A frontend module should not:
+
+- make generic framework layers branch on its concrete type name;
+- parse its syntax by scanning raw source after the parser;
+- activate behavior only through hidden global state;
+- silently depend on another module without documenting and testing that dependency;
+- register backend-specific behavior as if it were general frontend behavior.
+
+## Minimal checklist
+
+Before accepting a frontend module, verify:
+
+- it has a stable dialect alias;
+- it registers only syntax it owns;
+- parser priorities are intentional;
+- AST visitors self-filter;
+- the module can be selected and omitted through dialect files;
+- disabled dialects reject the feature;
+- interpreter/compiler behavior is tested when both backends support it.
+
+## Next
+
+Continue with [Parser Extension](/write-modules/parser-extension).

--- a/docs/write-modules/ordering-and-priority.md
+++ b/docs/write-modules/ordering-and-priority.md
@@ -5,22 +5,134 @@ description: Explain deterministic module ordering and parser priority.
 
 # Ordering and Priority
 
-<div class="placeholder-box">
+Ordering and priority decide which registered components see syntax first and how overlapping constructs are resolved.
 
-This page is a documentation placeholder.
+For module authors, this is not a cosmetic detail. Non-deterministic ordering can make the same dialect behave differently across machines, test runs or reflection results.
 
-**Purpose:** Explain deterministic module ordering and parser priority.
+## When to read this page
 
-</div>
+Read this page when you add parser node creators, AST visitors, optimizers, dialect modules or runtime exports whose order can affect behavior.
 
-## What this page should explain
+## Goal
 
-- The practical goal of this topic.
-- The minimal example a developer should run or read.
-- The important concepts needed before going deeper.
-- Links to the next page for gradual learning.
+Understand which ordering decisions must be explicit and tested.
 
-## Status
+## Places where ordering matters
 
-Content is not written yet.
+Ordering can affect several stages:
 
+| Stage | Why order matters |
+|---|---|
+| Lexeme registration | overlapping token patterns may compete |
+| Parser node creators | priorities define grammar behavior |
+| AST visitors | multiple visitors may inspect the same node |
+| Bytecode processors | transformations may depend on previous instructions |
+| Optimizers | one optimization may enable or invalidate another |
+| Runtime composition | selected modules must be resolved deterministically |
+| Backends | supported intrinsics and lowered shapes must match the selected backend |
+
+Do not assume order is irrelevant unless tests prove it.
+
+## Parser priority
+
+Parser priority is the most visible ordering mechanism.
+
+Arithmetic is a simple example: multiplication and division must bind tighter than addition and subtraction. Unary minus also needs its own position in the priority system.
+
+Conceptual ordering:
+
+```text
+unary operators
+  -> multiplication/division
+  -> addition/subtraction
+  -> broader expression constructs
+```
+
+The concrete numbers are implementation details, but the intent must be stable.
+
+## Deterministic module composition
+
+A dialect should produce the same module composition every time:
+
+```text
+same dialect file
+same repository state
+same selected modules
+same ordered runtime plan
+```
+
+If a test sometimes sees modules in a different order, that is an architecture smell. Fix deterministic resolution instead of adjusting the assertion randomly.
+
+## AST visitor ordering
+
+Visitor order matters less when every visitor self-filters correctly, but it can still matter when visitors cooperate or share scoped state.
+
+A safe visitor should:
+
+- return immediately for nodes it does not own;
+- avoid mutating unrelated nodes;
+- avoid hidden state that depends on previous visits;
+- document intentional cooperation with another visitor.
+
+When visitor order is important, test that order directly or test the observable behavior that depends on it.
+
+## Optimizer ordering
+
+Optimizer order can change performance and sometimes correctness if transformations are not isolated.
+
+Rules:
+
+- optimizers must preserve observable semantics;
+- backend-specific optimizers must run only where the backend supports their output;
+- optimizer order should be deterministic;
+- tests should compare optimized and unoptimized behavior when possible.
+
+Do not introduce an optimizer only to make broken base lowering work.
+
+## Priority changes are risky
+
+Changing an existing parser priority can affect syntax that appears unrelated to the feature you are modifying.
+
+Before changing a priority:
+
+1. identify which constructs can overlap;
+2. add a failing test that demonstrates the intended grammar change;
+3. run examples involving nearby syntax;
+4. verify interpreter/compiler parity;
+5. document the reason if the change is non-obvious.
+
+## What to test
+
+For ordering and priority, test:
+
+- precedence examples such as `2 + 3 * 4`;
+- grouping examples such as `(2 + 3) * 4`;
+- nested constructs;
+- syntax that could be parsed by more than one node creator;
+- deterministic module order in composition results;
+- backend parity when ordering affects emitted semantics;
+- optimizer behavior when one optimizer depends on another.
+
+## Common mistakes
+
+- Relying on reflection enumeration order.
+- Picking priority values by trial and error.
+- Adding a node creator with a broad match that steals syntax from another feature.
+- Assuming visitor order is safe without self-filtering.
+- Making optimizer ordering implicit.
+- Fixing ordering problems by hardcoding concrete module names in generic layers.
+
+## Practical checklist
+
+Before merging an ordering-sensitive change, verify:
+
+- the order is explicit;
+- the order is deterministic;
+- the order is covered by tests;
+- the feature can still be omitted by dialect composition;
+- restricted dialects do not gain the feature accidentally;
+- compiler and interpreter results still match when both backends are enabled.
+
+## Next
+
+Continue with [Testing a Module](/write-modules/testing-module).

--- a/docs/write-modules/parser-extension.md
+++ b/docs/write-modules/parser-extension.md
@@ -5,22 +5,179 @@ description: Show how parser behavior is extended.
 
 # Parser Extension
 
-<div class="placeholder-box">
+Parser extensions turn token streams into AST structure.
 
-This page is a documentation placeholder.
+A module that introduces syntax should register parser node creators through its frontend module. Parser behavior is part of the language contract, not a local implementation detail.
 
-**Purpose:** Show how parser behavior is extended.
+## When to read this page
 
-</div>
+Read this page when a feature needs new syntax shape: operators, declarations, conditions, loops, function calls or grouped constructs.
 
-## What this page should explain
+## Goal
 
-- The practical goal of this topic.
-- The minimal example a developer should run or read.
-- The important concepts needed before going deeper.
-- Links to the next page for gradual learning.
+Understand how parser node creators should be registered, prioritized and tested.
 
-## Status
+## Where parser extensions are registered
 
-Content is not written yet.
+A frontend module registers parser node creators in `InitParser`:
 
+```csharp
+public void InitParser(IParser parser) => parser.AddNodeCreators(...);
+```
+
+For example, arithmetic registers operator node creators with explicit priorities:
+
+```csharp
+private static readonly IReadOnlyList<NodeCreatorRegistration> _nodeCreatorRegistrations =
+[
+    new(-40f, new UnaryMinusOperationNodeCreator()),
+    new(-31f, new MultiplicationOperationNodeCreator()),
+    new(-31f, new DivisionOperationNodeCreator()),
+    new(-30f, new AdditionOperationNodeCreator()),
+    new(-30f, new SubtractionOperationNodeCreator())
+];
+```
+
+The exact priority values are implementation details, but the idea is important: parser ordering is deliberate.
+
+## What a node creator owns
+
+A node creator should own one syntax pattern or one tightly related family of patterns.
+
+Examples:
+
+- arithmetic operator creators own binary arithmetic expressions;
+- variable creators own `let` declaration and assignment forms;
+- loop creators own `while` and `for` forms;
+- condition creators own conditional expression forms.
+
+A node creator should not become a generic fallback that guesses what unrelated syntax means.
+
+## Priority is semantic
+
+Priority decides how overlapping parser candidates are applied. Treat it as part of the grammar design.
+
+Good priority work:
+
+- explains why the feature belongs before or after nearby syntax;
+- has tests for precedence and grouping;
+- has negative tests for malformed syntax;
+- avoids changing existing priorities unless the intended grammar change is clear.
+
+Bad priority work:
+
+- copying a nearby priority until one test passes;
+- using priority to hide an ambiguous syntax design;
+- fixing one construct by making another construct parse differently;
+- relying on reflection or registration order instead of explicit priority.
+
+## Minimal examples to test
+
+For arithmetic precedence:
+
+```wist
+2 + 3 * 4
+```
+
+Expected result:
+
+```text
+14
+```
+
+For grouping:
+
+```wist
+(2 + 3) * 4
+```
+
+Expected result:
+
+```text
+20
+```
+
+For variables:
+
+```wist
+let x = 5
+x = x + 1
+x
+```
+
+Expected result:
+
+```text
+6
+```
+
+For loops:
+
+```wist
+let sum = 0
+let i = 1
+
+while (i <= 5) (
+    sum = sum + i
+    i = i + 1
+)
+
+sum
+```
+
+Expected result:
+
+```text
+15
+```
+
+These examples are useful because they exercise interaction between parser extensions, not only one isolated token.
+
+## Syntax ownership rule
+
+Syntax must be owned by the lexer/parser/AST path.
+
+Do not add behavior like this:
+
+```text
+raw source contains "some keyword"
+  -> bypass parser
+  -> create semantics manually
+```
+
+That kind of shortcut breaks dialect composition and makes feature ownership unclear.
+
+## Dependency awareness
+
+Parser extensions often depend on other modules:
+
+- variable syntax needs identifiers;
+- loops usually need variables and comparisons to be useful;
+- conditional expressions need equality or comparison modules depending on the condition;
+- function calls need both call syntax and a runtime call target surface.
+
+Document these dependencies in the feature page or module reference. Also test that the feature is unavailable when the owning module is omitted.
+
+## What to test
+
+A parser extension should have tests for:
+
+- the smallest valid syntax;
+- a realistic multi-line example;
+- malformed syntax;
+- precedence or priority conflicts;
+- grouped syntax;
+- disabled dialect behavior;
+- compiler/interpreter parity when the feature has runtime semantics.
+
+## Common mistakes
+
+- Treating parser priority as a random number.
+- Adding node creators without negative tests.
+- Letting a node creator mutate unrelated ancestor nodes.
+- Recovering missing AST structure later during bytecode generation.
+- Making a generic parser layer aware of concrete module syntax.
+
+## Next
+
+Continue with [AST Nodes](/write-modules/ast-nodes).

--- a/docs/write-modules/semantic-tags.md
+++ b/docs/write-modules/semantic-tags.md
@@ -5,22 +5,142 @@ description: Explain why bytecode tags exist and how they support later stages.
 
 # Semantic Tags
 
-<div class="placeholder-box">
+Semantic tags are stable names that let later pipeline stages understand what kind of syntax or operation a node or instruction represents.
 
-This page is a documentation placeholder.
+They are useful only when they are owned, documented and tested. A tag should not become a magic string copied across unrelated files.
 
-**Purpose:** Explain why bytecode tags exist and how they support later stages.
+## When to read this page
 
-</div>
+Read this page when a feature needs a new AST node category, bytecode instruction kind, optimizer marker or backend-recognized operation.
 
-## What this page should explain
+## Goal
 
-- The practical goal of this topic.
-- The minimal example a developer should run or read.
-- The important concepts needed before going deeper.
-- Links to the next page for gradual learning.
+Understand how tags support modular lowering without turning the system into a set of stringly typed shortcuts.
 
-## Status
+## What tags are for
 
-Content is not written yet.
+A semantic tag can help answer questions such as:
 
+- is this AST node an arithmetic operation?
+- is this node a loop construct?
+- should this instruction be considered by an optimizer?
+- does this backend support this lowered operation?
+
+Tags make feature ownership visible to the pipeline.
+
+## What tags are not for
+
+Tags should not be used to hide missing architecture.
+
+Do not use tags as:
+
+- undocumented magic strings;
+- hidden activation switches;
+- replacements for dialect selection;
+- replacements for parser/AST ownership;
+- backend-specific shortcuts exposed as general frontend semantics.
+
+## Ownership rule
+
+Every tag should have an owner.
+
+The owner should define:
+
+- where the tag is introduced;
+- what shape or instruction it describes;
+- which visitors or processors consume it;
+- which dialect/module enables it;
+- which tests prove it behaves correctly.
+
+If no module clearly owns a tag, the design is probably too implicit.
+
+## Stable names
+
+Tags and token names often become contracts between stages. Once parser code, visitors, optimizers or backends depend on a name, changing it can break behavior far away from the module that introduced it.
+
+Prefer:
+
+```text
+module-owned constants or centralized registration lists
+```
+
+over:
+
+```text
+repeated string literals in unrelated layers
+```
+
+This does not mean every internal name is public API. It means cross-stage names should be deliberate.
+
+## Producer and consumer tests
+
+A tag needs at least one producer and one consumer.
+
+For example:
+
+```text
+parser node creator produces an AST node tag
+  -> AST visitor consumes that tag
+  -> bytecode instruction is emitted
+  -> backend executes it
+```
+
+Tests should cover the chain. A tag that is produced but never consumed is dead metadata. A consumer that relies on a tag no test produces is a hidden coupling risk.
+
+## Tags and optimizers
+
+Optimizers may use tags to identify operations that can be folded, normalized or lowered into native forms.
+
+That creates an extra obligation:
+
+- the optimizer must preserve semantics;
+- the backend must support the optimized shape;
+- unsupported backend paths must not receive backend-specific operations;
+- the original unoptimized path must still be correct.
+
+## Tags and dialects
+
+A tag does not enable a feature by itself. Dialect selection does.
+
+Correct model:
+
+```text
+dialect selects module
+  -> module registers parser/visitor behavior
+  -> parser/visitor produces and consumes tags
+```
+
+Incorrect model:
+
+```text
+tag exists somewhere
+  -> feature becomes available implicitly
+```
+
+The second model makes restricted dialects unreliable.
+
+## What to document
+
+For a new tag, document:
+
+- the owning module;
+- the syntax or semantic concept it represents;
+- where it is produced;
+- where it is consumed;
+- backend support expectations;
+- optimizer interaction, if any.
+
+This can live in the module page, reference page or tests, depending on how public the feature is.
+
+## Common mistakes
+
+- Copying tag names by string literal across many files.
+- Adding a tag without a consumer test.
+- Letting an optimizer introduce tags a backend does not support.
+- Using tags to bypass dialect composition.
+- Reusing a tag for two unrelated meanings.
+- Treating tag presence as proof that semantics are implemented.
+
+## Next
+
+Continue with [Ordering and Priority](/write-modules/ordering-and-priority).

--- a/docs/write-modules/testing-module.md
+++ b/docs/write-modules/testing-module.md
@@ -5,22 +5,193 @@ description: Show module-level and parity tests.
 
 # Testing a Module
 
-<div class="placeholder-box">
+A module is not complete when one example runs. It is complete when its syntax, composition boundary, runtime behavior and backend support are tested.
 
-This page is a documentation placeholder.
+Module tests protect the project from silent architecture drift: hardcoded syntax, accidental full-profile dependencies, backend-only behavior and optimizer-specific semantics.
 
-**Purpose:** Show module-level and parity tests.
+## When to read this page
 
-</div>
+Read this page before opening a PR that adds or changes a language feature module.
 
-## What this page should explain
+## Goal
 
-- The practical goal of this topic.
-- The minimal example a developer should run or read.
-- The important concepts needed before going deeper.
-- Links to the next page for gradual learning.
+Build a test set that proves the module works when selected and disappears when omitted.
 
-## Status
+## Test categories
 
-Content is not written yet.
+A non-trivial module should usually have tests for:
 
+| Test category | What it proves |
+|---|---|
+| Lexer/parser ownership | syntax is recognized by the owning module |
+| Positive execution | a valid program runs |
+| Negative syntax | malformed source fails deterministically |
+| Dialect selection | the feature exists only when selected |
+| Backend availability | unsupported modes fail explicitly |
+| Backend parity | compiler and interpreter agree when both are supported |
+| Optimizer safety | optimizers preserve behavior |
+| Composition determinism | module order and runtime surface are stable |
+
+Do not collapse all of these into one smoke test.
+
+## Positive execution
+
+Start with the smallest valid example.
+
+For variables:
+
+```wist
+let x = 10
+x
+```
+
+Expected result:
+
+```text
+10
+```
+
+Then add a realistic example:
+
+```wist
+let x = 5
+x = x + 1
+x
+```
+
+Expected result:
+
+```text
+6
+```
+
+The first test proves declaration and lookup. The second test proves mutation.
+
+## Negative syntax
+
+Every parser feature needs malformed input tests.
+
+Examples:
+
+```wist
+let
+```
+
+```wist
+while
+```
+
+```wist
+if 2 == 2 (1)
+```
+
+The exact expected diagnostic may change while internals evolve. For high-level module tests, it is often enough to assert deterministic failure in both supported backends, unless a stable diagnostic contract already exists.
+
+## Dialect selection tests
+
+A module should be selectable and omittable through dialect composition.
+
+If `Variables` is omitted, this should not behave like valid variable syntax:
+
+```wist
+let x = 1
+x
+```
+
+If `Loops` is omitted, loop syntax should not be available. If `CSharpInterop` is omitted, interop expressions should not be available.
+
+This prevents restricted dialects from accidentally growing into full Wist.
+
+## Backend parity tests
+
+When both interpreter and compiler are available, run the same source through both and compare observable results.
+
+Useful parity cases:
+
+```wist
+2 + 3 * 4
+```
+
+```wist
+let x = 5
+x = x + 1
+x
+```
+
+```wist
+if 2 == 2 (1) else (2)
+```
+
+```wist
+let sum = 0
+let i = 1
+
+while (i <= 5) (
+    sum = sum + i
+    i = i + 1
+)
+
+sum
+```
+
+Choose examples that belong to the module and its documented dependencies.
+
+## Backend availability tests
+
+If a dialect exposes only `interpreter`, asking for `compiler` should fail.
+
+If a dialect exposes only `cil`, asking for `interpreter` should fail.
+
+Do not silently fall back to another backend. Silent fallback hides composition and backend-support errors.
+
+## Optimizer safety tests
+
+When a module interacts with optimizers, test behavior before and after optimization when possible.
+
+The optimizer should not be required to make the feature correct. It may improve or normalize execution, but the base lowering must already represent valid semantics.
+
+For backend-specific optimizers, also test that backend-specific intrinsics are not exposed to unsupported backends.
+
+## Composition determinism tests
+
+Module composition should be deterministic:
+
+```text
+same dialect
+  -> same selected modules
+  -> same ordering
+  -> same runtime surface
+```
+
+Tests should catch unexpected modules, order changes that affect behavior and accidental inclusion of unsafe or unrelated features in restricted dialects.
+
+## What not to rely on
+
+Do not rely only on:
+
+- the demo application;
+- README examples;
+- benchmark output;
+- one happy-path source file;
+- compiler mode only;
+- full-default dialect only.
+
+A module that works only in a broad profile may still be incorrectly integrated.
+
+## Suggested PR checklist
+
+Before merging a module PR, verify:
+
+- syntax is module-owned;
+- parser priority is intentional;
+- AST visitors self-filter;
+- bytecode generation follows stack discipline;
+- disabled dialects reject the feature;
+- both backends are covered when supported;
+- optimizer behavior is covered when relevant;
+- restricted dialects remain restricted;
+- no generic framework layer branches on concrete module names.
+
+## Next
+
+Continue with [Internals](/internals/) only when you need deeper details about the execution pipeline. For most feature work, the module authoring pages and tests should be enough for the first pass.


### PR DESCRIPTION
## Summary

This PR replaces placeholder pages in the `Writing Modules` section with practical module authoring documentation.

Updated pages:

- `docs/write-modules/frontend-module.md`
- `docs/write-modules/parser-extension.md`
- `docs/write-modules/ast-nodes.md`
- `docs/write-modules/bytecode-generation.md`
- `docs/write-modules/semantic-tags.md`
- `docs/write-modules/ordering-and-priority.md`
- `docs/write-modules/testing-module.md`

## What changed

- Documents the expected frontend module shape and responsibilities.
- Explains parser extension ownership, parser priority, and syntax ownership rules.
- Adds AST node ownership guidance and visitor self-filtering rules.
- Documents bytecode lowering discipline, stack behavior, and backend parity expectations.
- Explains semantic tags as owned pipeline contracts rather than magic strings.
- Adds guidance for deterministic ordering, parser priority, visitor order, and optimizer order.
- Adds a practical module testing checklist covering positive cases, negative syntax, dialect selection, backend availability, parity, optimizer safety, and composition determinism.

## Scope

Documentation-only change. No runtime code, VitePress config, sidebar, theme, or architecture changes.

This intentionally avoids deeper internals pages; those should be handled in a later, more code-verified pass.