### PR TITLE
Extract shared test infrastructure into dedicated test project

### DIFF
--- a/UniversalToolchain/Tests/Tests.csproj
+++ b/UniversalToolchain/Tests/Tests.csproj
@@ -52,6 +52,7 @@
         <ProjectReference Include="..\UniversalToolchain.Dialects.Wist\UniversalToolchain.Dialects.Wist.csproj"/>
         <ProjectReference Include="..\CommentsModule\CommentsModule.csproj"/>
         <ProjectReference Include="..\Example\Example.csproj"/>
+            <ProjectReference Include="..\UniversalToolchain.Testing.Infrastructure\UniversalToolchain.Testing.Infrastructure.csproj"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/UniversalToolchain.Dialects.Tests.csproj
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/UniversalToolchain.Dialects.Tests.csproj
@@ -40,9 +40,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <Compile Include="..\Tests\Infrastructure\BackendParityInfrastructure.cs" Link="Infrastructure\BackendParityInfrastructure.cs"/>
-        <Compile Include="..\Tests\Infrastructure\BackendResultAssertions.cs" Link="Infrastructure\BackendResultAssertions.cs"/>
-        <Compile Include="..\Tests\Infrastructure\DialectTestHostInfrastructure.cs" Link="Infrastructure\DialectTestHostInfrastructure.cs"/>
+        <ProjectReference Include="..\UniversalToolchain.Testing.Infrastructure\UniversalToolchain.Testing.Infrastructure.csproj"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/UniversalToolchain/UniversalToolchain.Modules.Tests/UniversalToolchain.Modules.Tests.csproj
+++ b/UniversalToolchain/UniversalToolchain.Modules.Tests/UniversalToolchain.Modules.Tests.csproj
@@ -27,7 +27,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <Compile Include="..\Tests\Infrastructure\BackendParityInfrastructure.cs" Link="Infrastructure\BackendParityInfrastructure.cs"/>
+        <ProjectReference Include="..\UniversalToolchain.Testing.Infrastructure\UniversalToolchain.Testing.Infrastructure.csproj"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/UniversalToolchain/UniversalToolchain.Testing.Infrastructure/BackendParityInfrastructure.cs
+++ b/UniversalToolchain/UniversalToolchain.Testing.Infrastructure/BackendParityInfrastructure.cs
@@ -1,3 +1,6 @@
+using ExceptionsManager;
+using Microsoft.Extensions.DependencyInjection;
+using UniversalToolchain.Dialects.Integration;
 using UniversalToolchain.Dialects.Tests;
 using UniversalToolchain.Dialects.Wist;
 

--- a/UniversalToolchain/UniversalToolchain.Testing.Infrastructure/BackendResultAssertions.cs
+++ b/UniversalToolchain/UniversalToolchain.Testing.Infrastructure/BackendResultAssertions.cs
@@ -1,3 +1,4 @@
+using ExceptionsManager;
 using NumbersModule.Core;
 
 namespace UniversalToolchain.Dialects.Tests;

--- a/UniversalToolchain/UniversalToolchain.Testing.Infrastructure/DialectTestHostInfrastructure.cs
+++ b/UniversalToolchain/UniversalToolchain.Testing.Infrastructure/DialectTestHostInfrastructure.cs
@@ -1,3 +1,6 @@
+using ExceptionsManager;
+using Microsoft.Extensions.DependencyInjection;
+using UniversalToolchain.Dialects.Integration;
 using UniversalToolchain.Dialects.Wist;
 using UniversalToolchain.Modules.Tests;
 

--- a/UniversalToolchain/UniversalToolchain.Testing.Infrastructure/UniversalToolchain.Testing.Infrastructure.csproj
+++ b/UniversalToolchain/UniversalToolchain.Testing.Infrastructure/UniversalToolchain.Testing.Infrastructure.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <LangVersion>14</LangVersion>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.1" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.1" />
+        <PackageReference Include="NUnit" Version="4.2.2" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\ExceptionsManager\ExceptionsManager.csproj" />
+        <ProjectReference Include="..\NumbersModule\NumbersModule.csproj" />
+        <ProjectReference Include="..\UniversalToolchain.Dialects.Integration\UniversalToolchain.Dialects.Integration.csproj" />
+        <ProjectReference Include="..\UniversalToolchain.Dialects.Wist\UniversalToolchain.Dialects.Wist.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="NUnit.Framework" />
+    </ItemGroup>
+
+</Project>

--- a/UniversalToolchain/Wist.sln
+++ b/UniversalToolchain/Wist.sln
@@ -142,6 +142,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UniversalToolchain.Capabili
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VariablesRuntime", "VariablesRuntime\VariablesRuntime.csproj", "{87B9C90A-20D2-4F91-A54D-C3D90181C03B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UniversalToolchain.Testing.Infrastructure", "UniversalToolchain.Testing.Infrastructure\UniversalToolchain.Testing.Infrastructure.csproj", "{EBFBA873-B624-4DD4-AA1A-9E2A2C5A3DEA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -884,6 +886,18 @@ Global
 		{87B9C90A-20D2-4F91-A54D-C3D90181C03B}.Release|x64.Build.0 = Release|Any CPU
 		{87B9C90A-20D2-4F91-A54D-C3D90181C03B}.Release|x86.ActiveCfg = Release|Any CPU
 		{87B9C90A-20D2-4F91-A54D-C3D90181C03B}.Release|x86.Build.0 = Release|Any CPU
+		{EBFBA873-B624-4DD4-AA1A-9E2A2C5A3DEA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EBFBA873-B624-4DD4-AA1A-9E2A2C5A3DEA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EBFBA873-B624-4DD4-AA1A-9E2A2C5A3DEA}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{EBFBA873-B624-4DD4-AA1A-9E2A2C5A3DEA}.Debug|x64.Build.0 = Debug|Any CPU
+		{EBFBA873-B624-4DD4-AA1A-9E2A2C5A3DEA}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{EBFBA873-B624-4DD4-AA1A-9E2A2C5A3DEA}.Debug|x86.Build.0 = Debug|Any CPU
+		{EBFBA873-B624-4DD4-AA1A-9E2A2C5A3DEA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EBFBA873-B624-4DD4-AA1A-9E2A2C5A3DEA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EBFBA873-B624-4DD4-AA1A-9E2A2C5A3DEA}.Release|x64.ActiveCfg = Release|Any CPU
+		{EBFBA873-B624-4DD4-AA1A-9E2A2C5A3DEA}.Release|x64.Build.0 = Release|Any CPU
+		{EBFBA873-B624-4DD4-AA1A-9E2A2C5A3DEA}.Release|x86.ActiveCfg = Release|Any CPU
+		{EBFBA873-B624-4DD4-AA1A-9E2A2C5A3DEA}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
### Motivation
- Fix failing test-project builds caused by shared test helpers being compiled as linked source without required imports (missing `Thrower` and DI symbols) and eliminate duplicate-type compilation smells (CS0436) from multiple test assemblies.
- Centralize reusable backend-parity and dialect-host helpers into a single maintainable surface to preserve test semantics and avoid ad-hoc linked-source duplication.

### Description
- Added a new project `UniversalToolchain.Testing.Infrastructure` targeting `net10.0` with `LangVersion 14`, `ImplicitUsings` and `Nullable` enabled, and package references for DI and `NUnit` (`UniversalToolchain/UniversalToolchain.Testing.Infrastructure/UniversalToolchain.Testing.Infrastructure.csproj`).
- Moved shared helpers into the new project: `BackendParityInfrastructure` (and `BackendExecutionResult`), `BackendResultAssertions`, and `DialectTestHostInfrastructure`, and updated their `using` and namespace imports to compile correctly with `ExceptionsManager`, `Microsoft.Extensions.DependencyInjection`, and dialect integration.
- Updated test projects (`Tests`, `UniversalToolchain.Dialects.Tests`, `UniversalToolchain.Modules.Tests`) to reference the new project and removed the linked `Compile Include` entries that previously duplicated the same source files across assemblies.
- Added the new project to the solution and fixed a small string-splitting literal bug (use `['\r','\n']`) so the moved helpers compile cleanly; preserved existing test intent and parity logic.

### Testing
- Ran `dotnet restore UniversalToolchain/Wist.sln`, which completed successfully restoring projects in the solution.
- Ran `dotnet build UniversalToolchain/Wist.sln`, which succeeded (build warnings remained for pre-existing obsolete API usages but no errors).
- Ran `dotnet test UniversalToolchain/Wist.sln --no-build`, and all automated tests passed with no failures (test assemblies executed successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f71aaa67ec83249071a734812284b0)