### PR TITLE
Use capability-gated external-load folding in NativeCilOptimizer

### DIFF
--- a/UniversalToolchain/NativeMathModule/NativeCILOptimizerModule.cs
+++ b/UniversalToolchain/NativeMathModule/NativeCILOptimizerModule.cs
@@ -44,8 +44,7 @@ public class NativeCilOptimizerModule : IIRProcessingModule
             "Native CIL optimizer requires intrinsic capability context initialization.");
 
         var supportsLoadConst = SupportsAllLoadConstTypes(capabilityContext);
-        var supportsLoadExternal = typeof(TCompilationOutput).FullName == "System.Reflection.Emit.DynamicMethod"
-                                   && SupportsAllLoadExternalTypes(capabilityContext);
+        var supportsLoadExternal = SupportsAllLoadExternalTypes(capabilityContext);
 
         if (!supportsLoadConst && !supportsLoadExternal)
             return current;

--- a/UniversalToolchain/Tests/Backends/InterpreterBackendOptimizerIntrinsicSurfaceTests.cs
+++ b/UniversalToolchain/Tests/Backends/InterpreterBackendOptimizerIntrinsicSurfaceTests.cs
@@ -6,6 +6,17 @@ namespace Tests.Backends;
 public sealed class InterpreterBackendOptimizerIntrinsicSurfaceTests
 {
     [Test]
+    public void InterpreterBackendStub_SupportedIntrinsics_ShouldContainOnlyUniversalCallIntrinsics()
+    {
+        var supported = AbstractIrConverters.AbstractIrToAbstractIrStub.SupportedIntrinsicIds;
+
+        Assert.That(supported, Does.Contain("call C#"));
+        Assert.That(supported, Does.Contain("call C# ctor"));
+        Assert.That(supported, Does.Not.Contain("load_external"));
+        Assert.That(supported, Does.Not.Contain("store_external"));
+    }
+
+    [Test]
     public void InterpreterBackend_WithOptimizersEnabled_ContainsOnlyInterpreterSupportedIntrinsics()
     {
         var dialect = """

--- a/UniversalToolchain/UniversalToolchain.Modules.Tests/ModuleCoverage/TypedIntrinsicEmitterOptimizerTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Modules.Tests/ModuleCoverage/TypedIntrinsicEmitterOptimizerTests.cs
@@ -4,6 +4,7 @@ using BasicCore.Capabilities;
 using BasicCore.Compilation;
 using BasicCore.Contracts;
 using BasicCore.Core;
+using BasicCore.Execution;
 using ConditionsModule.Enums;
 using ConditionsModule.Optimizers;
 using ConditionsModule.Visitors;
@@ -163,6 +164,48 @@ public sealed class TypedIntrinsicEmitterOptimizerTests
         var result = optimizer.ProcessIr(input, new FakeCompiler());
 
         AssertTypedIntrinsic(result.Instructions[0], BuiltinIntrinsicSymbols.Core.LoadConst, typeof(double), 1.5d);
+    }
+
+    [Test]
+    public void NativeCilOptimizer_WhenCapabilitySupportsLoadExternal_RewritesLegacyExternalLoadSequence()
+    {
+        var optimizer = CreateOptimizer(
+            new NativeCilOptimizerModule(),
+            (BuiltinIntrinsicSymbols.Core.LoadExternal, typeof(int)),
+            (BuiltinIntrinsicSymbols.Core.LoadExternal, typeof(long)),
+            (BuiltinIntrinsicSymbols.Core.LoadExternal, typeof(float)),
+            (BuiltinIntrinsicSymbols.Core.LoadExternal, typeof(double)),
+            (BuiltinIntrinsicSymbols.Core.LoadExternal, typeof(decimal)));
+
+        var input = CreateIr(
+            new Instruction(UOpCode.Intrinsic, ["call C#", ExternalRuntimeMethodDescriptors.LoadEnvironmentDescriptor]),
+            new Instruction(UOpCode.Push, [2]),
+            new Instruction(UOpCode.Intrinsic, ["call C#", ExternalRuntimeMethodDescriptors.CreateLoadExternalMethod(typeof(double))]));
+
+        var result = optimizer.ProcessIr(input, new FakeCompiler());
+
+        Assert.That(result.Instructions, Has.Count.EqualTo(1));
+        AssertTypedIntrinsic(result.Instructions[0], BuiltinIntrinsicSymbols.Core.LoadExternal, typeof(double), 2);
+    }
+
+    [Test]
+    public void NativeCilOptimizer_WhenCapabilityDoesNotSupportLoadExternal_KeepsLegacyExternalLoadSequence()
+    {
+        var optimizer = CreateOptimizer(
+            new NativeCilOptimizerModule(),
+            (BuiltinIntrinsicSymbols.Core.LoadExternal, typeof(int)),
+            (BuiltinIntrinsicSymbols.Core.LoadExternal, typeof(long)),
+            (BuiltinIntrinsicSymbols.Core.LoadExternal, typeof(float)),
+            (BuiltinIntrinsicSymbols.Core.LoadExternal, typeof(decimal)));
+
+        var input = CreateIr(
+            new Instruction(UOpCode.Intrinsic, ["call C#", ExternalRuntimeMethodDescriptors.LoadEnvironmentDescriptor]),
+            new Instruction(UOpCode.Push, [2]),
+            new Instruction(UOpCode.Intrinsic, ["call C#", ExternalRuntimeMethodDescriptors.CreateLoadExternalMethod(typeof(double))]));
+
+        var result = optimizer.ProcessIr(input, new FakeCompiler());
+
+        Assert.That(result, Is.SameAs(input));
     }
 
     [Test]


### PR DESCRIPTION
### Motivation
- Remove backend/output-type hardcoding from the native optimizer and rely on intrinsic capability contracts for optimizer decisions. 
- Ensure the interpreter/AIR stub advertises only universal-call intrinsics so the interpreter never receives backend-native intrinsics it cannot execute. 
- Add tests that protect the capability-driven optimizer behavior and prevent regressions that reintroduce type/name-based shortcuts.

### Description
- Removed the `DynamicMethod`/output-type check from `NativeCilOptimizerModule.ProcessIr<TCompilationOutput>` so `load_external` folding is now driven only by `SupportsAllLoadExternalTypes(capabilityContext)`.
- Kept existing `load_const` capability gating via `SupportsAllLoadConstTypes` and retained CIL constant-to-typed-intrinsic generator logic.
- Added a unit test `InterpreterBackendStub_SupportedIntrinsics_ShouldContainOnlyUniversalCallIntrinsics` to verify `AbstractIrToAbstractIrStub.SupportedIntrinsicIds` contains only `call C#` and `call C# ctor` and does not contain `load_external` / `store_external`.
- Added optimizer unit tests to `TypedIntrinsicEmitterOptimizerTests` that verify the legacy external runtime load sequence rewrites to typed `load_external` only when the compiler capability for `load_external<T>` is present and remains unchanged when that capability is missing.
- Minor test import fix (`using BasicCore.Execution;`) to resolve references used by the new tests.

### Testing
- Ran `dotnet restore UniversalToolchain/Wist.sln` and `dotnet build UniversalToolchain/Wist.sln -c Release --no-restore` successfully. 
- Ran `dotnet test UniversalToolchain/Wist.sln -c Release --no-build` and all unit tests passed. 
- Ran a benchmark dry run with `dotnet run -c Release --project UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/UniversalToolchain.Benchmarks.csproj -- --job dry --filter "*ExternalConstantsHeavy6ExecutionBenchmarks*"`; benchmark project setup/build completed but the BenchmarkDotNet generated runner hit the environment timeout during execution phase (no failure related to the previous dynamic-method parameter-count issue was observed during setup).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7b6208ec883248297ed41ae6d7d52)