### PR TITLE
docs: clarify Wist loop syntax

### DIFF
--- a/docs/wist/examples.md
+++ b/docs/wist/examples.md
@@ -135,7 +135,7 @@ Program:
 let sum = 0
 let i = 1
 
-while (i <= 5) (
+while i <= 5 (
     sum = sum + i
     i = i + 1
 )
@@ -148,6 +148,8 @@ Expected result:
 ```text
 15
 ```
+
+The `while` condition does not have to be parenthesized when it parses as one expression node. The loop body remains grouped because it contains multiple operations.
 
 Typical modules:
 
@@ -177,7 +179,7 @@ Expected result:
 15
 ```
 
-This is the shipped `full-default` example shape. It is useful for validating a broader Wist dialect over both interpreter and compiler modes.
+This is the shipped `full-default` example shape. It is useful for validating a broader Wist dialect over both interpreter and compiler modes. The current `for` parser expects initialization, condition, update and body to be grouped.
 
 ## Nested loop aggregate
 
@@ -187,9 +189,9 @@ Program:
 let total = 0
 let outer = 1
 
-while (outer <= 3) (
+while outer <= 3 (
     let inner = 1
-    while (inner <= 2) (
+    while inner <= 2 (
         total = total + (outer * inner)
         inner = inner + 1
     )
@@ -242,6 +244,7 @@ Use the smallest example that proves the concept:
 - Using a broad full-default example to document a restricted DSL.
 - Showing interop in user-facing formula documentation.
 - Using loop examples before explaining variables and comparisons.
+- Treating parenthesized `while` conditions as the only valid form.
 - Forgetting to mention which dialect or modules make an example valid.
 - Treating examples as complete language specification.
 

--- a/docs/wist/loops.md
+++ b/docs/wist/loops.md
@@ -25,7 +25,7 @@ A `while` loop repeats while its condition remains satisfied:
 let sum = 0
 let i = 1
 
-while (i <= 5) (
+while i <= 5 (
     sum = sum + i
     i = i + 1
 )
@@ -41,6 +41,17 @@ Expected result:
 
 This program sums numbers from 1 to 5.
 
+The condition does not have to be wrapped in parentheses when it parses as one expression node. The parser builds the `while` node from the next AST node as the condition and the following AST node as the body. Parentheses around the condition are still allowed and can be used for readability:
+
+```wist
+while (i <= 5) (
+    sum = sum + i
+    i = i + 1
+)
+```
+
+For multi-operation loop bodies, keep the body grouped with parentheses.
+
 ## Zero-iteration loop
 
 If the condition is not satisfied initially, the body is not executed:
@@ -49,7 +60,7 @@ If the condition is not satisfied initially, the body is not executed:
 let marker = 17
 let i = 10
 
-while (i < 10) (
+while i < 10 (
     marker = marker + 100
     i = i + 1
 )
@@ -91,7 +102,7 @@ The `for` loop groups initialization, condition, update and body:
 for (initialization) (condition) (update) (body)
 ```
 
-Use this as the canonical documented shape for current Wist `for` syntax.
+Use this as the canonical documented shape for current Wist `for` syntax. Unlike `while`, the current `for` parser expects the initialization, condition, update and body to be grouped as scopes.
 
 ## Required modules
 
@@ -121,6 +132,7 @@ For a dialect that enables loops, test:
 - normal loop execution;
 - zero iterations;
 - mutation of a loop variable;
+- parenthesized and unparenthesized `while` conditions when both are intended to remain valid;
 - nested loops if they are supported by the intended dialect;
 - malformed loop syntax;
 - compiler/interpreter parity when both backends are exposed.
@@ -128,6 +140,7 @@ For a dialect that enables loops, test:
 ## Common mistakes
 
 - Adding `Loops` without the variable and comparison modules required by the loop body.
+- Assuming `while` requires a parenthesized condition.
 - Forgetting to update the loop variable.
 - Using loops in a restricted formula DSL when a simpler expression would be enough.
 - Testing only the happy path and missing zero-iteration behavior.

--- a/docs/wist/scopes.md
+++ b/docs/wist/scopes.md
@@ -5,9 +5,9 @@ description: Explain block scopes and variable visibility.
 
 # Scopes
 
-Scopes and grouped expressions help Wist organize nested syntax such as conditions and loops.
+Scopes and grouped expressions help Wist organize nested syntax such as conditions and loop bodies.
 
-In current Wist examples, parentheses are used heavily for grouping: arithmetic precedence, conditional result expressions, loop conditions and loop bodies.
+In current Wist examples, parentheses are used heavily for grouping: arithmetic precedence, conditional result expressions, loop bodies and the grouped parts of `for` loops. Some constructs, such as `while` conditions, can also accept an unparenthesized expression when it parses as a single AST node.
 
 ## When to read this page
 
@@ -73,7 +73,7 @@ Loop bodies are grouped with parentheses:
 let sum = 0
 let i = 1
 
-while (i <= 5) (
+while i <= 5 (
     sum = sum + i
     i = i + 1
 )
@@ -89,6 +89,15 @@ Expected result:
 
 The grouped body contains multiple operations: update the accumulator and update the loop variable.
 
+The `while` condition above is not wrapped in parentheses because it already parses as one expression node. Parenthesized conditions are also valid and may be clearer in longer examples:
+
+```wist
+while (i <= 5) (
+    sum = sum + i
+    i = i + 1
+)
+```
+
 ## Variables and grouped bodies
 
 A grouped body often reads and writes variables declared before the body:
@@ -97,9 +106,9 @@ A grouped body often reads and writes variables declared before the body:
 let total = 0
 let outer = 1
 
-while (outer <= 3) (
+while outer <= 3 (
     let inner = 1
-    while (inner <= 2) (
+    while inner <= 2 (
         total = total + (outer * inner)
         inner = inner + 1
     )
@@ -140,6 +149,7 @@ When changing scope-related behavior, test:
 - arithmetic grouping;
 - grouped conditional expressions;
 - loop bodies with multiple operations;
+- parenthesized and unparenthesized `while` conditions when both forms should remain accepted;
 - nested loops or nested conditional groups;
 - variable declarations inside grouped bodies;
 - compiler/interpreter parity.
@@ -147,6 +157,7 @@ When changing scope-related behavior, test:
 ## Common mistakes
 
 - Treating parentheses as plain text delimiters outside the parser/AST pipeline.
+- Assuming every `while` condition must be parenthesized.
 - Assuming grouped loop bodies work without `Loops`, `Variables` and comparison modules.
 - Testing only flat expressions and missing nested grouped behavior.
 - Documenting stronger scope guarantees than the current tests prove.

--- a/docs/wist/syntax-tour.md
+++ b/docs/wist/syntax-tour.md
@@ -84,7 +84,7 @@ A `while` loop:
 let sum = 0
 let i = 1
 
-while (i <= 5) (
+while i <= 5 (
     sum = sum + i
     i = i + 1
 )
@@ -97,6 +97,8 @@ Expected result:
 ```text
 15
 ```
+
+For `while`, the condition can be written without parentheses when it parses as one expression node. Parentheses are still allowed for readability. Multi-operation loop bodies should remain grouped.
 
 Loops require the `Loops` module plus variables, comparison and arithmetic support.
 
@@ -120,7 +122,7 @@ Expected result:
 15
 ```
 
-Use this example as the canonical reference for current `for` syntax.
+Use this example as the canonical reference for current `for` syntax. The current `for` parser expects initialization, condition, update and body to be grouped.
 
 ### 6. Comments
 
@@ -168,6 +170,7 @@ Each syntax feature is introduced by one or more modules. Modules register lexer
 
 - Trying to use variables in a dialect that omits `Variables` or `Identifier`.
 - Trying to use loops in a dialect that omits `Loops`.
+- Treating the parenthesized `while` condition examples as the only valid form.
 - Using `compiler` mode with a dialect that only exposes `interpreter`.
 - Assuming restricted dialects are hardened sandboxes. They constrain composition, but process isolation is still required for untrusted execution.
 

--- a/docs/wist/variables.md
+++ b/docs/wist/variables.md
@@ -124,7 +124,7 @@ Variables are commonly used as loop counters and accumulators:
 let sum = 0
 let i = 1
 
-while (i <= 5) (
+while i <= 5 (
     sum = sum + i
     i = i + 1
 )
@@ -138,7 +138,7 @@ Expected result:
 15
 ```
 
-This requires variables plus loop and comparison support.
+This requires variables plus loop and comparison support. Parentheses around the `while` condition are optional when the condition parses as one expression node.
 
 ## Common mistakes
 

--- a/docs/write-modules/parser-extension.md
+++ b/docs/write-modules/parser-extension.md
@@ -117,7 +117,7 @@ For loops:
 let sum = 0
 let i = 1
 
-while (i <= 5) (
+while i <= 5 (
     sum = sum + i
     i = i + 1
 )
@@ -129,6 +129,15 @@ Expected result:
 
 ```text
 15
+```
+
+Also test the parenthesized form if both variants are intended to remain valid:
+
+```wist
+while (i <= 5) (
+    sum = sum + i
+    i = i + 1
+)
 ```
 
 These examples are useful because they exercise interaction between parser extensions, not only one isolated token.
@@ -167,6 +176,7 @@ A parser extension should have tests for:
 - malformed syntax;
 - precedence or priority conflicts;
 - grouped syntax;
+- optional grouping variants when the parser accepts more than one form;
 - disabled dialect behavior;
 - compiler/interpreter parity when the feature has runtime semantics.
 

--- a/docs/write-modules/testing-module.md
+++ b/docs/write-modules/testing-module.md
@@ -126,12 +126,21 @@ if 2 == 2 (1) else (2)
 let sum = 0
 let i = 1
 
-while (i <= 5) (
+while i <= 5 (
     sum = sum + i
     i = i + 1
 )
 
 sum
+```
+
+For loop modules, also include the parenthesized `while` condition form if both parser shapes are intended to remain valid:
+
+```wist
+while (i <= 5) (
+    sum = sum + i
+    i = i + 1
+)
 ```
 
 Choose examples that belong to the module and its documented dependencies.
@@ -188,6 +197,7 @@ Before merging a module PR, verify:
 - bytecode generation follows stack discipline;
 - disabled dialects reject the feature;
 - both backends are covered when supported;
+- optional syntax variants are documented and tested when they are intentionally accepted;
 - optimizer behavior is covered when relevant;
 - restricted dialects remain restricted;
 - no generic framework layer branches on concrete module names.


### PR DESCRIPTION
## Summary

This PR corrects the Wist documentation around `while` syntax.

The previous wording and examples could imply that `while` conditions must always be parenthesized. The current `WhileNodeCreator` does not require the condition to be a `Scope`; it takes the next AST node as the condition and the following AST node as the body. In contrast, the current `ForNodeCreator` expects the four `for` parts to be grouped as scopes.

## Updated pages

- `docs/wist/loops.md`
- `docs/wist/syntax-tour.md`
- `docs/wist/scopes.md`
- `docs/wist/examples.md`
- `docs/wist/variables.md`
- `docs/write-modules/parser-extension.md`
- `docs/write-modules/testing-module.md`

## What changed

- Uses unparenthesized `while i <= 5 (...)` as the main `while` example.
- Explicitly documents that `while` conditions may be unparenthesized when they parse as one expression node.
- Keeps the grouped body examples because multi-operation bodies still need grouping.
- Keeps `for (init) (condition) (update) (body)` as the canonical documented `for` form because the parser expects those parts to be scopes.
- Adds test guidance for covering both parenthesized and unparenthesized `while` conditions when both forms should remain accepted.

## Scope

Documentation-only correction. No runtime code, VitePress config, sidebar, theme, or architecture changes.