### PR TITLE
docs: harden developer documentation routes

### DIFF
--- a/.github/workflows/dotnet-ci.yml
+++ b/.github/workflows/dotnet-ci.yml
@@ -32,6 +32,12 @@ jobs:
       - name: Test
         run: dotnet test UniversalToolchain/Wist.sln -c Release --no-build
 
+      - name: Install docs dependencies
+        run: npm install
+
+      - name: Build docs
+        run: npm run docs:build
+
       - name: Markdown bash smoke checks
         shell: bash
         run: python3 .github/scripts/run-markdown-bash-blocks.py

--- a/UniversalToolchain/UniversalToolchain.Testing.Infrastructure/BackendResultAssertions.cs
+++ b/UniversalToolchain/UniversalToolchain.Testing.Infrastructure/BackendResultAssertions.cs
@@ -1,5 +1,5 @@
+using System.Reflection;
 using ExceptionsManager;
-using NumbersModule.Core;
 
 namespace UniversalToolchain.Dialects.Tests;
 
@@ -31,7 +31,7 @@ public static class BackendResultAssertions
             float floatValue => floatValue,
             double doubleValue => doubleValue,
             decimal decimalValue => (double)decimalValue,
-            RealNumberImpl realNumberImpl => realNumberImpl.GetValue(),
+            _ when TryReadNumericWrapper(value, out var numericValue) => numericValue,
             _ => Thrower.InvalidOpEx<double>(
                 $"Value '{value?.ToString() ?? "null"}' of runtime type '{value?.GetType().FullName ?? "null"}' is not a supported numeric result.")
         };
@@ -45,5 +45,35 @@ public static class BackendResultAssertions
             _ => Thrower.InvalidOpEx<bool>(
                 $"Value '{value?.ToString() ?? "null"}' of runtime type '{value?.GetType().FullName ?? "null"}' is not a boolean result.")
         };
+    }
+
+    private static bool TryReadNumericWrapper(object? value, out double numericValue)
+    {
+        numericValue = 0;
+        if (value is null)
+            return false;
+
+        var method = value.GetType().GetMethod(
+            "GetValue",
+            BindingFlags.Instance | BindingFlags.Public,
+            binder: null,
+            types: Type.EmptyTypes,
+            modifiers: null);
+
+        if (method is null)
+            return false;
+
+        var result = method.Invoke(value, null);
+        numericValue = result switch
+        {
+            int intValue => intValue,
+            long longValue => longValue,
+            float floatValue => floatValue,
+            double doubleValue => doubleValue,
+            decimal decimalValue => (double)decimalValue,
+            _ => 0
+        };
+
+        return result is int or long or float or double or decimal;
     }
 }

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -17,9 +17,10 @@ const bookSidebar = [
         items: [
             { text: '1.1 Installation', link: '/start/installation' },
             { text: '1.2 First Program', link: '/start/first-program' },
-            { text: '1.3 Wist Overview', link: '/wist/' },
-            { text: '1.4 Wist Syntax Tour', link: '/wist/syntax-tour' },
-            { text: '1.5 Examples', link: '/wist/examples' }
+            { text: '1.3 CLI Reference', link: '/start/cli-reference' },
+            { text: '1.4 Wist Overview', link: '/wist/' },
+            { text: '1.5 Wist Syntax Tour', link: '/wist/syntax-tour' },
+            { text: '1.6 Examples', link: '/wist/examples' }
         ]
     },
     {
@@ -42,7 +43,9 @@ const bookSidebar = [
             { text: '3.3 Minimal DSL', link: '/build-dsls/minimal-dsl' },
             { text: '3.4 Module Composition', link: '/build-dsls/module-composition' },
             { text: '3.5 Backend Selection', link: '/build-dsls/backend-selection' },
-            { text: '3.6 Testing a DSL', link: '/build-dsls/testing-dsl' }
+            { text: '3.6 Embedding in .NET', link: '/build-dsls/embedding-dotnet' },
+            { text: '3.7 Testing a DSL', link: '/build-dsls/testing-dsl' },
+            { text: '3.8 Restricted DSL Security', link: '/build-dsls/restricted-dsl-security' }
         ]
     },
     {
@@ -88,11 +91,13 @@ const bookSidebar = [
             { text: '6.1 Overview', link: '/reference/' },
             { text: '6.2 Dialect Reference', link: '/reference/dialect-reference' },
             { text: '6.3 Module Reference', link: '/reference/module-reference' },
-            { text: '6.4 Bytecode Reference', link: '/reference/bytecode-reference' },
-            { text: '6.5 AIR Reference', link: '/reference/air-reference' },
-            { text: '6.6 Intrinsics Reference', link: '/reference/intrinsics-reference' },
-            { text: '6.7 Backend Contracts', link: '/reference/backend-contracts' },
-            { text: '6.8 Project Rules', link: '/reference/project-rules' }
+            { text: '6.4 Module Contracts', link: '/reference/module-contracts' },
+            { text: '6.5 Bytecode Reference', link: '/reference/bytecode-reference' },
+            { text: '6.6 AIR Reference', link: '/reference/air-reference' },
+            { text: '6.7 Intrinsics Reference', link: '/reference/intrinsics-reference' },
+            { text: '6.8 Backend Contracts', link: '/reference/backend-contracts' },
+            { text: '6.9 Project Rules', link: '/reference/project-rules' },
+            { text: '6.10 Documentation Rules', link: '/reference/documentation-rules' }
         ]
     }
 ]

--- a/docs/build-dsls/embedding-dotnet.md
+++ b/docs/build-dsls/embedding-dotnet.md
@@ -1,0 +1,112 @@
+---
+title: Embedding in .NET
+description: Show how a host application uses a composed Wist runtime instead of shelling out to the CLI.
+---
+
+# Embedding in .NET
+
+UniversalToolchain is intended to be embedded into .NET applications. The CLI is useful for learning and smoke checks, but production-style DSL usage normally runs through a host API.
+
+## When to read this page
+
+Read this after [Minimal DSL](/build-dsls/minimal-dsl) when you want to run formulas or restricted scripts from application code.
+
+## Goal
+
+Create a Wist runtime facade, select a shipped dialect preset, pass source text and named inputs, choose a backend mode and read the result.
+
+## Minimal host shape
+
+A host application should treat the DSL runtime as a composed execution surface:
+
+```text
+select dialect or preset
+  -> create runtime facade
+  -> pass source and declared inputs
+  -> choose requested mode
+  -> receive result or explicit failure
+```
+
+The facade is an entry point into the same dialect/runtime composition model. It is not a second implementation of Wist.
+
+## Example: restricted pricing expression
+
+```csharp
+using UniversalToolchain.Dialects.Wist.Facade;
+
+using var runtime = WistRuntimeFacadeBuilder
+    .CreateDefault()
+    .WithShippedDialectPreset("pricing-restricted")
+    .Build();
+
+var result = runtime.Run(
+    "price + fee * 2",
+    new Dictionary<string, object?>
+    {
+        ["price"] = 100,
+        ["fee"] = 5
+    },
+    mode: "compiler");
+```
+
+Expected numeric result:
+
+```text
+110
+```
+
+The exact result wrapper shape depends on the current facade API. The important contract is that the host selects a dialect, supplies inputs explicitly and requests a backend mode intentionally.
+
+## Why inputs are explicit
+
+Runtime inputs such as `price` and `fee` are host-provided bindings. They are not the same concept as local variables declared by the Wist program.
+
+A correct runtime path must keep these concerns separate:
+
+```text
+external binding: provided by the host
+local variable: declared and mutated by the program
+```
+
+This boundary matters for formula DSLs because a host parameter should not accidentally overwrite an unrelated local variable.
+
+## Choosing a dialect for embedding
+
+Use the narrowest dialect that supports the business case.
+
+| Scenario | Recommended dialect shape |
+|---|---|
+| Pricing/scoring formula | arithmetic, identifiers, selected variable/input support, no interop |
+| Workflow-like script | variables, conditions and loops only if needed |
+| Demonstrating Wist | broad reference profile |
+| Untrusted user-authored code | narrow dialect plus process/resource isolation outside Wist |
+
+Do not embed `full-default` only because it is convenient. A broad profile exposes more syntax and runtime behavior than a restricted formula surface usually needs.
+
+## Backend mode selection
+
+`mode: "compiler"` requests the CIL-backed compiler path when the selected dialect exposes CIL. `mode: "interpreter"` requests the interpreter path when exposed.
+
+When both modes are available, add parity tests for important formulas. When only one mode is available, test that the unsupported mode fails explicitly.
+
+## What to test in a host application
+
+A host using Wist should test:
+
+- valid formula execution;
+- missing input behavior;
+- wrong input type behavior;
+- syntax rejected when the owning module is omitted;
+- backend availability failures;
+- compiler/interpreter parity when both modes are exposed;
+- interop rejection for restricted formula dialects.
+
+## Security boundary
+
+A restricted dialect is a composition constraint. It limits which modules, syntax and runtime components are selected. It is not a hardened process sandbox.
+
+For arbitrary untrusted third-party code, combine dialect restriction with external isolation, resource limits and host-level policy.
+
+## Next
+
+Continue with [Backend Selection](/build-dsls/backend-selection), [Testing a DSL](/build-dsls/testing-dsl) and [Backend Contracts](/reference/backend-contracts).

--- a/docs/build-dsls/restricted-dsl-security.md
+++ b/docs/build-dsls/restricted-dsl-security.md
@@ -1,0 +1,101 @@
+---
+title: Restricted DSL Security
+description: Explain the boundary between dialect restriction and real sandboxing.
+---
+
+# Restricted DSL Security
+
+A restricted dialect is a composition boundary. It is useful, but it is not a complete security sandbox.
+
+## When to read this page
+
+Read this before exposing Wist or a UniversalToolchain-based DSL to user-authored formulas, customer configuration, pricing rules or workflow scripts.
+
+## Goal
+
+Understand what restricted dialects can honestly guarantee, what they cannot guarantee and what must be handled by the host application.
+
+## What a restricted dialect does
+
+A restricted dialect can limit the selected runtime surface:
+
+- selected frontend modules;
+- selected optimizers;
+- selected backend modes;
+- selected intrinsic policies;
+- declared capabilities;
+- trusted or restricted security intent.
+
+This is valuable because omitted modules should make their syntax unavailable. For example, a pricing dialect can omit C# interop, loops or labels.
+
+## What a restricted dialect does not do
+
+A restricted dialect does not automatically provide:
+
+- process isolation;
+- CPU or memory limits;
+- timeout enforcement;
+- protection from all host API exposure;
+- protection from bugs in selected modules or backends;
+- validation that business rules are safe or fair.
+
+Do not document a dialect as safe for arbitrary untrusted third-party code only because it has `security restricted`.
+
+## Recommended host model
+
+Use layered protection:
+
+```text
+narrow dialect
+  -> explicit input bindings
+  -> no trusted interop unless intended
+  -> backend availability checks
+  -> timeouts and resource limits outside the DSL runtime
+  -> process/container isolation for untrusted third-party code
+  -> business-level validation of accepted formulas
+```
+
+The dialect controls the language surface. The host controls the execution environment.
+
+## Interop risk
+
+`CSharpInterop` belongs to trusted profiles. Do not include it in end-user formula dialects unless the host intentionally exposes a trusted interop surface.
+
+A restricted pricing DSL should normally reject expressions that call arbitrary .NET methods.
+
+## Loop and resource risk
+
+Loops may be valid for workflow-style DSLs, but they change the resource profile. A formula DSL often does not need loops. If loops are selected, the host should consider timeouts or step limits outside the documented language surface.
+
+## Testing restricted profiles
+
+A restricted dialect should include negative tests for syntax that must remain unavailable:
+
+- C# interop;
+- loops when not intended;
+- labels when not intended;
+- broad function calls when not intended;
+- backend modes not exposed by the dialect;
+- optimizer or intrinsic paths not supported by the selected backend.
+
+Negative tests are not optional. They prove the restriction is real.
+
+## Documentation wording
+
+Good wording:
+
+```text
+This dialect restricts the available Wist modules and omits C# interop.
+```
+
+Bad wording:
+
+```text
+This dialect safely sandboxes arbitrary untrusted code.
+```
+
+Use the first wording unless the host also provides and documents process-level isolation and resource controls.
+
+## Next
+
+Continue with [Testing a DSL](/build-dsls/testing-dsl) and [Backend Contracts](/reference/backend-contracts).

--- a/docs/reference/documentation-rules.md
+++ b/docs/reference/documentation-rules.md
@@ -1,0 +1,76 @@
+---
+title: Documentation Rules
+description: Summarize documentation synchronization and executable example rules.
+---
+
+# Documentation Rules
+
+Markdown files in this repository are architectural source material, not optional notes.
+
+For the full source document, see `docs/DOCUMENTATION_RULES.md`. This page exposes the rules in the public documentation route so contributors can find them from the sidebar.
+
+## Core rule
+
+Documentation must be preserved and synchronized with implementation.
+
+If code and Markdown disagree, treat it as architecture drift. Do not silently choose code just because it currently compiles, and do not silently choose stale documentation just because it sounds like the intended design.
+
+## Required behavior
+
+Before non-trivial changes, identify the Markdown files that govern the task and the constraints they impose.
+
+This matters for changes touching:
+
+- parser behavior;
+- runtime composition;
+- modules;
+- capabilities;
+- function calls;
+- CLI behavior;
+- CI behavior;
+- public API;
+- documentation smoke checks.
+
+## Forbidden fixes
+
+Do not fix CI or tests by:
+
+- deleting architectural documentation;
+- replacing substantial documents with placeholders;
+- adding path-based Markdown exclusions to smoke checks;
+- weakening documentation checks instead of fixing stale examples;
+- restoring removed runtime functionality only because old documentation references it;
+- implementing behavior that contradicts current architecture docs without explicitly resolving the conflict.
+
+## Executable examples
+
+When a Markdown `bash` block is stale, choose the narrowest honest fix:
+
+1. If the command describes supported behavior, update the command.
+2. If the command is future or historical, convert the fence to `text` and say it is not executable in the current state.
+3. If the surrounding document is obsolete, rewrite only the obsolete section.
+
+The Markdown bash smoke runner executes tracked Markdown `bash` fences unless the block is explicitly marked with supported CI attributes.
+
+## Current versus future docs
+
+Current-state documents describe what the repository supports now.
+
+Future or historical documents may describe planned or removed behavior, but they must not contain executable `bash` blocks for commands that do not exist in the current branch.
+
+## Practical validation
+
+For documentation changes that affect public examples, run:
+
+```text
+python3 .github/scripts/run-markdown-bash-blocks.py
+npm run docs:build
+```
+
+For code or behavior changes, also run the relevant .NET build and test commands from [Installation](/start/installation).
+
+## Related pages
+
+- [Project Rules](/reference/project-rules)
+- [Module Contracts](/reference/module-contracts)
+- [Testing a DSL](/build-dsls/testing-dsl)

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -18,7 +18,8 @@ Use reference pages when you need to answer questions such as:
 - which backend modes exist;
 - what a backend must preserve;
 - which dialect/module names are intended as stable aliases;
-- which intrinsic symbols or capability families need documentation.
+- which intrinsic symbols or capability families need documentation;
+- which project and documentation rules constrain changes.
 
 ## Current reference map
 
@@ -26,11 +27,13 @@ Use reference pages when you need to answer questions such as:
 |---|---|
 | [Dialect Reference](/reference/dialect-reference) | dialect file syntax, directive families and shipped profiles |
 | [Module Reference](/reference/module-reference) | module aliases, feature ownership and runtime exports |
+| [Module Contracts](/reference/module-contracts) | token, parser priority, visitor ownership, bytecode tag, state and backend-capability contracts |
 | [Bytecode Reference](/reference/bytecode-reference) | bytecode concepts and lowering responsibilities |
 | [AIR Reference](/reference/air-reference) | AIR opcode table and instruction contracts |
 | [Intrinsics Reference](/reference/intrinsics-reference) | intrinsic symbols, type arguments and capability expectations |
 | [Backend Contracts](/reference/backend-contracts) | interpreter/CIL/shared backend obligations |
 | [Project Rules](/reference/project-rules) | coding and contribution rules relevant to documentation and internals |
+| [Documentation Rules](/reference/documentation-rules) | documentation synchronization and executable example rules |
 
 ## Stability levels
 
@@ -79,4 +82,4 @@ If the source of truth is uncertain, document the item as current implementation
 
 ## Next
 
-Start with [AIR Reference](/reference/air-reference) or [Backend Contracts](/reference/backend-contracts).
+Start with [Dialect Reference](/reference/dialect-reference), [Module Contracts](/reference/module-contracts), [AIR Reference](/reference/air-reference) or [Backend Contracts](/reference/backend-contracts).

--- a/docs/reference/module-contracts.md
+++ b/docs/reference/module-contracts.md
@@ -1,0 +1,126 @@
+---
+title: Module Contracts
+description: Make module ownership and extension contracts visible in the public documentation route.
+---
+
+# Module Contracts
+
+This page summarizes the contracts module authors must preserve when adding or changing Wist/UniversalToolchain language features.
+
+For the full source document, see `docs/contracts/module-contracts.md`. This reference page exists because these contracts are part of the public module-authoring route, not hidden project notes.
+
+## Why this page exists
+
+UniversalToolchain is intentionally modular. A new feature can affect lexing, parsing, AST translation, bytecode, AIR, runtime manifests, optimizers and backends. Hidden assumptions in any of those layers can silently change language behavior.
+
+A module is not complete when one example runs. It is complete when its syntax ownership, dialect selection, runtime behavior and backend support are explicit and tested.
+
+## Token-name contract
+
+Token names are part of the internal module API.
+
+Rules:
+
+- Do not invent a token name in one file and consume it by raw string in another unrelated file without a shared constant or clear documentation.
+- Do not reuse an existing token name for a different semantic meaning.
+- Do not rename token names without updating parser, visitor and dialect tests.
+- Prefer feature-scoped constants for shared token names.
+
+Risk: a misspelled or reused token name can compile successfully while changing parser behavior.
+
+## Parser-priority contract
+
+Parser creator priority is a grammar contract, not just an ordering hint.
+
+Rules:
+
+- Priority must reflect intended precedence and syntax ownership.
+- Do not copy nearby priority values until a single example passes.
+- Priority changes require parser regression tests.
+- Overlapping syntax requires tests that show the wrong node creator does not take ownership.
+
+Risk: a small priority change can silently change how existing programs parse.
+
+## Visitor-ownership contract
+
+AST translation visitors must be self-filtering.
+
+Rules:
+
+- A visitor must return without output when it does not own the node.
+- A visitor must not emit only because a token name or child count loosely matches.
+- A visitor must not assume it is the only visitor that can see a node.
+- Intentional cooperation between visitors must be documented and tested.
+
+Risk: two visitors can emit for the same node, or no visitor can emit for a valid node.
+
+## Bytecode-tag contract
+
+Bytecode tags are semantic metadata, not decoration.
+
+Rules:
+
+- A tag must have a documented producer and consumer.
+- Backend-specific tags must not be used as generic semantic truth.
+- Optimizers must not depend on undocumented tag strings.
+- Tags affecting safety, purity, side effects, stack shape or backend lowering need documentation and tests.
+
+Risk: tags can become a second untyped language hidden inside bytecode.
+
+## Shared-state contract
+
+Mutable state shared between module components must be explicit, narrow and scoped.
+
+Rules:
+
+- Avoid static mutable state.
+- Avoid state that survives across independent compilations unless it is immutable configuration.
+- Pass shared data explicitly.
+- Add tests that compile independent inputs and prove state does not leak.
+
+Risk: a module can become order-dependent or compilation-history-dependent.
+
+## Dialect-selection contract
+
+A feature is not modular unless a dialect can include or exclude it predictably.
+
+Rules:
+
+- New features should be selectable through dialect/runtime composition when practical.
+- Restricted dialects must reject syntax or runtime behavior that is not selected.
+- Generic framework layers must not activate features through hardcoded module names.
+- Capability reports explain selected behavior; they must not activate behavior.
+
+Risk: a feature can appear enabled even when the selected dialect did not request it.
+
+## Backend-capability contract
+
+Optimized lowering must be backend-capability gated.
+
+Rules:
+
+- Do not emit backend-specific intrinsics unless the selected backend supports them.
+- If an optimization changes AIR or bytecode shape, prove semantic parity with a reference backend.
+- Backend-specific fast paths need fallback behavior or clear diagnostics.
+- Unsupported backend operations must fail explicitly instead of silently falling back.
+
+Risk: a program can work in CIL and fail in interpreter, or an optimizer can leak backend-specific intrinsics into unsupported backends.
+
+## Documentation contract
+
+Every module with non-obvious behavior should document:
+
+- alias;
+- syntax ownership;
+- parser priority assumptions;
+- visitors;
+- bytecode/AIR responsibilities;
+- backend or intrinsic requirements;
+- dialect inclusion and exclusion behavior.
+
+## Related pages
+
+- [Write Modules](/write-modules/)
+- [Create Your First Module](/write-modules/create-your-first-module)
+- [Testing a Module](/write-modules/testing-module)
+- [Backend Contracts](/reference/backend-contracts)

--- a/docs/start/cli-reference.md
+++ b/docs/start/cli-reference.md
@@ -5,7 +5,7 @@ description: Document the current Wistc command surface used by onboarding examp
 
 # CLI Reference
 
-This page documents the Wist command-line surface used by the public examples. It is a practical reference for running source text, files, dialect files and backend modes from the repository checkout.
+This page documents the Wist command-line surface used by the public examples. It is a practical reference for running source text, files, dialect files and backend aliases from the repository checkout.
 
 ## When to read this page
 
@@ -28,15 +28,16 @@ The `--` separates `dotnet run` options from Wistc options.
 | `--eval "source"` | Runs source text passed directly on the command line. |
 | `--file path/to/program.wist` | Runs a source file. |
 | `--dialect-file path/to/dialect.wistdialect` | Uses an explicit dialect file instead of the default runtime surface. |
-| `--mode compiler` | Runs through the user-facing compiler mode when the selected dialect exposes CIL. |
-| `--mode interpreter` | Runs through the interpreter mode when the selected dialect exposes the interpreter backend. |
+| `--backend compiler` | Runs through the user-facing compiler alias when the selected dialect exposes CIL. |
+| `--backend interpreter` | Runs through the interpreter backend alias when the selected dialect exposes the interpreter backend. |
+| `--list-modules` | Lists available runtime components and exits. |
 
-`compiler` is a user-facing mode name. In dialect files, the backend id is usually `cil`.
+`compiler` is a user-facing backend alias. In dialect files, the backend id is usually `cil`.
 
 ## Minimal expression
 
 ```text
-dotnet run --project UniversalToolchain/Wistc/Wistc.csproj -- run --eval "(2 + 2) * 3" --mode compiler
+dotnet run --project UniversalToolchain/Wistc/Wistc.csproj -- run --eval "(2 + 2) * 3" --backend compiler
 ```
 
 Expected output:
@@ -48,7 +49,7 @@ Expected output:
 Interpreter mode should produce the same observable result when it is available:
 
 ```text
-dotnet run --project UniversalToolchain/Wistc/Wistc.csproj -- run --eval "(2 + 2) * 3" --mode interpreter
+dotnet run --project UniversalToolchain/Wistc/Wistc.csproj -- run --eval "(2 + 2) * 3" --backend interpreter
 ```
 
 ## Running a program file
@@ -56,31 +57,31 @@ dotnet run --project UniversalToolchain/Wistc/Wistc.csproj -- run --eval "(2 + 2
 A file-based run combines a program file with an optional dialect file:
 
 ```text
-dotnet run --project UniversalToolchain/Wistc/Wistc.csproj -- run --dialect-file UniversalToolchain/Dialects/examples/wist/minimal-arithmetic/dialect.wistdialect --file UniversalToolchain/Dialects/examples/wist/minimal-arithmetic/program.wist --mode interpreter
+dotnet run --project UniversalToolchain/Wistc/Wistc.csproj -- run --dialect-file UniversalToolchain/Dialects/examples/wist/minimal-arithmetic/dialect.wistdialect --file UniversalToolchain/Dialects/examples/wist/minimal-arithmetic/program.wist --backend interpreter
 ```
 
 Use this form for documentation examples, tests and local debugging because the program and dialect are both explicit.
 
-## Backend mode versus dialect backend id
+## Backend alias versus dialect backend id
 
-Wistc accepts user-facing modes such as `compiler` and `interpreter`. Dialect files select backend ids such as `cil` and `interpreter`.
+Wistc accepts backend aliases such as `compiler` and `interpreter`. Dialect files select backend ids such as `cil` and `interpreter`.
 
 The mapping is intentional:
 
-| CLI mode | Dialect backend requirement |
+| CLI backend alias | Dialect backend requirement |
 |---|---|
 | `compiler` | selected dialect exposes `cil` |
 | `interpreter` | selected dialect exposes `interpreter` |
 
-A dialect that exposes only `interpreter` should reject `--mode compiler`. A dialect that exposes only `cil` should reject `--mode interpreter`. Silent fallback would hide composition errors.
+A dialect that exposes only `interpreter` should reject `--backend compiler`. A dialect that exposes only `cil` should reject `--backend interpreter`. Silent fallback would hide composition errors.
 
 ## Common failures
 
 | Symptom | Likely cause |
 |---|---|
 | Project path cannot be found | Command was run from the wrong directory. Run from the repository root. |
-| Compiler mode is rejected | The selected dialect does not expose the `cil` backend. |
-| Interpreter mode is rejected | The selected dialect does not expose the `interpreter` backend. |
+| Compiler backend alias is rejected | The selected dialect does not expose the `cil` backend. |
+| Interpreter backend alias is rejected | The selected dialect does not expose the `interpreter` backend. |
 | Syntax is rejected | The dialect does not select the module that owns the syntax. |
 | Interop expression is rejected | The selected dialect does not include trusted interop support. |
 | Dialect file fails to parse | The file may use older shorthand syntax instead of the current parser-tested directive form. |

--- a/docs/start/cli-reference.md
+++ b/docs/start/cli-reference.md
@@ -1,0 +1,105 @@
+---
+title: CLI Reference
+description: Document the current Wistc command surface used by onboarding examples.
+---
+
+# CLI Reference
+
+This page documents the Wist command-line surface used by the public examples. It is a practical reference for running source text, files, dialect files and backend modes from the repository checkout.
+
+## When to read this page
+
+Read this after [First Program](/start/first-program) when you want to run more than the smallest quick-start expression.
+
+## Command shape
+
+From the repository root, Wist examples are run through the `Wistc` project:
+
+```text
+dotnet run --project UniversalToolchain/Wistc/Wistc.csproj -- run [options]
+```
+
+The `--` separates `dotnet run` options from Wistc options.
+
+## Common options
+
+| Option | Meaning |
+|---|---|
+| `--eval "source"` | Runs source text passed directly on the command line. |
+| `--file path/to/program.wist` | Runs a source file. |
+| `--dialect-file path/to/dialect.wistdialect` | Uses an explicit dialect file instead of the default runtime surface. |
+| `--mode compiler` | Runs through the user-facing compiler mode when the selected dialect exposes CIL. |
+| `--mode interpreter` | Runs through the interpreter mode when the selected dialect exposes the interpreter backend. |
+
+`compiler` is a user-facing mode name. In dialect files, the backend id is usually `cil`.
+
+## Minimal expression
+
+```text
+dotnet run --project UniversalToolchain/Wistc/Wistc.csproj -- run --eval "(2 + 2) * 3" --mode compiler
+```
+
+Expected output:
+
+```text
+12
+```
+
+Interpreter mode should produce the same observable result when it is available:
+
+```text
+dotnet run --project UniversalToolchain/Wistc/Wistc.csproj -- run --eval "(2 + 2) * 3" --mode interpreter
+```
+
+## Running a program file
+
+A file-based run combines a program file with an optional dialect file:
+
+```text
+dotnet run --project UniversalToolchain/Wistc/Wistc.csproj -- run --dialect-file UniversalToolchain/Dialects/examples/wist/minimal-arithmetic/dialect.wistdialect --file UniversalToolchain/Dialects/examples/wist/minimal-arithmetic/program.wist --mode interpreter
+```
+
+Use this form for documentation examples, tests and local debugging because the program and dialect are both explicit.
+
+## Backend mode versus dialect backend id
+
+Wistc accepts user-facing modes such as `compiler` and `interpreter`. Dialect files select backend ids such as `cil` and `interpreter`.
+
+The mapping is intentional:
+
+| CLI mode | Dialect backend requirement |
+|---|---|
+| `compiler` | selected dialect exposes `cil` |
+| `interpreter` | selected dialect exposes `interpreter` |
+
+A dialect that exposes only `interpreter` should reject `--mode compiler`. A dialect that exposes only `cil` should reject `--mode interpreter`. Silent fallback would hide composition errors.
+
+## Common failures
+
+| Symptom | Likely cause |
+|---|---|
+| Project path cannot be found | Command was run from the wrong directory. Run from the repository root. |
+| Compiler mode is rejected | The selected dialect does not expose the `cil` backend. |
+| Interpreter mode is rejected | The selected dialect does not expose the `interpreter` backend. |
+| Syntax is rejected | The dialect does not select the module that owns the syntax. |
+| Interop expression is rejected | The selected dialect does not include trusted interop support. |
+| Dialect file fails to parse | The file may use older shorthand syntax instead of the current parser-tested directive form. |
+
+## Current dialect syntax reminder
+
+Current parser-tested dialect examples use one directive per line:
+
+```text
+dialect MinimalArithmetic
+use Arithmetic
+use Numbers
+use Scopes
+use Whitespaces
+backend interpreter enable
+```
+
+Older shorthand such as `use Arithmetic,Numbers` or `backend cil,interpreter` may appear in historical material, but it should not be used for new public examples unless that compatibility path is explicitly being documented.
+
+## Next
+
+Continue with [Wist Syntax Tour](/wist/syntax-tour) or [Minimal DSL](/build-dsls/minimal-dsl).

--- a/docs/start/first-program.md
+++ b/docs/start/first-program.md
@@ -18,8 +18,8 @@ Run one Wist expression through the CLI and verify the expected output.
 ## Prerequisites
 
 - You are in the repository root.
-- The repository is on the `docs-site` branch.
 - The .NET solution has been restored and built.
+- You are using the branch required by your current task or pull request.
 
 ## Steps
 
@@ -35,7 +35,7 @@ Expected output:
 12
 ```
 
-`compiler` is the user-facing mode that selects the CIL backend when the active dialect exposes the CIL backend.
+`compiler` is the user-facing backend alias that selects the CIL backend when the active dialect exposes the CIL backend.
 
 ### 2. Run the same expression through the interpreter
 
@@ -49,7 +49,7 @@ Expected output:
 12
 ```
 
-The interpreter path is useful when validating semantic parity. If a selected dialect does not expose `interpreter`, Wistc will reject that mode.
+The interpreter path is useful when validating semantic parity. If a selected dialect does not expose `interpreter`, Wistc will reject that backend alias.
 
 ### 3. Run the pricing demo
 
@@ -84,4 +84,4 @@ The same source should produce the same observable result in compiler and interp
 
 ## Next
 
-Read the [Mental Model](/start/mental-model), then continue with the [Wist Syntax Tour](/wist/syntax-tour).
+Read the [CLI Reference](/start/cli-reference) if you want the command surface, or continue with the [Mental Model](/start/mental-model) and the [Wist Syntax Tour](/wist/syntax-tour).

--- a/docs/start/index.md
+++ b/docs/start/index.md
@@ -24,23 +24,25 @@ Understand the difference between UniversalToolchain and Wist, identify your rol
 
 | User type | What to read first | Then read |
 |---|---|---|
-| **Wist user** (run programs, learn syntax) | [First Program](/start/first-program) | [Syntax Tour](/wist/syntax-tour) |
-| **DSL developer** (compose your own language) | [Mental Model](/start/mental-model), [Dialect Files](/build-dsls/dialect-files) | [Minimal DSL](/build-dsls/minimal-dsl) |
-| **Module author** (add new language features) | [Write Modules](/write-modules/) | Later: Bytecode generation and backend guides |
-| **Runtime/compiler engineer** | [Internals](/internals/pipeline) | [Bytecode and AIR](/architecture/bytecode-and-air) |
-| **Contributor/maintainer** | [Internals](/internals/) | Project rules and architecture docs |
-| **Reference user** | [Reference](/reference/) | Backend contracts, module specifications |
+| **Wist user** (run programs, learn syntax) | [First Program](/start/first-program), [CLI Reference](/start/cli-reference) | [Syntax Tour](/wist/syntax-tour), [Examples](/wist/examples) |
+| **DSL developer** (compose your own language) | [Mental Model](/start/mental-model), [Dialect Files](/build-dsls/dialect-files) | [Minimal DSL](/build-dsls/minimal-dsl), [Embedding in .NET](/build-dsls/embedding-dotnet) |
+| **Module author** (add new language features) | [Write Modules](/write-modules/) | [Module Contracts](/reference/module-contracts), [Testing a Module](/write-modules/testing-module) |
+| **Runtime/compiler engineer** | [Pipeline](/internals/pipeline) | [Bytecode](/internals/bytecode), [AIR](/internals/air), [Backends](/internals/backends) |
+| **Contributor/maintainer** | [Internals](/internals/) | [Project Rules](/reference/project-rules), [Documentation Rules](/reference/documentation-rules) |
+| **Reference user** | [Reference](/reference/) | [Backend Contracts](/reference/backend-contracts), [Module Reference](/reference/module-reference) |
 
 ## Recommended order
 
 1. [First Program](/start/first-program)
-2. [Mental Model](/start/mental-model)
-3. [Syntax Tour](/wist/syntax-tour)
-4. [Dialect Files](/build-dsls/dialect-files)
-5. [Minimal DSL](/build-dsls/minimal-dsl)
-6. [Write Modules](/write-modules/)
-7. [Pipeline overview](/internals/pipeline)
-8. [Reference](/reference/)
+2. [CLI Reference](/start/cli-reference)
+3. [Mental Model](/start/mental-model)
+4. [Syntax Tour](/wist/syntax-tour)
+5. [Dialect Files](/build-dsls/dialect-files)
+6. [Minimal DSL](/build-dsls/minimal-dsl)
+7. [Embedding in .NET](/build-dsls/embedding-dotnet)
+8. [Write Modules](/write-modules/)
+9. [Pipeline overview](/internals/pipeline)
+10. [Reference](/reference/)
 
 ## Next
 


### PR DESCRIPTION
## Summary

This PR hardens the public developer documentation routes instead of only adding more prose.

Changes:

- adds a dedicated Wist CLI reference page;
- removes the branch-specific `docs-site` prerequisite from the first-program guide;
- fixes the start-page route for runtime/compiler engineers by replacing the stale `/architecture/bytecode-and-air` route with current internals links;
- adds a .NET embedding guide for DSL developers;
- adds a restricted DSL security guide that clearly separates dialect restriction from process sandboxing;
- exposes module contracts and documentation rules in the public Reference route;
- updates the VitePress sidebar to include the new pages;
- extends CI so the VitePress documentation site is built, not only Markdown bash blocks.

## Why

The documentation already has a strong skeleton, but several important developer routes were incomplete or hidden:

- Wist users had quick-start commands but no CLI reference.
- DSL developers had dialect composition docs but no embedding path.
- Restricted DSL warnings were repeated across pages but not centralized.
- Module contracts and documentation rules existed as project Markdown files but were not visible from the generated documentation site.
- CI validated Markdown bash blocks but did not validate the VitePress site build.

## Validation

I could not run the repository locally from this environment because outbound `git clone` failed with DNS resolution for `github.com`. The PR adds `npm install` and `npm run docs:build` to GitHub Actions so the documentation build is validated in CI, alongside the existing .NET build/test and Markdown bash smoke checks.