### PR TITLE
Align documentation with current Wist runtime dialect contract

### DIFF
--- a/docs/build-dsls/backend-selection.md
+++ b/docs/build-dsls/backend-selection.md
@@ -7,7 +7,7 @@ description: Explain interpreter, CIL, and backend choice.
 
 Backends decide how a composed DSL program is executed after parsing and lowering.
 
-Wist currently exposes two user-facing backends:
+Wist currently exposes two user-facing backend modes:
 
 - `interpreter`
 - `compiler`
@@ -37,11 +37,8 @@ Dialect example:
 
 ```text
 dialect MinimalArithmetic
-use Arithmetic
-use Numbers
-use Scopes
-use Whitespaces
-backend interpreter enable
+use Arithmetic,Numbers,Scopes,Whitespaces
+backend interpreter
 ```
 
 Run example:
@@ -63,15 +60,11 @@ Dialect example:
 
 ```text
 dialect MinimalArithmeticNative
-use Arithmetic
-use Numbers
-use Scopes
-use Whitespaces
-use NativeTypes
-backend cil enable
-enable optimizer ArithmeticOptimization for cil
-enable optimizer NativeCilOptimization for cil
-enable optimizer NativeTypesOptimization for cil
+use Arithmetic,Numbers,Scopes,Whitespaces,NativeTypes
+backend cil
+enable ArithmeticOptimization
+enable NativeCilOptimization
+enable NativeTypesOptimization
 ```
 
 Run example:
@@ -91,8 +84,7 @@ Use both backends when you need:
 Dialect example:
 
 ```text
-backend cil enable
-backend interpreter enable
+backend cil,interpreter
 ```
 
 When both are enabled, tests should run the same source through both modes and compare observable results.
@@ -129,7 +121,7 @@ var result = runtime.Run(
         ["price"] = 100,
         ["fee"] = 5
     },
-    mode: "compiler");
+    backend: "compiler");
 ```
 
 The facade still uses the composed dialect runtime. It should not be treated as a separate language implementation.
@@ -166,7 +158,7 @@ Parity does not mean every backend must support every dialect. A dialect may int
 - Treating the interpreter as a fallback when the selected backend fails.
 - Adding backend-specific intrinsics to a general interpreter surface.
 - Comparing benchmark numbers before separating compilation time from execution time.
-- Copying older shorthand backend directives such as `backend cil,interpreter` instead of parser-tested v1 directives.
+- Copying syntax from secondary parser experiments instead of the runtime `.wistdialect` format used by shipped profiles.
 
 ## Next
 

--- a/docs/build-dsls/dialect-files.md
+++ b/docs/build-dsls/dialect-files.md
@@ -1,11 +1,11 @@
 ---
 title: Dialect Files
-description: Document the dialect file format and its role.
+description: Document the runtime dialect file format and its role.
 ---
 
 # Dialect Files
 
-Dialect files describe which modules, optimizers and backends are available for a Wist runtime composition.
+Dialect files describe which modules, optimizers, capabilities and backends are available for a Wist runtime composition.
 
 ## Problem
 
@@ -19,44 +19,28 @@ A Wist dialect file uses the `.wistdialect` extension. It is compiled before pro
 dialect source → dialect compilation → build plan → manifest-backed runtime selection → host creation → execution
 ```
 
-A parser-tested v1 dialect file uses one directive per line:
+The public runtime dialect format used by shipped Wist profiles is intentionally compact. Selection directives accept comma-separated identifier lists:
 
 ```text
 dialect FullDefault
-use Arithmetic
-use BooleanConditions
-use Comments
-use ComparisonConditions
-use Conditions
-use CSharpInterop
-use Equality
-use Identifier
-use Labels
-use Loops
-use Numbers
-use Scopes
-use SemicolonAsNewLine
-use Variables
-use Whitespaces
-backend cil enable
-backend interpreter enable
-enable optimizer BooleanOptimization for any
-enable optimizer ComparisonIntrinsicOptimization for any
+use Arithmetic,BooleanConditions,Comments,ComparisonConditions,Conditions,CSharpInterop,Equality,Identifier,Labels,Loops,Numbers,Scopes,SemicolonAsNewLine,Variables,Whitespaces
+backend cil,interpreter
+enable BooleanOptimization
+enable ComparisonIntrinsicOptimization
 security trusted
-capability interop-enabled = true
+capability unsafe-interop
 ```
+
+This is the format used by the executable examples under `UniversalToolchain/Dialects/examples/wist`.
 
 ## Minimal example
 
-A minimal arithmetic dialect looks like this in the current parser-tested v1 form:
+A minimal arithmetic dialect looks like this:
 
 ```text
 dialect MinimalArithmetic
-use Arithmetic
-use Numbers
-use Scopes
-use Whitespaces
-backend interpreter enable
+use Arithmetic,Numbers,Scopes,Whitespaces
+backend interpreter
 ```
 
 This dialect can run a program such as:
@@ -85,40 +69,31 @@ The name is used in diagnostics and composition output.
 
 ### `use`
 
-Selects one module:
+Selects one or more module aliases:
 
 ```text
-use Arithmetic
+use Arithmetic,Numbers,Scopes,Whitespaces
 ```
 
-Use multiple `use` lines to select multiple modules:
-
-```text
-use Arithmetic
-use Numbers
-use Scopes
-use Whitespaces
-```
-
-A module must be selected for its syntax and runtime behavior to exist. For example, arithmetic syntax needs arithmetic and number support; variable syntax needs variables and identifier support.
+A module must be selected for its syntax and runtime behavior to exist. For example, arithmetic syntax needs arithmetic and number support; variable syntax usually needs variables and identifier support.
 
 ### `exclude`
 
-Removes one selected module from a composition:
+Removes one or more modules from a composition:
 
 ```text
 exclude CSharpInterop
 ```
 
-Use multiple `exclude` lines for multiple modules.
+Use this when deriving a narrower profile from a broader one.
 
 ### `backend`
 
-Enables or disables one execution backend:
+Selects one or more execution backend ids:
 
 ```text
-backend cil enable
-backend interpreter enable
+backend interpreter
+backend cil,interpreter
 ```
 
 Currently documented user-facing modes are:
@@ -128,24 +103,24 @@ Currently documented user-facing modes are:
 
 Some dialects expose both `cil` and `interpreter`. Others expose only one backend.
 
-### `enable optimizer` / `disable optimizer`
+### `enable` / `disable`
 
-Enables or disables an optimizer for a backend selector:
+Enables or disables an optimizer alias:
 
 ```text
-enable optimizer ArithmeticOptimization for any
-disable optimizer AggressiveInline for interpreter
+enable ArithmeticOptimization
+disable EGraphOptimization
 ```
 
-Use `any` or `*` for all applicable backends, or a specific backend id such as `cil` or `interpreter`.
+Optimizer directives apply to the current runtime dialect frontend policy. Enable optimizers after base semantics are already correct.
 
-### `allow intrinsic` / `forbid intrinsic`
+### `allow` / `forbid`
 
-Allows or forbids an intrinsic for a backend selector:
+Allows or forbids an intrinsic name:
 
 ```text
-allow intrinsic "add_i32" for any
-forbid intrinsic "reflect-call" for cil
+allow add_i32
+forbid reflect-call
 ```
 
 This is a dialect-level intrinsic policy directive. It should match backend capability expectations.
@@ -168,10 +143,11 @@ A restricted dialect is a composition constraint, not a process isolation guaran
 
 ### `capability`
 
-Declares a boolean capability marker:
+Declares one or more enabled capability markers:
 
 ```text
-capability interop-enabled = false
+capability interop-enabled
+capability pricing-formula,user-authored
 ```
 
 Capabilities explain selected composition. They must not be treated as hidden runtime activation mechanisms.
@@ -200,7 +176,7 @@ Examples are located under `UniversalToolchain/Dialects/examples/wist`:
 - Keep dialect files explicit. A future reader should be able to see which syntax and backend paths are available.
 - Do not treat `restricted-sandbox` as a process isolation guarantee.
 - Do not add raw-source parsing workarounds for missing language features. Syntax must be owned by lexer/parser/AST/module code.
-- Prefer the parser-tested v1 directive shape documented in [Dialect Reference](/reference/dialect-reference).
+- Keep public dialect examples aligned with the shipped runtime dialect frontend, not with secondary parser experiments.
 
 ## Next
 

--- a/docs/build-dsls/embedding-dotnet.md
+++ b/docs/build-dsls/embedding-dotnet.md
@@ -13,7 +13,7 @@ Read this after [Minimal DSL](/build-dsls/minimal-dsl) when you want to run form
 
 ## Goal
 
-Create a Wist runtime facade, select a shipped dialect preset, pass source text and named inputs, choose a backend mode and read the result.
+Create a Wist runtime facade, select a shipped dialect preset, pass source text and named inputs, choose a backend and read the result.
 
 ## Minimal host shape
 
@@ -23,7 +23,7 @@ A host application should treat the DSL runtime as a composed execution surface:
 select dialect or preset
   -> create runtime facade
   -> pass source and declared inputs
-  -> choose requested mode
+  -> choose requested backend
   -> receive result or explicit failure
 ```
 
@@ -46,7 +46,7 @@ var result = runtime.Run(
         ["price"] = 100,
         ["fee"] = 5
     },
-    mode: "compiler");
+    backend: "compiler");
 ```
 
 Expected numeric result:
@@ -55,7 +55,7 @@ Expected numeric result:
 110
 ```
 
-The exact result wrapper shape depends on the current facade API. The important contract is that the host selects a dialect, supplies inputs explicitly and requests a backend mode intentionally.
+The important contract is that the host selects a dialect, supplies inputs explicitly and requests a backend intentionally.
 
 ## Why inputs are explicit
 
@@ -83,11 +83,11 @@ Use the narrowest dialect that supports the business case.
 
 Do not embed `full-default` only because it is convenient. A broad profile exposes more syntax and runtime behavior than a restricted formula surface usually needs.
 
-## Backend mode selection
+## Backend selection
 
-`mode: "compiler"` requests the CIL-backed compiler path when the selected dialect exposes CIL. `mode: "interpreter"` requests the interpreter path when exposed.
+`backend: "compiler"` requests the CIL-backed compiler path when the selected dialect exposes CIL. `backend: "interpreter"` requests the interpreter path when exposed.
 
-When both modes are available, add parity tests for important formulas. When only one mode is available, test that the unsupported mode fails explicitly.
+When both backends are available, add parity tests for important formulas. When only one backend is available, test that the unsupported backend request fails explicitly.
 
 ## What to test in a host application
 

--- a/docs/build-dsls/index.md
+++ b/docs/build-dsls/index.md
@@ -48,11 +48,8 @@ The smallest useful path is to start from an arithmetic dialect:
 
 ```text
 dialect MinimalArithmetic
-use Arithmetic
-use Numbers
-use Scopes
-use Whitespaces
-backend interpreter enable
+use Arithmetic,Numbers,Scopes,Whitespaces
+backend interpreter
 ```
 
 This dialect is intentionally narrow. It can run arithmetic expressions such as:
@@ -129,7 +126,7 @@ This order keeps composition errors visible. It also prevents optimizers or back
 - A backend must not change the observable meaning of a program.
 - A module should own the syntax and semantics it introduces.
 - Do not document removed or internal rule-declaration behavior as public runtime functionality.
-- Prefer the parser-tested v1 dialect directive shape documented in [Dialect Reference](/reference/dialect-reference).
+- Public DSL examples must follow the runtime `.wistdialect` format used by shipped profiles.
 
 ## Pages in this section
 

--- a/docs/build-dsls/minimal-dsl.md
+++ b/docs/build-dsls/minimal-dsl.md
@@ -31,15 +31,12 @@ The repository already contains a minimal arithmetic example:
 UniversalToolchain/Dialects/examples/wist/minimal-arithmetic/dialect.wistdialect
 ```
 
-In parser-tested v1 syntax, the dialect shape is:
+Its dialect file is intentionally small:
 
 ```text
 dialect MinimalArithmetic
-use Arithmetic
-use Numbers
-use Scopes
-use Whitespaces
-backend interpreter enable
+use Arithmetic,Numbers,Scopes,Whitespaces
+backend interpreter
 ```
 
 The matching program is:
@@ -68,13 +65,8 @@ If you need variables, extend the module list:
 
 ```text
 dialect MinimalVariables
-use Arithmetic
-use Numbers
-use Identifier
-use Variables
-use Scopes
-use Whitespaces
-backend interpreter enable
+use Arithmetic,Numbers,Identifier,Variables,Scopes,Whitespaces
+backend interpreter
 ```
 
 Then a program like this becomes valid:
@@ -88,10 +80,7 @@ x + y
 If you need comparisons and conditions, add the owning modules explicitly:
 
 ```text
-use ComparisonConditions
-use Conditions
-use Equality
-use BooleanConditions
+use ComparisonConditions,Conditions,Equality,BooleanConditions
 ```
 
 The exact module set depends on the syntax you want to allow. Start narrow and add only the features you can test.
@@ -101,20 +90,19 @@ The exact module set depends on the syntax you want to allow. Start narrow and a
 For interpreter-only DSLs:
 
 ```text
-backend interpreter enable
+backend interpreter
 ```
 
 For CIL-backed DSLs:
 
 ```text
-backend cil enable
+backend cil
 ```
 
 For both modes:
 
 ```text
-backend cil enable
-backend interpreter enable
+backend cil,interpreter
 ```
 
 If both backends are enabled, add parity tests so the same source produces the same observable result in both modes.
@@ -124,10 +112,10 @@ If both backends are enabled, add parity tests so the same source produces the s
 A native arithmetic dialect can enable optimizers such as:
 
 ```text
-enable optimizer ArithmeticOptimization for cil
-enable optimizer EGraphOptimization for any
-enable optimizer NativeCilOptimization for cil
-enable optimizer NativeTypesOptimization for any
+enable ArithmeticOptimization
+enable EGraphOptimization
+enable NativeCilOptimization
+enable NativeTypesOptimization
 ```
 
 Do this after the minimal interpreter version works. Optimizers should not be used to hide missing semantics.
@@ -144,10 +132,10 @@ The dialect file is compiled into a build plan, resolved against runtime manifes
 
 - Starting with `full-default` and removing features without testing the result.
 - Forgetting `Identifier` when adding `Variables`.
-- Enabling `compiler` mode in the CLI while the dialect declares only `backend interpreter enable`.
+- Enabling `compiler` mode in the CLI while the dialect declares only `backend interpreter`.
 - Adding `CSharpInterop` or interop capabilities to a DSL intended for restricted user-authored formulas.
 - Documenting rules as available. Rule runtime functionality is currently removed from the public surface.
-- Copying older shorthand dialect examples instead of the parser-tested v1 directive shape.
+- Copying syntax from secondary parser experiments instead of the runtime `.wistdialect` format used by shipped profiles.
 
 ## Next
 

--- a/docs/build-dsls/module-composition.md
+++ b/docs/build-dsls/module-composition.md
@@ -55,11 +55,8 @@ This dialect:
 
 ```text
 dialect MinimalArithmetic
-use Arithmetic
-use Numbers
-use Scopes
-use Whitespaces
-backend interpreter enable
+use Arithmetic,Numbers,Scopes,Whitespaces
+backend interpreter
 ```
 
 is a composition of four capabilities:
@@ -139,7 +136,7 @@ For untrusted third-party code, combine dialect restriction with process, enviro
 - Depending on one backend while documenting the dialect as backend-neutral.
 - Adding marker-only capabilities that imply behavior without implementation ownership.
 - Hiding missing module dependencies behind fallback parser behavior.
-- Copying older shorthand dialect examples instead of parser-tested v1 directives.
+- Copying syntax from secondary parser experiments instead of the runtime `.wistdialect` format used by shipped profiles.
 
 ## Practical checklist
 

--- a/docs/build-dsls/testing-dsl.md
+++ b/docs/build-dsls/testing-dsl.md
@@ -66,7 +66,7 @@ Negative tests are as important as positive tests. Without them, a “restricted
 If a dialect declares:
 
 ```text
-backend interpreter enable
+backend interpreter
 ```
 
 then asking for compiler mode should fail.
@@ -74,7 +74,7 @@ then asking for compiler mode should fail.
 If a dialect declares:
 
 ```text
-backend cil enable
+backend cil
 ```
 
 then asking for interpreter mode should fail.
@@ -86,8 +86,7 @@ The failure should be explicit. Do not silently fall back to another backend, be
 When a dialect exposes both:
 
 ```text
-backend cil enable
-backend interpreter enable
+backend cil,interpreter
 ```
 
 run the same source through both modes and compare the result.
@@ -119,11 +118,11 @@ Test optimizer-sensitive programs in two ways:
 
 Compare observable results. For backend-specific optimizers, also verify that unsupported backends do not receive backend-specific intrinsics.
 
-Current parser-tested optimizer directives use this shape:
+Current runtime optimizer directives use this shape:
 
 ```text
-enable optimizer ArithmeticOptimization for cil
-disable optimizer AggressiveInline for interpreter
+enable ArithmeticOptimization
+disable EGraphOptimization
 ```
 
 ## 6. Runtime surface test
@@ -168,7 +167,7 @@ Before documenting a dialect as stable, verify:
 - parity tests exist when both compiler and interpreter are enabled;
 - optimizer behavior is tested separately from base semantics;
 - restricted dialects do not expose interop or unrelated modules;
-- dialect examples use the parser-tested v1 directive shape.
+- dialect examples use the runtime `.wistdialect` format used by shipped profiles.
 
 ## Next
 

--- a/docs/internals/dependency-injection.md
+++ b/docs/internals/dependency-injection.md
@@ -1,6 +1,6 @@
 ---
 title: Dependency Injection
-description: Explain service registration and deterministic module discovery.
+description: Explain service registration and deterministic runtime composition.
 ---
 
 # Dependency Injection
@@ -11,15 +11,30 @@ It is not only a convenience mechanism for constructing objects. It is how diale
 
 ## Place in the architecture
 
-The Wist dialect runtime is normally bootstrapped with:
+The canonical Wist dialect orchestration path starts by registering the Wist dialect services:
 
 ```csharp
 services.AddWistDialectServices();
+```
+
+This registers the core dialect workflow, runtime catalog services and runtime resolution infrastructure.
+
+For shipped Wist dialect profiles, concrete backend runtimes should not be treated as globally enabled just because they exist in the outer service collection. The selected dialect is compiled into a build plan, resolved against runtime manifests and then used to create a runtime provider for that selected composition.
+
+Backend activation happens from the selected runtime plan during host creation, not by assuming that every registered backend is available to every dialect.
+
+## Compatibility backend registration helpers
+
+The repository still exposes manual backend registration helpers:
+
+```csharp
 services.AddWistCilBackend();
 services.AddWistInterpreterBackend();
 ```
 
-The first call registers the core dialect workflow and runtime resolution infrastructure. Backend registration calls add concrete backend runtime surfaces.
+These helpers register backend registrars directly and are useful for compatibility paths, legacy tests, benchmarks or specialized manual wiring.
+
+They are not the normal shipped-profile execution contract. Normal CLI, facade and shipped dialect execution should resolve backend manifest entries and activate the selected backend registrars from those manifests.
 
 ## Wist dialect services
 
@@ -31,11 +46,11 @@ AddFileSystemRuntimeCatalogServices
 AddReflectionRuntimeResolutionServices
 ```
 
-This means the default Wist setup includes:
+This means the default Wist orchestration setup includes:
 
 - dialect DSL compilation and build-plan services;
 - runtime catalog services;
-- reflection-based runtime resolution services.
+- reflection-based runtime resolution services used by manifest-backed activation.
 
 ## Core Wist services
 
@@ -55,9 +70,11 @@ Important registered services include:
 | `SelectedRuntimeExecutionShapeBuilder` | builds execution shape from selected runtime modules |
 | `DialectBackendRuntimeConfigurationBuilder` | builds backend runtime configuration |
 | `IntrinsicSemanticBootstrapPlanBuilder` | prepares intrinsic semantic bootstrap |
+| `IntrinsicSemanticBootstrapPreProviderValidator` | validates intrinsic bootstrap before provider construction |
+| `IntrinsicSemanticBootstrapRuntimeValidator` | validates intrinsic bootstrap after provider construction |
 | `IDialectCompiledDialectBuildPlanBuilder` | builds compiled dialect build plans |
 | `WistDialectExecutionConfigurationBuilder` | builds execution configuration |
-| `WistDialectServiceProviderFactory` | creates the runtime service provider |
+| `WistDialectServiceProviderFactory` | creates the selected runtime service provider |
 | `WistDialectExecutionWorkflow` | composes dialect text/files and creates execution hosts |
 
 This is a Wist-first composition path. It should not be described as a fully generic language-workbench API unless the generic layer provides the same capability directly.
@@ -82,6 +99,8 @@ The final Wist host is created from a service provider built for the selected ex
 
 This matters because a dialect should not run against every service registered in the outer application. It should run against the selected runtime plan and backend/runtime surface chosen by dialect composition.
 
+In the canonical path, backend activation happens inside `WistDialectServiceProviderFactory`. Selected backend manifest entries resolve exact backend registrar types, and only the selected backend runtimes are registered for the host.
+
 ## Determinism
 
 DI-based composition must remain deterministic.
@@ -99,6 +118,7 @@ Good patterns:
 - deterministic group expansion;
 - explicit runtime exports;
 - selected runtime plans;
+- exact activation from selected manifest entries;
 - tests that inspect selected modules/backends;
 - failure diagnostics when resolution is ambiguous or incomplete.
 
@@ -130,7 +150,8 @@ DI/runtime composition changes should test:
 - missing backend behavior;
 - duplicate or conflicting runtime exports;
 - restricted dialect surface;
-- interpreter/CIL backend registration matrix;
+- selected backend activation from manifests;
+- compatibility backend registration helpers separately from canonical shipped runtime paths;
 - execution host creation from successful composition only.
 
 ## Common mistakes
@@ -139,6 +160,7 @@ DI/runtime composition changes should test:
 - Adding a module service without a stable dialect alias or runtime export.
 - Making Wist convenience APIs the only true framework path.
 - Assuming all registered backends are available to every dialect.
+- Presenting compatibility backend helper methods as the normal shipped profile bootstrap path.
 - Letting reflection discovery decide behavior without deterministic ordering tests.
 
 ## Next

--- a/docs/reference/dialect-reference.md
+++ b/docs/reference/dialect-reference.md
@@ -1,27 +1,19 @@
 ---
 title: Dialect Reference
-description: Document the dialect file format precisely.
+description: Document the current runtime .wistdialect format used by shipped Wist profiles.
 ---
 
 # Dialect Reference
 
-This page documents the current v1 dialect DSL syntax implemented by `DialectDefinitionParser`.
+This page documents the current public `.wistdialect` format used by the Wist runtime path.
 
-For conceptual guidance, read [Dialect Files](/build-dsls/dialect-files). This page is stricter: it describes parser-accepted directive shapes.
+The source of truth for public Wist dialect execution is the manifest-backed runtime workflow:
 
-## Lexical rules
+```text
+dialect source -> dialect compilation -> build plan -> manifest-backed runtime selection -> host creation -> execution
+```
 
-The dialect lexer currently recognizes:
-
-| Token | Shape |
-|---|---|
-| identifier | letters, digits, `_`, `-`, `.` |
-| string literal | double-quoted text on one line |
-| arrow | `->` |
-| equals | `=` |
-| newline | line separator |
-
-Whitespace other than newlines is skipped. Newlines are significant because each directive is line-based.
+The compiler used by that path is `DialectDslCompiler` through the Wist dialect execution workflow. The shipped dialect profiles under `UniversalToolchain/Dialects/examples/wist` use this format and should be treated as executable references.
 
 ## Document shape
 
@@ -31,228 +23,168 @@ A dialect file starts with a required header:
 dialect <Name>
 ```
 
-or with an explicit version:
+Directives then follow one per line. Most selection directives accept comma-separated identifier lists.
+
+## Minimal runtime dialect
+
+The shipped minimal arithmetic dialect uses this shape:
 
 ```text
-dialect <Name> version "<Version>"
+dialect MinimalArithmetic
+use Arithmetic,Numbers,Scopes,Whitespaces
+backend interpreter
 ```
 
-Then zero or more directives follow, one directive per line.
+This selects only the modules required for basic arithmetic and exposes only the interpreter backend.
 
-## Minimal valid dialect
+## Full profile example
 
-The parser accepts a dialect header alone:
+A broader Wist profile can select many modules and both built-in backend ids:
 
 ```text
-dialect Core
+dialect FullDefault
+use Arithmetic,BooleanConditions,Comments,ComparisonConditions,Conditions,CSharpInterop,Equality,Identifier,Labels,Loops,Numbers,Scopes,SemicolonAsNewLine,Variables,Whitespaces
+backend cil,interpreter
+enable BooleanOptimization
+enable ComparisonIntrinsicOptimization
+security trusted
+capability unsafe-interop
 ```
 
-This only defines a dialect document. It does not by itself select a useful runtime surface.
+The user-facing CLI alias `compiler` selects the `cil` backend when the active dialect exposes it. Dialect files should still declare the backend id `cil`.
 
 ## Directive reference
 
+### `dialect`
+
+Declares the dialect name:
+
+```text
+dialect PricingRestricted
+```
+
+The name is used in diagnostics, composition output and execution configuration.
+
 ### `use`
 
-Selects one module alias.
-
-```text
-use Arithmetic
-```
-
-Current parser shape:
-
-```text
-use <ModuleAlias>
-```
-
-Use multiple lines for multiple modules:
-
-```text
-use Numbers
-use Arithmetic
-use Scopes
-use Whitespaces
-```
-
-### `exclude`
-
-Excludes one module alias.
-
-```text
-exclude CSharpInterop
-```
-
-Current parser shape:
-
-```text
-exclude <ModuleAlias>
-```
-
-A module cannot be both used and excluded in the same dialect document.
-
-### `requires`, `before`, `after`
-
-Adds dependency/order rules.
-
-```text
-requires Variables -> Scopes
-before Conditions -> Labels
-after Loops -> Labels
-```
-
-Current parser shapes:
-
-```text
-requires <LeftAlias> -> <RightAlias>
-before <LeftAlias> -> <RightAlias>
-after <LeftAlias> -> <RightAlias>
-```
-
-### `backend`
-
-Enables or disables one backend id.
-
-```text
-backend interpreter enable
-backend cil disable
-```
-
-Current parser shape:
-
-```text
-backend <BackendId> enable
-backend <BackendId> disable
-```
-
-Backend identifiers are open-ended identifiers. A custom backend id is accepted syntactically, but runtime resolution still requires a matching registered backend/runtime surface.
-
-### `allow intrinsic` and `forbid intrinsic`
-
-Allows or forbids an intrinsic for a backend selector.
-
-```text
-allow intrinsic "add_i32" for any
-forbid intrinsic "reflect-call" for cil
-```
-
-Current parser shapes:
-
-```text
-allow intrinsic "<IntrinsicName>" for <BackendSelector>
-forbid intrinsic "<IntrinsicName>" for <BackendSelector>
-```
-
-### `enable optimizer` and `disable optimizer`
-
-Enables or disables an optimizer for a backend selector.
-
-```text
-enable optimizer ArithmeticOptimization for any
-disable optimizer AggressiveInline for interpreter
-```
-
-Current parser shapes:
-
-```text
-enable optimizer <OptimizerAlias> for <BackendSelector>
-disable optimizer <OptimizerAlias> for <BackendSelector>
-```
-
-### `security`
-
-Declares the intended security profile.
-
-```text
-security restricted
-security trusted
-```
-
-Only one security directive may be present.
-
-### `capability`
-
-Declares a boolean capability marker.
-
-```text
-capability supports-floats = true
-capability interop-enabled = false
-```
-
-Current parser shape:
-
-```text
-capability <Name> = true
-capability <Name> = false
-```
-
-Duplicate capability names are parser errors.
-
-## Backend selector
-
-Backend selectors are used by intrinsic and optimizer directives.
-
-Accepted selector shapes:
-
-| Selector | Meaning |
-|---|---|
-| `any` | all applicable backends |
-| `*` | all applicable backends |
-| `<BackendId>` | one backend id, such as `interpreter` or `cil` |
-
-`any` and `*` are accepted only where the parser allows wildcard selectors.
-
-## Duplicate/conflict diagnostics
-
-The parser currently reports errors for:
-
-| Code | Condition |
-|---|---|
-| `P100` | duplicate `use` module |
-| `P101` | same module is both used and excluded |
-| `P102` | duplicate `exclude` module |
-| `P103` | conflicting backend directive for the same backend |
-| `P104` | duplicate backend directive with the same state |
-| `P105` | duplicate security directive |
-| `P106` | duplicate capability directive |
-| `P107` | unknown directive |
-
-Lexing and parser expectation errors also have `P001`, `P002`, and `P200`-series diagnostics.
-
-## Complete parser-tested example
-
-```text
-dialect Strict version "1.0"
-use Arithmetic
-exclude CSharpInterop
-requires Variables -> Scopes
-before Conditions -> Labels
-after Loops -> Labels
-backend interpreter enable
-backend cil disable
-allow intrinsic "add_i32" for any
-forbid intrinsic "reflect-call" for cil
-enable optimizer ConstFold for any
-disable optimizer AggressiveInline for interpreter
-security restricted
-capability supports-floats = true
-capability interop-enabled = false
-```
-
-## Compatibility note
-
-Older docs or examples may contain shorthand forms such as:
+Selects one or more module aliases:
 
 ```text
 use Arithmetic,Numbers,Scopes,Whitespaces
-backend interpreter
-backend cil,interpreter
-enable ArithmeticOptimization
-capability interop-enabled
 ```
 
-The current parser-tested v1 shape is stricter than those shorthand examples: it parses one module per `use`, requires backend `enable` or `disable`, requires `enable optimizer ... for ...`, and requires boolean values for `capability`.
+You may also split module selection across several `use` lines when that is clearer:
 
-When updating examples, prefer the parser-tested v1 form documented on this page.
+```text
+use Arithmetic,Numbers
+use Scopes,Whitespaces
+```
+
+A module must be selected for the syntax and runtime behavior it owns to exist.
+
+### `exclude`
+
+Excludes one or more module aliases from the composition:
+
+```text
+exclude CSharpInterop
+```
+
+Use this when building from a broader base/profile and intentionally removing a runtime surface.
+
+### `requires`, `before`, `after`
+
+Declares ordering constraints over a comma-separated module chain:
+
+```text
+requires Variables,Scopes
+before Conditions,Labels
+after Loops,Labels
+```
+
+The runtime frontend lowers adjacent items in the list into pairwise order directives. Use these directives sparingly; prefer coherent module selections and deterministic module metadata when possible.
+
+### `backend`
+
+Selects one or more backend ids:
+
+```text
+backend interpreter
+backend cil,interpreter
+```
+
+Currently shipped Wist backends include:
+
+| Dialect backend id | User-facing mode |
+|---|---|
+| `interpreter` | `interpreter` |
+| `cil` | `compiler` |
+
+Backend identifiers are not a closed conceptual model. A backend is usable only when the runtime catalog contains a matching backend manifest entry and registrar.
+
+### `enable` / `disable`
+
+Enables or disables one optimizer alias:
+
+```text
+enable ArithmeticOptimization
+disable EGraphOptimization
+```
+
+Optimizer directives target all applicable backends in the current runtime dialect frontend. Do not use an optimizer to hide missing base semantics.
+
+### `allow` / `forbid`
+
+Allows or forbids one intrinsic name:
+
+```text
+allow add_i32
+forbid reflect-call
+```
+
+Intrinsic policy should match backend capability expectations. Backend-specific intrinsics must not leak into backend-agnostic runtime surfaces without an explicit capability story.
+
+### `security`
+
+Declares the intended security profile:
+
+```text
+security restricted
+```
+
+or:
+
+```text
+security trusted
+```
+
+A restricted dialect is a composition constraint, not a process isolation guarantee.
+
+### `capability`
+
+Declares one or more enabled capability markers:
+
+```text
+capability unsafe-interop
+capability pricing-formula,user-authored
+```
+
+Capabilities explain selected composition. They must not be treated as hidden runtime activation mechanisms.
+
+## Current syntax boundary
+
+The repository also contains `DialectDefinitionParser`, which accepts a stricter parser-specific shape such as:
+
+```text
+backend interpreter enable
+capability supports-floats = true
+```
+
+That parser is not the current public runtime `.wistdialect` contract used by shipped Wist profiles. Do not document its syntax as canonical for Wist runtime execution unless the runtime path is intentionally migrated to it.
+
+## Compatibility rule
+
+Public documentation, shipped examples and CLI onboarding must use the same dialect shape as the manifest-backed Wist runtime path. If the runtime parser changes in the future, update shipped `.wistdialect` files and this reference together.
 
 ## Related pages
 

--- a/docs/start/cli-reference.md
+++ b/docs/start/cli-reference.md
@@ -16,7 +16,7 @@ Read this after [First Program](/start/first-program) when you want to run more 
 From the repository root, Wist examples are run through the `Wistc` project:
 
 ```text
-dotnet run --project UniversalToolchain/Wistc/Wistc.csproj -- run [options]
+dotnet run --project UniversalToolchain/Wistc/Wistc.csproj -- run [options] [code]
 ```
 
 The `--` separates `dotnet run` options from Wistc options.
@@ -25,7 +25,7 @@ The `--` separates `dotnet run` options from Wistc options.
 
 | Option | Meaning |
 |---|---|
-| `--eval "source"` | Runs source text passed directly on the command line. |
+| `--eval` | Treats the positional `code` argument as an expression and prints the result. |
 | `--file path/to/program.wist` | Runs a source file. |
 | `--dialect-file path/to/dialect.wistdialect` | Uses an explicit dialect file instead of the default runtime surface. |
 | `--backend compiler` | Runs through the user-facing compiler alias when the selected dialect exposes CIL. |
@@ -45,6 +45,8 @@ Expected output:
 ```text
 12
 ```
+
+In this command, `--eval` is a flag and `"(2 + 2) * 3"` is the positional source argument.
 
 Interpreter mode should produce the same observable result when it is available:
 
@@ -84,22 +86,30 @@ A dialect that exposes only `interpreter` should reject `--backend compiler`. A 
 | Interpreter backend alias is rejected | The selected dialect does not expose the `interpreter` backend. |
 | Syntax is rejected | The dialect does not select the module that owns the syntax. |
 | Interop expression is rejected | The selected dialect does not include trusted interop support. |
-| Dialect file fails to parse | The file may use older shorthand syntax instead of the current parser-tested directive form. |
+| Dialect file fails to parse | The file may use syntax from a secondary parser path instead of the runtime `.wistdialect` format. |
 
 ## Current dialect syntax reminder
 
-Current parser-tested dialect examples use one directive per line:
+Current shipped runtime dialect examples use compact comma-separated selection directives:
 
 ```text
 dialect MinimalArithmetic
-use Arithmetic
-use Numbers
-use Scopes
-use Whitespaces
-backend interpreter enable
+use Arithmetic,Numbers,Scopes,Whitespaces
+backend interpreter
 ```
 
-Older shorthand such as `use Arithmetic,Numbers` or `backend cil,interpreter` may appear in historical material, but it should not be used for new public examples unless that compatibility path is explicitly being documented.
+For a CIL-capable dialect, select the `cil` backend id and request it from the CLI through `--backend compiler`:
+
+```text
+dialect MinimalArithmeticNative
+use Arithmetic,Numbers,Scopes,Whitespaces,NativeTypes
+backend cil
+enable ArithmeticOptimization
+enable NativeCilOptimization
+enable NativeTypesOptimization
+```
+
+The repository also contains a stricter parser-specific dialect syntax, but public Wist runtime examples should follow the syntax used by shipped `.wistdialect` profiles unless the runtime path is intentionally migrated.
 
 ## Next
 

--- a/docs/start/first-program.md
+++ b/docs/start/first-program.md
@@ -71,7 +71,7 @@ For the simple expression, the runtime path is:
 source → parser → AST → bytecode/AIR → selected backend → result
 ```
 
-The CLI receives source text through `--eval`. Wist uses the active dialect to select modules and backends, parses the expression, translates it into intermediate representations and runs it through the selected backend.
+The CLI receives source text as the positional `code` argument. The `--eval` flag tells Wistc to evaluate that argument as an expression and print the result. Wist uses the active dialect to select modules and backends, parses the expression, translates it into intermediate representations and runs it through the selected backend.
 
 The same source should produce the same observable result in compiler and interpreter modes when both modes are available. This parity is one of the main correctness expectations for Wist backends.
 

--- a/readme.md
+++ b/readme.md
@@ -57,7 +57,7 @@ var result = wist.Run(
         ["price"] = 100.0,
         ["fee"] = 5.0
     },
-    mode: "compiler");
+    backend: "compiler");
 
 var compiledResult = (double)result!; // 95.0
 ```
@@ -79,7 +79,7 @@ var attempt = wist.TryCompile(
         ["price"] = typeof(double),
         ["fee"] = typeof(double)
     },
-    mode: "interpreter");
+    backend: "interpreter");
 ```
 
 ## When to use UniversalToolchain
@@ -196,7 +196,7 @@ Common options:
 - `--dialect-file <path>`
 
 The user-facing `compiler` mode selects the canonical `cil` backend when a dialect declares `backend cil` or the
-`compiler` alias.
+`compiler` alias. `--eval` is a flag; the source expression itself is passed as the positional code argument.
 
 Examples:
 
@@ -240,6 +240,8 @@ Located under `UniversalToolchain/Dialects/examples/wist`:
 
 These directories are runnable canonical references for the manifest-driven dialect path. Each README includes
 repository-root CLI commands, expected behavior, and the capabilities intentionally excluded by that profile.
+
+Public dialect documentation should follow the `.wistdialect` shape used by these shipped profiles. Secondary parser experiments must not be treated as the runtime dialect contract unless the runtime path is intentionally migrated to them.
 
 ## Why .NET 10 right now?
 


### PR DESCRIPTION
## Summary

This PR aligns the public documentation with the current Wist runtime path in `master`.

The main fix is to stop documenting the stricter `DialectDefinitionParser` syntax as the canonical public `.wistdialect` contract. The shipped runtime profiles currently use the `DialectDslCompiler` path and compact comma-separated directives such as:

```text
dialect MinimalArithmetic
use Arithmetic,Numbers,Scopes,Whitespaces
backend interpreter
```

The PR updates the documentation to treat shipped `.wistdialect` profiles as the executable public reference and explicitly marks the stricter parser-specific syntax as non-canonical for runtime execution until a deliberate runtime migration happens.

## Changed

- Rewrote `docs/reference/dialect-reference.md` around the actual runtime `.wistdialect` format.
- Updated DSL-building pages to use shipped runtime dialect syntax instead of `backend ... enable` examples.
- Fixed C# facade examples from `mode:` to the real API parameter name `backend:`.
- Clarified that CLI `--eval` is a flag and the expression is the positional `code` argument.
- Added wording that public examples must follow shipped runtime profiles, not secondary parser experiments.

## Files touched

- `readme.md`
- `docs/reference/dialect-reference.md`
- `docs/start/cli-reference.md`
- `docs/start/first-program.md`
- `docs/build-dsls/index.md`
- `docs/build-dsls/dialect-files.md`
- `docs/build-dsls/minimal-dsl.md`
- `docs/build-dsls/module-composition.md`
- `docs/build-dsls/backend-selection.md`
- `docs/build-dsls/testing-dsl.md`
- `docs/build-dsls/embedding-dotnet.md`

## Validation

- Static consistency pass against the current master code and shipped `.wistdialect` files.
- No runtime/code changes were made.
- I did not run local `dotnet test` or docs build in this environment.