### PR TITLE
Fix Wist NuGet dialect content paths

### DIFF
--- a/.github/workflows/dotnet-ci.yml
+++ b/.github/workflows/dotnet-ci.yml
@@ -32,6 +32,14 @@ jobs:
       - name: Test
         run: dotnet test UniversalToolchain/Wist.sln -c Release --no-build
 
+      - name: Pack Wist facade
+        run: >
+          dotnet pack UniversalToolchain/UniversalToolchain.Wist/UniversalToolchain.Wist.csproj
+          -c Release
+          --no-build
+          -o artifacts/packages
+          /p:WarningsAsErrors=NU5118
+
       - name: Install docs dependencies
         run: npm install
 

--- a/.github/workflows/dotnet-ci.yml
+++ b/.github/workflows/dotnet-ci.yml
@@ -40,6 +40,41 @@ jobs:
           -o artifacts/packages
           /p:WarningsAsErrors=NU5118
 
+      - name: Smoke test Wist facade package
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          smoke_dir="$(mktemp -d)"
+          dotnet new console --framework net10.0 --output "$smoke_dir"
+
+          dotnet add "$smoke_dir" package UniversalToolchain.Wist \
+            --version 0.1.0-preview.1 \
+            --source "$GITHUB_WORKSPACE/artifacts/packages"
+
+          cat > "$smoke_dir/Program.cs" <<'EOF'
+          using UniversalToolchain.Wist;
+
+          using var wist = WistEngine.CreateSafeFormulas();
+
+          double result = wist.Evaluate<double>(
+              "price * 0.9 + fee",
+              new
+              {
+                  price = 100.0,
+                  fee = 5.0
+              });
+
+          if (Math.Abs(result - 95.0) > 1e-9)
+          {
+              throw new InvalidOperationException($"Expected 95, got {result}.");
+          }
+
+          Console.WriteLine("UniversalToolchain.Wist package smoke passed.");
+          EOF
+
+          dotnet run --project "$smoke_dir" -c Release
+
       - name: Install docs dependencies
         run: npm install
 

--- a/.github/workflows/dotnet-ci.yml
+++ b/.github/workflows/dotnet-ci.yml
@@ -70,6 +70,18 @@ jobs:
               throw new InvalidOperationException($"Expected 95, got {result}.");
           }
 
+          var compiled = wist.CompileFunc<double, double, double>(
+              "price * 0.9 + fee",
+              "price",
+              "fee");
+
+          double compiledResult = compiled.Invoke(100.0, 5.0);
+
+          if (Math.Abs(compiledResult - 95.0) > 1e-9)
+          {
+              throw new InvalidOperationException($"Expected 95, got {compiledResult}.");
+          }
+
           Console.WriteLine("UniversalToolchain.Wist package smoke passed.");
           EOF
 

--- a/UniversalToolchain/UniversalToolchain.Wist/UniversalToolchain.Wist.csproj
+++ b/UniversalToolchain/UniversalToolchain.Wist/UniversalToolchain.Wist.csproj
@@ -11,13 +11,14 @@
         <Description>A Wist-first .NET DSL/runtime facade for evaluating restricted formulas and compiling typed fast functions.</Description>
         <PackageTags>dotnet;dsl;rules;expression;compiler;interpreter;runtime;wist</PackageTags>
         <PackageReadmeFile>README.md</PackageReadmeFile>
+        <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);IncludeProjectReferenceAssembliesInPackage</TargetsForTfmSpecificBuildOutput>
     </PropertyGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\BasicCore\BasicCore.csproj"/>
-        <ProjectReference Include="..\DynamicMethodCalling\DynamicMethodCalling.csproj"/>
-        <ProjectReference Include="..\ExceptionsManager\ExceptionsManager.csproj"/>
-        <ProjectReference Include="..\UniversalToolchain.Dialects.Wist\UniversalToolchain.Dialects.Wist.csproj"/>
+        <ProjectReference Include="..\BasicCore\BasicCore.csproj" PrivateAssets="all"/>
+        <ProjectReference Include="..\DynamicMethodCalling\DynamicMethodCalling.csproj" PrivateAssets="all"/>
+        <ProjectReference Include="..\ExceptionsManager\ExceptionsManager.csproj" PrivateAssets="all"/>
+        <ProjectReference Include="..\UniversalToolchain.Dialects.Wist\UniversalToolchain.Dialects.Wist.csproj" PrivateAssets="all"/>
     </ItemGroup>
 
     <ItemGroup>
@@ -39,5 +40,13 @@
             <PackageFlatten>false</PackageFlatten>
         </Content>
     </ItemGroup>
+
+    <Target Name="IncludeProjectReferenceAssembliesInPackage" DependsOnTargets="ResolveReferences">
+        <ItemGroup>
+            <BuildOutputInPackage
+                Include="@(ReferenceCopyLocalPaths)"
+                Condition="'%(ReferenceCopyLocalPaths.ReferenceSourceTarget)' == 'ProjectReference'"/>
+        </ItemGroup>
+    </Target>
 
 </Project>

--- a/UniversalToolchain/UniversalToolchain.Wist/UniversalToolchain.Wist.csproj
+++ b/UniversalToolchain/UniversalToolchain.Wist/UniversalToolchain.Wist.csproj
@@ -23,6 +23,7 @@
     </ItemGroup>
 
     <ItemGroup>
+        <PackageReference Include="GrEmit" Version="3.5.1"/>
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.1"/>
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.1"/>
     </ItemGroup>

--- a/UniversalToolchain/UniversalToolchain.Wist/UniversalToolchain.Wist.csproj
+++ b/UniversalToolchain/UniversalToolchain.Wist/UniversalToolchain.Wist.csproj
@@ -12,6 +12,7 @@
         <PackageTags>dotnet;dsl;rules;expression;compiler;interpreter;runtime;wist</PackageTags>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);IncludeProjectReferenceAssembliesInPackage</TargetsForTfmSpecificBuildOutput>
+        <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);IncludeRuntimeManifestsInPackage</TargetsForTfmSpecificContentInPackage>
     </PropertyGroup>
 
     <ItemGroup>
@@ -46,6 +47,17 @@
             <BuildOutputInPackage
                 Include="@(ReferenceCopyLocalPaths)"
                 Condition="'%(ReferenceCopyLocalPaths.ReferenceSourceTarget)' == 'ProjectReference'"/>
+        </ItemGroup>
+    </Target>
+
+    <Target Name="IncludeRuntimeManifestsInPackage">
+        <ItemGroup>
+            <TfmSpecificPackageFile Include="$(TargetDir)*.dialect.runtime.json">
+                <PackagePath>contentFiles/any/$(TargetFramework)</PackagePath>
+                <BuildAction>Content</BuildAction>
+                <PackageCopyToOutput>true</PackageCopyToOutput>
+                <PackageFlatten>true</PackageFlatten>
+            </TfmSpecificPackageFile>
         </ItemGroup>
     </Target>
 

--- a/UniversalToolchain/UniversalToolchain.Wist/UniversalToolchain.Wist.csproj
+++ b/UniversalToolchain/UniversalToolchain.Wist/UniversalToolchain.Wist.csproj
@@ -33,6 +33,10 @@
         <Content Include="..\Dialects\examples\wist\**\dialect.wistdialect">
             <Link>Dialects\examples\wist\%(RecursiveDir)%(Filename)%(Extension)</Link>
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+            <Pack>true</Pack>
+            <PackagePath>contentFiles/any/$(TargetFramework)/Dialects/examples/wist/%(RecursiveDir)%(Filename)%(Extension)</PackagePath>
+            <PackageCopyToOutput>true</PackageCopyToOutput>
+            <PackageFlatten>false</PackageFlatten>
         </Content>
     </ItemGroup>
 


### PR DESCRIPTION
## Summary

- Preserve shipped Wist dialect directory structure inside the `UniversalToolchain.Wist` NuGet package.
- Add explicit `PackagePath`, `PackageCopyToOutput`, and `PackageFlatten=false` metadata for packaged `dialect.wistdialect` files.
- Add a CI `dotnet pack` step for `UniversalToolchain.Wist` with `NU5118` treated as an error, so duplicate flattened package content paths cannot regress silently.

## Why

`dotnet pack` previously emitted `NU5118` warnings because every shipped preset file was packed as the same flattened `content/dialect.wistdialect` and `contentFiles/any/net10.0/dialect.wistdialect` path. That meant only one dialect file could be kept under those package paths, while the rest were skipped.

The runtime resolver expects shipped dialect files to be copied beside the consumer application under their relative preset paths. The package must therefore keep the full `Dialects/examples/wist/<preset>/dialect.wistdialect` structure.

## Validation

- Static diff checked: only `UniversalToolchain.Wist.csproj` and `.github/workflows/dotnet-ci.yml` changed.
- CI now performs `dotnet pack UniversalToolchain.Wist` with `/p:WarningsAsErrors=NU5118`.

After CI passes, locally re-run:

```bash
dotnet pack UniversalToolchain/UniversalToolchain.Wist/UniversalToolchain.Wist.csproj \
  -c Release \
  -o artifacts/packages

unzip -l artifacts/packages/UniversalToolchain.Wist.0.1.0-preview.1.nupkg | grep wistdialect
```

Expected package paths should include one entry per preset under `contentFiles/any/net10.0/Dialects/examples/wist/...`.