### PR TITLE
feat: add TextualAddition module tutorial

### DIFF
--- a/UniversalToolchain/ArithmeticModule/Creators/TextualAdditionOperationNodeCreator.cs
+++ b/UniversalToolchain/ArithmeticModule/Creators/TextualAdditionOperationNodeCreator.cs
@@ -1,0 +1,5 @@
+namespace ArithmeticModule.Creators;
+
+[AutoRegisterService]
+[ArithmeticModeCompatibility(ArithmeticMode.Universal)]
+public class TextualAdditionOperationNodeCreator() : BinaryOperationBase("TextualAddition");

--- a/UniversalToolchain/ArithmeticModule/Module/TextualAdditionModuleImpl.cs
+++ b/UniversalToolchain/ArithmeticModule/Module/TextualAdditionModuleImpl.cs
@@ -8,7 +8,7 @@ public class TextualAdditionModuleImpl : IFrontendCoreModule
 {
     private static readonly IReadOnlyList<LexemeRegistration> _lexemeRegistrations =
     [
-        new(@"plus", "TextualAddition")
+        new(@"\bplus\b", "TextualAddition", Priority: 110f)
     ];
 
     private static readonly IReadOnlyList<NodeCreatorRegistration> _nodeCreatorRegistrations =

--- a/UniversalToolchain/ArithmeticModule/Module/TextualAdditionModuleImpl.cs
+++ b/UniversalToolchain/ArithmeticModule/Module/TextualAdditionModuleImpl.cs
@@ -1,0 +1,24 @@
+namespace ArithmeticModule.Module;
+
+[DialectModuleAlias("TextualAddition")]
+[DialectRuntimeExport("FrontendModule", "TextualAddition")]
+[AutoRegisterService]
+[ArithmeticModeCompatibility(ArithmeticMode.Universal)]
+public class TextualAdditionModuleImpl : IFrontendCoreModule
+{
+    private static readonly IReadOnlyList<LexemeRegistration> _lexemeRegistrations =
+    [
+        new(@"plus", "TextualAddition")
+    ];
+
+    private static readonly IReadOnlyList<NodeCreatorRegistration> _nodeCreatorRegistrations =
+    [
+        new(-30f, new TextualAdditionOperationNodeCreator())
+    ];
+
+    public void InitLexer(ILexer lexer) => lexer.AddLexemes(_lexemeRegistrations);
+
+    public void InitParser(IParser parser) => parser.AddNodeCreators(_nodeCreatorRegistrations);
+
+    public void InitAstTranslator(IAstToBytecodeTranslator translator) => translator.AddVisitors(new TextualAdditionAstVisitor());
+}

--- a/UniversalToolchain/ArithmeticModule/Visitors/TextualAdditionAstVisitor.cs
+++ b/UniversalToolchain/ArithmeticModule/Visitors/TextualAdditionAstVisitor.cs
@@ -1,0 +1,24 @@
+namespace ArithmeticModule.Visitors;
+
+[AutoRegisterService]
+[ArithmeticModeCompatibility(ArithmeticMode.Universal)]
+public class TextualAdditionAstVisitor : IAstVisitor
+{
+    private static readonly ExtensibleEnum<AstNodeTag> _nodeType = ExtensibleEnum<AstNodeTag>.CreateOrGet("TextualAddition");
+
+    public void TryVisit(BytecodeVisitorData data)
+    {
+        if (data.Node.NodeType != _nodeType)
+            return;
+
+        foreach (var child in data.Node.Children)
+            data.AstToBytecodeTranslator.Translate(child);
+
+        var method = new AbstractMethodImpl(
+            "Op_plus",
+            (il, context) => il.CallCSharp(context.Stack[^1].GetMethod("Add").NotNull())
+        );
+
+        data.Bytecode.Instructions.Add(new BytecodeInstruction(method));
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/TextualAdditionModuleTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/TextualAdditionModuleTests.cs
@@ -1,0 +1,49 @@
+using UniversalToolchain.Modules.Tests;
+
+namespace UniversalToolchain.Dialects.Tests;
+
+[TestFixture]
+public sealed class TextualAdditionModuleTests
+{
+    private const string TextualAdditionDialect = """
+                                                 dialect TextualAdditionDemo
+                                                 use Whitespaces,Numbers,Scopes,Arithmetic,TextualAddition
+                                                 backend compiler,interpreter
+                                                 """;
+
+    private const string ArithmeticOnlyDialect = """
+                                                dialect ArithmeticOnlyDemo
+                                                use Whitespaces,Numbers,Scopes,Arithmetic
+                                                backend compiler,interpreter
+                                                """;
+
+    [Test]
+    public void TextualAddition_Module_ExecutesPlusKeyword()
+    {
+        var result = DialectTestHostInfrastructure.RunInBothBackends(TextualAdditionDialect, "2 plus 3");
+
+        Assert.That(BackendParityInfrastructure.AsNumber(result), Is.EqualTo(5.0d).Within(1e-9));
+    }
+
+    [Test]
+    public void TextualAddition_Module_UsesAdditionPrecedence()
+    {
+        var result = DialectTestHostInfrastructure.RunInBothBackends(TextualAdditionDialect, "2 plus 3 * 4");
+
+        Assert.That(BackendParityInfrastructure.AsNumber(result), Is.EqualTo(14.0d).Within(1e-9));
+    }
+
+    [Test]
+    public void TextualAddition_Syntax_IsUnavailable_WhenModuleIsNotSelected()
+    {
+        var (compilerResult, interpreterResult) = BackendParityInfrastructure.RunBoth(ArithmeticOnlyDialect, "2 plus 3");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(compilerResult.IsSuccess, Is.False, "Compiler path must reject syntax owned by an unselected module.");
+            Assert.That(interpreterResult.IsSuccess, Is.False, "Interpreter path must reject syntax owned by an unselected module.");
+            Assert.That(compilerResult.Exception, Is.Not.Null);
+            Assert.That(interpreterResult.Exception, Is.Not.Null);
+        });
+    }
+}

--- a/docs/reference/module-reference.md
+++ b/docs/reference/module-reference.md
@@ -7,7 +7,7 @@ description: List built-in modules and their responsibilities.
 
 This page lists the currently documented Wist frontend module aliases and their broad responsibilities.
 
-For module authoring guidance, read [Writing Modules](/write-modules/). This page is a reference index, not a tutorial.
+For module authoring guidance, read [Writing Modules](/write-modules/). This page is a reference index, not a tutorial. For a complete beginner-friendly walkthrough, read [Create Your First Module](/write-modules/create-your-first-module).
 
 ## Alias source
 
@@ -39,6 +39,7 @@ The following aliases are used by the current Wist module coverage tests and mod
 | `Numbers` | numeric literal lexemes and number AST translation | `NumbersModuleImpl` |
 | `Identifier` | identifier lexemes and identifier handling | identifier module |
 | `Arithmetic` | arithmetic operator lexemes, parser creators and visitors | `ArithmeticModuleImpl` |
+| `TextualAddition` | textual `plus` operator that lowers to arithmetic addition | `TextualAdditionModuleImpl` |
 | `Equality` | equality operations | equality module |
 | `Conditions` | `if` / `elif` / `else` conditional syntax | `ConditionsModuleImpl` |
 | `ComparisonConditions` | comparison operations such as `<`, `<=`, `>`, `>=` | comparison condition module |
@@ -102,6 +103,7 @@ Examples:
 - `Variables` usually requires `Identifier`.
 - `Loops` usually requires variables and comparisons to be useful.
 - `Conditions` often requires equality or comparison modules depending on the condition expression.
+- `TextualAddition` is useful with `Arithmetic`, `Numbers`, `Scopes` and `Whitespaces` in the first-module tutorial.
 - `CSharpInterop` belongs to trusted/full profiles, not restricted user-facing formula DSLs.
 
 Dialect authors are responsible for selecting coherent module sets and testing omitted syntax.
@@ -113,5 +115,6 @@ This page is a curated reference, not an automatically generated catalog. When a
 ## Related pages
 
 - [Writing Modules](/write-modules/)
+- [Create Your First Module](/write-modules/create-your-first-module)
 - [Dialect Reference](/reference/dialect-reference)
 - [Testing a DSL](/build-dsls/testing-dsl)

--- a/docs/write-modules/choose-extension-type.md
+++ b/docs/write-modules/choose-extension-type.md
@@ -1,0 +1,94 @@
+---
+title: Choose an Extension Type
+description: Decide whether you need a dialect, frontend module, optimizer, backend feature, or intrinsic.
+---
+
+# Choose an Extension Type
+
+Before writing a module, decide whether you really need one. UniversalToolchain has several extension points. Choosing the wrong one usually creates hardcoded behavior, duplicate syntax ownership, or backend drift.
+
+## Start with the smallest extension point
+
+Use this decision table before creating new code:
+
+| You want to... | Prefer... | Why |
+|---|---|---|
+| Restrict or combine existing language features | a `.wistdialect` file | no new syntax or runtime behavior is needed |
+| Add new syntax that lowers to existing semantics | a frontend module | the module owns lexer/parser/AST integration |
+| Add new syntax with new runtime behavior | a frontend module plus bytecode/AIR/backend support | syntax and execution must evolve together |
+| Add a performance rewrite for existing AIR | an optimizer module | semantics already exist; only lowering changes |
+| Add a backend-specific fast path | an intrinsic plus backend capability checks | the backend must explicitly declare support |
+| Add a new execution target | a backend declaration and backend service provider | execution is a runtime concern, not a frontend concern |
+
+## When a dialect file is enough
+
+Do not create a module when the feature is only a product profile.
+
+For example, this is a dialect composition problem:
+
+```text
+dialect PricingFormula
+use Whitespaces,Numbers,Scopes,Arithmetic
+backend interpreter
+```
+
+The dialect says which existing syntax exists. It does not add syntax.
+
+## When a frontend module is right
+
+Create a frontend module when the feature introduces new source-level syntax.
+
+Examples:
+
+- a new operator;
+- a new keyword;
+- a new expression form;
+- a new statement form;
+- a new module-owned AST translation rule.
+
+A frontend module usually contributes:
+
+1. module metadata;
+2. lexer registrations;
+3. parser node creators;
+4. AST visitors;
+5. tests proving dialect visibility and backend parity.
+
+The next page walks through a small frontend module that adds `plus` as a textual addition operator.
+
+## When backend work is required
+
+A frontend module can reuse existing semantics, but not every feature can do that.
+
+You need backend work when:
+
+- the emitted bytecode operation is new;
+- the generated AIR shape is new;
+- an optimizer emits backend-specific intrinsics;
+- interpreter and compiler do not already understand the behavior;
+- the feature has backend-specific availability.
+
+Do not hide missing backend behavior behind a parser shortcut or a fallback path. If both compiler and interpreter are supported, add parity tests.
+
+## When an optimizer is right
+
+Use an optimizer when the source language already works without it.
+
+An optimizer may improve generated AIR or backend execution, but it must not be the only implementation of the feature semantics. Base execution should remain correct with optimizers disabled.
+
+## Checklist
+
+Before adding a module, answer:
+
+- What source syntax does this feature own?
+- Which existing modules does it depend on?
+- Does it lower to existing semantics or introduce new runtime behavior?
+- Which backend modes must support it?
+- What should fail when the module is not selected?
+- Which tests prove positive execution, negative dialect surface, and backend parity?
+
+If the answers are unclear, start with a dialect or design note rather than a new runtime component.
+
+## Next
+
+Continue with [Create Your First Module](/write-modules/create-your-first-module).

--- a/docs/write-modules/create-your-first-module.md
+++ b/docs/write-modules/create-your-first-module.md
@@ -7,7 +7,7 @@ description: Build a small frontend module from syntax idea to tested dialect be
 
 This tutorial builds a real, intentionally small frontend module: `TextualAddition`.
 
-The module adds a textual addition operator:
+It adds this Wist syntax:
 
 ```wist
 2 plus 3
@@ -19,7 +19,7 @@ Expected result:
 5
 ```
 
-The feature is small on purpose. It touches the full module authoring path without requiring a new backend or intrinsic.
+The feature is deliberately small. It exercises the module pipeline without requiring a new backend, new AIR shape, or new intrinsic.
 
 ## What you will build
 
@@ -28,16 +28,12 @@ The feature is small on purpose. It touches the full module authoring path witho
 | Module alias | `TextualAddition` |
 | Runtime export | `FrontendModule/TextualAddition` |
 | New syntax | `<expression> plus <expression>` |
-| Parser precedence | same as normal addition |
-| Runtime behavior | reuse existing `Add` operation on the left operand type |
+| Parser precedence | same as addition/subtraction |
+| Runtime behavior | lower to the existing `Add` operation |
 | Required related modules | `Whitespaces`, `Numbers`, `Scopes`, `Arithmetic` |
-| Backend expectation | compiler and interpreter parity |
-
-This module is a good first example because it adds syntax but reuses existing arithmetic semantics.
+| Tests | positive execution, precedence, missing-module rejection |
 
 ## Files created
-
-The implementation lives in the existing `ArithmeticModule` project because this tutorial feature is semantically arithmetic-related:
 
 | Concern | File |
 |---|---|
@@ -46,23 +42,19 @@ The implementation lives in the existing `ArithmeticModule` project because this
 | AST visitor | `UniversalToolchain/ArithmeticModule/Visitors/TextualAdditionAstVisitor.cs` |
 | Tests | `UniversalToolchain/UniversalToolchain.Dialects.Tests/TextualAdditionModuleTests.cs` |
 
-A production feature could live in its own project. For a first tutorial, keeping the example near the existing arithmetic code makes ownership and reuse easier to understand.
+The example lives in `ArithmeticModule` because it is semantically arithmetic-related. A larger external feature can live in its own project, but the same responsibilities apply.
 
 ## Step 1. Define the feature boundary
 
-`TextualAddition` owns only one source-level feature: the keyword-like operator `plus`.
+`TextualAddition` owns exactly one source-level feature: the keyword-like binary operator `plus`.
 
-It does not own numeric literals, scopes, multiplication, or backend selection. Those are provided by existing modules.
-
-This boundary matters because a module should not quietly duplicate unrelated language behavior.
+It does not own numbers, scopes, multiplication, backend selection, or optimizer behavior. Those remain separate module/backend concerns.
 
 ## Step 2. Add the module entry point
 
-Create `UniversalToolchain/ArithmeticModule/Module/TextualAdditionModuleImpl.cs`:
+The module entry point declares dialect metadata and registers lexer, parser, and AST translation contributions.
 
 ```csharp
-namespace ArithmeticModule.Module;
-
 [DialectModuleAlias("TextualAddition")]
 [DialectRuntimeExport("FrontendModule", "TextualAddition")]
 [AutoRegisterService]
@@ -89,81 +81,57 @@ public class TextualAdditionModuleImpl : IFrontendCoreModule
 
 Important details:
 
-- `DialectModuleAlias("TextualAddition")` makes the module selectable from a dialect file.
-- `DialectRuntimeExport("FrontendModule", "TextualAddition")` exposes the runtime component to manifest-backed composition.
-- `AutoRegisterService` keeps service registration consistent with the rest of the module system.
-- The lexeme uses `\bplus\b` so `surplus` does not accidentally become `sur` + `plus`.
-- Lexeme priority is higher than the identifier pattern, so `plus` is recognized as module-owned syntax when this module is selected.
-- Parser priority `-30f` matches normal addition/subtraction precedence.
+- `DialectModuleAlias` makes the module selectable from a dialect file.
+- `DialectRuntimeExport` exposes it to manifest-backed runtime composition.
+- `\bplus\b` prevents accidental matches inside words such as `surplus`.
+- priority `110f` keeps `plus` above identifier-like lexemes when both are selected;
+- parser priority `-30f` matches ordinary addition/subtraction precedence.
 
 ## Step 3. Add the parser node creator
 
-Create `UniversalToolchain/ArithmeticModule/Creators/TextualAdditionOperationNodeCreator.cs`:
+The parser node creator reuses the existing binary-operation parser shape:
 
 ```csharp
-namespace ArithmeticModule.Creators;
-
-[AutoRegisterService]
-[ArithmeticModeCompatibility(ArithmeticMode.Universal)]
 public class TextualAdditionOperationNodeCreator() : BinaryOperationBase("TextualAddition");
 ```
 
-This reuses `BinaryOperationBase`, the same shape used by ordinary arithmetic binary operators.
+This transforms a flat token sequence like `2 plus 3` into a binary AST node with left and right operands.
 
-The parser creator turns this flat token sequence:
-
-```text
-2 plus 3
-```
-
-into a binary AST node where `plus` has left and right operands.
-
-The node type is `TextualAddition`, not `Addition`, because the module owns a distinct syntax surface. The visitor will map that syntax to addition semantics explicitly.
+The node type remains `TextualAddition`, not `Addition`, because this module owns a distinct syntax surface. The AST visitor maps that syntax to addition semantics explicitly.
 
 ## Step 4. Add the AST visitor
 
-Create `UniversalToolchain/ArithmeticModule/Visitors/TextualAdditionAstVisitor.cs`:
+The visitor must self-filter and emit bytecode only for `TextualAddition` nodes.
 
 ```csharp
-namespace ArithmeticModule.Visitors;
-
-[AutoRegisterService]
-[ArithmeticModeCompatibility(ArithmeticMode.Universal)]
-public class TextualAdditionAstVisitor : IAstVisitor
+public void TryVisit(BytecodeVisitorData data)
 {
-    private static readonly ExtensibleEnum<AstNodeTag> _nodeType = ExtensibleEnum<AstNodeTag>.CreateOrGet("TextualAddition");
+    if (data.Node.NodeType != ExtensibleEnum<AstNodeTag>.CreateOrGet("TextualAddition"))
+        return;
 
-    public void TryVisit(BytecodeVisitorData data)
-    {
-        if (data.Node.NodeType != _nodeType)
-            return;
+    foreach (var child in data.Node.Children)
+        data.AstToBytecodeTranslator.Translate(child);
 
-        foreach (var child in data.Node.Children)
-            data.AstToBytecodeTranslator.Translate(child);
+    var method = new AbstractMethodImpl(
+        "Op_plus",
+        (il, context) => il.CallCSharp(context.Stack[^1].GetMethod("Add").NotNull())
+    );
 
-        var method = new AbstractMethodImpl(
-            "Op_plus",
-            (il, context) => il.CallCSharp(context.Stack[^1].GetMethod("Add").NotNull())
-        );
-
-        data.Bytecode.Instructions.Add(new BytecodeInstruction(method));
-    }
+    data.Bytecode.Instructions.Add(new BytecodeInstruction(method));
 }
 ```
 
-The visitor must self-filter. It should emit bytecode only for `TextualAddition` nodes.
-
-The child translation order matters:
+The stack order is:
 
 ```text
-left operand → right operand → Add operation
+left operand -> right operand -> Add operation
 ```
 
-That keeps stack behavior consistent with the existing arithmetic visitor.
+That mirrors the existing arithmetic visitor and keeps compiler/interpreter behavior aligned.
 
 ## Step 5. Enable the module in a dialect
 
-A dialect must select the module explicitly:
+The syntax exists only when the dialect selects the module:
 
 ```text
 dialect TextualAdditionDemo
@@ -171,75 +139,34 @@ use Whitespaces,Numbers,Scopes,Arithmetic,TextualAddition
 backend compiler,interpreter
 ```
 
-`TextualAddition` is not a global language feature. Without this `use` entry, the `plus` syntax should be unavailable.
+Without `TextualAddition`, `2 plus 3` should be rejected. This is part of the module contract, not an optional nicety.
 
-## Step 6. Add positive and parity tests
+## Step 6. Add tests
 
-Create `UniversalToolchain/UniversalToolchain.Dialects.Tests/TextualAdditionModuleTests.cs`:
+The module test file covers three cases:
 
 ```csharp
-using UniversalToolchain.Modules.Tests;
-
-namespace UniversalToolchain.Dialects.Tests;
-
-[TestFixture]
-public sealed class TextualAdditionModuleTests
+[Test]
+public void TextualAddition_Module_ExecutesPlusKeyword()
 {
-    private const string TextualAdditionDialect = """
-                                                 dialect TextualAdditionDemo
-                                                 use Whitespaces,Numbers,Scopes,Arithmetic,TextualAddition
-                                                 backend compiler,interpreter
-                                                 """;
+    var result = DialectTestHostInfrastructure.RunInBothBackends(TextualAdditionDialect, "2 plus 3");
 
-    private const string ArithmeticOnlyDialect = """
-                                                dialect ArithmeticOnlyDemo
-                                                use Whitespaces,Numbers,Scopes,Arithmetic
-                                                backend compiler,interpreter
-                                                """;
-
-    [Test]
-    public void TextualAddition_Module_ExecutesPlusKeyword()
-    {
-        var result = DialectTestHostInfrastructure.RunInBothBackends(TextualAdditionDialect, "2 plus 3");
-
-        Assert.That(BackendParityInfrastructure.AsNumber(result), Is.EqualTo(5.0d).Within(1e-9));
-    }
-
-    [Test]
-    public void TextualAddition_Module_UsesAdditionPrecedence()
-    {
-        var result = DialectTestHostInfrastructure.RunInBothBackends(TextualAdditionDialect, "2 plus 3 * 4");
-
-        Assert.That(BackendParityInfrastructure.AsNumber(result), Is.EqualTo(14.0d).Within(1e-9));
-    }
-
-    [Test]
-    public void TextualAddition_Syntax_IsUnavailable_WhenModuleIsNotSelected()
-    {
-        var (compilerResult, interpreterResult) = BackendParityInfrastructure.RunBoth(ArithmeticOnlyDialect, "2 plus 3");
-
-        Assert.Multiple(() =>
-        {
-            Assert.That(compilerResult.IsSuccess, Is.False, "Compiler path must reject syntax owned by an unselected module.");
-            Assert.That(interpreterResult.IsSuccess, Is.False, "Interpreter path must reject syntax owned by an unselected module.");
-            Assert.That(compilerResult.Exception, Is.Not.Null);
-            Assert.That(interpreterResult.Exception, Is.Not.Null);
-        });
-    }
+    Assert.That(BackendParityInfrastructure.AsNumber(result), Is.EqualTo(5.0d).Within(1e-9));
 }
 ```
 
-These tests prove three things:
+Also test:
 
-1. selected module syntax works;
-2. `plus` uses addition precedence;
-3. unselected module syntax is rejected in both backend paths.
+- `2 plus 3 * 4` returns `14`, proving addition-level precedence;
+- `2 plus 3` fails when the dialect selects `Arithmetic` but not `TextualAddition`, proving dialect visibility is real.
+
+Use `BackendParityInfrastructure` rather than a legacy smoke-test base. A module is not done until the intended backend paths agree.
 
 ## Step 7. Run the checks
 
 From repository root:
 
-```bash
+```bash ci-run=false
 dotnet restore UniversalToolchain/Wist.sln
 dotnet build UniversalToolchain/Wist.sln -c Release --no-restore
 dotnet test UniversalToolchain/Wist.sln -c Release --no-build
@@ -247,27 +174,11 @@ dotnet test UniversalToolchain/Wist.sln -c Release --no-build
 
 For documentation smoke checks:
 
-```bash
+```bash ci-run=false
 python3 .github/scripts/run-markdown-bash-blocks.py
 ```
 
-The GitHub workflow runs the same broad restore/build/test path, so keep the tutorial code blocks copyable and consistent with CI.
-
-## What you have learned
-
-This module demonstrates the minimum useful vertical slice:
-
-```text
-module metadata
-  → lexeme registration
-  → parser node creator
-  → AST visitor
-  → bytecode emission
-  → dialect selection
-  → backend parity tests
-```
-
-It does not demonstrate new backend behavior. That is the next level: a feature that emits new bytecode/AIR or requires interpreter/compiler support.
+These blocks are marked `ci-run=false` because the GitHub workflow already runs restore/build/test before the markdown smoke pass. The commands remain copyable for humans without making the documentation smoke step slow or recursive.
 
 ## Finished module checklist
 
@@ -278,7 +189,7 @@ Before considering a module complete, verify:
 - syntax belongs to lexer/parser, not raw source scanning;
 - parser priority is intentional and tested;
 - AST visitors self-filter;
-- emitted bytecode preserves stack discipline;
+- bytecode emission preserves stack discipline;
 - the feature is available only when selected by dialect;
 - selected backend modes agree on observable results;
 - negative tests prove omitted syntax stays unavailable.

--- a/docs/write-modules/create-your-first-module.md
+++ b/docs/write-modules/create-your-first-module.md
@@ -1,0 +1,288 @@
+---
+title: Create Your First Module
+description: Build a small frontend module from syntax idea to tested dialect behavior.
+---
+
+# Create Your First Module
+
+This tutorial builds a real, intentionally small frontend module: `TextualAddition`.
+
+The module adds a textual addition operator:
+
+```wist
+2 plus 3
+```
+
+Expected result:
+
+```text
+5
+```
+
+The feature is small on purpose. It touches the full module authoring path without requiring a new backend or intrinsic.
+
+## What you will build
+
+| Concern | Value |
+|---|---|
+| Module alias | `TextualAddition` |
+| Runtime export | `FrontendModule/TextualAddition` |
+| New syntax | `<expression> plus <expression>` |
+| Parser precedence | same as normal addition |
+| Runtime behavior | reuse existing `Add` operation on the left operand type |
+| Required related modules | `Whitespaces`, `Numbers`, `Scopes`, `Arithmetic` |
+| Backend expectation | compiler and interpreter parity |
+
+This module is a good first example because it adds syntax but reuses existing arithmetic semantics.
+
+## Files created
+
+The implementation lives in the existing `ArithmeticModule` project because this tutorial feature is semantically arithmetic-related:
+
+| Concern | File |
+|---|---|
+| Module entry point | `UniversalToolchain/ArithmeticModule/Module/TextualAdditionModuleImpl.cs` |
+| Parser node creator | `UniversalToolchain/ArithmeticModule/Creators/TextualAdditionOperationNodeCreator.cs` |
+| AST visitor | `UniversalToolchain/ArithmeticModule/Visitors/TextualAdditionAstVisitor.cs` |
+| Tests | `UniversalToolchain/UniversalToolchain.Dialects.Tests/TextualAdditionModuleTests.cs` |
+
+A production feature could live in its own project. For a first tutorial, keeping the example near the existing arithmetic code makes ownership and reuse easier to understand.
+
+## Step 1. Define the feature boundary
+
+`TextualAddition` owns only one source-level feature: the keyword-like operator `plus`.
+
+It does not own numeric literals, scopes, multiplication, or backend selection. Those are provided by existing modules.
+
+This boundary matters because a module should not quietly duplicate unrelated language behavior.
+
+## Step 2. Add the module entry point
+
+Create `UniversalToolchain/ArithmeticModule/Module/TextualAdditionModuleImpl.cs`:
+
+```csharp
+namespace ArithmeticModule.Module;
+
+[DialectModuleAlias("TextualAddition")]
+[DialectRuntimeExport("FrontendModule", "TextualAddition")]
+[AutoRegisterService]
+[ArithmeticModeCompatibility(ArithmeticMode.Universal)]
+public class TextualAdditionModuleImpl : IFrontendCoreModule
+{
+    private static readonly IReadOnlyList<LexemeRegistration> _lexemeRegistrations =
+    [
+        new(@"\bplus\b", "TextualAddition", Priority: 110f)
+    ];
+
+    private static readonly IReadOnlyList<NodeCreatorRegistration> _nodeCreatorRegistrations =
+    [
+        new(-30f, new TextualAdditionOperationNodeCreator())
+    ];
+
+    public void InitLexer(ILexer lexer) => lexer.AddLexemes(_lexemeRegistrations);
+
+    public void InitParser(IParser parser) => parser.AddNodeCreators(_nodeCreatorRegistrations);
+
+    public void InitAstTranslator(IAstToBytecodeTranslator translator) => translator.AddVisitors(new TextualAdditionAstVisitor());
+}
+```
+
+Important details:
+
+- `DialectModuleAlias("TextualAddition")` makes the module selectable from a dialect file.
+- `DialectRuntimeExport("FrontendModule", "TextualAddition")` exposes the runtime component to manifest-backed composition.
+- `AutoRegisterService` keeps service registration consistent with the rest of the module system.
+- The lexeme uses `\bplus\b` so `surplus` does not accidentally become `sur` + `plus`.
+- Lexeme priority is higher than the identifier pattern, so `plus` is recognized as module-owned syntax when this module is selected.
+- Parser priority `-30f` matches normal addition/subtraction precedence.
+
+## Step 3. Add the parser node creator
+
+Create `UniversalToolchain/ArithmeticModule/Creators/TextualAdditionOperationNodeCreator.cs`:
+
+```csharp
+namespace ArithmeticModule.Creators;
+
+[AutoRegisterService]
+[ArithmeticModeCompatibility(ArithmeticMode.Universal)]
+public class TextualAdditionOperationNodeCreator() : BinaryOperationBase("TextualAddition");
+```
+
+This reuses `BinaryOperationBase`, the same shape used by ordinary arithmetic binary operators.
+
+The parser creator turns this flat token sequence:
+
+```text
+2 plus 3
+```
+
+into a binary AST node where `plus` has left and right operands.
+
+The node type is `TextualAddition`, not `Addition`, because the module owns a distinct syntax surface. The visitor will map that syntax to addition semantics explicitly.
+
+## Step 4. Add the AST visitor
+
+Create `UniversalToolchain/ArithmeticModule/Visitors/TextualAdditionAstVisitor.cs`:
+
+```csharp
+namespace ArithmeticModule.Visitors;
+
+[AutoRegisterService]
+[ArithmeticModeCompatibility(ArithmeticMode.Universal)]
+public class TextualAdditionAstVisitor : IAstVisitor
+{
+    private static readonly ExtensibleEnum<AstNodeTag> _nodeType = ExtensibleEnum<AstNodeTag>.CreateOrGet("TextualAddition");
+
+    public void TryVisit(BytecodeVisitorData data)
+    {
+        if (data.Node.NodeType != _nodeType)
+            return;
+
+        foreach (var child in data.Node.Children)
+            data.AstToBytecodeTranslator.Translate(child);
+
+        var method = new AbstractMethodImpl(
+            "Op_plus",
+            (il, context) => il.CallCSharp(context.Stack[^1].GetMethod("Add").NotNull())
+        );
+
+        data.Bytecode.Instructions.Add(new BytecodeInstruction(method));
+    }
+}
+```
+
+The visitor must self-filter. It should emit bytecode only for `TextualAddition` nodes.
+
+The child translation order matters:
+
+```text
+left operand → right operand → Add operation
+```
+
+That keeps stack behavior consistent with the existing arithmetic visitor.
+
+## Step 5. Enable the module in a dialect
+
+A dialect must select the module explicitly:
+
+```text
+dialect TextualAdditionDemo
+use Whitespaces,Numbers,Scopes,Arithmetic,TextualAddition
+backend compiler,interpreter
+```
+
+`TextualAddition` is not a global language feature. Without this `use` entry, the `plus` syntax should be unavailable.
+
+## Step 6. Add positive and parity tests
+
+Create `UniversalToolchain/UniversalToolchain.Dialects.Tests/TextualAdditionModuleTests.cs`:
+
+```csharp
+using UniversalToolchain.Modules.Tests;
+
+namespace UniversalToolchain.Dialects.Tests;
+
+[TestFixture]
+public sealed class TextualAdditionModuleTests
+{
+    private const string TextualAdditionDialect = """
+                                                 dialect TextualAdditionDemo
+                                                 use Whitespaces,Numbers,Scopes,Arithmetic,TextualAddition
+                                                 backend compiler,interpreter
+                                                 """;
+
+    private const string ArithmeticOnlyDialect = """
+                                                dialect ArithmeticOnlyDemo
+                                                use Whitespaces,Numbers,Scopes,Arithmetic
+                                                backend compiler,interpreter
+                                                """;
+
+    [Test]
+    public void TextualAddition_Module_ExecutesPlusKeyword()
+    {
+        var result = DialectTestHostInfrastructure.RunInBothBackends(TextualAdditionDialect, "2 plus 3");
+
+        Assert.That(BackendParityInfrastructure.AsNumber(result), Is.EqualTo(5.0d).Within(1e-9));
+    }
+
+    [Test]
+    public void TextualAddition_Module_UsesAdditionPrecedence()
+    {
+        var result = DialectTestHostInfrastructure.RunInBothBackends(TextualAdditionDialect, "2 plus 3 * 4");
+
+        Assert.That(BackendParityInfrastructure.AsNumber(result), Is.EqualTo(14.0d).Within(1e-9));
+    }
+
+    [Test]
+    public void TextualAddition_Syntax_IsUnavailable_WhenModuleIsNotSelected()
+    {
+        var (compilerResult, interpreterResult) = BackendParityInfrastructure.RunBoth(ArithmeticOnlyDialect, "2 plus 3");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(compilerResult.IsSuccess, Is.False, "Compiler path must reject syntax owned by an unselected module.");
+            Assert.That(interpreterResult.IsSuccess, Is.False, "Interpreter path must reject syntax owned by an unselected module.");
+            Assert.That(compilerResult.Exception, Is.Not.Null);
+            Assert.That(interpreterResult.Exception, Is.Not.Null);
+        });
+    }
+}
+```
+
+These tests prove three things:
+
+1. selected module syntax works;
+2. `plus` uses addition precedence;
+3. unselected module syntax is rejected in both backend paths.
+
+## Step 7. Run the checks
+
+From repository root:
+
+```bash
+dotnet restore UniversalToolchain/Wist.sln
+dotnet build UniversalToolchain/Wist.sln -c Release --no-restore
+dotnet test UniversalToolchain/Wist.sln -c Release --no-build
+```
+
+For documentation smoke checks:
+
+```bash
+python3 .github/scripts/run-markdown-bash-blocks.py
+```
+
+The GitHub workflow runs the same broad restore/build/test path, so keep the tutorial code blocks copyable and consistent with CI.
+
+## What you have learned
+
+This module demonstrates the minimum useful vertical slice:
+
+```text
+module metadata
+  → lexeme registration
+  → parser node creator
+  → AST visitor
+  → bytecode emission
+  → dialect selection
+  → backend parity tests
+```
+
+It does not demonstrate new backend behavior. That is the next level: a feature that emits new bytecode/AIR or requires interpreter/compiler support.
+
+## Finished module checklist
+
+Before considering a module complete, verify:
+
+- the module has a clear alias;
+- runtime export metadata is present;
+- syntax belongs to lexer/parser, not raw source scanning;
+- parser priority is intentional and tested;
+- AST visitors self-filter;
+- emitted bytecode preserves stack discipline;
+- the feature is available only when selected by dialect;
+- selected backend modes agree on observable results;
+- negative tests prove omitted syntax stays unavailable.
+
+## Next
+
+Read [Frontend Module](/write-modules/frontend-module) for the contract shape, then [Testing a Module](/write-modules/testing-module) for the broader test matrix.

--- a/docs/write-modules/index.md
+++ b/docs/write-modules/index.md
@@ -5,9 +5,18 @@ description: Introduce language module development.
 
 # Write Modules
 
-A module is the normal way to add a language feature to Wist or to a UniversalToolchain-based DSL. This page gives the lifecycle for module authors without pretending that every extension point is already fully formalized.
+A module is the normal way to add a language feature to Wist or to a UniversalToolchain-based DSL. This section gives the lifecycle for module authors without pretending that every extension point is already fully formalized.
 
-## When to read this page
+## Recommended path
+
+If you are new to module authoring, do not start from the reference pages. Use this order:
+
+1. [Choose an Extension Type](/write-modules/choose-extension-type) — decide whether you need a module, a dialect, an optimizer, an intrinsic, or backend work.
+2. [Create Your First Module](/write-modules/create-your-first-module) — build the small `TextualAddition` module from syntax idea to tests.
+3. [Frontend Module](/write-modules/frontend-module) — read the contract shape after seeing the end-to-end example.
+4. [Testing a Module](/write-modules/testing-module) — expand the tutorial tests into a full module test matrix.
+
+## When to read this section
 
 Read this when existing modules are not enough and you need to add syntax, AST translation, bytecode/AIR behavior or backend support.
 
@@ -22,7 +31,7 @@ Understand the expected path from syntax idea to tested language feature.
 - Build the repository and run relevant tests before changing behavior.
 - Review `docs/guides/module-authoring.md` and `docs/contracts/module-contracts.md` before implementing a real module.
 
-## Steps
+## Lifecycle
 
 ### 1. Define the feature boundary
 
@@ -30,6 +39,7 @@ A module should own one language feature or one tightly scoped set of related fe
 
 - `Numbers`
 - `Arithmetic`
+- `TextualAddition`
 - `Identifier`
 - `Variables`
 - `Scopes`
@@ -139,4 +149,4 @@ This is why module work requires both implementation tests and architecture disc
 
 ## Next
 
-Continue with the detailed [Module Authoring Guide](/guides/module-authoring) and [Module Contracts](/contracts/module-contracts), then read the internals pages for bytecode, AIR, backends and semantic parity.
+Continue with [Choose an Extension Type](/write-modules/choose-extension-type) and [Create Your First Module](/write-modules/create-your-first-module), then use [Module Authoring Guide](/guides/module-authoring) and [Module Contracts](/contracts/module-contracts) for deeper review.


### PR DESCRIPTION
Adds a small TextualAddition frontend module, dialect tests, and beginner-focused module authoring documentation. Local tests were not run because the sandbox cannot clone the repository; validation is delegated to GitHub Actions.