### PR TITLE
docs: align dialect examples with parser syntax

### DIFF
--- a/docs/build-dsls/backend-selection.md
+++ b/docs/build-dsls/backend-selection.md
@@ -37,8 +37,11 @@ Dialect example:
 
 ```text
 dialect MinimalArithmetic
-use Arithmetic,Numbers,Scopes,Whitespaces
-backend interpreter
+use Arithmetic
+use Numbers
+use Scopes
+use Whitespaces
+backend interpreter enable
 ```
 
 Run example:
@@ -60,11 +63,15 @@ Dialect example:
 
 ```text
 dialect MinimalArithmeticNative
-use Arithmetic,Numbers,Scopes,Whitespaces,NativeTypes
-backend cil
-enable ArithmeticOptimization
-enable NativeCilOptimization
-enable NativeTypesOptimization
+use Arithmetic
+use Numbers
+use Scopes
+use Whitespaces
+use NativeTypes
+backend cil enable
+enable optimizer ArithmeticOptimization for cil
+enable optimizer NativeCilOptimization for cil
+enable optimizer NativeTypesOptimization for cil
 ```
 
 Run example:
@@ -84,7 +91,8 @@ Use both backends when you need:
 Dialect example:
 
 ```text
-backend cil,interpreter
+backend cil enable
+backend interpreter enable
 ```
 
 When both are enabled, tests should run the same source through both modes and compare observable results.
@@ -100,7 +108,7 @@ When both are enabled, tests should run the same source through both modes and c
 | Restricted user-authored formulas | usually `compiler` or `interpreter`, but only with a narrow module set |
 | Backend feature development | both, with explicit parity and negative tests |
 
-The backend choice is not a substitute for language restriction. A CIL-backed DSL can still be too broad if the dialect selects unsafe or unnecessary modules.
+The backend choice is not a substitute for language restriction. A CIL-backed DSL can still be too broad if the dialect selects unnecessary modules.
 
 ## Programmatic entry point
 
@@ -158,6 +166,7 @@ Parity does not mean every backend must support every dialect. A dialect may int
 - Treating the interpreter as a fallback when the selected backend fails.
 - Adding backend-specific intrinsics to a general interpreter surface.
 - Comparing benchmark numbers before separating compilation time from execution time.
+- Copying older shorthand backend directives such as `backend cil,interpreter` instead of parser-tested v1 directives.
 
 ## Next
 

--- a/docs/build-dsls/dialect-files.md
+++ b/docs/build-dsls/dialect-files.md
@@ -19,26 +19,44 @@ A Wist dialect file uses the `.wistdialect` extension. It is compiled before pro
 dialect source → dialect compilation → build plan → manifest-backed runtime selection → host creation → execution
 ```
 
-A typical dialect file contains:
+A parser-tested v1 dialect file uses one directive per line:
 
 ```text
 dialect FullDefault
-use Arithmetic,BooleanConditions,Comments,ComparisonConditions,Conditions,CSharpInterop,Equality,Identifier,Labels,Loops,Numbers,Scopes,SemicolonAsNewLine,Variables,Whitespaces
-backend cil,interpreter
-enable BooleanOptimization
-enable ComparisonIntrinsicOptimization
+use Arithmetic
+use BooleanConditions
+use Comments
+use ComparisonConditions
+use Conditions
+use CSharpInterop
+use Equality
+use Identifier
+use Labels
+use Loops
+use Numbers
+use Scopes
+use SemicolonAsNewLine
+use Variables
+use Whitespaces
+backend cil enable
+backend interpreter enable
+enable optimizer BooleanOptimization for any
+enable optimizer ComparisonIntrinsicOptimization for any
 security trusted
-capability unsafe-interop
+capability interop-enabled = true
 ```
 
 ## Minimal example
 
-The smallest shipped arithmetic dialect is:
+A minimal arithmetic dialect looks like this in the current parser-tested v1 form:
 
 ```text
 dialect MinimalArithmetic
-use Arithmetic,Numbers,Scopes,Whitespaces
-backend interpreter
+use Arithmetic
+use Numbers
+use Scopes
+use Whitespaces
+backend interpreter enable
 ```
 
 This dialect can run a program such as:
@@ -67,30 +85,40 @@ The name is used in diagnostics and composition output.
 
 ### `use`
 
-Selects modules:
+Selects one module:
 
 ```text
-use Arithmetic,Numbers,Scopes,Whitespaces
+use Arithmetic
+```
+
+Use multiple `use` lines to select multiple modules:
+
+```text
+use Arithmetic
+use Numbers
+use Scopes
+use Whitespaces
 ```
 
 A module must be selected for its syntax and runtime behavior to exist. For example, arithmetic syntax needs arithmetic and number support; variable syntax needs variables and identifier support.
 
 ### `exclude`
 
-Removes selected modules from a composition:
+Removes one selected module from a composition:
 
 ```text
-exclude CSharpInterop,Identifier,InternalPreprocessorLexemes,Labels,Loops,NativeTypes,ParametersSetter,SemicolonAsNewLine,Variables
+exclude CSharpInterop
 ```
 
-The shipped `restricted-sandbox` example uses this to keep the runtime surface narrower.
+Use multiple `exclude` lines for multiple modules.
 
 ### `backend`
 
-Selects execution backends:
+Enables or disables one execution backend:
 
 ```text
-backend cil,interpreter
+backend cil enable
+backend interpreter enable
 ```
 
 Currently documented user-facing modes are:
@@ -98,20 +126,29 @@ Currently documented user-facing modes are:
 - `compiler`, which maps to the CIL backend when the dialect exposes `cil`;
 - `interpreter`, which runs through the interpreter backend when exposed.
 
-Some dialect examples expose both `cil` and `interpreter`. Others expose only one backend.
+Some dialects expose both `cil` and `interpreter`. Others expose only one backend.
 
-### `enable`
+### `enable optimizer` / `disable optimizer`
 
-Enables optimizers:
+Enables or disables an optimizer for a backend selector:
 
 ```text
-enable ArithmeticOptimization
-enable EGraphOptimization
-enable NativeCilOptimization
-enable NativeTypesOptimization
+enable optimizer ArithmeticOptimization for any
+disable optimizer AggressiveInline for interpreter
 ```
 
-Only enable optimizers that are supported by the selected modules and backend path.
+Use `any` or `*` for all applicable backends, or a specific backend id such as `cil` or `interpreter`.
+
+### `allow intrinsic` / `forbid intrinsic`
+
+Allows or forbids an intrinsic for a backend selector:
+
+```text
+allow intrinsic "add_i32" for any
+forbid intrinsic "reflect-call" for cil
+```
+
+This is a dialect-level intrinsic policy directive. It should match backend capability expectations.
 
 ### `security`
 
@@ -127,14 +164,14 @@ or:
 security trusted
 ```
 
-A restricted dialect is a composition constraint, not a hardened sandbox. Use process and environment isolation for untrusted code.
+A restricted dialect is a composition constraint, not a process isolation guarantee.
 
 ### `capability`
 
-Declares a capability marker:
+Declares a boolean capability marker:
 
 ```text
-capability unsafe-interop
+capability interop-enabled = false
 ```
 
 Capabilities explain selected composition. They must not be treated as hidden runtime activation mechanisms.
@@ -151,7 +188,7 @@ Examples are located under `UniversalToolchain/Dialects/examples/wist`:
 | `minimal-arithmetic` | Smallest interpreter arithmetic profile. |
 | `minimal-arithmetic-native` | Smallest native arithmetic profile over `cil`. |
 | `pricing-restricted` | Composition-constrained pricing profile with a restricted runtime surface. |
-| `restricted-sandbox` | Composition-constrained profile; not a hardened sandbox guarantee. |
+| `restricted-sandbox` | Composition-constrained profile; not an isolation guarantee. |
 
 ## How it fits into the pipeline
 
@@ -161,8 +198,9 @@ Examples are located under `UniversalToolchain/Dialects/examples/wist`:
 
 - Do not document rules as an available public runtime feature. `rule-schema`, `rule-run`, raw-source RuleSet MVP parsing and `RuleDeclarationsModule` are temporarily removed.
 - Keep dialect files explicit. A future reader should be able to see which syntax and backend paths are available.
-- Do not treat `restricted-sandbox` as a real security sandbox.
+- Do not treat `restricted-sandbox` as a process isolation guarantee.
 - Do not add raw-source parsing workarounds for missing language features. Syntax must be owned by lexer/parser/AST/module code.
+- Prefer the parser-tested v1 directive shape documented in [Dialect Reference](/reference/dialect-reference).
 
 ## Next
 

--- a/docs/build-dsls/index.md
+++ b/docs/build-dsls/index.md
@@ -44,12 +44,15 @@ dialect file
 
 ## Minimal example
 
-The smallest useful path is to start from a shipped arithmetic dialect:
+The smallest useful path is to start from an arithmetic dialect:
 
 ```text
 dialect MinimalArithmetic
-use Arithmetic,Numbers,Scopes,Whitespaces
-backend interpreter
+use Arithmetic
+use Numbers
+use Scopes
+use Whitespaces
+backend interpreter enable
 ```
 
 This dialect is intentionally narrow. It can run arithmetic expressions such as:
@@ -64,7 +67,7 @@ Expected result:
 14
 ```
 
-It should not accept syntax whose owning modules are not selected. For example, variables require `Identifier` and `Variables`; loops require loop-related modules; C# interop requires an explicit unsafe/trusted runtime surface.
+It should not accept syntax whose owning modules are not selected. For example, variables require `Identifier` and `Variables`; loops require loop-related modules; C# interop requires an explicit trusted runtime surface.
 
 ## What you usually build
 
@@ -77,7 +80,7 @@ Use this for pricing, scoring, limits, thresholds or other numeric expressions.
 Typical properties:
 
 - narrow module set;
-- no unsafe interop;
+- no interop modules;
 - deterministic input bindings;
 - compiler mode only when performance matters and CIL support is available;
 - negative tests for syntax that must remain unavailable.
@@ -126,6 +129,7 @@ This order keeps composition errors visible. It also prevents optimizers or back
 - A backend must not change the observable meaning of a program.
 - A module should own the syntax and semantics it introduces.
 - Do not document removed or internal rule-declaration behavior as public runtime functionality.
+- Prefer the parser-tested v1 dialect directive shape documented in [Dialect Reference](/reference/dialect-reference).
 
 ## Pages in this section
 

--- a/docs/build-dsls/minimal-dsl.md
+++ b/docs/build-dsls/minimal-dsl.md
@@ -31,12 +31,15 @@ The repository already contains a minimal arithmetic example:
 UniversalToolchain/Dialects/examples/wist/minimal-arithmetic/dialect.wistdialect
 ```
 
-Its contents are:
+In parser-tested v1 syntax, the dialect shape is:
 
 ```text
 dialect MinimalArithmetic
-use Arithmetic,Numbers,Scopes,Whitespaces
-backend interpreter
+use Arithmetic
+use Numbers
+use Scopes
+use Whitespaces
+backend interpreter enable
 ```
 
 The matching program is:
@@ -65,8 +68,13 @@ If you need variables, extend the module list:
 
 ```text
 dialect MinimalVariables
-use Arithmetic,Numbers,Identifier,Variables,Scopes,Whitespaces
-backend interpreter
+use Arithmetic
+use Numbers
+use Identifier
+use Variables
+use Scopes
+use Whitespaces
+backend interpreter enable
 ```
 
 Then a program like this becomes valid:
@@ -80,7 +88,10 @@ x + y
 If you need comparisons and conditions, add the owning modules explicitly:
 
 ```text
-use Arithmetic,Numbers,Identifier,Variables,Scopes,Whitespaces,ComparisonConditions,Conditions,Equality,BooleanConditions
+use ComparisonConditions
+use Conditions
+use Equality
+use BooleanConditions
 ```
 
 The exact module set depends on the syntax you want to allow. Start narrow and add only the features you can test.
@@ -90,19 +101,20 @@ The exact module set depends on the syntax you want to allow. Start narrow and a
 For interpreter-only DSLs:
 
 ```text
-backend interpreter
+backend interpreter enable
 ```
 
 For CIL-backed DSLs:
 
 ```text
-backend cil
+backend cil enable
 ```
 
 For both modes:
 
 ```text
-backend cil,interpreter
+backend cil enable
+backend interpreter enable
 ```
 
 If both backends are enabled, add parity tests so the same source produces the same observable result in both modes.
@@ -112,10 +124,10 @@ If both backends are enabled, add parity tests so the same source produces the s
 A native arithmetic dialect can enable optimizers such as:
 
 ```text
-enable ArithmeticOptimization
-enable EGraphOptimization
-enable NativeCilOptimization
-enable NativeTypesOptimization
+enable optimizer ArithmeticOptimization for cil
+enable optimizer EGraphOptimization for any
+enable optimizer NativeCilOptimization for cil
+enable optimizer NativeTypesOptimization for any
 ```
 
 Do this after the minimal interpreter version works. Optimizers should not be used to hide missing semantics.
@@ -132,9 +144,10 @@ The dialect file is compiled into a build plan, resolved against runtime manifes
 
 - Starting with `full-default` and removing features without testing the result.
 - Forgetting `Identifier` when adding `Variables`.
-- Enabling `compiler` mode in the CLI while the dialect declares only `backend interpreter`.
-- Adding `CSharpInterop` or `unsafe-interop` to a DSL intended for restricted user-authored formulas.
+- Enabling `compiler` mode in the CLI while the dialect declares only `backend interpreter enable`.
+- Adding `CSharpInterop` or interop capabilities to a DSL intended for restricted user-authored formulas.
 - Documenting rules as available. Rule runtime functionality is currently removed from the public surface.
+- Copying older shorthand dialect examples instead of the parser-tested v1 directive shape.
 
 ## Next
 

--- a/docs/build-dsls/module-composition.md
+++ b/docs/build-dsls/module-composition.md
@@ -55,8 +55,11 @@ This dialect:
 
 ```text
 dialect MinimalArithmetic
-use Arithmetic,Numbers,Scopes,Whitespaces
-backend interpreter
+use Arithmetic
+use Numbers
+use Scopes
+use Whitespaces
+backend interpreter enable
 ```
 
 is a composition of four capabilities:
@@ -88,7 +91,7 @@ Some modules are meaningful only with related modules. For example:
 - `Variables` usually requires `Identifier`.
 - conditional syntax usually requires comparison/equality/boolean support, depending on the exact program shape;
 - native/CIL-oriented optimizations require backend support;
-- unsafe interop should not appear in a restricted user-facing formula DSL.
+- interop modules should not appear in a restricted user-facing formula DSL.
 
 The documentation should not pretend that module composition is magic. A dialect author is responsible for selecting a coherent set of capabilities and testing it.
 
@@ -117,7 +120,7 @@ A restricted dialect reduces the available language surface. That is useful, but
 Use restricted dialects to say:
 
 ```text
-This formula language does not include variables, loops or unsafe interop.
+This formula language does not include variables, loops or interop modules.
 ```
 
 Do not use restricted dialects alone to say:
@@ -136,6 +139,7 @@ For untrusted third-party code, combine dialect restriction with process, enviro
 - Depending on one backend while documenting the dialect as backend-neutral.
 - Adding marker-only capabilities that imply behavior without implementation ownership.
 - Hiding missing module dependencies behind fallback parser behavior.
+- Copying older shorthand dialect examples instead of parser-tested v1 directives.
 
 ## Practical checklist
 
@@ -145,7 +149,7 @@ Before accepting a dialect composition, verify:
 - omitted syntax is rejected;
 - selected backends match the intended runtime modes;
 - compiler and interpreter results match when both are enabled;
-- unsafe interop is absent from user-authored restricted DSLs;
+- interop modules are absent from restricted user-authored DSLs unless explicitly intended;
 - optimizer support is tested separately from base semantics.
 
 ## Next

--- a/docs/build-dsls/testing-dsl.md
+++ b/docs/build-dsls/testing-dsl.md
@@ -26,7 +26,7 @@ At minimum, a dialect should have these test categories:
 | Backend availability | unsupported modes fail |
 | Backend parity | interpreter and compiler agree when both are exposed |
 | Optimizer safety | optimizers do not change observable results |
-| Runtime surface | unsafe or unrelated modules are not accidentally selected |
+| Runtime surface | interop or unrelated modules are not accidentally selected |
 
 ## 1. Positive execution test
 
@@ -66,7 +66,7 @@ Negative tests are as important as positive tests. Without them, a “restricted
 If a dialect declares:
 
 ```text
-backend interpreter
+backend interpreter enable
 ```
 
 then asking for compiler mode should fail.
@@ -74,7 +74,7 @@ then asking for compiler mode should fail.
 If a dialect declares:
 
 ```text
-backend cil
+backend cil enable
 ```
 
 then asking for interpreter mode should fail.
@@ -86,7 +86,8 @@ The failure should be explicit. Do not silently fall back to another backend, be
 When a dialect exposes both:
 
 ```text
-backend cil,interpreter
+backend cil enable
+backend interpreter enable
 ```
 
 run the same source through both modes and compare the result.
@@ -118,13 +119,20 @@ Test optimizer-sensitive programs in two ways:
 
 Compare observable results. For backend-specific optimizers, also verify that unsupported backends do not receive backend-specific intrinsics.
 
+Current parser-tested optimizer directives use this shape:
+
+```text
+enable optimizer ArithmeticOptimization for cil
+disable optimizer AggressiveInline for interpreter
+```
+
 ## 6. Runtime surface test
 
 A DSL intended for end-user formulas should not accidentally expose broad runtime features.
 
 For a pricing formula dialect, test that these are unavailable unless intentionally selected:
 
-- unsafe C# interop;
+- C# interop;
 - loops;
 - labels;
 - broad native/runtime functionality;
@@ -138,7 +146,7 @@ This is not only a security concern. It also keeps the product behavior predicta
 |---|---|---|---|
 | `minimal-arithmetic` | `2 + 3 * 4` | `let x = 2` | `interpreter` |
 | `minimal-arithmetic-native` | `2 + 3 * 4` | unsupported non-arithmetic syntax | `compiler` |
-| `pricing-restricted` | pricing expression with declared inputs | unsafe interop or unrelated syntax | selected restricted backend path |
+| `pricing-restricted` | pricing expression with declared inputs | interop or unrelated syntax | selected restricted backend path |
 | `full-default` | broad Wist examples | invalid syntax only | `compiler`, `interpreter` |
 
 ## What not to test as a shortcut
@@ -159,7 +167,8 @@ Before documenting a dialect as stable, verify:
 - unsupported backend modes fail explicitly;
 - parity tests exist when both compiler and interpreter are enabled;
 - optimizer behavior is tested separately from base semantics;
-- restricted dialects do not expose unsafe or unrelated modules.
+- restricted dialects do not expose interop or unrelated modules;
+- dialect examples use the parser-tested v1 directive shape.
 
 ## Next
 


### PR DESCRIPTION
## Summary

This PR aligns `Build DSLs` documentation examples with the parser-tested v1 dialect directive syntax documented in `docs/reference/dialect-reference.md`.

Updated pages:

- `docs/build-dsls/index.md`
- `docs/build-dsls/dialect-files.md`
- `docs/build-dsls/minimal-dsl.md`
- `docs/build-dsls/backend-selection.md`
- `docs/build-dsls/module-composition.md`
- `docs/build-dsls/testing-dsl.md`

## What changed

- Replaces older shorthand examples such as `use Arithmetic,Numbers,Scopes,Whitespaces` with one `use` directive per module.
- Replaces shorthand backend examples such as `backend interpreter` and `backend cil,interpreter` with parser-tested forms such as `backend interpreter enable` and `backend cil enable`.
- Replaces older optimizer examples such as `enable ArithmeticOptimization` with parser-tested forms such as `enable optimizer ArithmeticOptimization for cil`.
- Updates restricted-dialect wording to describe composition boundaries more precisely.
- Adds references to the parser-tested v1 shape documented in `Dialect Reference`.

## Evidence

The changes follow `DialectDefinitionParser`, `DialectLexer`, `ParserState`, and parser tests, which currently accept one directive per line and require explicit backend enable/disable plus optimizer target selectors.

## Scope

Documentation-only change. No runtime code, VitePress config, sidebar, theme, or architecture changes.