### PR TITLE
docs: fill advanced internals and core reference

### DIFF
--- a/docs/internals/dependency-injection.md
+++ b/docs/internals/dependency-injection.md
@@ -5,22 +5,142 @@ description: Explain service registration and deterministic module discovery.
 
 # Dependency Injection
 
-<div class="placeholder-box">
+Dependency injection is part of UniversalToolchain's runtime composition model.
 
-This page is a documentation placeholder.
+It is not only a convenience mechanism for constructing objects. It is how dialect services, runtime catalogs, selected runtime plans, backend infrastructure and Wist execution hosts are assembled.
 
-**Purpose:** Explain service registration and deterministic module discovery.
+## Place in the architecture
 
-</div>
+The Wist dialect runtime is normally bootstrapped with:
 
-## What this page should explain
+```csharp
+services.AddWistDialectServices();
+services.AddWistCilBackend();
+services.AddWistInterpreterBackend();
+```
 
-- The practical goal of this topic.
-- The minimal example a developer should run or read.
-- The important concepts needed before going deeper.
-- Links to the next page for gradual learning.
+The first call registers the core dialect workflow and runtime resolution infrastructure. Backend registration calls add concrete backend runtime surfaces.
 
-## Status
+## Wist dialect services
 
-Content is not written yet.
+`AddWistDialectServices()` composes three groups:
 
+```text
+AddWistDialectCoreServices
+AddFileSystemRuntimeCatalogServices
+AddReflectionRuntimeResolutionServices
+```
+
+This means the default Wist setup includes:
+
+- dialect DSL compilation and build-plan services;
+- runtime catalog services;
+- reflection-based runtime resolution services.
+
+## Core Wist services
+
+`AddWistDialectCoreServices()` registers the orchestration layer used by Wist execution workflows.
+
+Important registered services include:
+
+| Service | Role |
+|---|---|
+| `IDialectGroupProvider` | contributes named dialect groups |
+| `IDialectGroupCatalog` | combines group providers |
+| `DialectGroupExpander` | expands group references in dialect definitions |
+| `SelectedRuntimePlanResolver` | resolves selected runtime components from a build plan |
+| `IDialectBackendIntrinsicPolicyResolver` | resolves backend intrinsic policies |
+| `IWistRequiredInfrastructureModulesProvider` | provides required Wist infrastructure modules |
+| `SelectedRuntimeModuleClassifier` | classifies selected runtime modules |
+| `SelectedRuntimeExecutionShapeBuilder` | builds execution shape from selected runtime modules |
+| `DialectBackendRuntimeConfigurationBuilder` | builds backend runtime configuration |
+| `IntrinsicSemanticBootstrapPlanBuilder` | prepares intrinsic semantic bootstrap |
+| `IDialectCompiledDialectBuildPlanBuilder` | builds compiled dialect build plans |
+| `WistDialectExecutionConfigurationBuilder` | builds execution configuration |
+| `WistDialectServiceProviderFactory` | creates the runtime service provider |
+| `WistDialectExecutionWorkflow` | composes dialect text/files and creates execution hosts |
+
+This is a Wist-first composition path. It should not be described as a fully generic language-workbench API unless the generic layer provides the same capability directly.
+
+## Workflow object
+
+`WistDialectExecutionWorkflow` is the main orchestration object for dialect execution.
+
+It supports:
+
+```text
+ComposeFile(path)
+ComposeText(sourceText, sourceName)
+CreateHost(compositionResult)
+```
+
+The workflow compiles dialect source text, builds a dialect build plan, resolves a selected runtime plan, builds execution configuration and creates a `WistDialectExecutionHost`.
+
+## Runtime service provider
+
+The final Wist host is created from a service provider built for the selected execution configuration.
+
+This matters because a dialect should not run against every service registered in the outer application. It should run against the selected runtime plan and backend/runtime surface chosen by dialect composition.
+
+## Determinism
+
+DI-based composition must remain deterministic.
+
+Dangerous patterns:
+
+- relying on reflection enumeration order;
+- accepting duplicate runtime exports without deterministic conflict handling;
+- changing module order accidentally through service registration order;
+- letting full Wist modules appear inside restricted dialect hosts;
+- making tests pass only because all modules are registered globally.
+
+Good patterns:
+
+- deterministic group expansion;
+- explicit runtime exports;
+- selected runtime plans;
+- tests that inspect selected modules/backends;
+- failure diagnostics when resolution is ambiguous or incomplete.
+
+## DI and module discovery
+
+Modules may be registered through attributes and service registration helpers.
+
+This is useful, but it creates hidden contracts:
+
+- aliases must be stable;
+- runtime exports must match dialect declarations;
+- backend/runtime component kinds must be classified correctly;
+- required infrastructure modules must be included intentionally;
+- restricted dialects must not receive unrelated modules by accident.
+
+## DI is not a security boundary
+
+A restricted runtime service provider can reduce the runtime surface exposed to a dialect.
+
+That is not the same as process isolation. Do not document DI selection as a hardened sandbox. It is a composition and activation boundary.
+
+## What to test
+
+DI/runtime composition changes should test:
+
+- service registration smoke path;
+- dialect composition success and failure;
+- deterministic selected runtime plan;
+- missing backend behavior;
+- duplicate or conflicting runtime exports;
+- restricted dialect surface;
+- interpreter/CIL backend registration matrix;
+- execution host creation from successful composition only.
+
+## Common mistakes
+
+- Treating global service registration as selected runtime composition.
+- Adding a module service without a stable dialect alias or runtime export.
+- Making Wist convenience APIs the only true framework path.
+- Assuming all registered backends are available to every dialect.
+- Letting reflection discovery decide behavior without deterministic ordering tests.
+
+## Next
+
+Continue with [Reference](/reference/) for tables and contracts.

--- a/docs/internals/intrinsics.md
+++ b/docs/internals/intrinsics.md
@@ -5,22 +5,148 @@ description: Document intrinsic capabilities and backend support.
 
 # Intrinsics
 
-<div class="placeholder-box">
+Intrinsics are named operations that travel through AIR and are executed or compiled by a backend-specific intrinsic implementation.
 
-This page is a documentation placeholder.
+They are not just strings in an instruction. In the current architecture, an intrinsic is a contract between emitters, optimizers, capability sets and backends.
 
-**Purpose:** Document intrinsic capabilities and backend support.
+## Place in the pipeline
 
-</div>
+Intrinsics appear after bytecode has been lowered to AIR:
 
-## What this page should explain
+```text
+bytecode
+  -> bytecode-to-AIR translator
+  -> AIR instructions
+  -> optimizers
+  -> backend compiler/interpreter
+```
 
-- The practical goal of this topic.
-- The minimal example a developer should run or read.
-- The important concepts needed before going deeper.
-- Links to the next page for gradual learning.
+The fixed AIR opcode set is small. `UOpCode.Intrinsic` is used for operations that need a typed, named operation beyond `Push`, `Drop`, labels and jumps.
 
-## Status
+## Core idea
 
-Content is not written yet.
+An intrinsic has several parts:
 
+| Part | Purpose |
+|---|---|
+| intrinsic symbol | stable operation identity |
+| type arguments | runtime type specialization, when needed |
+| operands | operation-specific values or descriptors |
+| capability metadata | whether a backend can consume the operation |
+| executor/compiler implementation | backend behavior for the operation |
+
+The important rule is simple: emitting an intrinsic is valid only when the selected backend path can consume it.
+
+## Capability checks
+
+Optimizer capability checks are performed through `IOptimizerIntrinsicCapabilityContext`.
+
+The context answers questions of this shape:
+
+```csharp
+Supports(symbol, typeArguments)
+```
+
+The implementation delegates to an `IIntrinsicCapabilitySet` and converts runtime `Type` values into intrinsic type arguments.
+
+For multiple requirements, `OptimizerCapabilityGuards.SupportsAll(...)` checks that every required symbol/type pair is supported.
+
+## Why capability checks matter
+
+Optimizers may replace general AIR shapes with more specific intrinsic instructions.
+
+That is safe only when the backend supports the replacement. Otherwise, the optimizer would produce AIR that the selected backend cannot execute or compile.
+
+Correct model:
+
+```text
+selected backend
+  -> supported intrinsic capability set
+  -> optimizer checks requirements
+  -> optimizer emits backend-compatible intrinsic form
+```
+
+Incorrect model:
+
+```text
+optimizer emits intrinsic form
+  -> hope every backend accepts it
+```
+
+The second model breaks backend parity and restricted backend support.
+
+## Intrinsics and backends
+
+Backends may support different intrinsic sets.
+
+The interpreter executes intrinsic instructions through an interpreter intrinsic executor. The CIL backend compiles supported intrinsic instructions through a CIL intrinsic compiler/registry.
+
+A backend-specific intrinsic must not be treated as a general language feature. It is a backend capability.
+
+## Intrinsics and optimizers
+
+Several optimizers depend on intrinsic support.
+
+For example:
+
+- arithmetic optimization can replace C# call descriptors with built-in arithmetic intrinsic instructions, but only when arithmetic intrinsic capabilities are supported for the relevant types;
+- native CIL optimization can replace `Push` constants with typed load-constant intrinsics, but only when typed load constants are supported;
+- comparison or boolean optimizers must respect the same capability boundary.
+
+This is why `InitIntrinsicCapabilityContext` runs before `ProcessIr`.
+
+## Intrinsics and type stack
+
+AIR conversion and backend compilation both care about stack type behavior.
+
+When AIR instructions are generated from bytecode, type-stack effects are applied after generated AIR instructions are appended. Backend compilers may also simulate stack types to determine return type, label stack state and IL shape.
+
+An intrinsic therefore needs more than a name. It needs a predictable stack effect for every supported type shape.
+
+## Intrinsics are not syntax
+
+Do not expose intrinsics as if they were source-level syntax.
+
+Source syntax belongs to lexer, parser and AST modules. Intrinsics belong to AIR/backend execution. A feature may lower to intrinsics, but users should not have to understand intrinsic internals to write ordinary Wist programs.
+
+## What an intrinsic provider should define
+
+A backend or module that introduces intrinsic behavior should define:
+
+- intrinsic symbol identity;
+- supported type arguments;
+- stack effects;
+- backend executor/compiler behavior;
+- optimizer interaction;
+- tests for supported and unsupported paths.
+
+## Failure mode
+
+Unsupported intrinsic paths should fail explicitly or be avoided by capability checks.
+
+Silent fallback is dangerous because it can make a dialect appear to support a backend while actually executing through an unintended path.
+
+## Common mistakes
+
+- Treating an intrinsic identifier as a magic string without a producer/consumer contract.
+- Emitting backend-specific intrinsics before checking capabilities.
+- Assuming CIL-supported intrinsics are also interpreter-supported.
+- Assuming interpreter-supported intrinsics are also CIL-supported.
+- Using intrinsics to hide missing frontend semantics.
+- Changing intrinsic stack behavior without parity tests.
+
+## What to test
+
+Intrinsic-affecting changes should test:
+
+- supported symbol/type combinations;
+- unsupported symbol/type combinations;
+- stack type effects;
+- interpreter execution when supported;
+- CIL compilation when supported;
+- optimizer behavior with and without required capabilities;
+- semantic parity for dialects that expose both backends.
+
+## Next
+
+Continue with [Optimizers](/internals/optimizers).

--- a/docs/internals/optimizers.md
+++ b/docs/internals/optimizers.md
@@ -5,22 +5,157 @@ description: Explain optimization passes and their contracts.
 
 # Optimizers
 
-<div class="placeholder-box">
+Optimizers transform AIR while preserving observable program behavior.
 
-This page is a documentation placeholder.
+In UniversalToolchain, optimizers are implemented as `IIRProcessingModule` instances. They are selected by dialect/runtime composition and run after bytecode has been translated into AIR.
 
-**Purpose:** Explain optimization passes and their contracts.
+## Place in the pipeline
 
-</div>
+Optimizer-related hooks appear in three places:
 
-## What this page should explain
+```text
+modules.ProcessBytecode
+  -> optimizers.InitMethodsTranslator
+  -> optimizers.InitIntrinsicCapabilityContext
+  -> methodsTranslator.Translate(bytecode)
+  -> optimizers.ProcessIr(current, compiler)
+  -> compiler.Compile
+```
 
-- The practical goal of this topic.
-- The minimal example a developer should run or read.
-- The important concepts needed before going deeper.
-- Links to the next page for gradual learning.
+This order matters. Optimizers may prepare the bytecode-to-AIR translator, receive backend capability context and then transform AIR before backend compilation.
 
-## Status
+## IIRProcessingModule hooks
 
-Content is not written yet.
+`IIRProcessingModule` exposes three responsibilities:
 
+| Hook | Purpose |
+|---|---|
+| `InitMethodsTranslator` | configure bytecode-to-AIR translation before AIR exists |
+| `InitIntrinsicCapabilityContext` | receive backend intrinsic capability information |
+| `ProcessIr` | transform AIR after translation and before backend compilation |
+
+A module may use only one hook or all three.
+
+## Optimizer is not semantics
+
+An optimizer must not be required for base program correctness.
+
+Correct layering:
+
+```text
+AST visitor emits correct bytecode
+  -> bytecode translates to correct AIR
+  -> optimizer improves AIR without changing meaning
+  -> backend executes/compiles optimized AIR
+```
+
+Incorrect layering:
+
+```text
+AST/bytecode emits incomplete semantics
+  -> optimizer repairs it
+  -> program only works when optimization is enabled
+```
+
+The second model makes dialect behavior unpredictable and breaks non-optimized paths.
+
+## Capability-gated optimization
+
+Some optimizations produce intrinsic forms that only specific backends support.
+
+The optimizer should ask the capability context before producing those forms:
+
+```text
+capabilityContext.Supports(symbol, typeArguments)
+```
+
+or use `OptimizerCapabilityGuards.SupportsAll(...)` when several requirements must be present.
+
+If required capabilities are missing, the optimizer should return the original AIR unchanged.
+
+## Example: arithmetic optimization
+
+The arithmetic optimizer first requires an intrinsic capability context. Then it checks that the backend supports arithmetic intrinsic symbols for the supported numeric types.
+
+Only after the capability check passes does it transform AIR.
+
+Its transformations include:
+
+- replacing certain C# call descriptors with built-in arithmetic intrinsic instructions;
+- simplifying identity operations such as adding zero or multiplying by one;
+- canonicalizing commutative operands;
+- folding selected integer reassociation patterns.
+
+This is intentionally capability-gated because the optimized instruction form must be supported by the selected backend.
+
+## Example: native CIL loads
+
+The native CIL optimizer can replace generic `Push` constants with typed load-constant intrinsics.
+
+It does this only when the backend capability set supports `LoadConst` for the relevant types. Otherwise it leaves the original AIR unchanged.
+
+This avoids emitting CIL-oriented intrinsic forms into a backend that cannot consume them.
+
+## Optimizer order
+
+Optimizer order can affect the final AIR shape.
+
+Examples:
+
+- one optimizer may introduce intrinsic forms another optimizer can simplify;
+- native type lowering may make arithmetic optimization possible;
+- a backend-specific optimizer may require prior normalization.
+
+Therefore optimizer order must be deterministic and tested when behavior depends on it.
+
+## Optimizer state
+
+Optimizers may hold state such as a received capability context.
+
+That state must be initialized before `ProcessIr` and must not leak across incompatible compilation paths. If an optimizer requires initialization, it should fail explicitly when used incorrectly.
+
+Prefer request-scoped or build-scoped state. Be cautious with static mutable collections.
+
+## Backend compiler parameter
+
+`ProcessIr<TCompilationOutput>` receives the selected backend compiler.
+
+This is a signal that optimization is backend-aware. The optimizer should use backend capabilities and contracts to decide whether a transformation is valid.
+
+Do not use this parameter to special-case unrelated runtime behavior or to bypass dialect composition.
+
+## What optimizers must not do
+
+Optimizers must not:
+
+- parse source syntax;
+- depend on AST node shapes;
+- provide required base semantics;
+- emit unsupported intrinsics;
+- silently switch backend execution path;
+- make restricted dialects broader;
+- change observable behavior for the same source/input.
+
+## What to test
+
+Optimizer changes should test:
+
+- unoptimized behavior still works;
+- optimized behavior matches unoptimized behavior;
+- required capabilities are checked;
+- missing capabilities leave AIR unchanged or fail explicitly as designed;
+- interpreter/compiler parity when both backends are exposed;
+- optimized AIR does not contain backend-specific intrinsics for unsupported backends;
+- deterministic output when optimizer order matters.
+
+## Common mistakes
+
+- Treating optimizer output as universally backend-compatible.
+- Running optimizer logic before capability context is initialized.
+- Adding a transformation without a negative capability test.
+- Changing stack effects while preserving only the final happy-path result.
+- Benchmarking an optimizer before proving semantic equivalence.
+
+## Next
+
+Continue with [Semantic Parity](/internals/semantic-parity).

--- a/docs/internals/semantic-parity.md
+++ b/docs/internals/semantic-parity.md
@@ -5,22 +5,175 @@ description: Explain why interpreter and compiled execution must agree.
 
 # Semantic Parity
 
-<div class="placeholder-box">
+Semantic parity means that two supported execution paths produce the same observable behavior for the same dialect, source program and runtime inputs.
 
-This page is a documentation placeholder.
+For Wist, the most important parity boundary is interpreter vs. CIL compiler.
 
-**Purpose:** Explain why interpreter and compiled execution must agree.
+## What parity is
 
-</div>
+When a dialect exposes both `interpreter` and `compiler`, the same program should produce equivalent results through both modes:
 
-## What this page should explain
+```text
+same dialect
+same source
+same external bindings
+  -> interpreter result
+  -> compiler result
+  -> same observable behavior
+```
 
-- The practical goal of this topic.
-- The minimal example a developer should run or read.
-- The important concepts needed before going deeper.
-- Links to the next page for gradual learning.
+This is a correctness requirement, not a performance benchmark.
 
-## Status
+## What parity is not
 
-Content is not written yet.
+Parity does not mean every backend supports every dialect.
 
+A dialect may intentionally expose only one backend. In that case, unsupported modes should fail explicitly. That is backend availability, not backend parity.
+
+Keep these concepts separate:
+
+| Concept | Meaning |
+|---|---|
+| backend availability | whether a dialect exposes a backend mode |
+| semantic parity | whether exposed backends agree |
+| optimizer safety | whether optimized and unoptimized behavior match |
+| failure parity | whether invalid programs fail consistently enough across paths |
+
+## Why parity matters
+
+The interpreter and CIL backend consume the same AIR but implement execution differently.
+
+The interpreter executes instructions directly with an instruction pointer, value stack and label positions.
+
+The CIL backend simulates stack types, emits IL into a `DynamicMethod`, and executes compiled code.
+
+Because the implementations are different, tests are required to prove they preserve the same language semantics.
+
+## Value parity
+
+Value parity compares successful results.
+
+Examples:
+
+```wist
+2 + 3 * 4
+```
+
+```wist
+let x = 5
+x = x + 1
+x
+```
+
+```wist
+if 2 == 2 (1) else (2)
+```
+
+```wist
+let sum = 0
+let i = 1
+
+while i <= 5 (
+    sum = sum + i
+    i = i + 1
+)
+
+sum
+```
+
+If both backends are exposed for the dialect, these examples should return equivalent values.
+
+## Failure parity
+
+Failure parity compares invalid or unsupported programs.
+
+For high-level module tests, it is often enough to assert that both backends fail and that the failure is comparable. Exact diagnostic text may be too brittle if diagnostics are not yet a stable public contract.
+
+Failure parity is useful for:
+
+- malformed syntax;
+- omitted module features;
+- unsupported backend modes;
+- unsupported intrinsic forms;
+- invalid runtime binding shapes.
+
+## Optimizer parity
+
+Optimizer parity compares optimized and unoptimized behavior.
+
+An optimizer may change AIR shape, but it must not change observable semantics.
+
+Useful structure:
+
+```text
+run source without optimizer
+run source with optimizer
+compare results
+then compare interpreter/compiler if both are exposed
+```
+
+This catches optimizer bugs that would not appear in one backend-only test.
+
+## Runtime binding parity
+
+External bindings must have the same meaning across backends.
+
+A compiled artifact may use declared parameter types, while runtime execution passes values. The same source should not resolve a local variable differently depending on backend mode.
+
+This matters especially for variables and formulas with external inputs.
+
+## Current test infrastructure pattern
+
+The module coverage tests use helper methods with this shape:
+
+```text
+CreateHost(modules, optimizers, backends)
+ExecuteBoth(code, modules, optimizers)
+AssertParity(compiler, interpreter)
+AssertCompilerAndInterpreterFailSameWay(code, modules)
+```
+
+This pattern is valuable because it tests the composed dialect surface rather than only one hardcoded runtime path.
+
+## What to test for a feature
+
+A feature that affects execution should have parity cases for:
+
+- smallest valid source;
+- realistic source with neighboring modules;
+- nested source when nesting is supported;
+- failure when the owning module is omitted;
+- backend availability when only one backend is exposed;
+- optimizer behavior when optimizers touch the feature.
+
+## What to test for a backend
+
+A backend-affecting change should have parity cases for:
+
+- `Push` / result behavior;
+- arithmetic intrinsics;
+- local variables and external bindings;
+- labels and jumps;
+- conditions;
+- loops;
+- unsupported intrinsic handling;
+- empty stack / void-like result behavior.
+
+## Common mistakes
+
+- Testing compiler mode only.
+- Treating interpreter success as proof that CIL works.
+- Treating CIL success as proof that semantics are correct.
+- Comparing performance before proving correctness.
+- Letting unsupported backend modes silently fall back.
+- Testing only successful examples and ignoring failure parity.
+
+## Documentation rule
+
+Do not document a dialect as supporting both modes unless there are tests or examples that exercise both modes.
+
+Do not document an optimizer as semantics-preserving unless optimized and unoptimized behavior are compared somewhere.
+
+## Next
+
+Continue with [Dependency Injection](/internals/dependency-injection).

--- a/docs/reference/air-reference.md
+++ b/docs/reference/air-reference.md
@@ -5,22 +5,101 @@ description: List AIR nodes, operations, and contracts.
 
 # AIR Reference
 
-<div class="placeholder-box">
+This page lists the current AIR instruction contract.
 
-This page is a documentation placeholder.
+For conceptual background, read [AIR internals](/internals/air) first.
 
-**Purpose:** List AIR nodes, operations, and contracts.
+## Instruction shape
 
-</div>
+An AIR instruction has:
 
-## What this page should explain
+| Field | Meaning |
+|---|---|
+| `UOpCode` | operation code |
+| `Operands` | operation-specific operands |
+| `Metadata` | additional metadata, currently implementation-facing |
+| `Comment` | optional debugging/comment text |
 
-- The practical goal of this topic.
-- The minimal example a developer should run or read.
-- The important concepts needed before going deeper.
-- Links to the next page for gradual learning.
+Current implementation type:
 
-## Status
+```csharp
+Instruction(UOpCode uOpCode, List<object>? operands = null, List<object>? metadata = null, string? comment = null)
+```
 
-Content is not written yet.
+## Opcode table
 
+| Opcode | Operands | Stack effect | Control effect | Notes |
+|---|---|---|---|---|
+| `Nop` | none | none | none | no operation |
+| `Push` | `[value]` | push value | none | value type affects CIL return/type simulation |
+| `Drop` | none | pop top value | none | interpreter ignores empty stack; CIL path expects stack discipline |
+| `Jmp` | `[labelId]` | none | jump to label | label id is currently `Guid` in normal control-flow paths |
+| `JmpIf` | `[labelId]` | pop bool | jump when true | condition must be boolean-compatible |
+| `JmpIfNot` | `[labelId]` | pop bool | jump when false | condition must be boolean-compatible |
+| `Label` | `[labelId]` | none | mark target | interpreter precomputes positions; CIL defines/marks IL labels |
+| `Annotate` | annotation operands | none | none | metadata-like instruction; not required runtime semantics |
+| `Intrinsic` | `[intrinsicId, ...operands]` | intrinsic-specific | intrinsic-specific | backend support required |
+
+## Builder methods
+
+`GenericAbstractIR<TIdentifier>` exposes helper methods:
+
+| Method | Emitted opcode |
+|---|---|
+| `Nop()` | `Nop` |
+| `Push<T>(T value)` | `Push` |
+| `Drop()` | `Drop` |
+| `Jmp(identifier)` | `Jmp` |
+| `JmpIf(identifier)` | `JmpIf` |
+| `JmpIfNot(identifier)` | `JmpIfNot` |
+| `SetLabel(label)` | `Label` |
+| `Annotate(...)` | `Annotate` |
+| `Intrinsic(instructionIdentifier, operands...)` | `Intrinsic` |
+| `AppendInstructions(...)` | appends existing instructions |
+
+## Stack contract
+
+AIR uses a value stack model.
+
+Important rules:
+
+- expression producers must leave their result on the stack;
+- consumers must pop the values they consume;
+- `JmpIf` and `JmpIfNot` consume a condition;
+- final execution returns the top value when a value remains;
+- empty-stack final behavior is backend-specific but should be parity-tested.
+
+## Label contract
+
+Labels and jumps use an identifier operand.
+
+Current normal control-flow paths use `Guid` labels. Backends must map those labels to their own execution representation:
+
+- interpreter: instruction indexes;
+- CIL: IL labels.
+
+## Intrinsic contract
+
+`Intrinsic` operands begin with an intrinsic identifier, followed by operation-specific operands.
+
+The exact stack effect and runtime behavior depend on the intrinsic. A backend must support the intrinsic form before it can execute or compile it.
+
+Do not assume `Intrinsic` is portable across all backends.
+
+## Backend notes
+
+| Backend | AIR consumption model |
+|---|---|
+| Interpreter | executes instructions sequentially with an instruction pointer, value stack and label map |
+| CIL | simulates stack types, emits IL for each instruction and compiles a `DynamicMethod` |
+
+## Stability note
+
+The opcode enum is a developer-facing contract for backend and optimizer work. The exact object types inside operands and metadata are more implementation-sensitive and should be documented per feature/intrinsic when they matter.
+
+## Related pages
+
+- [AIR internals](/internals/air)
+- [Backends](/internals/backends)
+- [Backend Contracts](/reference/backend-contracts)
+- [Intrinsics](/internals/intrinsics)

--- a/docs/reference/backend-contracts.md
+++ b/docs/reference/backend-contracts.md
@@ -5,22 +5,131 @@ description: Document what each backend must support.
 
 # Backend Contracts
 
-<div class="placeholder-box">
+This page summarizes backend obligations for current UniversalToolchain/Wist execution paths.
 
-This page is a documentation placeholder.
+For conceptual background, read [Backends](/internals/backends) and [Semantic Parity](/internals/semantic-parity).
 
-**Purpose:** Document what each backend must support.
+## Backend modes
 
-</div>
+Current Wist-facing modes:
 
-## What this page should explain
+| Mode | Meaning |
+|---|---|
+| `interpreter` | execute AIR through the interpreter backend |
+| `compiler` | compile through the CIL backend when the selected runtime exposes CIL |
 
-- The practical goal of this topic.
-- The minimal example a developer should run or read.
-- The important concepts needed before going deeper.
-- Links to the next page for gradual learning.
+Dialect files decide which backend modes are available for a runtime host.
 
-## Status
+## Shared contract
 
-Content is not written yet.
+Every backend must preserve:
 
+- AIR opcode semantics;
+- value stack behavior;
+- label and jump behavior;
+- external binding shape;
+- final result semantics;
+- supported intrinsic behavior;
+- explicit failure for unsupported operations.
+
+## Interpreter contract
+
+The interpreter backend:
+
+| Area | Contract |
+|---|---|
+| input | AIR plus execution environment |
+| state | instruction pointer, value stack, label positions, execution environment |
+| labels | built before execution from `Label` instructions |
+| execution | sequential dispatch over AIR instructions |
+| final result | `null` when stack is empty, otherwise top stack value |
+| intrinsics | delegated to interpreter intrinsic executor |
+
+The interpreter is useful as a semantic reference because behavior maps directly to AIR instructions.
+
+## CIL contract
+
+The CIL backend:
+
+| Area | Contract |
+|---|---|
+| input | AIR plus declared compilation input |
+| output | `DynamicMethod` |
+| arguments | `IExecutionEnvironment` first, then external binding argument types |
+| return type | derived by AIR type simulation |
+| labels | converted to IL labels with simulated stack state |
+| intrinsics | compiled through CIL intrinsic compiler/registry |
+| constants | current implementation stores pushed constants in generic static holders |
+
+The CIL backend is a compiler, not a second interpreter. Its type simulation and IL emission must still preserve AIR semantics.
+
+## Backend availability
+
+Availability is selected by dialect/runtime composition.
+
+A dialect exposing only `interpreter` should reject `compiler` mode.
+
+A dialect exposing only CIL/compiler mode should reject `interpreter` mode.
+
+Do not silently fall back to a different backend when the requested mode is unavailable.
+
+## Backend parity
+
+When a dialect exposes both backend modes, they must agree on observable behavior.
+
+Parity should cover:
+
+- successful values;
+- comparable failures;
+- external bindings;
+- variables;
+- conditions;
+- loops;
+- intrinsic-heavy programs;
+- optimizer-enabled programs.
+
+## Intrinsic support
+
+A backend is not required to support every intrinsic.
+
+Backend-specific intrinsic support must be represented through capability sets or supported intrinsic lists. Optimizers and emitters must check those capabilities before producing backend-specific intrinsic forms.
+
+## Unsupported operations
+
+Unsupported backend operations should produce explicit failure.
+
+Bad behavior:
+
+```text
+requested compiler
+  -> compiler cannot consume AIR
+  -> silently run interpreter
+```
+
+Good behavior:
+
+```text
+requested compiler
+  -> compiler cannot consume AIR
+  -> fail with a clear unsupported operation/backend diagnostic
+```
+
+## Backend author checklist
+
+A backend implementation should provide or document:
+
+- supported AIR opcodes;
+- supported intrinsic symbols/type arguments;
+- stack behavior;
+- label/jump behavior;
+- external binding argument handling;
+- final result handling;
+- failure behavior for unsupported instructions;
+- parity tests against existing backends when sharing dialects.
+
+## Related pages
+
+- [AIR Reference](/reference/air-reference)
+- [Backends](/internals/backends)
+- [Intrinsics](/internals/intrinsics)
+- [Semantic Parity](/internals/semantic-parity)

--- a/docs/reference/bytecode-reference.md
+++ b/docs/reference/bytecode-reference.md
@@ -5,22 +5,132 @@ description: List bytecode instructions and semantic tags.
 
 # Bytecode Reference
 
-<div class="placeholder-box">
+This page summarizes the current bytecode representation used between AST translation and AIR conversion.
 
-This page is a documentation placeholder.
+For conceptual background, read [Bytecode internals](/internals/bytecode).
 
-**Purpose:** List bytecode instructions and semantic tags.
+## Stability note
 
-</div>
+Bytecode is an internal developer-facing layer. It is important for module authors and backend/optimizer work, but it should not be treated as a stable public user API.
 
-## What this page should explain
+## Core shape
 
-- The practical goal of this topic.
-- The minimal example a developer should run or read.
-- The important concepts needed before going deeper.
-- Links to the next page for gradual learning.
+Current bytecode is represented as:
 
-## Status
+```csharp
+Bytecode(List<BytecodeInstruction> Instructions)
+```
 
-Content is not written yet.
+Each instruction is represented as:
 
+```csharp
+BytecodeInstruction(HashSet<string> Tags, LevelCollection<float, IAbstractMethodConvertable> Ops)
+```
+
+There is also a convenience constructor:
+
+```csharp
+BytecodeInstruction(IAbstractMethodConvertable op)
+```
+
+which creates an instruction with no tags and one operation at level `0`.
+
+## Instruction fields
+
+| Field | Meaning |
+|---|---|
+| `Tags` | string tags attached to the bytecode instruction |
+| `Ops` | level-ordered collection of convertable operation fragments |
+
+Tags are semantic markers. Operations are convertable fragments that can produce AIR.
+
+## Convertable operation contract
+
+Bytecode operations implement:
+
+```csharp
+public interface IAbstractMethodConvertable
+{
+    string Name { get; }
+    IAbstractIR GetAbstractIR(Context context);
+}
+```
+
+The conversion context currently exposes:
+
+```csharp
+Context(IReadOnlyList<Type> Stack)
+```
+
+This means a bytecode operation may use current stack type information while producing AIR.
+
+## Bytecode-to-AIR conversion
+
+Current conversion walks:
+
+```text
+Bytecode.Instructions
+  -> BytecodeInstruction.Ops
+  -> IAbstractMethodConvertable.GetAbstractIR(context)
+  -> append generated AIR instructions
+  -> apply AIR instruction type-stack effects
+```
+
+The converter keeps a type stack during conversion. Generated AIR instructions are appended to the result and then type effects are applied.
+
+## Tags
+
+Tags are currently string-based.
+
+Use tags only when they have an owner and a consumer. A tag that is produced but never consumed is dead metadata; a consumer that depends on undocumented tags creates hidden coupling.
+
+For new tags, document:
+
+- owning module;
+- producer;
+- consumer;
+- expected shape;
+- tests that prove the contract.
+
+## Operation levels
+
+`Ops` uses `LevelCollection<float, IAbstractMethodConvertable>`. This allows more than one convertable operation to be associated with one bytecode instruction and ordered by level.
+
+Do not depend on incidental operation order. If level order affects semantics, cover it with tests.
+
+## Relationship to AIR
+
+Bytecode is not AIR.
+
+| Layer | Shape |
+|---|---|
+| Bytecode | tagged instructions with convertable operation fragments |
+| AIR | concrete `Instruction` list with `UOpCode`, operands, metadata and comments |
+
+Bytecode is module-owned semantic lowering. AIR is backend-facing instruction stream.
+
+## Module author checklist
+
+When emitting bytecode from an AST visitor:
+
+- self-filter before emitting;
+- translate children in the intended order;
+- emit only feature-owned operations;
+- keep tags owned and documented;
+- do not emit backend-specific AIR directly from parser logic;
+- test the resulting AIR/backend behavior through execution or converter tests.
+
+## Common mistakes
+
+- Treating bytecode tags as public language syntax.
+- Using tags as magic strings without producer/consumer tests.
+- Depending on optimizer behavior to make bytecode meaningful.
+- Repairing parser mistakes during bytecode generation.
+- Emitting operations whose stack effects are not understood by AIR conversion.
+
+## Related pages
+
+- [Bytecode internals](/internals/bytecode)
+- [AIR Reference](/reference/air-reference)
+- [Writing Modules: Bytecode Generation](/write-modules/bytecode-generation)
+- [Writing Modules: Semantic Tags](/write-modules/semantic-tags)

--- a/docs/reference/dialect-reference.md
+++ b/docs/reference/dialect-reference.md
@@ -5,22 +5,257 @@ description: Document the dialect file format precisely.
 
 # Dialect Reference
 
-<div class="placeholder-box">
+This page documents the current v1 dialect DSL syntax implemented by `DialectDefinitionParser`.
 
-This page is a documentation placeholder.
+For conceptual guidance, read [Dialect Files](/build-dsls/dialect-files). This page is stricter: it describes parser-accepted directive shapes.
 
-**Purpose:** Document the dialect file format precisely.
+## Lexical rules
 
-</div>
+The dialect lexer currently recognizes:
 
-## What this page should explain
+| Token | Shape |
+|---|---|
+| identifier | letters, digits, `_`, `-`, `.` |
+| string literal | double-quoted text on one line |
+| arrow | `->` |
+| equals | `=` |
+| newline | line separator |
 
-- The practical goal of this topic.
-- The minimal example a developer should run or read.
-- The important concepts needed before going deeper.
-- Links to the next page for gradual learning.
+Whitespace other than newlines is skipped. Newlines are significant because each directive is line-based.
 
-## Status
+## Document shape
 
-Content is not written yet.
+A dialect file starts with a required header:
 
+```text
+dialect <Name>
+```
+
+or with an explicit version:
+
+```text
+dialect <Name> version "<Version>"
+```
+
+Then zero or more directives follow, one directive per line.
+
+## Minimal valid dialect
+
+The parser accepts a dialect header alone:
+
+```text
+dialect Core
+```
+
+This only defines a dialect document. It does not by itself select a useful runtime surface.
+
+## Directive reference
+
+### `use`
+
+Selects one module alias.
+
+```text
+use Arithmetic
+```
+
+Current parser shape:
+
+```text
+use <ModuleAlias>
+```
+
+Use multiple lines for multiple modules:
+
+```text
+use Numbers
+use Arithmetic
+use Scopes
+use Whitespaces
+```
+
+### `exclude`
+
+Excludes one module alias.
+
+```text
+exclude CSharpInterop
+```
+
+Current parser shape:
+
+```text
+exclude <ModuleAlias>
+```
+
+A module cannot be both used and excluded in the same dialect document.
+
+### `requires`, `before`, `after`
+
+Adds dependency/order rules.
+
+```text
+requires Variables -> Scopes
+before Conditions -> Labels
+after Loops -> Labels
+```
+
+Current parser shapes:
+
+```text
+requires <LeftAlias> -> <RightAlias>
+before <LeftAlias> -> <RightAlias>
+after <LeftAlias> -> <RightAlias>
+```
+
+### `backend`
+
+Enables or disables one backend id.
+
+```text
+backend interpreter enable
+backend cil disable
+```
+
+Current parser shape:
+
+```text
+backend <BackendId> enable
+backend <BackendId> disable
+```
+
+Backend identifiers are open-ended identifiers. A custom backend id is accepted syntactically, but runtime resolution still requires a matching registered backend/runtime surface.
+
+### `allow intrinsic` and `forbid intrinsic`
+
+Allows or forbids an intrinsic for a backend selector.
+
+```text
+allow intrinsic "add_i32" for any
+forbid intrinsic "reflect-call" for cil
+```
+
+Current parser shapes:
+
+```text
+allow intrinsic "<IntrinsicName>" for <BackendSelector>
+forbid intrinsic "<IntrinsicName>" for <BackendSelector>
+```
+
+### `enable optimizer` and `disable optimizer`
+
+Enables or disables an optimizer for a backend selector.
+
+```text
+enable optimizer ArithmeticOptimization for any
+disable optimizer AggressiveInline for interpreter
+```
+
+Current parser shapes:
+
+```text
+enable optimizer <OptimizerAlias> for <BackendSelector>
+disable optimizer <OptimizerAlias> for <BackendSelector>
+```
+
+### `security`
+
+Declares the intended security profile.
+
+```text
+security restricted
+security trusted
+```
+
+Only one security directive may be present.
+
+### `capability`
+
+Declares a boolean capability marker.
+
+```text
+capability supports-floats = true
+capability interop-enabled = false
+```
+
+Current parser shape:
+
+```text
+capability <Name> = true
+capability <Name> = false
+```
+
+Duplicate capability names are parser errors.
+
+## Backend selector
+
+Backend selectors are used by intrinsic and optimizer directives.
+
+Accepted selector shapes:
+
+| Selector | Meaning |
+|---|---|
+| `any` | all applicable backends |
+| `*` | all applicable backends |
+| `<BackendId>` | one backend id, such as `interpreter` or `cil` |
+
+`any` and `*` are accepted only where the parser allows wildcard selectors.
+
+## Duplicate/conflict diagnostics
+
+The parser currently reports errors for:
+
+| Code | Condition |
+|---|---|
+| `P100` | duplicate `use` module |
+| `P101` | same module is both used and excluded |
+| `P102` | duplicate `exclude` module |
+| `P103` | conflicting backend directive for the same backend |
+| `P104` | duplicate backend directive with the same state |
+| `P105` | duplicate security directive |
+| `P106` | duplicate capability directive |
+| `P107` | unknown directive |
+
+Lexing and parser expectation errors also have `P001`, `P002`, and `P200`-series diagnostics.
+
+## Complete parser-tested example
+
+```text
+dialect Strict version "1.0"
+use Arithmetic
+exclude CSharpInterop
+requires Variables -> Scopes
+before Conditions -> Labels
+after Loops -> Labels
+backend interpreter enable
+backend cil disable
+allow intrinsic "add_i32" for any
+forbid intrinsic "reflect-call" for cil
+enable optimizer ConstFold for any
+disable optimizer AggressiveInline for interpreter
+security restricted
+capability supports-floats = true
+capability interop-enabled = false
+```
+
+## Compatibility note
+
+Older docs or examples may contain shorthand forms such as:
+
+```text
+use Arithmetic,Numbers,Scopes,Whitespaces
+backend interpreter
+backend cil,interpreter
+enable ArithmeticOptimization
+capability interop-enabled
+```
+
+The current parser-tested v1 shape is stricter than those shorthand examples: it parses one module per `use`, requires backend `enable` or `disable`, requires `enable optimizer ... for ...`, and requires boolean values for `capability`.
+
+When updating examples, prefer the parser-tested v1 form documented on this page.
+
+## Related pages
+
+- [Dialect Files](/build-dsls/dialect-files)
+- [Module Reference](/reference/module-reference)
+- [Backend Contracts](/reference/backend-contracts)

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -5,22 +5,78 @@ description: Index strict reference pages for advanced users.
 
 # Reference Overview
 
-<div class="placeholder-box">
+Reference pages are for readers who need compact contracts, tables and implementation-facing facts.
 
-This page is a documentation placeholder.
+They are not tutorials. If you are learning the project for the first time, start with [Getting Started](/start/) and [Internals](/internals/) before using this section.
 
-**Purpose:** Index strict reference pages for advanced users.
+## How to use reference pages
 
-</div>
+Use reference pages when you need to answer questions such as:
 
-## What this page should explain
+- which AIR opcodes exist;
+- what operands an instruction expects;
+- which backend modes exist;
+- what a backend must preserve;
+- which dialect/module names are intended as stable aliases;
+- which intrinsic symbols or capability families need documentation.
 
-- The practical goal of this topic.
-- The minimal example a developer should run or read.
-- The important concepts needed before going deeper.
-- Links to the next page for gradual learning.
+## Current reference map
 
-## Status
+| Page | Purpose |
+|---|---|
+| [Dialect Reference](/reference/dialect-reference) | dialect file syntax, directive families and shipped profiles |
+| [Module Reference](/reference/module-reference) | module aliases, feature ownership and runtime exports |
+| [Bytecode Reference](/reference/bytecode-reference) | bytecode concepts and lowering responsibilities |
+| [AIR Reference](/reference/air-reference) | AIR opcode table and instruction contracts |
+| [Intrinsics Reference](/reference/intrinsics-reference) | intrinsic symbols, type arguments and capability expectations |
+| [Backend Contracts](/reference/backend-contracts) | interpreter/CIL/shared backend obligations |
+| [Project Rules](/reference/project-rules) | coding and contribution rules relevant to documentation and internals |
 
-Content is not written yet.
+## Stability levels
 
+Not every internal detail has the same stability.
+
+| Stability level | Meaning |
+|---|---|
+| Public usage contract | safe to show in user-facing docs |
+| Developer contract | expected by module/backend authors and protected by tests |
+| Current implementation | true today, but should not be treated as public API without tests |
+| Review note | useful for architecture review, not normative |
+
+Reference pages should label current implementation details when they are not yet stable API.
+
+## What belongs here
+
+Reference pages should include:
+
+- tables;
+- aliases;
+- opcode/operand shapes;
+- supported modes;
+- explicit constraints;
+- links to internals pages for deeper explanation.
+
+## What does not belong here
+
+Reference pages should not become:
+
+- marketing copy;
+- long tutorials;
+- speculative roadmap;
+- undocumented guarantees;
+- replacements for tests.
+
+## Documentation rule
+
+If a reference page lists a contract, it should be backed by one of:
+
+- current source code;
+- tests;
+- public project rules;
+- architecture docs.
+
+If the source of truth is uncertain, document the item as current implementation rather than stable contract.
+
+## Next
+
+Start with [AIR Reference](/reference/air-reference) or [Backend Contracts](/reference/backend-contracts).

--- a/docs/reference/intrinsics-reference.md
+++ b/docs/reference/intrinsics-reference.md
@@ -5,22 +5,144 @@ description: List supported intrinsics and backend capabilities.
 
 # Intrinsics Reference
 
-<div class="placeholder-box">
+This page lists the current built-in intrinsic symbol families and documents how to treat intrinsic support.
 
-This page is a documentation placeholder.
+For conceptual background, read [Intrinsics](/internals/intrinsics).
 
-**Purpose:** List supported intrinsics and backend capabilities.
+## Symbol shape
 
-</div>
+Built-in intrinsic symbols are represented as namespaced symbols such as:
 
-## What this page should explain
+```text
+Core.LoadConst
+Arithmetic.Add
+Comparison.Equal
+Storage.LoadLocal
+```
 
-- The practical goal of this topic.
-- The minimal example a developer should run or read.
-- The important concepts needed before going deeper.
-- Links to the next page for gradual learning.
+Do not treat these as arbitrary strings scattered across the codebase. They are producer/consumer contracts between AIR emitters, optimizers and backends.
 
-## Status
+## Built-in symbol families
 
-Content is not written yet.
+### Core
 
+| Symbol | Purpose |
+|---|---|
+| `Core.LoadConst` | typed constant loading |
+| `Core.CallCSharp` | C# method call descriptor path |
+| `Core.CallCSharpCtor` | C# constructor call descriptor path |
+| `Core.LoadExternal` | external binding load |
+| `Core.StoreExternal` | external binding store |
+
+### Arithmetic
+
+| Symbol | Purpose |
+|---|---|
+| `Arithmetic.Add` | addition |
+| `Arithmetic.Subtract` | subtraction |
+| `Arithmetic.Multiply` | multiplication |
+| `Arithmetic.Divide` | division |
+
+### Comparison
+
+| Symbol | Purpose |
+|---|---|
+| `Comparison.Equal` | equality comparison |
+| `Comparison.NotEqual` | inequality comparison |
+| `Comparison.Greater` | greater-than comparison |
+| `Comparison.GreaterOrEqual` | greater-or-equal comparison |
+| `Comparison.Less` | less-than comparison |
+| `Comparison.LessOrEqual` | less-or-equal comparison |
+
+### Boolean
+
+| Symbol | Purpose |
+|---|---|
+| `Boolean.And` | boolean conjunction |
+| `Boolean.Or` | boolean disjunction |
+| `Boolean.Not` | boolean negation |
+
+### Storage
+
+| Symbol | Purpose |
+|---|---|
+| `Storage.LoadLocal` | local value load |
+| `Storage.StoreLocal` | local value store |
+| `Storage.LoadLocalRef` | local reference load |
+
+## Capability model
+
+Intrinsic support is capability-based.
+
+A backend or optimizer path should check whether a symbol and type argument set is supported before emitting or consuming that intrinsic form.
+
+Current optimizer-side checks use:
+
+```text
+IOptimizerIntrinsicCapabilityContext.Supports(symbol, typeArguments)
+OptimizerCapabilityGuards.SupportsAll(...)
+```
+
+## Type arguments
+
+Many intrinsics are type-specialized.
+
+Examples:
+
+- arithmetic intrinsics may be specialized for numeric runtime types;
+- constant loading may be specialized for concrete primitive types;
+- comparison and boolean intrinsics may have their own supported type shapes.
+
+Do not assume a symbol is supported for every type.
+
+## Backend support
+
+Backend support is not universal.
+
+| Backend | Intrinsic behavior |
+|---|---|
+| Interpreter | executes supported intrinsic instructions through interpreter intrinsic execution |
+| CIL | compiles supported intrinsic instructions through the CIL intrinsic compiler/registry |
+
+A dialect exposing both backends should not enable optimizer output that only one backend can consume unless the selected runtime plan keeps that output backend-specific and guarded.
+
+## Optimizer interaction
+
+Optimizers may introduce built-in intrinsic instructions from more general AIR shapes.
+
+Examples:
+
+- arithmetic optimization may rewrite C# call descriptors into `Arithmetic.*` intrinsic instructions;
+- native CIL optimization may rewrite `Push` constants into `Core.LoadConst` instructions;
+- comparison and boolean optimization may rewrite general calls into typed comparison/boolean intrinsics.
+
+These rewrites must be capability-gated.
+
+## What to document for new intrinsics
+
+When adding a new intrinsic, document:
+
+- symbol family;
+- symbol name;
+- expected operands;
+- supported type arguments;
+- stack effect;
+- interpreter support;
+- CIL support;
+- optimizer producers;
+- tests covering supported and unsupported cases.
+
+## Common mistakes
+
+- Assuming a symbol is supported by every backend.
+- Assuming a symbol is supported for every type argument.
+- Adding an optimizer rewrite without a capability check.
+- Adding backend support without type-stack simulation support.
+- Treating C# interop descriptors and built-in intrinsics as the same abstraction.
+
+## Related pages
+
+- [Intrinsics](/internals/intrinsics)
+- [Optimizers](/internals/optimizers)
+- [AIR Reference](/reference/air-reference)
+- [Backend Contracts](/reference/backend-contracts)

--- a/docs/reference/module-reference.md
+++ b/docs/reference/module-reference.md
@@ -5,22 +5,113 @@ description: List built-in modules and their responsibilities.
 
 # Module Reference
 
-<div class="placeholder-box">
+This page lists the currently documented Wist frontend module aliases and their broad responsibilities.
 
-This page is a documentation placeholder.
+For module authoring guidance, read [Writing Modules](/write-modules/). This page is a reference index, not a tutorial.
 
-**Purpose:** List built-in modules and their responsibilities.
+## Alias source
 
-</div>
+Module aliases are declared through `DialectModuleAliasAttribute`.
 
-## What this page should explain
+The attribute accepts one or more aliases:
 
-- The practical goal of this topic.
-- The minimal example a developer should run or read.
-- The important concepts needed before going deeper.
-- Links to the next page for gradual learning.
+```csharp
+[DialectModuleAlias("Arithmetic")]
+```
 
-## Status
+Most Wist frontend modules also expose themselves through:
 
-Content is not written yet.
+```csharp
+[DialectRuntimeExport("FrontendModule", "...")]
+```
 
+Runtime export metadata is what lets dialect/runtime composition select concrete runtime components.
+
+## Common frontend modules
+
+The following aliases are used by the current Wist module coverage tests and module implementations.
+
+| Alias | Broad responsibility | Typical owner evidence |
+|---|---|---|
+| `Whitespaces` | whitespace lexeme handling | whitespace module |
+| `SemicolonAsNewLine` | semicolon/newline normalization | semicolon module |
+| `Comments` | comment lexemes | comments module |
+| `Numbers` | numeric literal lexemes and number AST translation | `NumbersModuleImpl` |
+| `Identifier` | identifier lexemes and identifier handling | identifier module |
+| `Arithmetic` | arithmetic operator lexemes, parser creators and visitors | `ArithmeticModuleImpl` |
+| `Equality` | equality operations | equality module |
+| `Conditions` | `if` / `elif` / `else` conditional syntax | `ConditionsModuleImpl` |
+| `ComparisonConditions` | comparison operations such as `<`, `<=`, `>`, `>=` | comparison condition module |
+| `BooleanConditions` | boolean operations such as and/or/not | boolean condition module |
+| `Loops` | `while` and `for` syntax | `LoopsModuleImpl` |
+| `Variables` | `let`, assignment and local variable behavior | `VariablesModuleImpl` |
+| `Scopes` | grouped scopes and parenthesized bodies | scopes module |
+| `Labels` | label-related control constructs | labels module |
+| `InternalPreprocessorLexemes` | internal preprocessing lexeme support | internal preprocessor module |
+| `CSharpInterop` | trusted C# interop surface | C# interop module |
+
+## Native and specialized modules
+
+Additional modules exist for specialized profiles:
+
+| Alias | Broad responsibility |
+|---|---|
+| `NativeTypes` | native type-oriented execution/profile support |
+| `SafeMathFunctions` | safe math function surface |
+| `FunctionCalls` | function call syntax/runtime support |
+| `ParametersSetter` | parameter-setting syntax/runtime support |
+
+These should be used only when the dialect actually needs the corresponding surface.
+
+## Optimizer aliases
+
+Optimizers are separate from frontend modules and use `DialectOptimizerAliasAttribute`.
+
+Examples visible in current code include:
+
+| Alias | Broad responsibility |
+|---|---|
+| `ArithmeticOptimization` | arithmetic intrinsic lowering and peephole simplification |
+| `NativeCilOptimization` | typed native CIL-oriented constant loading |
+| `NativeTypesOptimization` | native type optimization support |
+| `EGraphOptimization` | e-graph-inspired arithmetic/profile optimization support |
+| `BooleanOptimization` | boolean intrinsic optimization support |
+| `ComparisonIntrinsicOptimization` | comparison intrinsic optimization support |
+
+Optimizer aliases are enabled through dialect optimizer directives, not through `use` module directives.
+
+## Module responsibilities
+
+A frontend module may contribute:
+
+- lexeme registrations;
+- parser node creators;
+- AST visitors;
+- bytecode post-processing;
+- capability providers;
+- runtime export metadata.
+
+A module should own only the syntax and semantics it introduces.
+
+## Dependencies are not automatic magic
+
+Some modules are useful only with related modules.
+
+Examples:
+
+- `Variables` usually requires `Identifier`.
+- `Loops` usually requires variables and comparisons to be useful.
+- `Conditions` often requires equality or comparison modules depending on the condition expression.
+- `CSharpInterop` belongs to trusted/full profiles, not restricted user-facing formula DSLs.
+
+Dialect authors are responsible for selecting coherent module sets and testing omitted syntax.
+
+## Stability note
+
+This page is a curated reference, not an automatically generated catalog. When adding a new module, update this page only after confirming the module's alias, runtime export and intended responsibility from code.
+
+## Related pages
+
+- [Writing Modules](/write-modules/)
+- [Dialect Reference](/reference/dialect-reference)
+- [Testing a DSL](/build-dsls/testing-dsl)

--- a/docs/reference/project-rules.md
+++ b/docs/reference/project-rules.md
@@ -5,22 +5,95 @@ description: Document coding, testing, and architecture rules.
 
 # Project Rules
 
-<div class="placeholder-box">
+This page is a compact reference index for the canonical project rules.
 
-This page is a documentation placeholder.
+The source of truth is [`docs/PROJECT_RULES.md`](/PROJECT_RULES). Do not treat this page as a full replacement for that file.
 
-**Purpose:** Document coding, testing, and architecture rules.
+## Rule categories
 
-</div>
+| Category | Summary |
+|---|---|
+| Core principles | preserve universality, layering, determinism and composition boundaries |
+| Language/comments | English-only comments, XML docs, diagnostics and technical text |
+| Naming | PascalCase types/members, `_camelCase` private fields, `I...` interfaces |
+| File layout | one main public type per file, file-scoped namespaces |
+| Formatting | Allman braces, readable wrapping, guard clauses |
+| Async | async methods use `Async`; `async void` only for true event handlers |
+| Null handling | use `Thrower`-based guards; validate at public boundaries |
+| Exceptions | all project exceptions go through `Thrower` or approved helpers |
+| Public API docs | non-trivial public APIs should have XML documentation |
+| Data flow | prefer read-only abstractions and boundary input normalization |
+| Parser/AST | use safe child access, local parser mutations and processed-node markers |
+| Type stack/IR | preserve stack order, type inference and backend intrinsic contracts |
+| Architecture | avoid hidden authorities and concrete Wist/profile coupling in framework layers |
+| DI/reflection | centralize reflection and keep behavior deterministic |
+| Testing | add tests for non-trivial parsing, binding, intrinsic, optimizer, parity and DI changes |
 
-## What this page should explain
+## High-impact rules for documentation work
 
-- The practical goal of this topic.
-- The minimal example a developer should run or read.
-- The important concepts needed before going deeper.
-- Links to the next page for gradual learning.
+When updating documentation, preserve these rules:
 
-## Status
+- write English technical text in code and docs that behave as project references;
+- do not document implementation details as stable public API unless tests support them;
+- distinguish framework-level UniversalToolchain behavior from Wist convenience behavior;
+- avoid implying that restricted dialect composition is a hardened sandbox;
+- avoid performance claims without benchmark evidence;
+- document current implementation details honestly when they are not yet stable contracts.
 
-Content is not written yet.
+## High-impact rules for module work
 
+When adding or changing modules:
+
+- use stable aliases and runtime exports;
+- keep syntax owned by lexer/parser/AST stages;
+- use `SafeGet` where child access may be out of range;
+- do not mutate ancestors outside allowed parser scope;
+- mark processed nodes when required by parser flow;
+- self-filter AST visitors;
+- preserve bytecode/AIR stack discipline;
+- add interpreter/compiler parity tests when both backends are supported.
+
+## High-impact rules for backend and optimizer work
+
+When changing backend or optimizer behavior:
+
+- do not add intrinsics without backend support analysis;
+- register type-stack behavior where required;
+- check backend capabilities before emitting backend-specific intrinsic forms;
+- keep optimizers semantics-preserving;
+- avoid making optimizer output required for base correctness;
+- test unsupported backend/intrinsic paths explicitly.
+
+## Forbidden practices summary
+
+The canonical rules forbid, among other things:
+
+- direct exception throwing outside `Thrower` or approved Thrower helpers;
+- non-English comments or XML docs;
+- mixed null-check styles;
+- hidden parser mutations outside allowed local scope;
+- unsafe indexing where `SafeGet` is required;
+- scattered reflection logic;
+- magic strings for protocol-like behavior without a clear shared contract;
+- stateful mutable static fields in new code;
+- convenience layers that become hidden framework authorities;
+- framework-level branching on concrete shipped profile ids when a general path exists.
+
+## Contributor checklist
+
+Before merging non-trivial code changes, verify:
+
+- naming and formatting match project style;
+- exceptions/null checks use project-approved mechanisms;
+- public APIs are documented when non-trivial;
+- parser/visitor/IR stack invariants are preserved;
+- intrinsics have backend and type-processing support;
+- tests cover behavior and parity where applicable;
+- the change preserves universality rather than narrowing architecture for a local case.
+
+## Related pages
+
+- [Writing Modules](/write-modules/)
+- [Internals](/internals/)
+- [Semantic Parity](/internals/semantic-parity)
+- [Backend Contracts](/reference/backend-contracts)


### PR DESCRIPTION
## Summary

This PR fills the remaining advanced `Internals` placeholders, completes the current `Reference` placeholder set, and aligns the `Build DSLs` documentation with the parser-tested v1 dialect directive shape.

## Updated internals pages

- `docs/internals/intrinsics.md`
- `docs/internals/optimizers.md`
- `docs/internals/semantic-parity.md`
- `docs/internals/dependency-injection.md`

## Updated reference pages

- `docs/reference/index.md`
- `docs/reference/air-reference.md`
- `docs/reference/backend-contracts.md`
- `docs/reference/bytecode-reference.md`
- `docs/reference/dialect-reference.md`
- `docs/reference/intrinsics-reference.md`
- `docs/reference/module-reference.md`
- `docs/reference/project-rules.md`

## Updated consistency pages

- `docs/build-dsls/index.md`
- `docs/build-dsls/dialect-files.md`
- `docs/build-dsls/minimal-dsl.md`
- `docs/build-dsls/backend-selection.md`
- `docs/build-dsls/module-composition.md`
- `docs/build-dsls/testing-dsl.md`

## What changed

- Documents intrinsics as contracts between AIR, optimizer capability checks, and backend execution/compilation.
- Documents `IIRProcessingModule` optimizer hooks: `InitMethodsTranslator`, `InitIntrinsicCapabilityContext`, and `ProcessIr`.
- Clarifies optimizer capability gating with examples from arithmetic and native CIL optimization.
- Documents semantic parity as a correctness invariant distinct from backend availability and optimizer safety.
- Documents DI as part of Wist runtime composition rather than just object construction.
- Adds reference overview and stability levels.
- Adds AIR opcode and backend contract references.
- Adds bytecode reference based on `Bytecode`, `BytecodeInstruction`, and `IAbstractMethodConvertable`.
- Adds dialect reference based on `DialectDefinitionParser`, `DialectLexer`, `ParserState`, and parser tests.
- Adds module and intrinsic reference pages using current aliases/symbol families visible in code.
- Adds project rules reference as an index to `docs/PROJECT_RULES.md`.
- Updates `Build DSLs` examples away from older shorthand forms such as `backend interpreter` and `use A,B,C` toward parser-tested v1 forms such as `backend interpreter enable` and one `use` directive per module.

## Scope

Documentation-only change. No runtime code, VitePress config, sidebar, theme, or architecture changes.

## Note

The branch may need to be rebased or updated from `master` before merge if `master` moved after this PR was opened.