### PR TITLE
docs: fill internals foundation

### DIFF
--- a/docs/internals/air.md
+++ b/docs/internals/air.md
@@ -5,22 +5,154 @@ description: Explain Abstract IR and backend-independent lowering.
 
 # AIR
 
-<div class="placeholder-box">
+AIR means Abstract Intermediate Representation.
 
-This page is a documentation placeholder.
+It is the backend-facing instruction stream produced from bytecode after method/operation conversion and before backend compilation or interpretation.
 
-**Purpose:** Explain Abstract IR and backend-independent lowering.
+## Place in the pipeline
 
-</div>
+AIR is produced after bytecode post-processing and before IR optimizers/backend compilation:
 
-## What this page should explain
+```text
+modules.ProcessBytecode
+  -> optimizers.InitMethodsTranslator
+  -> optimizers.InitIntrinsicCapabilityContext
+  -> methodsTranslator.Translate(bytecode)
+  -> optimizers.ProcessIr
+  -> compiler.Compile
+```
 
-- The practical goal of this topic.
-- The minimal example a developer should run or read.
-- The important concepts needed before going deeper.
-- Links to the next page for gradual learning.
+The backend consumes AIR, not source text, tokens or AST nodes.
 
-## Status
+## Current instruction model
 
-Content is not written yet.
+The core AIR instruction set is intentionally small:
 
+| Opcode | Purpose |
+|---|---|
+| `Nop` | no operation |
+| `Push` | push a value onto the runtime stack |
+| `Drop` | drop the top value from the runtime stack |
+| `Jmp` | unconditional jump to a label |
+| `JmpIf` | jump when the popped condition is true |
+| `JmpIfNot` | jump when the popped condition is false |
+| `Label` | mark a jump target |
+| `Annotate` | carry metadata-like annotations |
+| `Intrinsic` | represent an operation handled by an intrinsic executor/compiler |
+
+An AIR instruction stores:
+
+- opcode;
+- operands;
+- metadata;
+- optional comment.
+
+## Generic AIR builder
+
+The generic AIR implementation accumulates instructions and exposes helper methods such as:
+
+```text
+Nop
+Push
+Drop
+Jmp
+JmpIf
+JmpIfNot
+SetLabel
+Annotate
+Intrinsic
+AppendInstructions
+```
+
+This makes AIR simple to construct while keeping the instruction stream explicit.
+
+## Bytecode-to-AIR conversion
+
+The current bytecode-to-AIR converter does not simply rename bytecode instructions.
+
+It walks through:
+
+```text
+bytecode instructions
+  -> instruction operations
+  -> convertable operation fragments
+  -> convertable.GetAbstractIR(context)
+  -> append generated AIR instructions
+  -> apply type-stack effects
+```
+
+The converter maintains a type stack while converting. After generated AIR instructions are appended, `InstructionTypeStackApplier` applies the type effects of those instructions.
+
+This is important for later optimizer and backend correctness.
+
+## Stack behavior
+
+AIR is stack-oriented for values.
+
+Examples:
+
+- `Push` adds a value to the stack;
+- `Drop` removes a value;
+- `JmpIf` and `JmpIfNot` consume a boolean condition;
+- `Intrinsic` behavior depends on the intrinsic identifier and operands.
+
+Backends must preserve the same observable stack behavior.
+
+## Control flow
+
+Control flow uses labels and jumps:
+
+```text
+Label(id)
+Jmp(id)
+JmpIf(id)
+JmpIfNot(id)
+```
+
+The interpreter resolves label positions before execution. The CIL backend defines and marks IL labels while compiling AIR.
+
+## Intrinsics
+
+`Intrinsic` represents operations that are not covered by the small fixed opcode set.
+
+This does not mean every backend supports every intrinsic. Intrinsic support is a backend capability and must be checked before optimizers or emitters produce backend-specific intrinsic forms.
+
+## Optimizer boundary
+
+Optimizers run on AIR after bytecode-to-AIR translation.
+
+A valid optimizer:
+
+- preserves observable semantics;
+- respects backend capability sets;
+- does not make base semantics depend on optimization;
+- does not emit intrinsic forms unsupported by the selected backend.
+
+## AIR vs. backend-specific IR
+
+AIR is backend-facing but should not become one backend's private representation.
+
+For example, the CIL backend may simulate stack types and emit `DynamicMethod` IL, but AIR itself should remain readable by interpreter and compiler paths when both are supported.
+
+## Common mistakes
+
+- Treating `Intrinsic` as automatically supported by all backends.
+- Adding optimizer output without checking backend capabilities.
+- Assuming AIR is source-level syntax.
+- Relying on comments or annotations for required semantics.
+- Changing stack behavior without interpreter/compiler parity tests.
+
+## What to test
+
+AIR-affecting changes should test:
+
+- opcode shape and operands;
+- stack effects;
+- label/jump behavior;
+- intrinsic support boundaries;
+- optimized and unoptimized behavior where possible;
+- interpreter/compiler parity when both backends support the dialect.
+
+## Next
+
+Continue with [Backends](/internals/backends).

--- a/docs/internals/ast.md
+++ b/docs/internals/ast.md
@@ -5,22 +5,145 @@ description: Explain AST structure and translation responsibilities.
 
 # AST
 
-<div class="placeholder-box">
+The AST is the source-oriented structure produced by the parser.
 
-This page is a documentation placeholder.
+It represents parsed language constructs before they are lowered into bytecode. This makes the AST the boundary between grammar ownership and executable semantics.
 
-**Purpose:** Explain AST structure and translation responsibilities.
+## Place in the pipeline
 
-</div>
+AST processing happens between parser output and binding/translation:
 
-## What this page should explain
+```text
+parser.Parse
+  -> modules.ProcessAst
+  -> Binder
+  -> modules.InitAstTranslator
+  -> astTranslator.Translate
+```
 
-- The practical goal of this topic.
-- The minimal example a developer should run or read.
-- The important concepts needed before going deeper.
-- Links to the next page for gradual learning.
+The AST should describe what the program says. It should not encode a concrete backend strategy.
 
-## Status
+## Current AST construction
 
-Content is not written yet.
+The current parser starts by converting every lexeme into an AST node. These nodes are initially flat children under a `Program` root.
 
+Parser node creators then reorganize those nodes into structured AST shapes:
+
+```text
+flat lexeme-derived nodes
+  -> parser node creators
+  -> structured AST
+  -> tree validation
+```
+
+The exact shape depends on selected modules and parser creators.
+
+## Module-owned nodes
+
+A module that introduces syntax should also own the AST shape for that syntax.
+
+Examples:
+
+- arithmetic modules own arithmetic operation nodes;
+- variable modules own declaration and assignment shapes;
+- condition modules own conditional shapes;
+- loop modules own loop shapes.
+
+A later pipeline stage should not have to rediscover the syntax by scanning source text or guessing from unrelated child layouts.
+
+## AST post-processing
+
+Frontend modules can transform the AST through `ProcessAst`.
+
+This hook should be used for AST-level normalization only. It should not be used to implement missing parser behavior or backend-specific lowering.
+
+Good uses:
+
+- normalize module-owned tree shape;
+- combine related AST nodes when that is an AST concern;
+- validate feature-owned shape before translation.
+
+Bad uses:
+
+- parse raw source text;
+- emit bytecode semantics;
+- insert backend-specific execution details;
+- repair syntax that should have been handled by node creators.
+
+## Binding
+
+After AST post-processing, the pipeline applies external bindings through `Binder`.
+
+This means AST visitors receive a bound tree. They should not independently reinterpret runtime parameters or merge external input values with local variable storage.
+
+The boundary is important:
+
+- external bindings come from the host/program input boundary;
+- local variables come from program semantics;
+- bytecode visitors should preserve that distinction.
+
+## AST-to-bytecode visitors
+
+Modules register AST visitors through `InitAstTranslator`.
+
+The current translator gives registered visitors a chance to inspect nodes. Therefore visitors must self-filter:
+
+```text
+if this node is not mine
+  -> return without emitting
+else
+  -> translate children and emit owned semantics
+```
+
+A visitor that emits for unrelated nodes can double-emit bytecode or consume another module's syntax.
+
+## Child translation
+
+Visitors often translate children before emitting the parent operation.
+
+For expression-like constructs, this usually means:
+
+```text
+translate child expressions
+  -> emit operation for parent node
+```
+
+The order is semantically important because bytecode and AIR are stack-oriented in many paths.
+
+## Current implementation detail
+
+The basic AST-to-bytecode translator creates one `Bytecode` instance for the translation request and uses a request-local translator wrapper to visit nodes.
+
+This keeps the bytecode output shared across recursive visitor calls without making bytecode global state.
+
+## What AST docs should not overclaim
+
+Do not document every current node layout as a stable public language contract unless tests explicitly protect it.
+
+It is safe to document:
+
+- which module owns a syntax family;
+- which broad shape the feature uses;
+- which visitor consumes it;
+- which invariants must hold.
+
+It is risky to document:
+
+- incidental child indexes without tests;
+- parser implementation quirks as language guarantees;
+- backend-specific expectations as AST requirements.
+
+## What to test
+
+AST-related changes should test:
+
+- valid source produces executable behavior;
+- malformed AST shapes fail before incorrect bytecode is emitted;
+- visitors self-filter;
+- nested constructs preserve intended structure;
+- binding does not confuse external inputs with local variables;
+- interpreter/compiler parity remains intact when AST shape changes.
+
+## Next
+
+Continue with [Bytecode](/internals/bytecode).

--- a/docs/internals/backends.md
+++ b/docs/internals/backends.md
@@ -5,22 +5,150 @@ description: Explain interpreter and CIL execution backends.
 
 # Backends
 
-<div class="placeholder-box">
+Backends consume AIR and produce executable behavior.
 
-This page is a documentation placeholder.
+Current Wist runtime paths are centered around two backend styles:
 
-**Purpose:** Explain interpreter and CIL execution backends.
+- interpreter execution over AIR;
+- CIL compilation into a `DynamicMethod`.
 
-</div>
+## Place in the pipeline
 
-## What this page should explain
+Backends run after AIR translation and IR optimization:
 
-- The practical goal of this topic.
-- The minimal example a developer should run or read.
-- The important concepts needed before going deeper.
-- Links to the next page for gradual learning.
+```text
+methodsTranslator.Translate(bytecode)
+  -> optimizers.ProcessIr
+  -> middleEndModules.InitMethodsCompiler
+  -> compiler.Compile
+  -> middleEndModules.ProcessCompilation
+  -> middleEndModules.InitExecutor
+```
 
-## Status
+A backend should not parse source text or reinterpret frontend syntax. It consumes AIR.
 
-Content is not written yet.
+## Shared backend contract
 
+A backend must preserve AIR semantics.
+
+This includes:
+
+- stack behavior;
+- labels and jumps;
+- intrinsic behavior that the backend declares as supported;
+- external binding shape;
+- final result behavior.
+
+When two backends are exposed for the same dialect, they should produce the same observable result for the same source and runtime inputs.
+
+## Interpreter backend
+
+The interpreter executes AIR instruction by instruction.
+
+Current behavior:
+
+1. create an `InterpreterState`;
+2. attach the execution environment;
+3. build label positions from AIR instructions;
+4. execute instructions while the instruction pointer is inside the instruction list;
+5. return `null` when the value stack is empty;
+6. otherwise return the top value on the stack.
+
+Supported instruction behavior includes:
+
+| Opcode | Interpreter behavior |
+|---|---|
+| `Nop` | no operation |
+| `Push` | push operand value |
+| `Drop` | pop a value when present |
+| `Jmp` | set instruction pointer to label position |
+| `JmpIf` | pop condition and jump if true |
+| `JmpIfNot` | pop condition and jump if false |
+| `Label` | no direct runtime action |
+| `Annotate` | no direct runtime action |
+| `Intrinsic` | delegate to interpreter intrinsic executor |
+
+The interpreter is useful as a semantic reference because its behavior maps directly to AIR instructions.
+
+## CIL backend
+
+The CIL backend compiles AIR into a `DynamicMethod`.
+
+Current behavior:
+
+1. simulate AIR stack types to determine return type;
+2. create a `DynamicMethod` named `main`;
+3. pass `IExecutionEnvironment` as the first argument;
+4. add external binding types as additional arguments;
+5. initialize labels and label stack states;
+6. compile each AIR instruction into IL;
+7. emit a method return compatible with the simulated return type.
+
+The CIL backend is not just a faster interpreter. It has its own compilation contract and type-stack simulation path.
+
+## CIL constants
+
+For `Push`, the current CIL backend stores pushed constant values in a generic static holder and emits IL to load them by index.
+
+This is an implementation detail. Do not document it as a public API contract, but keep it in mind when analyzing global state and compiled artifact behavior.
+
+## Intrinsic support
+
+Backends do not automatically support every intrinsic.
+
+The CIL compiler exposes a supported intrinsic list through its registry. Optimizers and intrinsic policies must respect backend capability sets before producing backend-specific forms.
+
+If an intrinsic is unsupported by a selected backend, the correct behavior is explicit failure or rejection, not silent fallback to another backend.
+
+## Backend availability vs. backend parity
+
+These are separate concerns:
+
+- **availability**: whether a dialect exposes a backend at all;
+- **parity**: whether two exposed backends agree on observable behavior.
+
+A dialect may intentionally expose only interpreter or only CIL. In that case, unsupported modes should fail explicitly.
+
+When a dialect exposes both, tests should compare interpreter and CIL results.
+
+## What backends must not own
+
+A backend should not own:
+
+- source syntax;
+- parser node selection;
+- dialect module composition;
+- feature availability decisions outside selected runtime plans;
+- optimizer-only semantics required for correctness.
+
+Backends may own:
+
+- execution of AIR opcodes;
+- compilation of AIR opcodes;
+- backend-specific intrinsic implementation;
+- backend-specific artifact creation;
+- backend-specific type simulation.
+
+## Common mistakes
+
+- Treating interpreter as a silent fallback for failed CIL compilation.
+- Adding CIL support without interpreter parity tests when both backends are exposed.
+- Emitting backend-specific intrinsics before checking backend capability.
+- Assuming `DynamicMethod` behavior defines language semantics.
+- Making a frontend module depend on concrete backend artifact types.
+
+## What to test
+
+Backend-affecting changes should test:
+
+- basic AIR opcode execution;
+- labels and conditional jumps;
+- final result behavior when stack is empty or non-empty;
+- external binding argument shape;
+- supported and unsupported intrinsic paths;
+- interpreter/compiler parity for shared dialects;
+- explicit failure for unavailable backend modes.
+
+## Next
+
+Continue with [Intrinsics](/internals/intrinsics).

--- a/docs/internals/bytecode.md
+++ b/docs/internals/bytecode.md
@@ -5,22 +5,128 @@ description: Explain bytecode as a semantic intermediate layer.
 
 # Bytecode
 
-<div class="placeholder-box">
+Bytecode is the intermediate layer produced from the bound AST before AIR translation.
 
-This page is a documentation placeholder.
+It is where module-owned AST semantics become a more execution-oriented representation while still remaining above backend-specific implementation details.
 
-**Purpose:** Explain bytecode as a semantic intermediate layer.
+## Place in the pipeline
 
-</div>
+Bytecode appears after AST visitors run and before bytecode-to-AIR translation:
 
-## What this page should explain
+```text
+modules.InitAstTranslator
+  -> astTranslator.Translate
+  -> modules.ProcessBytecode
+  -> optimizers.InitMethodsTranslator
+  -> methodsTranslator.Translate(bytecode)
+```
 
-- The practical goal of this topic.
-- The minimal example a developer should run or read.
-- The important concepts needed before going deeper.
-- Links to the next page for gradual learning.
+AST visitors produce bytecode. Modules may then post-process bytecode before AIR is built.
 
-## Status
+## What bytecode is for
 
-Content is not written yet.
+Bytecode provides a shared semantic layer between source-level AST nodes and backend-facing AIR.
 
+It is useful because it can:
+
+- collect feature-owned semantics from multiple modules;
+- preserve structure needed by later conversion;
+- allow bytecode-level validation or normalization;
+- keep backend-specific decisions out of AST nodes;
+- feed a bytecode-to-AIR translator that produces backend-consumable instructions.
+
+## Current translation model
+
+The basic AST-to-bytecode translator:
+
+1. creates a new `Bytecode` instance;
+2. creates a request-local translator wrapper;
+3. asks configured visitors to inspect the current AST node;
+4. lets visitors recursively translate child nodes;
+5. returns the accumulated bytecode.
+
+The bytecode instance is shared for the translation request, not global.
+
+## Visitor responsibility
+
+A visitor that emits bytecode must:
+
+- check whether the current AST node is owned by that visitor;
+- translate children in the correct order;
+- emit only feature-owned operations;
+- leave stack expectations clear for later stages;
+- avoid depending on unrelated visitors unless that cooperation is explicit and tested.
+
+Visitors that do not self-filter are dangerous because multiple visitors can inspect the same node.
+
+## Bytecode post-processing
+
+`IFrontendCoreModule.ProcessBytecode` runs after AST translation.
+
+Use it for bytecode-level work only:
+
+- feature-owned bytecode normalization;
+- validation of feature-owned instruction shapes;
+- removal or rewriting of module-owned intermediate artifacts.
+
+Do not use it to repair parser mistakes, rediscover syntax, or add backend-only behavior that should belong to AIR/backends.
+
+## Bytecode vs. AIR
+
+Bytecode and AIR have different jobs.
+
+| Layer | Main concern |
+|---|---|
+| AST | source syntax structure |
+| Bytecode | module-owned semantic lowering |
+| AIR | backend-facing abstract instruction stream |
+
+Bytecode may still contain higher-level operations or method-like convertables. AIR is the representation that interpreter and compiler paths consume.
+
+## Stack discipline
+
+Many bytecode paths ultimately lower into stack-oriented AIR. Therefore bytecode generation must preserve evaluation order.
+
+For a binary expression, the usual pattern is:
+
+```text
+left expression
+right expression
+operation
+```
+
+If children are translated in the wrong order, interpreter and compiler results can diverge even when both backends compile successfully.
+
+## Relationship with intrinsics
+
+Some bytecode operations lower into intrinsic AIR instructions.
+
+That does not mean bytecode should blindly emit backend-specific intrinsics. Backend capability checks and optimizer policies should happen in the IR/optimizer/backend path, not as hidden frontend assumptions.
+
+## What bytecode docs should not overclaim
+
+The current bytecode model is an internal representation. Do not document incidental implementation details as stable public API unless reference pages and tests make them explicit.
+
+For stable documentation, focus on:
+
+- stage ownership;
+- visitor responsibilities;
+- stack discipline;
+- bytecode-to-AIR boundary;
+- backend parity expectations.
+
+## What to test
+
+Bytecode-affecting changes should test:
+
+- simple feature execution;
+- nested feature execution;
+- interpreter/compiler parity;
+- disabled dialect behavior;
+- bytecode post-processing does not affect unrelated modules;
+- optimizer behavior is not required for base correctness;
+- malformed syntax fails before invalid bytecode becomes valid AIR.
+
+## Next
+
+Continue with [AIR](/internals/air).

--- a/docs/internals/index.md
+++ b/docs/internals/index.md
@@ -5,22 +5,125 @@ description: Give a map of the compiler pipeline and runtime architecture.
 
 # Internals Overview
 
-<div class="placeholder-box">
+This section documents how UniversalToolchain currently works internally.
 
-This page is a documentation placeholder.
+It is written for maintainers, backend authors, module authors and reviewers who need more than the public “source → execution” mental model.
 
-**Purpose:** Give a map of the compiler pipeline and runtime architecture.
+## How to read this section
 
-</div>
+Read internals in this order:
 
-## What this page should explain
+1. [Pipeline](/internals/pipeline) — the real lifecycle from `CompilationInput` to compiled artifact/session.
+2. [Lexer](/internals/lexer) — token recognition, registration order and ignored lexemes.
+3. [Parser](/internals/parser) — AST construction through registered node creators.
+4. [AST](/internals/ast) — source-level structure and visitor responsibilities.
+5. [Bytecode](/internals/bytecode) — feature-owned semantic lowering before AIR.
+6. [AIR](/internals/air) — backend-facing abstract instruction stream.
+7. [Backends](/internals/backends) — interpreter and CIL execution paths.
+8. [Intrinsics](/internals/intrinsics) — intrinsic identifiers, capability checks and type-stack effects.
+9. [Optimizers](/internals/optimizers) — IR transformations and backend capability boundaries.
+10. [Semantic Parity](/internals/semantic-parity) — why interpreter and compiler must agree.
+11. [Dependency Injection](/internals/dependency-injection) — runtime composition and service wiring.
 
-- The practical goal of this topic.
-- The minimal example a developer should run or read.
-- The important concepts needed before going deeper.
-- Links to the next page for gradual learning.
+## What internals are for
 
-## Status
+Internals pages answer questions such as:
 
-Content is not written yet.
+- where a module may extend the pipeline;
+- which stage owns source syntax;
+- when bytecode becomes AIR;
+- what a backend is expected to consume;
+- how optimizer capability checks fit into compilation;
+- why semantic parity tests matter;
+- which parts are current implementation details rather than stable public API.
 
+## Canonical pipeline shape
+
+The current core build path is orchestrated by `PreparedExecutionBuilder<TCompilationOutput>`.
+
+At a high level:
+
+```text
+CompilationInput
+  -> frontend module text/lexeme/AST hooks
+  -> lexer
+  -> parser
+  -> binder
+  -> AST-to-bytecode translation
+  -> bytecode post-processing
+  -> bytecode-to-AIR translation
+  -> IR optimizers
+  -> backend compiler
+  -> middle-end modules
+  -> compiled artifact/session
+```
+
+This is more precise than the simplified public model:
+
+```text
+source -> lexer -> parser -> AST -> bytecode -> AIR -> backend -> result
+```
+
+The simplified model is useful for learning. Internals should use the precise lifecycle.
+
+## Main internal actors
+
+| Actor | Role |
+|---|---|
+| `BasicCoreImpl<TCompilationOutput>` | Public core façade over compile/prepare/run operations. |
+| `PreparedExecutionBuilder<TCompilationOutput>` | Builds compiled artifacts and prepared execution sessions. |
+| `IFrontendCoreModule` | Lets modules participate in text, lexeme, parser, AST and bytecode stages. |
+| `ILexer` | Turns source text into lexeme values. |
+| `IParser` | Turns lexemes into an AST through registered node creators. |
+| `Binder` | Binds external inputs before translation. |
+| `IAstToBytecodeTranslator` | Runs AST visitors and produces bytecode. |
+| `IAbstractMethodsTranslator` | Converts bytecode methods/operations into AIR. |
+| `IIRProcessingModule` | Initializes intrinsic capability context and transforms AIR. |
+| `IAbstractIrCompiler<T>` | Compiles AIR into a backend-specific artifact. |
+| `IMiddleEndCoreModule<T>` | Initializes compiler/executor integration and post-processes compilation output. |
+| `IExecutor<T>` | Executes a compiled artifact/session. |
+
+## Current implementation vs. contract
+
+Internals pages distinguish two kinds of statements:
+
+- **Current implementation** — how the code works today.
+- **Required invariant** — behavior that should be preserved by future changes.
+
+For example:
+
+- current parser implementation builds unknown nodes and rewrites them through node creators;
+- required invariant: parser behavior must remain deterministic and module-owned;
+- current CIL backend compiles AIR into `DynamicMethod`;
+- required invariant: backend output must preserve AIR semantics.
+
+Do not promote an implementation detail into a public guarantee unless tests and architecture rules already support it.
+
+## Strong invariants
+
+When changing internals, preserve these invariants:
+
+- module registration and execution order must be deterministic;
+- syntax must be owned by lexer/parser/AST stages, not recovered from raw text later;
+- visitors must self-filter and emit only owned semantics;
+- bytecode and AIR must remain inspectable enough for tests and optimizers;
+- optimizers must not be required to make base semantics correct;
+- backend-specific intrinsics must not leak into unsupported backends;
+- interpreter and compiled execution must agree when both backends are supported;
+- mutable state must be scoped to compilation/execution unless intentionally global and tested.
+
+## What not to use this section for
+
+This section is not:
+
+- a user tutorial;
+- a complete language specification;
+- a promise that every internal type is stable API;
+- a replacement for tests;
+- a license to depend on undocumented internal ordering.
+
+For user-facing examples, use [Wist Language](/wist/). For authoring guidance, use [Writing Modules](/write-modules/). For tables and contracts, use [Reference](/reference/).
+
+## Next
+
+Start with [Pipeline](/internals/pipeline).

--- a/docs/internals/lexer.md
+++ b/docs/internals/lexer.md
@@ -5,22 +5,107 @@ description: Document lexing responsibilities and extension points.
 
 # Lexer
 
-<div class="placeholder-box">
+The lexer converts processed source text into `LexemeValue` objects.
 
-This page is a documentation placeholder.
+In the current implementation, lexing is performed by `BasicLexerImpl`. Frontend modules contribute token patterns before lexing through `IFrontendCoreModule.InitLexer`.
 
-**Purpose:** Document lexing responsibilities and extension points.
+## Place in the pipeline
 
-</div>
+The lexer runs after module text preprocessing and before lexeme post-processing:
 
-## What this page should explain
+```text
+modules.ProcessText
+  -> modules.InitLexer
+  -> lexer.Lexemize
+  -> modules.ProcessLexemes
+```
 
-- The practical goal of this topic.
-- The minimal example a developer should run or read.
-- The important concepts needed before going deeper.
-- Links to the next page for gradual learning.
+Lexing should recognize tokens. It should not decide high-level language structure.
 
-## Status
+## Current implementation shape
 
-Content is not written yet.
+`BasicLexerImpl.Lexemize` works in this order:
 
+1. copy configured patterns into a local list;
+2. collect all regex matches for all patterns;
+3. sort matches by source position and then by pattern registration order;
+4. walk through the source text from left to right;
+5. at each position, take the next matching lexeme;
+6. throw a lexer error if there is an unmatched gap;
+7. skip lexemes whose type is configured as ignored;
+8. return the filtered `LexemeValue` list.
+
+This is not a simple “try the next regex and advance” scanner. It first gathers matches and then consumes them in source order.
+
+## Pattern order matters
+
+When multiple patterns match at the same position, the order of patterns in the lexer configuration matters.
+
+Frontend modules should therefore register lexemes deterministically. If two modules introduce overlapping token patterns, the resulting behavior depends on deterministic module and pattern order.
+
+Do not rely on reflection enumeration order for lexeme registration.
+
+## Invalid gaps
+
+The lexer expects the entire source text to be covered by registered patterns, including whitespace or ignored lexemes.
+
+If the current source index does not match the next lexeme start, the lexer reports an invalid token segment.
+
+This means a dialect must register whitespace/comment handling when ordinary source text contains whitespace/comments that should be ignored.
+
+## Ignored lexemes
+
+Some lexemes are recognized but omitted from the final token list. This is how whitespace and comments can be handled without losing coverage of the source text.
+
+The important distinction is:
+
+- recognized and ignored: valid input, not passed to the parser;
+- not recognized: invalid token gap.
+
+## Regex timeout
+
+Regex matching uses a timeout. This prevents a single token pattern from blocking lexing indefinitely.
+
+When adding complex token patterns, keep them simple and test them against representative input.
+
+## Module responsibilities
+
+A frontend module that introduces token syntax should:
+
+- register lexemes in `InitLexer`;
+- keep token names stable once parser code depends on them;
+- avoid recognizing syntax through raw text scans outside the lexer/parser path;
+- add tests for valid tokens and invalid gaps;
+- document dependencies on whitespace/comment modules when relevant.
+
+## Examples
+
+Arithmetic modules register operator tokens such as addition, subtraction, multiplication and division.
+
+Variable modules register `let`.
+
+Loop modules register keywords such as `while` and `for`.
+
+These registrations make tokens visible. Parser node creators are still responsible for turning tokens into AST structure.
+
+## Common mistakes
+
+- Assuming ignored whitespace does not need to be recognized.
+- Adding a parser node creator without registering the token it depends on.
+- Adding overlapping token patterns without deterministic order tests.
+- Using text preprocessing to simulate lexing.
+- Treating token names as private when parser/visitor code depends on them.
+
+## What to test
+
+For lexer changes, test:
+
+- a valid token appears with the expected type;
+- ordinary whitespace/comment handling still covers the source text;
+- invalid characters produce a lexer failure;
+- overlapping patterns resolve deterministically;
+- disabling a module removes the token from that dialect surface.
+
+## Next
+
+Continue with [Parser](/internals/parser).

--- a/docs/internals/parser.md
+++ b/docs/internals/parser.md
@@ -5,22 +5,122 @@ description: Document parser architecture and extension points.
 
 # Parser
 
-<div class="placeholder-box">
+The parser converts lexeme values into an AST.
 
-This page is a documentation placeholder.
+In the current implementation, parsing is performed by `BasicParserImpl`. Frontend modules contribute parser node creators before parsing through `IFrontendCoreModule.InitParser`.
 
-**Purpose:** Document parser architecture and extension points.
+## Place in the pipeline
 
-</div>
+The parser runs after lexeme post-processing and before AST post-processing:
 
-## What this page should explain
+```text
+modules.ProcessLexemes
+  -> modules.InitParser
+  -> parser.Parse
+  -> modules.ProcessAst
+```
 
-- The practical goal of this topic.
-- The minimal example a developer should run or read.
-- The important concepts needed before going deeper.
-- Links to the next page for gradual learning.
+The parser owns syntax structure. It should not decide backend execution behavior.
 
-## Status
+## Current implementation shape
 
-Content is not written yet.
+`BasicParserImpl.Parse` works in this order:
 
+1. convert every lexeme into an AST node with initial type `Unknown`;
+2. create a root `Program` node containing those nodes;
+3. set node types from lexeme types;
+4. run configured node creators through `ParseRoot`;
+5. validate the resulting tree with `TreeValidator`;
+6. return the root AST node.
+
+This means parsing starts from a flat token-derived AST and then rewrites it into structured nodes.
+
+## Node creators
+
+Parser behavior is provided by `IAstNodeCreator` instances grouped in parser configuration.
+
+A node creator receives:
+
+- the current scope node;
+- the current child index;
+- the nearby children in that scope.
+
+It may replace or reorganize children when it recognizes syntax it owns.
+
+Examples:
+
+- arithmetic creators combine operand/operator/operand forms;
+- variable creators build declaration or assignment nodes;
+- loop creators build `while` or `for` nodes;
+- condition creators build conditional nodes.
+
+## ParseScope algorithm
+
+`ParseScope` is recursive and restart-oriented:
+
+1. recursively parse child scopes first;
+2. iterate over children in the current scope;
+3. try registered node creators whose visit predicate accepts the child;
+4. when a creator succeeds, mark the child as parser-handled;
+5. recursively parse the changed node;
+6. reset the index and scan the scope again.
+
+This reset matters. A successful creator can change the child list, so the parser restarts scanning the scope to let later syntax become visible.
+
+## Parser-handled nodes
+
+After a creator succeeds, the parser marks the node as handled.
+
+The default visit predicate skips handled nodes. A creator can provide a custom visit predicate when it needs different behavior.
+
+This prevents the same syntax from being repeatedly consumed by unrelated creators.
+
+## Priority and ordering
+
+The parser runs node creators through configured groups. Priority and registration order affect which creators see ambiguous syntax first.
+
+Examples:
+
+- multiplication should bind tighter than addition;
+- unary minus must be handled in a position compatible with binary operations;
+- `for` and `while` should not steal syntax from unrelated constructs;
+- optional grouping forms must be tested when accepted.
+
+Parser priority is therefore a grammar decision, not a magic number.
+
+## Scope-sensitive syntax
+
+Different node creators can require different child shapes.
+
+For example, current `while` parsing takes the next AST node as the condition and the following AST node as the body. The condition does not have to be a `Scope` when it parses as one expression node.
+
+By contrast, current `for` parsing expects initialization, condition, update and body to be grouped as `Scope` nodes.
+
+Internals documentation should describe these differences as current implementation facts, not infer a global rule from one construct.
+
+## What parser extensions must not do
+
+A parser extension should not:
+
+- inspect raw source text after lexing;
+- rely on accidental reflection order;
+- mutate unrelated ancestor nodes;
+- create backend-specific nodes;
+- hide missing module dependencies;
+- accept syntax that should be unavailable in a restricted dialect.
+
+## What to test
+
+Parser changes need tests for:
+
+- minimal valid syntax;
+- malformed syntax;
+- precedence and grouping;
+- overlapping constructs;
+- optional syntax forms that are intentionally accepted;
+- disabled dialect behavior;
+- downstream parity when parsing changes emitted semantics.
+
+## Next
+
+Continue with [AST](/internals/ast).

--- a/docs/internals/pipeline.md
+++ b/docs/internals/pipeline.md
@@ -5,9 +5,27 @@ description: Explain source to execution pipeline.
 
 # Pipeline
 
-UniversalToolchain separates language processing into explicit stages. Each stage has a narrow job, produces a more structured representation, and gives modules a controlled place to extend behavior.
+The internal pipeline is the lifecycle that turns `CompilationInput` into a compiled artifact or a prepared execution session.
 
-The practical shape is:
+The canonical implementation entry point is `PreparedExecutionBuilder<TCompilationOutput>`. `BasicCoreImpl<TCompilationOutput>` delegates compilation and preparation to this builder.
+
+## Why this page matters
+
+Most architecture mistakes happen when a change is placed in the wrong stage.
+
+Examples:
+
+- parsing syntax in a bytecode visitor;
+- fixing AST shape during bytecode post-processing;
+- letting an optimizer provide required semantics;
+- making a backend silently accept unsupported intrinsics;
+- mixing runtime input values with local variable semantics.
+
+This page defines the actual order of operations so each stage can keep a narrow responsibility.
+
+## Public model vs. internal lifecycle
+
+The public mental model is:
 
 ```text
 source text
@@ -20,129 +38,254 @@ source text
   -> result
 ```
 
-This page explains what each stage is responsible for and where a developer should normally make changes.
+The internal lifecycle is more precise:
 
-## Why the pipeline is split
-
-The project is not designed as a single hardcoded Wist compiler. Wist is a reference language built on top of the UniversalToolchain infrastructure. The split pipeline keeps three concerns separate:
-
-- language syntax and parsing;
-- intermediate semantics and optimization;
-- execution by a concrete backend.
-
-That separation is what allows a dialect to be assembled from modules instead of being baked into one compiler class.
-
-## Stage overview
-
-| Stage | Input | Output | Main responsibility |
-| --- | --- | --- | --- |
-| Lexer | Source text | Tokens | Recognize lexical units while preserving enough information for the parser. |
-| Parser | Tokens | AST | Build a structured syntax tree using module-provided parsing behavior. |
-| AST | Parsed structure | AST nodes | Represent source-level language constructs before lowering. |
-| Bytecode | AST nodes | Bytecode operations | Normalize module semantics into a compact executable/intermediate form. |
-| AIR | Bytecode | Abstract IR | Represent backend-oriented operations and enable backend-safe processing. |
-| Backend | AIR | Execution result | Interpret or compile the program while preserving the same semantics. |
-
-## Lexer
-
-The lexer is the first boundary between raw text and the rest of the compiler. It should remain simple and deterministic: it recognizes tokens, but it should not decide high-level language meaning.
-
-A lexer change is usually appropriate when a dialect needs a new token category, a new literal form, or different whitespace/comment handling.
-
-## Parser
-
-The parser consumes tokens and produces AST nodes. This is where syntax becomes structure.
-
-Parser extensions should avoid global assumptions about the whole language. A module should claim only the syntax it owns and should cooperate with other modules through deterministic ordering and priority rules.
-
-When a parsing bug appears, the first question should be whether the syntax decision belongs in the parser or whether it is actually a later semantic/lowering concern.
-
-## AST
-
-The AST is source-oriented. It should describe what the program says, not how a backend will execute it.
-
-Good AST nodes are useful for:
-
-- making source constructs explicit;
-- keeping module-specific syntax isolated;
-- delaying backend decisions until lowering;
-- writing tests around language behavior before execution details matter.
-
-A common mistake is to put backend knowledge into AST nodes. That makes a feature harder to run through both interpreter and compiled backends.
-
-## Bytecode
-
-Bytecode is the first major normalization layer. It lowers AST-level constructs into operations that are easier to translate, inspect, and execute.
-
-Bytecode is useful because it gives the system a stable semantic layer between syntax and backend-specific execution. It can carry tags or metadata that describe meaning without forcing every backend to rediscover it from syntax.
-
-This is the right place to encode language semantics that should be shared by different backends.
-
-## AIR
-
-AIR, the Abstract Intermediate Representation, is closer to execution than bytecode. It is the representation backends consume or compile.
-
-AIR should be backend-neutral, but backend-aware enough to support efficient execution. That means it can expose operations that are meaningful to optimizers and backends without becoming CIL-specific, interpreter-specific, or tied to a single runtime strategy.
-
-The important rule is: AIR may prepare work for backends, but it should not leak one backend's private implementation into the whole pipeline.
-
-## Optimizers and intrinsics
-
-Optimizers should operate on representations where their assumptions are explicit. Intrinsics should be treated as contracts: a backend may support a fast path only when it can preserve the same observable semantics.
-
-A safe optimization has three properties:
-
-- it is guarded by backend capabilities;
-- it does not change interpreter/compiler parity;
-- it has tests proving both optimized and unoptimized behavior.
-
-This matters especially when adding native arithmetic, local-variable optimizations, or backend-specific fast paths.
-
-## Backends
-
-Backends execute the program represented by AIR.
-
-The interpreter backend is useful as a semantic reference: it should make behavior clear and testable. A compiled backend can then optimize execution, but it must not silently change language meaning.
-
-The main backend contract is semantic parity. If the interpreter and compiler disagree on the same dialect, input, and runtime bindings, the pipeline has a correctness bug.
-
-## Where to make changes
-
-| Change | Preferred place |
-| --- | --- |
-| New token syntax | Lexer module |
-| New expression or statement grammar | Parser extension / frontend module |
-| New source-level construct | AST node and parser extension |
-| Shared language semantics | Bytecode lowering |
-| Backend-facing execution operation | AIR translation |
-| Runtime acceleration | Optimizer or backend intrinsic |
-| Backend-specific implementation | Backend only |
-| Cross-backend correctness rule | Semantic parity tests |
-
-## Professional invariants
-
-A pipeline change should preserve these invariants:
-
-1. Module order is deterministic.
-2. Parsing does not depend on accidental service registration order.
-3. AST nodes do not contain backend-specific execution logic.
-4. Bytecode and AIR keep semantics explicit enough for tests and optimizers.
-5. Interpreter and compiled execution are tested against the same cases.
-6. Mutable state is scoped to one compilation/execution request unless explicitly designed otherwise.
-7. Backend-specific fast paths are capability-checked before use.
-
-## Minimal validation checklist
-
-After changing the pipeline, run at least:
-
-```bash ci-run=false
-dotnet build UniversalToolchain/Wist.sln -c Release
-dotnet test UniversalToolchain/Wist.sln -c Release --no-build
-npm run docs:build
+```text
+CompilationInput
+  -> create per-build services
+  -> modules.ProcessText
+  -> modules.InitLexer
+  -> lexer.Lexemize
+  -> modules.ProcessLexemes
+  -> modules.InitParser
+  -> parser.Parse
+  -> modules.ProcessAst
+  -> Binder
+  -> modules.InitAstTranslator
+  -> astTranslator.Translate
+  -> modules.ProcessBytecode
+  -> optimizers.InitMethodsTranslator
+  -> optimizers.InitIntrinsicCapabilityContext
+  -> methodsTranslator.Translate(bytecode)
+  -> optimizers.ProcessIr
+  -> ExtractAllowedRuntimeProviderTypes
+  -> middleEndModules.InitMethodsCompiler
+  -> compiler.Compile
+  -> middleEndModules.ProcessCompilation
+  -> middleEndModules.InitExecutor
+  -> compiled artifact or prepared session
 ```
 
-Use more targeted tests when the change affects a specific module, dialect, optimizer, or backend.
+Use the second model when documenting internals.
+
+## Build setup
+
+`PreparedExecutionBuilder` creates fresh pipeline services for each build:
+
+```text
+lexer
+parser
+AST translator
+bytecode-to-AIR translator
+backend compiler
+executor
+intrinsic capability set
+optimizer capability context
+```
+
+This matters because pipeline services may carry request-local state. Module instances may be shared by DI, but lexer/parser/translator/compiler/executor instances are created through factories during the build.
+
+## Input normalization
+
+`BasicCoreImpl` accepts two common input shapes:
+
+- runtime input: `Run(string code, Dictionary<string, object>? parameters)`;
+- declared input: `Compile(string code, OrderedDictionary<string, Type>? parameters)`.
+
+Both are normalized into `CompilationInput` with `ExternalBinding` entries.
+
+Runtime input includes values. Declared input includes types. This distinction is important for compiled artifacts: compile-time parameter shape and runtime parameter values are not the same concern.
+
+## Frontend text stage
+
+First, every selected frontend module may transform source text:
+
+```text
+modules.ProcessText
+```
+
+This stage should be used sparingly. It is appropriate for explicit text-level preprocessing, not for hidden syntax recognition that should belong to lexer/parser/AST stages.
+
+## Lexer stage
+
+Modules register lexemes through:
+
+```text
+modules.InitLexer
+```
+
+Then the lexer turns the processed source text into lexeme values:
+
+```text
+lexer.Lexemize(targetCode)
+```
+
+After lexing, modules may transform the lexeme list:
+
+```text
+modules.ProcessLexemes
+```
+
+Lexeme post-processing should preserve the lexer/parser boundary. Do not use it to implement syntax that should be expressed through parser node creators.
+
+## Parser stage
+
+Modules register parser node creators through:
+
+```text
+modules.InitParser
+```
+
+Then the parser builds an AST:
+
+```text
+parser.Parse(targetLexemes)
+```
+
+Parser extensions are ordered and priority-sensitive. This stage owns syntax structure.
+
+## AST processing and binding
+
+After parsing, modules may transform the AST:
+
+```text
+modules.ProcessAst
+```
+
+Then external bindings are applied:
+
+```text
+new Binder(input.ExternalBindings).Bind(targetRoot)
+```
+
+Binding happens before AST-to-bytecode translation. This placement is important: visitors should receive a bound AST rather than rediscover external bindings independently.
+
+## AST-to-bytecode translation
+
+Modules register AST visitors through:
+
+```text
+modules.InitAstTranslator(astTranslator, modules)
+```
+
+Then the translator produces bytecode:
+
+```text
+astTranslator.Translate(boundRoot)
+```
+
+Visitors must self-filter because multiple visitors may inspect the same node. A visitor should emit only feature-owned semantics.
+
+## Bytecode post-processing
+
+After translation, modules may process bytecode:
+
+```text
+modules.ProcessBytecode
+```
+
+This is a bytecode-level hook. It should not be used to patch missing parser or AST behavior.
+
+## Bytecode-to-AIR translation
+
+Optimizers first initialize the bytecode-to-AIR translator:
+
+```text
+optimizers.InitMethodsTranslator(methodsTranslator)
+```
+
+Then they receive an intrinsic capability context:
+
+```text
+optimizers.InitIntrinsicCapabilityContext(optimizerCapabilityContext)
+```
+
+Then bytecode is translated into AIR:
+
+```text
+methodsTranslator.Translate(targetBytecode)
+```
+
+At this point, execution semantics are represented as backend-facing AIR instructions.
+
+## IR optimization
+
+Selected IR processing modules transform AIR:
+
+```text
+optimizers.ProcessIr(current, compiler)
+```
+
+The backend compiler is passed into the optimizer stage so optimizers can respect backend capabilities. This is a guardrail: backend-specific optimized instructions should not be emitted for backends that cannot consume them.
+
+## Runtime provider extraction
+
+The pipeline extracts allowed runtime provider types from AIR before compilation:
+
+```text
+ExtractAllowedRuntimeProviderTypes(targetIr)
+```
+
+Currently this scans AIR intrinsic calls for C# call descriptors that reference execution-scoped providers. The result becomes part of the compiled artifact.
+
+This is implementation-specific and should not be described as a general-purpose security boundary.
+
+## Backend compilation
+
+Middle-end modules initialize the compiler:
+
+```text
+middleEndModules.InitMethodsCompiler(compiler)
+```
+
+Then the backend compiler compiles AIR:
+
+```text
+compiler.Compile(targetIr, input)
+```
+
+The output type depends on the selected backend. For example, the interpreter path can use AIR directly, while the CIL path compiles into a `DynamicMethod`.
+
+## Compilation post-processing and executor setup
+
+After backend compilation:
+
+```text
+middleEndModules.ProcessCompilation
+middleEndModules.InitExecutor
+```
+
+This lets middle-end modules adapt backend output and executor wiring.
+
+## Artifact/session output
+
+`Compile(input)` returns a compiled artifact.
+
+`Build(input)` returns a prepared execution object containing:
+
+- source text;
+- compiled artifact;
+- execution session.
+
+`BasicCoreImpl.PrepareToRun` stores the prepared execution in an `AsyncLocal`, and `RunPrepared` executes the stored session.
+
+## Stage ownership summary
+
+| Stage | Owns | Should not own |
+|---|---|---|
+| `ProcessText` | explicit text preprocessing | hidden grammar |
+| Lexer | token recognition | AST shape |
+| `ProcessLexemes` | token-list normalization | semantic lowering |
+| Parser | AST structure | backend behavior |
+| `ProcessAst` | AST normalization | bytecode execution semantics |
+| Binder | external binding attachment | local variable runtime mutation |
+| AST visitors | bytecode emission | raw source parsing |
+| `ProcessBytecode` | bytecode-level transformations | parser fixes |
+| AIR translator | backend-facing instruction stream | optimizer-only semantics |
+| Optimizers | semantics-preserving IR transforms | required base semantics |
+| Backend compiler | backend artifact creation | language syntax decisions |
+| Executor | execution of compiled artifact | dialect composition |
 
 ## Next
 
-Continue with [Lexer](/internals/lexer) or [Bytecode](/internals/bytecode).
+Continue with [Lexer](/internals/lexer).


### PR DESCRIPTION
## Summary

This PR replaces the first major set of placeholder pages in the `Internals` section with implementation-checked documentation.

Updated pages:

- `docs/internals/index.md`
- `docs/internals/pipeline.md`
- `docs/internals/lexer.md`
- `docs/internals/parser.md`
- `docs/internals/ast.md`
- `docs/internals/bytecode.md`
- `docs/internals/air.md`
- `docs/internals/backends.md`

## What changed

- Rewrites the internals overview as a map for maintainers, module authors, backend authors, and reviewers.
- Replaces the simplified public pipeline with the actual `PreparedExecutionBuilder` lifecycle.
- Documents frontend module hooks in their real order: text, lexer, lexeme, parser, AST, binder, translator, bytecode, AIR, optimizers, compiler, executor.
- Documents the current lexer behavior: collect all regex matches, sort by source position and pattern order, detect invalid gaps, skip ignored lexemes.
- Documents the current parser behavior: flat lexeme-derived AST, node type assignment, recursive/restart-oriented `ParseScope`, parser-handled nodes, and node creator shape differences such as `while` vs `for`.
- Documents AST responsibilities, binding placement, visitor self-filtering, and request-local bytecode translation.
- Documents bytecode as the module-owned semantic layer before AIR.
- Adds a first AIR internals page covering current opcodes, stack/control behavior, bytecode-to-AIR conversion, and optimizer boundaries.
- Adds a first backend internals page covering interpreter execution and CIL `DynamicMethod` compilation contracts.

## Scope

Documentation-only change. No runtime code, VitePress config, sidebar, theme, or architecture changes.

This intentionally stops before deeper `intrinsics`, `optimizers`, `semantic-parity`, `dependency-injection`, and `reference` pages, which should be handled in later code-verified passes.