### PR TITLE
Use canonical test infrastructure for backend parity

### DIFF
--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/TestingInfrastructureGuardrailTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/TestingInfrastructureGuardrailTests.cs
@@ -83,7 +83,11 @@ public sealed class TestingInfrastructureGuardrailTests
             "1 + 2 * 3");
 
         UniversalToolchain.Modules.Tests.BackendParityInfrastructure.AssertSemanticParity(compilerResult, interpreterResult);
-        Assert.That(UniversalToolchain.Modules.Tests.BackendParityInfrastructure.AsNumber(compilerResult.Value), Is.EqualTo(7d));
+        Assert.Multiple(() =>
+        {
+            Assert.That(compilerResult.IsSuccess, Is.True);
+            Assert.That(interpreterResult.IsSuccess, Is.True);
+        });
     }
 
     private static IReadOnlyList<string> TestingInfrastructureFiles() =>

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/TestingInfrastructureGuardrailTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/TestingInfrastructureGuardrailTests.cs
@@ -1,3 +1,5 @@
+using UniversalToolchain.Modules.Tests;
+
 namespace UniversalToolchain.Dialects.Tests;
 
 public sealed class TestingInfrastructureGuardrailTests
@@ -74,19 +76,20 @@ public sealed class TestingInfrastructureGuardrailTests
     {
         const string dialectText = """
                                   dialect Parity
-                                  use Arithmetic,Numbers
+                                  use Arithmetic,Numbers,CSharpInterop,Identifier,Scopes,Whitespaces
                                   backend interpreter,compiler
                                   """;
 
-        var (compilerResult, interpreterResult) = UniversalToolchain.Modules.Tests.BackendParityInfrastructure.RunBoth(
+        var (compilerResult, interpreterResult) = BackendParityInfrastructure.RunBoth(
             dialectText,
-            "1 + 2 * 3");
+            "Main.Round((10 * 2) * 3.141592653589793)");
 
-        UniversalToolchain.Modules.Tests.BackendParityInfrastructure.AssertSemanticParity(compilerResult, interpreterResult);
+        BackendParityInfrastructure.AssertSemanticParity(compilerResult, interpreterResult);
         Assert.Multiple(() =>
         {
             Assert.That(compilerResult.IsSuccess, Is.True);
             Assert.That(interpreterResult.IsSuccess, Is.True);
+            Assert.That(BackendParityInfrastructure.AsNumber(compilerResult.Value), Is.EqualTo(63d));
         });
     }
 

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/TestingInfrastructureGuardrailTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/TestingInfrastructureGuardrailTests.cs
@@ -1,5 +1,3 @@
-using UniversalToolchain.Dialects.Tests;
-
 namespace UniversalToolchain.Dialects.Tests;
 
 public sealed class TestingInfrastructureGuardrailTests
@@ -85,7 +83,7 @@ public sealed class TestingInfrastructureGuardrailTests
             "1 + 2 * 3");
 
         UniversalToolchain.Modules.Tests.BackendParityInfrastructure.AssertSemanticParity(compilerResult, interpreterResult);
-        Assert.That(compilerResult.Value, Is.EqualTo(7).Or.EqualTo(7d));
+        Assert.That(UniversalToolchain.Modules.Tests.BackendParityInfrastructure.AsNumber(compilerResult.Value), Is.EqualTo(7d));
     }
 
     private static IReadOnlyList<string> TestingInfrastructureFiles() =>

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/TestingInfrastructureGuardrailTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/TestingInfrastructureGuardrailTests.cs
@@ -1,0 +1,117 @@
+using UniversalToolchain.Dialects.Tests;
+
+namespace UniversalToolchain.Dialects.Tests;
+
+public sealed class TestingInfrastructureGuardrailTests
+{
+    [Test]
+    public void TestingInfrastructure_ShouldNotRewriteDialectSourceByBackendDirectivePrefix()
+    {
+        var files = TestingInfrastructureFiles();
+        var forbiddenTokens = new[]
+        {
+            "EnsureSingleBackend",
+            "StartsWith(\"backend ",
+            "Split(['\\r', '\\n']",
+            "lines.Add($\"backend"
+        };
+
+        foreach (var file in files)
+        {
+            var source = File.ReadAllText(file);
+
+            foreach (var token in forbiddenTokens)
+                Assert.That(source, Does.Not.Contain(token), $"File '{file}' must not use raw dialect backend rewriting token '{token}'.");
+        }
+    }
+
+    [Test]
+    public void TestingInfrastructure_ShouldNotRegisterBuiltInBackendsManually()
+    {
+        var files = TestingInfrastructureFiles();
+        var forbiddenTokens = new[]
+        {
+            "AddWistCilBackend",
+            "AddWistInterpreterBackend"
+        };
+
+        foreach (var file in files)
+        {
+            var source = File.ReadAllText(file);
+
+            foreach (var token in forbiddenTokens)
+                Assert.That(source, Does.Not.Contain(token), $"File '{file}' must use canonical manifest-backed services instead of '{token}'.");
+        }
+    }
+
+    [Test]
+    public void DialectTestHostInfrastructure_CreateBackendSpecificHosts_UsesStructuredBackendOverride()
+    {
+        const string dialectText = """
+                                  dialect StructuredOverride
+
+                                  use Arithmetic,Numbers
+
+                                  backend interpreter,compiler
+                                  """;
+
+        using var interpreterHost = DialectTestHostInfrastructure.CreateInterpreterHost(dialectText);
+        using var compilerHost = DialectTestHostInfrastructure.CreateCompilerHost(dialectText);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                interpreterHost.Configuration.BackendConfigurations.Select(static x => x.BackendDescriptor.CanonicalId),
+                Is.EqualTo(new[] { "interpreter" }));
+            Assert.That(
+                compilerHost.Configuration.BackendConfigurations.Select(static x => x.BackendDescriptor.CanonicalId),
+                Is.EqualTo(new[] { "cil" }));
+            Assert.That(interpreterHost.Configuration.FrontendModules.Select(static x => x.Name), Is.EquivalentTo(compilerHost.Configuration.FrontendModules.Select(static x => x.Name)));
+            Assert.That(interpreterHost.Configuration.IrModules.Select(static x => x.Name), Is.EquivalentTo(compilerHost.Configuration.IrModules.Select(static x => x.Name)));
+        });
+    }
+
+    [Test]
+    public void BackendParityInfrastructure_RunBoth_UsesCanonicalCompositionBeforeStructuredOverride()
+    {
+        const string dialectText = """
+                                  dialect Parity
+                                  use Arithmetic,Numbers
+                                  backend interpreter,compiler
+                                  """;
+
+        var (compilerResult, interpreterResult) = UniversalToolchain.Modules.Tests.BackendParityInfrastructure.RunBoth(
+            dialectText,
+            "1 + 2 * 3");
+
+        UniversalToolchain.Modules.Tests.BackendParityInfrastructure.AssertSemanticParity(compilerResult, interpreterResult);
+        Assert.That(compilerResult.Value, Is.EqualTo(7).Or.EqualTo(7d));
+    }
+
+    private static IReadOnlyList<string> TestingInfrastructureFiles() =>
+    [
+        FindRepositoryFile(
+            "UniversalToolchain",
+            "UniversalToolchain.Testing.Infrastructure",
+            "BackendParityInfrastructure.cs"),
+        FindRepositoryFile(
+            "UniversalToolchain",
+            "UniversalToolchain.Testing.Infrastructure",
+            "DialectTestHostInfrastructure.cs")
+    ];
+
+    private static string FindRepositoryFile(params string[] relativeParts)
+    {
+        var directory = new DirectoryInfo(TestContext.CurrentContext.TestDirectory);
+        while (directory != null)
+        {
+            var candidate = Path.Combine(new[] { directory.FullName }.Concat(relativeParts).ToArray());
+            if (File.Exists(candidate))
+                return candidate;
+
+            directory = directory.Parent;
+        }
+
+        throw new FileNotFoundException("Could not locate repository file.", Path.Combine(relativeParts));
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/Wist/WistDialectParallelIsolationStressTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/Wist/WistDialectParallelIsolationStressTests.cs
@@ -11,7 +11,7 @@ public class WistDialectParallelIsolationStressTests
     [Test]
     public async Task ComposeText_ParallelCalls_ShouldNotMixRuntimeSelections()
     {
-        using var provider = WistDialectTestInfrastructure.CreateProviderWithExplicitBackends();
+        using var provider = WistDialectTestInfrastructure.CreateCanonicalProvider();
         var workflow = provider.GetRequiredService<WistDialectExecutionWorkflow>();
         var dialects = new[]
         {
@@ -32,7 +32,7 @@ public class WistDialectParallelIsolationStressTests
     [Test]
     public async Task CreateHost_ParallelCalls_ShouldNotMixBackendConfigurations()
     {
-        using var provider = WistDialectTestInfrastructure.CreateProviderWithExplicitBackends();
+        using var provider = WistDialectTestInfrastructure.CreateCanonicalProvider();
         var workflow = provider.GetRequiredService<WistDialectExecutionWorkflow>();
         var composition = workflow.ComposeText("dialect Stable\nuse Arithmetic,Numbers\n\nbackend compiler,interpreter", "stable");
         Assert.That(composition.IsSuccess, Is.True, FormatComposition(composition));
@@ -49,7 +49,7 @@ public class WistDialectParallelIsolationStressTests
     [Test]
     public void RepeatedCompose_ShouldNotAccumulateRuntimeMetadata()
     {
-        using var provider = WistDialectTestInfrastructure.CreateProviderWithExplicitBackends();
+        using var provider = WistDialectTestInfrastructure.CreateCanonicalProvider();
         var workflow = provider.GetRequiredService<WistDialectExecutionWorkflow>();
         var signatures = new List<string>(RepeatCount);
 
@@ -66,7 +66,7 @@ public class WistDialectParallelIsolationStressTests
     [Test]
     public void RepeatedCreateHost_ShouldNotAccumulateRegistrations()
     {
-        using var provider = WistDialectTestInfrastructure.CreateProviderWithExplicitBackends();
+        using var provider = WistDialectTestInfrastructure.CreateCanonicalProvider();
         var workflow = provider.GetRequiredService<WistDialectExecutionWorkflow>();
         var composition = workflow.ComposeText("dialect RepeatHost\nuse Arithmetic,Numbers\nbackend interpreter,compiler", "repeat-host");
         Assert.That(composition.IsSuccess, Is.True, FormatComposition(composition));
@@ -84,7 +84,7 @@ public class WistDialectParallelIsolationStressTests
     [Test]
     public async Task ParallelComposeAndCreateHost_ShouldRemainDeterministic()
     {
-        using var provider = WistDialectTestInfrastructure.CreateProviderWithExplicitBackends();
+        using var provider = WistDialectTestInfrastructure.CreateCanonicalProvider();
         var workflow = provider.GetRequiredService<WistDialectExecutionWorkflow>();
 
         var signatures = await Task.WhenAll(Enumerable.Range(0, ParallelCount).Select(i => Task.Run(() =>
@@ -104,7 +104,7 @@ public class WistDialectParallelIsolationStressTests
     [Test]
     public void FailedComposition_ShouldNotPoisonNextSuccessfulComposition()
     {
-        using var provider = WistDialectTestInfrastructure.CreateProviderWithExplicitBackends();
+        using var provider = WistDialectTestInfrastructure.CreateCanonicalProvider();
         var workflow = provider.GetRequiredService<WistDialectExecutionWorkflow>();
 
         var failed = workflow.ComposeText("dialect Broken\nuse MissingModule\nbackend interpreter", "broken");
@@ -123,7 +123,7 @@ public class WistDialectParallelIsolationStressTests
     [Test]
     public void RepeatedKnownBackendResolution_ShouldRemainStable()
     {
-        using var provider = WistDialectTestInfrastructure.CreateProviderWithExplicitBackends();
+        using var provider = WistDialectTestInfrastructure.CreateCanonicalProvider();
         var workflow = provider.GetRequiredService<WistDialectExecutionWorkflow>();
         var composition = workflow.ComposeText("dialect Backends\nuse Arithmetic\nbackend compiler,interpreter", "backends");
         Assert.That(composition.IsSuccess, Is.True, FormatComposition(composition));
@@ -141,7 +141,7 @@ public class WistDialectParallelIsolationStressTests
     [Test]
     public async Task ParallelTypeLoading_ShouldRemainDeterministic()
     {
-        using var provider = WistDialectTestInfrastructure.CreateProviderWithExplicitBackends();
+        using var provider = WistDialectTestInfrastructure.CreateCanonicalProvider();
         var workflow = provider.GetRequiredService<WistDialectExecutionWorkflow>();
         var loader = provider.GetRequiredService<IRuntimeComponentTypeLoader>();
 

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/Wist/WistDialectTestInfrastructure.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/Wist/WistDialectTestInfrastructure.cs
@@ -12,6 +12,10 @@ internal static class WistDialectTestInfrastructure
         return services.BuildServiceProvider();
     }
 
+    /// <summary>
+    ///     Creates a provider for tests that explicitly validate manual built-in backend registration behavior.
+    ///     Canonical runtime-path tests should use <see cref="CreateCanonicalProvider" /> instead.
+    /// </summary>
     public static ServiceProvider CreateProviderWithExplicitBackends()
     {
         var services = new ServiceCollection();

--- a/UniversalToolchain/UniversalToolchain.Testing.Infrastructure/BackendParityInfrastructure.cs
+++ b/UniversalToolchain/UniversalToolchain.Testing.Infrastructure/BackendParityInfrastructure.cs
@@ -16,8 +16,22 @@ public static class BackendParityInfrastructure
     /// </summary>
     public static (BackendExecutionResult CompilerResult, BackendExecutionResult InterpreterResult) RunBoth(string dialectText, string code)
     {
-        using var compilerHost = CreateHost(EnsureSingleBackend(dialectText, "compiler"));
-        using var interpreterHost = CreateHost(EnsureSingleBackend(dialectText, "interpreter"));
+        using var provider = CreateCanonicalProvider();
+        var workflow = provider.GetRequiredService<WistDialectExecutionWorkflow>();
+        var resolver = provider.GetRequiredService<SelectedRuntimePlanResolver>();
+        var baseComposition = workflow.ComposeText(dialectText, "backend-parity-inline");
+        if (!baseComposition.IsSuccess)
+            Thrower.InvalidOpEx(FormatComposition(baseComposition));
+
+        var compilerComposition = DialectCompositionTestOverrides.WithOnlyBackend(baseComposition, resolver, "compiler");
+        var interpreterComposition = DialectCompositionTestOverrides.WithOnlyBackend(baseComposition, resolver, "interpreter");
+        if (!compilerComposition.IsSuccess)
+            Thrower.InvalidOpEx(FormatComposition(compilerComposition));
+        if (!interpreterComposition.IsSuccess)
+            Thrower.InvalidOpEx(FormatComposition(interpreterComposition));
+
+        using var compilerHost = workflow.CreateHost(compilerComposition);
+        using var interpreterHost = workflow.CreateHost(interpreterComposition);
 
         var compilerResult = ExecuteSafely(() => compilerHost.Run(code, "compiler"));
         var interpreterResult = ExecuteSafely(() => interpreterHost.Run(code, "interpreter"));
@@ -63,32 +77,15 @@ public static class BackendParityInfrastructure
         }
     }
 
-    private static WistDialectExecutionHost CreateHost(string dialectText)
+    private static ServiceProvider CreateCanonicalProvider()
     {
         var services = new ServiceCollection();
         services.AddWistDialectServices();
-        services.AddWistCilBackend();
-        services.AddWistInterpreterBackend();
-
-        using var provider = services.BuildServiceProvider();
-        var workflow = provider.GetRequiredService<WistDialectExecutionWorkflow>();
-        var composition = workflow.ComposeText(dialectText, "backend-parity-inline");
-        if (!composition.IsSuccess)
-            Thrower.InvalidOpEx(DialectCompositionExplanationFormatter.FormatDeterministic(DialectCompositionExplanationProjector.Project(composition)));
-
-        return workflow.CreateHost(composition);
+        return services.BuildServiceProvider();
     }
 
-    private static string EnsureSingleBackend(string dialectText, string backend)
-    {
-        var lines = dialectText
-            .Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-            .Where(static line => !line.StartsWith("backend ", StringComparison.Ordinal))
-            .ToList();
-
-        lines.Add($"backend {backend}");
-        return string.Join(Environment.NewLine, lines);
-    }
+    private static string FormatComposition(DialectFrameworkCompositionResult composition) =>
+        DialectCompositionExplanationFormatter.FormatDeterministic(DialectCompositionExplanationProjector.Project(composition));
 }
 
 /// <summary>

--- a/UniversalToolchain/UniversalToolchain.Testing.Infrastructure/DialectCompositionTestOverrides.cs
+++ b/UniversalToolchain/UniversalToolchain.Testing.Infrastructure/DialectCompositionTestOverrides.cs
@@ -1,0 +1,50 @@
+using ExceptionsManager;
+using UniversalToolchain.Dialects.Abstractions;
+using UniversalToolchain.Dialects.Integration;
+
+namespace UniversalToolchain.Dialects.Tests;
+
+internal static class DialectCompositionTestOverrides
+{
+    public static DialectFrameworkCompositionResult WithOnlyBackend(
+        DialectFrameworkCompositionResult composition,
+        SelectedRuntimePlanResolver resolver,
+        string backend)
+    {
+        composition = composition.ArgNotNull();
+        resolver = resolver.ArgNotNull();
+
+        if (string.IsNullOrWhiteSpace(backend))
+            Thrower.Argument(nameof(backend), "Backend must not be empty.");
+
+        if (!composition.IsSuccess || composition.CompiledDialect == null || composition.BuildPlan == null)
+            Thrower.Argument(nameof(composition), "Composition must be successful before applying a backend override.");
+
+        var sourcePlan = composition.BuildPlan;
+        var backendId = new DialectBackendId(backend.Trim());
+        var overriddenPlan = new DialectBuildPlan(
+            sourcePlan.Name,
+            sourcePlan.Version,
+            sourcePlan.OrderedModules,
+            [backendId],
+            sourcePlan.DisabledBackends.Where(x => x != backendId),
+            sourcePlan.IntrinsicDirectives,
+            sourcePlan.OptimizerDirectives,
+            sourcePlan.SecurityProfile,
+            sourcePlan.Capabilities,
+            sourcePlan.ValidationResult);
+
+        var selectedRuntimePlan = resolver.Resolve(overriddenPlan);
+        var resolutionErrors = selectedRuntimePlan.Diagnostics
+            .Where(static x => x.Severity == DialectDiagnosticSeverity.Error)
+            .ToList();
+
+        return new DialectFrameworkCompositionResult(
+            composition.SourceName,
+            composition.CompiledDialect,
+            overriddenPlan,
+            composition.SemanticDiagnostics,
+            resolutionErrors,
+            selectedRuntimePlan);
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Testing.Infrastructure/DialectTestHostInfrastructure.cs
+++ b/UniversalToolchain/UniversalToolchain.Testing.Infrastructure/DialectTestHostInfrastructure.cs
@@ -12,7 +12,7 @@ namespace UniversalToolchain.Dialects.Tests;
 public static class DialectTestHostInfrastructure
 {
     /// <summary>
-    ///     Creates an execution host from inline dialect text.
+    ///     Creates an execution host from inline dialect text through the canonical runtime path.
     /// </summary>
     public static WistDialectExecutionHost CreateHostFromDialectText(string dialectText)
     {
@@ -21,27 +21,27 @@ public static class DialectTestHostInfrastructure
 
         var services = new ServiceCollection();
         services.AddWistDialectServices();
-        services.AddWistCilBackend();
-        services.AddWistInterpreterBackend();
 
         using var provider = services.BuildServiceProvider();
         var workflow = provider.GetRequiredService<WistDialectExecutionWorkflow>();
         var composition = workflow.ComposeText(dialectText, "tests-inline");
         if (!composition.IsSuccess)
-            Thrower.InvalidOpEx(DialectCompositionExplanationFormatter.FormatDeterministic(DialectCompositionExplanationProjector.Project(composition)));
+            Thrower.InvalidOpEx(FormatComposition(composition));
 
         return workflow.CreateHost(composition);
     }
 
     /// <summary>
-    ///     Creates a host configured only for the interpreter backend.
+    ///     Creates a host by composing the original dialect through the canonical pipeline,
+    ///     then applying a structured test-only backend override to the build plan.
     /// </summary>
-    public static WistDialectExecutionHost CreateInterpreterHost(string dialectText) => CreateHostFromDialectText(EnsureSingleBackend(dialectText, "interpreter"));
+    public static WistDialectExecutionHost CreateInterpreterHost(string dialectText) => CreateHostWithOnlyBackend(dialectText, "interpreter");
 
     /// <summary>
-    ///     Creates a host configured only for the compiler backend.
+    ///     Creates a host by composing the original dialect through the canonical pipeline,
+    ///     then applying a structured test-only backend override to the build plan.
     /// </summary>
-    public static WistDialectExecutionHost CreateCompilerHost(string dialectText) => CreateHostFromDialectText(EnsureSingleBackend(dialectText, "compiler"));
+    public static WistDialectExecutionHost CreateCompilerHost(string dialectText) => CreateHostWithOnlyBackend(dialectText, "compiler");
 
     /// <summary>
     ///     Executes code in both backends and verifies semantic parity.
@@ -53,14 +53,28 @@ public static class DialectTestHostInfrastructure
         return compilerResult.Value;
     }
 
-    private static string EnsureSingleBackend(string dialectText, string backend)
+    private static WistDialectExecutionHost CreateHostWithOnlyBackend(string dialectText, string backend)
     {
-        var lines = dialectText
-            .Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-            .Where(static line => !line.StartsWith("backend ", StringComparison.Ordinal))
-            .ToList();
+        if (string.IsNullOrWhiteSpace(dialectText))
+            Thrower.Argument(nameof(dialectText), "Dialect text must not be empty.");
 
-        lines.Add($"backend {backend}");
-        return string.Join(Environment.NewLine, lines);
+        var services = new ServiceCollection();
+        services.AddWistDialectServices();
+
+        using var provider = services.BuildServiceProvider();
+        var workflow = provider.GetRequiredService<WistDialectExecutionWorkflow>();
+        var resolver = provider.GetRequiredService<SelectedRuntimePlanResolver>();
+        var composition = workflow.ComposeText(dialectText, $"tests-inline-{backend}");
+        if (!composition.IsSuccess)
+            Thrower.InvalidOpEx(FormatComposition(composition));
+
+        var overriddenComposition = DialectCompositionTestOverrides.WithOnlyBackend(composition, resolver, backend);
+        if (!overriddenComposition.IsSuccess)
+            Thrower.InvalidOpEx(FormatComposition(overriddenComposition));
+
+        return workflow.CreateHost(overriddenComposition);
     }
+
+    private static string FormatComposition(DialectFrameworkCompositionResult composition) =>
+        DialectCompositionExplanationFormatter.FormatDeterministic(DialectCompositionExplanationProjector.Project(composition));
 }


### PR DESCRIPTION
## Summary

This PR removes non-canonical backend selection from shared test infrastructure.

The previous testing helpers selected a single backend by rewriting dialect source text line-by-line and manually registering built-in backends. That made the test infrastructure act like a second dialect processor and normalized non-canonical wiring.

Changes:

- add `DialectCompositionTestOverrides.WithOnlyBackend(...)` for structured test-only backend overrides;
- update `BackendParityInfrastructure` to compose dialect text once through the canonical workflow, then override backend selection at the build-plan/composition-result level;
- update `DialectTestHostInfrastructure` to use `AddWistDialectServices()` only and remove raw backend directive rewriting;
- add guardrail tests preventing shared test infrastructure from reintroducing `EnsureSingleBackend`, `StartsWith("backend ")`, or manual `AddWistCilBackend` / `AddWistInterpreterBackend` registration;
- document `CreateProviderWithExplicitBackends()` as non-canonical/manual-registration-only;
- move parallel isolation stress tests to `CreateCanonicalProvider()`.

## Architectural intent

Tests should validate the same manifest-backed runtime path that production uses. Backend-specific test scenarios may override the selected backend, but that override should happen on the semantic build-plan/composition model, not by reparsing or mutating dialect source text.

## Suggested verification

```bash
dotnet test UniversalToolchain/UniversalToolchain.Dialects.Tests/UniversalToolchain.Dialects.Tests.csproj --filter "TestingInfrastructure|BackendParity|WistRuntimePathGuardrail|WistDialectParallelIsolationStress"
dotnet test UniversalToolchain/UniversalToolchain.Dialects.Tests/UniversalToolchain.Dialects.Tests.csproj
dotnet test UniversalToolchain/UniversalToolchain.sln
```

## Notes

I could not run the test suite from the GitHub connector environment, so this PR should be validated by CI or locally before merge.