### PR TITLE
Fix Wist facade pack step in CI

### DIFF
--- a/.github/workflows/dotnet-ci.yml
+++ b/.github/workflows/dotnet-ci.yml
@@ -36,7 +36,6 @@ jobs:
         run: >
           dotnet pack UniversalToolchain/UniversalToolchain.Wist/UniversalToolchain.Wist.csproj
           -c Release
-          --no-build
           -o artifacts/packages
           /p:WarningsAsErrors=NU5118
 


### PR DESCRIPTION
## Summary

- Remove `--no-build` from the `Pack Wist facade` CI step.

## Why

The current master CI restores and builds `UniversalToolchain/Wist.sln`, but `UniversalToolchain.Wist.csproj` is not part of the solution build graph. As a result, `dotnet pack UniversalToolchain.Wist.csproj --no-build` fails in CI with:

```text
NETSDK1004: Assets file 'UniversalToolchain/UniversalToolchain.Wist/obj/project.assets.json' not found.
```

Letting `dotnet pack` perform the required project restore/build for the facade package keeps the package smoke gate self-contained and avoids relying on unrelated solution membership.

## Validation

Expected CI behavior after this change:

1. solution restore/build/test remains unchanged;
2. `dotnet pack UniversalToolchain.Wist.csproj` creates the local package;
3. the external consumer smoke test installs the package and runs both `Evaluate` and `CompileFunc`.