### PR TITLE
docs: explain generated module runtime manifests

### DIFF
--- a/docs/write-modules/create-your-first-module.md
+++ b/docs/write-modules/create-your-first-module.md
@@ -89,6 +89,35 @@ Important details:
 - priority `110f` keeps `plus` above identifier-like lexemes when both are selected.
 - parser priority `-30f` matches ordinary addition/subtraction precedence.
 
+## Step 2.1. Do not create runtime JSON by hand
+
+Older module registration flows required hand-maintained JSON metadata. Current module projects should not do that.
+
+Runtime manifest JSON files are generated during build from attributes such as:
+
+```csharp
+[DialectModuleAlias("TextualAddition")]
+[DialectRuntimeExport("FrontendModule", "TextualAddition")]
+```
+
+If you add a module inside an existing project that already emits manifests, such as `ArithmeticModule`, no extra JSON file is needed.
+
+If you create a new standalone module project, enable manifest generation in that project's `.csproj`:
+
+```xml
+<PropertyGroup>
+    <EmitDialectRuntimeManifest>true</EmitDialectRuntimeManifest>
+</PropertyGroup>
+```
+
+The build then emits a file named like this in the output directory:
+
+```text
+YourModuleAssembly.dialect.runtime.json
+```
+
+The generated file is a build artifact. Do not commit a hand-written copy unless a future document explicitly says a specific scenario still needs one.
+
 ## Step 3. Add the parser node creator
 
 Create `UniversalToolchain/ArithmeticModule/Creators/TextualAdditionOperationNodeCreator.cs` with the complete file content below:
@@ -247,6 +276,7 @@ The files above are intentionally complete, not illustrative fragments. The impl
 - `TextualAdditionModuleImpl` registers the `plus` lexeme, parser creator, and AST visitor.
 - `TextualAdditionOperationNodeCreator` creates a binary AST shape for the operator.
 - `TextualAdditionAstVisitor` lowers the node to the existing `Add` operation.
+- Runtime manifest metadata is generated from module/export attributes during build; this tutorial does not require a hand-written `.dialect.runtime.json` file.
 - `TextualAdditionModuleTests` verifies positive execution, precedence, and missing-module rejection through both selected backend paths.
 
 ## Finished module checklist
@@ -255,6 +285,7 @@ Before considering a module complete, verify:
 
 - the module has a clear alias;
 - runtime export metadata is present;
+- hand-written runtime JSON is not needed; manifest generation is enabled when the module lives in a new project;
 - syntax belongs to lexer/parser, not raw source scanning;
 - parser priority is intentional and tested;
 - AST visitors self-filter;

--- a/docs/write-modules/index.md
+++ b/docs/write-modules/index.md
@@ -13,8 +13,9 @@ If you are new to module authoring, do not start from the reference pages. Use t
 
 1. [Choose an Extension Type](/write-modules/choose-extension-type) — decide whether you need a module, a dialect, an optimizer, an intrinsic, or backend work.
 2. [Create Your First Module](/write-modules/create-your-first-module) — build the small `TextualAddition` module from syntax idea to tests.
-3. [Frontend Module](/write-modules/frontend-module) — read the contract shape after seeing the end-to-end example.
-4. [Testing a Module](/write-modules/testing-module) — expand the tutorial tests into a full module test matrix.
+3. [Runtime Manifests](/write-modules/runtime-manifests) — understand how module aliases become visible to dialect runtime composition without hand-written JSON.
+4. [Frontend Module](/write-modules/frontend-module) — read the contract shape after seeing the end-to-end example.
+5. [Testing a Module](/write-modules/testing-module) — expand the tutorial tests into a full module test matrix.
 
 ## When to read this section
 
@@ -108,6 +109,8 @@ The module must be selectable through dialect files. This usually requires modul
 use MyFeature,Numbers,Scopes,Whitespaces
 ```
 
+Read [Runtime Manifests](/write-modules/runtime-manifests) before creating new JSON files by hand. Normal module authoring relies on generated manifests.
+
 ### 8. Test the module
 
 At minimum, add:
@@ -146,7 +149,8 @@ This is why module work requires both implementation tests and architecture disc
 - Using global mutable state for feature coordination.
 - Treating capabilities as behavior activation.
 - Reintroducing rule declarations before the AST-owned rule declaration rewrite.
+- Hand-writing runtime manifest JSON instead of relying on generated manifests for normal module authoring.
 
 ## Next
 
-Continue with [Choose an Extension Type](/write-modules/choose-extension-type) and [Create Your First Module](/write-modules/create-your-first-module), then use [Module Authoring Guide](/guides/module-authoring) and [Module Contracts](/contracts/module-contracts) for deeper review.
+Continue with [Choose an Extension Type](/write-modules/choose-extension-type), [Create Your First Module](/write-modules/create-your-first-module), and [Runtime Manifests](/write-modules/runtime-manifests), then use [Module Authoring Guide](/guides/module-authoring) and [Module Contracts](/contracts/module-contracts) for deeper review.

--- a/docs/write-modules/runtime-manifests.md
+++ b/docs/write-modules/runtime-manifests.md
@@ -1,0 +1,102 @@
+---
+title: Runtime Manifests
+description: Explain how frontend modules become visible to dialect runtime composition.
+---
+
+# Runtime Manifests
+
+Runtime manifests are how dialect composition discovers selectable runtime components such as frontend modules, optimizers and backends.
+
+For normal module authoring, do not create these JSON files by hand. They are generated during build from attributes on compiled types.
+
+## Why manifests exist
+
+A dialect file names modules by alias:
+
+```text
+dialect Demo
+use Whitespaces,Numbers,Scopes,Arithmetic
+backend interpreter
+```
+
+Runtime composition then needs to resolve aliases such as `Arithmetic` to concrete assemblies and activation types.
+
+That lookup should not depend on hardcoded module lists in the dialect compiler. The manifest is the build-time metadata bridge between declarative dialect files and concrete runtime components.
+
+## The current authoring rule
+
+For a frontend module, provide metadata in code:
+
+```csharp
+[DialectModuleAlias("MyFeature")]
+[DialectRuntimeExport("FrontendModule", "MyFeature")]
+[AutoRegisterService]
+public class MyFeatureModuleImpl : IFrontendCoreModule
+{
+    // lexer, parser and translator registrations
+}
+```
+
+Then make sure the containing project emits runtime manifests:
+
+```xml
+<PropertyGroup>
+    <EmitDialectRuntimeManifest>true</EmitDialectRuntimeManifest>
+</PropertyGroup>
+```
+
+During build, the manifest emitter writes a generated file named after the assembly:
+
+```text
+MyFeatureModule.dialect.runtime.json
+```
+
+The file is produced in the build output directory. It is a generated artifact, not a normal source file.
+
+## Existing project vs new project
+
+If you add a module to an existing module project that already has `EmitDialectRuntimeManifest` enabled, no project-file change is needed.
+
+For example, adding `TextualAddition` inside `ArithmeticModule` does not require a new JSON file because `ArithmeticModule` already emits a runtime manifest.
+
+If you create a new standalone module project, add `EmitDialectRuntimeManifest` to that project. Without it, the assembly may compile, but manifest-backed runtime composition will not discover the new alias.
+
+## What not to do
+
+Do not:
+
+- commit a hand-written `.dialect.runtime.json` for a normal module;
+- maintain duplicate alias lists in JSON and C# attributes;
+- patch dialect composition with a hardcoded special case for the new module;
+- rely on a module being referenced by the solution alone as proof that dialect runtime selection can see it.
+
+The source of truth should be the module/export attributes plus generated manifest output.
+
+## What to test
+
+A module is visible only if composition can resolve it by alias. Add tests that prove both sides:
+
+- a dialect selecting the module can execute its syntax;
+- a dialect omitting the module rejects the same syntax;
+- compiler and interpreter agree when both backends are selected.
+
+For the first-module tutorial, this is covered by `TextualAdditionModuleTests`.
+
+## Troubleshooting
+
+If a dialect says a module alias cannot be resolved, check these in order:
+
+1. The module type has `[DialectModuleAlias("...")]`.
+2. The module type has `[DialectRuntimeExport("FrontendModule", "...")]`.
+3. The project containing the module has `<EmitDialectRuntimeManifest>true</EmitDialectRuntimeManifest>`.
+4. The project is built before the host tries to compose the dialect.
+5. The generated `.dialect.runtime.json` file appears in the output directory.
+6. Referenced manifests are copied into the consuming output directory.
+
+If the manifest exists but activation fails, inspect the activation type name and service registration rather than editing the generated JSON.
+
+## Relation to the tutorial
+
+[Create Your First Module](/write-modules/create-your-first-module) adds `TextualAddition` inside `ArithmeticModule`, so no hand-written runtime JSON is needed. The existing module project already participates in manifest generation.
+
+A future tutorial for a separate module assembly should include the `.csproj` manifest flag explicitly as part of the setup.


### PR DESCRIPTION
Clarifies that module runtime JSON manifests are generated from attributes during build and should not be hand-written for normal module authoring. Also notes the csproj flag required for new standalone module projects.