### PR TITLE
Scope CIL intrinsic registry through backend composition

### DIFF
--- a/UniversalToolchain/BytecodeDynamicMethodsCompiler/Compilers/AbstractMethodsCompilerImpl.cs
+++ b/UniversalToolchain/BytecodeDynamicMethodsCompiler/Compilers/AbstractMethodsCompilerImpl.cs
@@ -6,8 +6,14 @@ public class AbstractMethodsCompilerImpl : IAbstractIrCompiler<DynamicMethod>
     private readonly CilAbstractIrTypeSimulator _typeSimulator;
 
     public AbstractMethodsCompilerImpl()
+        : this(new CilIntrinsicRegistry())
     {
-        var registry = new CilIntrinsicRegistry();
+    }
+
+    public AbstractMethodsCompilerImpl(CilIntrinsicRegistry registry)
+    {
+        registry = registry.ArgNotNull();
+
         _intrinsicCompiler = new AbstractMethodsIntrinsicCompiler(registry);
         _typeSimulator = new CilAbstractIrTypeSimulator(_intrinsicCompiler);
     }

--- a/UniversalToolchain/BytecodeDynamicMethodsCompiler/Compilers/AbstractMethodsCompilerImpl.cs
+++ b/UniversalToolchain/BytecodeDynamicMethodsCompiler/Compilers/AbstractMethodsCompilerImpl.cs
@@ -20,7 +20,7 @@ public class AbstractMethodsCompilerImpl : IAbstractIrCompiler<DynamicMethod>
 
     public static IReadOnlyList<string> SupportedIntrinsicIds { get; } = BuildSupportedIntrinsicIds();
 
-    public IReadOnlyList<string> SupportedIntrinsics => SupportedIntrinsicIds;
+    public IReadOnlyList<string> SupportedIntrinsics => _intrinsicCompiler.SupportedIntrinsics;
 
     public DynamicMethod Compile(IAbstractIR air, CompilationInput input)
     {

--- a/UniversalToolchain/BytecodeDynamicMethodsCompiler/Compilers/AbstractMethodsIntrinsicCompiler.cs
+++ b/UniversalToolchain/BytecodeDynamicMethodsCompiler/Compilers/AbstractMethodsIntrinsicCompiler.cs
@@ -13,7 +13,7 @@ internal sealed class AbstractMethodsIntrinsicCompiler
 
     internal AbstractMethodsIntrinsicCompiler(CilIntrinsicRegistry registry)
     {
-        _registry = registry;
+        _registry = registry.ArgNotNull();
     }
 
     public IReadOnlyList<string> SupportedIntrinsics => _registry.SupportedIntrinsics;

--- a/UniversalToolchain/BytecodeDynamicMethodsCompiler/Compilers/CilIntrinsicRegistry.cs
+++ b/UniversalToolchain/BytecodeDynamicMethodsCompiler/Compilers/CilIntrinsicRegistry.cs
@@ -2,11 +2,31 @@ using BasicCore.Core;
 
 namespace BytecodeDynamicMethodsCompiler.Compilers;
 
-internal sealed class CilIntrinsicRegistry
+public sealed class CilIntrinsicRegistry
 {
     private readonly IReadOnlyDictionary<string, CilIntrinsicDescriptor> _descriptorsByName;
 
     public CilIntrinsicRegistry()
+        : this(BuildDefaultDescriptors())
+    {
+    }
+
+    private CilIntrinsicRegistry(IReadOnlyList<CilIntrinsicDescriptor> descriptors)
+    {
+        descriptors = descriptors.ArgNotNull();
+
+        var descriptorsByName = new OrderedDictionary<string, CilIntrinsicDescriptor>(descriptors.Count, StringComparer.Ordinal);
+        foreach (var descriptor in descriptors)
+        {
+            if (!descriptorsByName.TryAdd(descriptor.Name, descriptor))
+                Thrower.InvalidOpEx($"Duplicate CIL intrinsic registration: {descriptor.Name}");
+        }
+
+        _descriptorsByName = descriptorsByName;
+        SupportedIntrinsics = descriptors.Select(x => x.Name).ToArray();
+    }
+
+    private static IReadOnlyList<CilIntrinsicDescriptor> BuildDefaultDescriptors()
     {
         var descriptors = new List<CilIntrinsicDescriptor>();
 
@@ -93,24 +113,15 @@ internal sealed class CilIntrinsicRegistry
         RegisterComparisonFamily(descriptors, "f32");
         RegisterComparisonFamily(descriptors, "f64");
 
-        var descriptorsByName = new OrderedDictionary<string, CilIntrinsicDescriptor>(descriptors.Count, StringComparer.Ordinal);
-        foreach (var descriptor in descriptors)
-        {
-            if (!descriptorsByName.TryAdd(descriptor.Name, descriptor))
-                Thrower.InvalidOpEx($"Duplicate CIL intrinsic registration: {descriptor.Name}");
-        }
-
-        IReadOnlyList<CilIntrinsicDescriptor> descriptors1 = descriptors.AsReadOnly();
-        _descriptorsByName = descriptorsByName;
-        SupportedIntrinsics = descriptors1.Select(x => x.Name).ToArray();
+        return descriptors.AsReadOnly();
     }
 
     public IReadOnlyList<string> SupportedIntrinsics { get; }
 
-    public bool TryGet(string name, out CilIntrinsicDescriptor descriptor)
+    internal bool TryGet(string name, out CilIntrinsicDescriptor descriptor)
         => _descriptorsByName.TryGetValue(name, out descriptor!);
 
-    public CilIntrinsicDescriptor GetRequired(string name)
+    internal CilIntrinsicDescriptor GetRequired(string name)
         => TryGet(name, out var descriptor)
             ? descriptor
             : Thrower.InvalidOpEx<CilIntrinsicDescriptor>($"Unsupported intrinsic: {name}");

--- a/UniversalToolchain/Tests/Backends/CilIntrinsicRegistryCompositionTests.cs
+++ b/UniversalToolchain/Tests/Backends/CilIntrinsicRegistryCompositionTests.cs
@@ -1,4 +1,5 @@
 using UniversalToolchain.Dialects.Core.ServiceCollection;
+using UniversalToolchain.Dialects.Integration;
 using UniversalToolchain.Dialects.Wist;
 
 namespace Tests.Backends;
@@ -30,8 +31,13 @@ public sealed class CilIntrinsicRegistryCompositionTests
     [Test]
     public void WistCilBackendRegistrar_ShouldExposeRegistryIntrinsicSurface()
     {
+        var services = new ServiceCollection();
+        services.AddWistCilBackend();
+
+        using var provider = services.BuildServiceProvider();
+
         var registry = new CilIntrinsicRegistry();
-        var registrar = new WistCilDialectBackendServiceProvider();
+        var registrar = provider.GetServices<IDialectBackendRuntimeRegistrar>().Single();
 
         Assert.That(registrar.SupportedIntrinsics, Is.EqualTo(registry.SupportedIntrinsics));
     }

--- a/UniversalToolchain/Tests/Backends/CilIntrinsicRegistryCompositionTests.cs
+++ b/UniversalToolchain/Tests/Backends/CilIntrinsicRegistryCompositionTests.cs
@@ -1,4 +1,5 @@
 using UniversalToolchain.Dialects.Core.ServiceCollection;
+using UniversalToolchain.Dialects.Wist;
 
 namespace Tests.Backends;
 

--- a/UniversalToolchain/Tests/Backends/CilIntrinsicRegistryCompositionTests.cs
+++ b/UniversalToolchain/Tests/Backends/CilIntrinsicRegistryCompositionTests.cs
@@ -25,4 +25,13 @@ public sealed class CilIntrinsicRegistryCompositionTests
             Assert.That(compiler.SupportedIntrinsics, Is.EqualTo(firstRegistry.SupportedIntrinsics));
         });
     }
+
+    [Test]
+    public void WistCilBackendRegistrar_ShouldExposeRegistryIntrinsicSurface()
+    {
+        var registry = new CilIntrinsicRegistry();
+        var registrar = new WistCilDialectBackendServiceProvider();
+
+        Assert.That(registrar.SupportedIntrinsics, Is.EqualTo(registry.SupportedIntrinsics));
+    }
 }

--- a/UniversalToolchain/Tests/Backends/CilIntrinsicRegistryCompositionTests.cs
+++ b/UniversalToolchain/Tests/Backends/CilIntrinsicRegistryCompositionTests.cs
@@ -1,0 +1,28 @@
+using UniversalToolchain.Dialects.Core.ServiceCollection;
+
+namespace Tests.Backends;
+
+[TestFixture]
+public sealed class CilIntrinsicRegistryCompositionTests
+{
+    [Test]
+    public void AddCompilerBackendDefaults_ShouldResolveCompilerWithProviderScopedIntrinsicRegistry()
+    {
+        var services = new ServiceCollection();
+        services.AddCompilerBackendDefaults();
+
+        using var firstProvider = services.BuildServiceProvider();
+        using var secondProvider = services.BuildServiceProvider();
+
+        var firstRegistry = firstProvider.GetRequiredService<CilIntrinsicRegistry>();
+        var secondRegistry = secondProvider.GetRequiredService<CilIntrinsicRegistry>();
+        var compiler = firstProvider.GetRequiredService<AbstractMethodsCompilerImpl>();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(firstProvider.GetRequiredService<CilIntrinsicRegistry>(), Is.SameAs(firstRegistry));
+            Assert.That(secondRegistry, Is.Not.SameAs(firstRegistry));
+            Assert.That(compiler.SupportedIntrinsics, Is.EqualTo(firstRegistry.SupportedIntrinsics));
+        });
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Dialects.Core/ServiceCollection/CompilerBackendDefaultsServiceCollectionExtensions.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Core/ServiceCollection/CompilerBackendDefaultsServiceCollectionExtensions.cs
@@ -17,6 +17,7 @@ public static class CompilerBackendDefaultsServiceCollectionExtensions
     {
         services = services.ArgNotNull();
 
+        services.TryAddSingleton<CilIntrinsicRegistry>();
         services.TryAddTransient<AbstractMethodsCompilerImpl>();
         services.TryAddTransient<Func<IExecutor<DynamicMethod>>>(_ => () => new DynamicMethodExecutor());
 

--- a/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistCilDialectBackendServiceProvider.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Wist/WistCilDialectBackendServiceProvider.cs
@@ -9,9 +9,11 @@ namespace UniversalToolchain.Dialects.Wist;
 
 internal sealed class WistCilDialectBackendServiceProvider : DialectBackendRuntimeRegistrarBase<DynamicMethod>
 {
+    private readonly CilIntrinsicRegistry _intrinsicRegistry = new();
+
     public override DialectBackendId BackendId => WistDialectBackendIds.Cil;
 
-    public override IReadOnlyList<string> SupportedIntrinsics => AbstractMethodsCompilerImpl.SupportedIntrinsicIds;
+    public override IReadOnlyList<string> SupportedIntrinsics => _intrinsicRegistry.SupportedIntrinsics;
 
     override protected void RegisterBackendDefaults(IServiceCollection services)
         => services.AddCompilerBackendDefaults();


### PR DESCRIPTION
## Summary

This PR makes the CIL intrinsic registry an explicit immutable backend service and wires it through the CIL backend composition path without changing CIL emission semantics.

Changes:

- makes `CilIntrinsicRegistry` a public sealed service surface while keeping descriptor lookup internal
- keeps the registry immutable after construction and preserves duplicate intrinsic validation
- allows `AbstractMethodsCompilerImpl` to receive `CilIntrinsicRegistry` through constructor injection
- makes compiler instance `SupportedIntrinsics` come from the injected registry-backed intrinsic compiler
- registers `CilIntrinsicRegistry` in compiler backend DI defaults
- makes the Wist CIL backend runtime surface read from `CilIntrinsicRegistry` instead of the compiler static snapshot
- adds focused composition tests proving:
  - the DI provider scopes the registry and the resolved compiler observes the provider registry surface
  - the Wist CIL backend registrar exposes the same intrinsic surface as `CilIntrinsicRegistry` through the public `IDialectBackendRuntimeRegistrar` abstraction

## Architecture note

This intentionally avoids a broad rewrite of the intrinsic catalog or CIL emitter implementation. The goal is to remove the compiler-owned hidden registry lifecycle and prepare the backend for runtime-scoped composition while preserving compatibility through the existing default constructors and static `SupportedIntrinsicIds` snapshot.

The static `SupportedIntrinsicIds` property is kept for existing consumers. It should only be removed in a later PR after the remaining non-CIL/static consumers are handled deliberately.

The registrar test intentionally resolves the internal Wist CIL backend through the public `AddWistCilBackend()` / `IDialectBackendRuntimeRegistrar` path instead of making the internal implementation public just for tests.

## Validation

Latest head commit: `04ecf064d2d1d67f0c4a58f9323fc810b144dc1a`

GitHub Actions are green:

- `.NET CI`: success
- `UniversalToolchain validation`: success
- `Benchmark Smoke`: success