### PR TITLE
docs: simplify first impression overview

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,10 +1,29 @@
 # UniversalToolchain Documentation
 
-UniversalToolchain is a modular .NET framework for building domain-specific languages.
+UniversalToolchain is a Wist-first modular .NET DSL/runtime framework.
 
-Wist is the reference language built on top of UniversalToolchain. Start with the language, then move to dialects, modules, bytecode, AIR, and execution backends.
+It helps you build small embeddable languages for .NET applications when a plain expression evaluator is too limited, full C# scripting is too broad, and writing a compiler from scratch would be too expensive.
+
+Wist is the reference language built on top of UniversalToolchain. It is not the main product; it demonstrates how the framework pieces fit together.
 
 > This documentation is written as a developer manual. It is not a landing page, a project report, or a promotional overview.
+
+## In 60 seconds
+
+- **UniversalToolchain** is the framework.
+- **Wist** is the reference language used to validate the framework.
+- **Dialects** select modules, optimizers, security posture and execution backends.
+- **Modules** own reusable language features such as syntax, AST translation and bytecode behavior.
+- **Backends** execute the selected language surface through interpreter or compiled execution paths.
+- **Bytecode** and **AIR** keep frontend semantics separate from backend execution.
+
+A typical use case is a .NET application that needs configurable formulas or restricted business rules without exposing a full general-purpose language.
+
+## What this is not
+
+UniversalToolchain is not a production-grade sandbox, not a replacement for C#, and not a finished general-purpose language workbench. Restricted dialects control language composition, but untrusted execution still needs external process or environment isolation.
+
+See [Current Limitations](/limitations) for the current maturity boundaries.
 
 ## Entry points
 
@@ -29,7 +48,9 @@ Wist is the reference language built on top of UniversalToolchain. Start with th
 ## Pipeline
 
 ```text
-source
+.NET host application
+  -> Wist or custom DSL source
+  -> dialect-selected modules and backends
   -> lexer modules
   -> parser modules
   -> AST

--- a/docs/start/index.md
+++ b/docs/start/index.md
@@ -1,24 +1,42 @@
 ---
 title: Start Here
-description: Give developers the fastest path from zero to a running Wist program.
+description: Give developers the fastest path from zero to understanding and running Wist.
 ---
 
 # Start Here
 
-This page introduces **UniversalToolchain** and the **Wist** reference language, explains who should read which sections of the documentation and helps you choose your route through the project.
+This page introduces **UniversalToolchain** and the **Wist** reference language, explains the practical reason the project exists, and helps you choose your route through the documentation.
 
 ## When to read this page
 
-Read this page if you have just discovered the repository and want to get started. It helps you understand the difference between the framework and the reference language and points you to the right section.
+Read this page if you have just discovered the repository and want to understand the project before going deep into implementation details.
 
 ## Goal
 
-Understand the difference between UniversalToolchain and Wist, identify your role, and know where to start.
+Understand what UniversalToolchain is, what Wist is, when the project is useful, and where to start.
 
 ## Project overview
 
-- **UniversalToolchain** is an embeddable .NET framework for composing restricted DSLs. It provides infrastructure for lexing, parsing, abstract syntax trees (AST), bytecode/AIR layers, optimizers and execution backends. Modules are the building blocks; dialects select modules, backends and optimizations; manifests resolve runtime activation.
+- **UniversalToolchain** is a Wist-first modular .NET framework for building embeddable DSL runtimes. It provides infrastructure for lexing, parsing, abstract syntax trees (AST), bytecode/AIR layers, optimizers and execution backends.
 - **Wist** is the reference language built on top of UniversalToolchain. It demonstrates how to assemble modules into a usable language and provides CLI and programmatic entry points.
+- **Modules** are reusable language features. They can contribute lexer, parser, AST translation, bytecode and IR behavior.
+- **Dialects** select modules, backends and optimizations. They describe a chosen language/runtime surface instead of hardcoding one compiler profile.
+
+## Use it when
+
+- you want configurable formulas or restricted business rules inside a .NET application;
+- you need language features to be selectable and testable as modules;
+- you want a reference language that demonstrates a modular compiler/runtime pipeline;
+- you need to compare interpreter and compiled execution paths for the same language surface.
+
+## Do not treat it as
+
+- a hardened sandbox for untrusted code;
+- a drop-in replacement for C# scripting;
+- a mature general-purpose language workbench;
+- a simple expression evaluator with no compiler/runtime concepts.
+
+For the current maturity boundaries, read [Current Limitations](/limitations).
 
 ## Identify your route
 


### PR DESCRIPTION
## Summary

This PR slightly improves the first impression of the documentation for developers who open the project for the first time.

It does not change the architecture documentation, code, VitePress configuration, or runtime behavior.

## What changed

- Reworked the opening of `docs/index.md` to explain the practical purpose before the architecture details.
- Added a short `In 60 seconds` section that defines UniversalToolchain, Wist, dialects, modules, backends, bytecode and AIR.
- Added a clear `What this is not` section to avoid overclaiming sandboxing, C# replacement, or full language-workbench maturity.
- Updated `docs/start/index.md` with `Use it when` / `Do not treat it as` sections.
- Linked to `Current Limitations` for maturity boundaries.

## Why

The existing documentation already explains the architecture and routes, but the first two minutes were still too architecture-first. A new developer could understand the structure, but not immediately understand the practical reason the project exists.

This PR makes the first impression more direct while keeping the wording conservative and aligned with current limitations.

## Validation

- Text-only documentation change.
- Existing claims were cross-checked against current documentation and code-level project structure before editing.
- No code or configuration was modified.