### PR TITLE
docs: make Wist first impression product-first

### DIFF
--- a/UniversalToolchain/Example/Example.csproj
+++ b/UniversalToolchain/Example/Example.csproj
@@ -14,6 +14,7 @@
     </ItemGroup>
 
     <ItemGroup>
+        <ProjectReference Include="..\UniversalToolchain.Wist\UniversalToolchain.Wist.csproj"/>
         <ProjectReference Include="..\ArithmeticModule\ArithmeticModule.csproj"/>
         <ProjectReference Include="..\BasicCilCompiler\BasicCilCompiler.csproj"/>
         <ProjectReference Include="..\BasicCodeTranslator\BasicCodeTranslator.csproj"/>

--- a/UniversalToolchain/Example/Program.cs
+++ b/UniversalToolchain/Example/Program.cs
@@ -2,4 +2,4 @@ using Example.Scenarios;
 
 var verbose = Array.Exists(args, argument => argument == "--verbose");
 
-PricingDiscountScenario.Run(verbose);
+ShowcaseRuleScenario.Run(verbose);

--- a/UniversalToolchain/Example/Scenarios/ShowcaseRuleScenario.cs
+++ b/UniversalToolchain/Example/Scenarios/ShowcaseRuleScenario.cs
@@ -1,0 +1,67 @@
+using UniversalToolchain.Wist;
+
+namespace Example.Scenarios;
+
+public static class ShowcaseRuleScenario
+{
+    private const string RolloutScoreFormula = "usage * 0.7 + reliability * 0.3 - incidents * 15.0";
+    private const string DisallowedStatementRule = "let score = usage * 0.7\nscore";
+
+    public static void Run(bool verbose)
+    {
+        using var rules = WistEngine.CreateSafeFormulas();
+
+        Console.WriteLine("Tiny controlled rules for .NET");
+        Console.WriteLine();
+        Console.WriteLine("A product manager, config file, admin UI, or LLM suggests a numeric rollout rule:");
+        Console.WriteLine(RolloutScoreFormula);
+        Console.WriteLine();
+
+        var rolloutScore = rules.Compile<Func<double, double, double, double>>(
+            RolloutScoreFormula,
+            "usage",
+            "reliability",
+            "incidents");
+
+        var score = rolloutScore.CompiledDelegate(100.0d, 90.0d, 1.0d);
+        var enableNewDashboard = score >= 80.0d;
+
+        Console.WriteLine("Compiled once. Invoked as a typed .NET delegate.");
+        Console.WriteLine("Input: usage=100, reliability=90, incidents=1");
+        Console.WriteLine($"Score: {score}");
+        Console.WriteLine($"Application decision: enableNewDashboard={enableNewDashboard}");
+        Console.WriteLine();
+
+        var accepted = rules.Validate(
+            RolloutScoreFormula,
+            new
+            {
+                usage = 100.0d,
+                reliability = 90.0d,
+                incidents = 1.0d
+            });
+
+        var rejected = rules.Validate(
+            DisallowedStatementRule,
+            new
+            {
+                usage = 100.0d,
+                reliability = 90.0d,
+                incidents = 1.0d
+            });
+
+        Console.WriteLine("The restricted formula profile validates before execution.");
+        Console.WriteLine($"Allowed formula accepted: {accepted.IsValid}");
+        Console.WriteLine($"Statement-style rule rejected: {!rejected.IsValid}");
+
+        if (verbose)
+        {
+            Console.WriteLine();
+            Console.WriteLine("Rejected rule:");
+            Console.WriteLine(DisallowedStatementRule);
+            Console.WriteLine();
+            Console.WriteLine("Reason:");
+            Console.WriteLine(rejected.Message);
+        }
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Wist/README.md
+++ b/UniversalToolchain/UniversalToolchain.Wist/README.md
@@ -1,95 +1,71 @@
 # UniversalToolchain.Wist
 
-A compiler-first Wist facade for .NET formula execution.
+**Tiny controlled rules for .NET applications.**
 
-This package is the intended first-contact API for .NET developers. It hides the compiler pipeline, dialect runtime host,
-manifests, `DynamicMethod`, `IAbstractIR`, and session APIs behind a small facade.
+`UniversalToolchain.Wist` is the first-contact package for UniversalToolchain. It gives .NET applications a small facade for restricted formula execution without exposing the lower-level compiler pipeline, dialect host, manifests, `DynamicMethod`, AIR, or session APIs.
 
-Compiler-first. Interpreter-supported. `Compile<TDelegate>` is the primary hot-path API. `CompileFunc` remains as a
-small compatibility convenience for one, two, and three arguments. `Evaluate` is the convenience one-off API.
+Use it when configuration starts turning into logic:
 
-## Requirements
-
-- .NET SDK `10.0.103` or a compatible prerelease SDK selected by the repository `global.json`.
-- Target framework: `net10.0`.
+```text
+admin / config / LLM suggestion
+        -> tiny rule text
+        -> restricted formula surface
+        -> validation or rejection
+        -> typed compiled delegate for hot paths
+        -> your application decides the side effect
+```
 
 ## Install
 
-The package metadata in this repository is prepared for `UniversalToolchain.Wist` `0.1.0-preview.2`. This package-first
-command works when that version is available from NuGet.org or another configured package source:
+The package metadata in this repository is prepared for `UniversalToolchain.Wist` `0.1.0-preview.2`.
 
 ```bash ci-run=false
 dotnet add package UniversalToolchain.Wist --version 0.1.0-preview.2
 ```
 
-## Fast execution: compile once, invoke many times
+Requirements:
 
-Use `Compile<TDelegate>` when the same formula is executed many times.
+- target framework: `net10.0`;
+- .NET SDK `10.0.103` or a compatible prerelease SDK accepted by the repository `global.json`.
 
-```csharp
-using UniversalToolchain.Wist;
-
-using var wist = WistEngine.CreateSafeFormulas();
-
-var formula = wist.Compile<Func<double, double, double>>(
-    "price * 0.9 + fee",
-    "price",
-    "fee");
-
-double result = formula.CompiledDelegate(100.0, 5.0);
-```
-
-`Compile<TDelegate>` compiles once and returns a typed program with backend-neutral metadata. The hot delegate path does
-not use dictionaries, anonymous-object reflection, session setup, backend strings, or boxing for typed primitive
-arguments.
-
-`CompileFunc` remains available for compatibility and small examples:
-
-```csharp
-var formula = wist.CompileFunc<double, double, double>(
-    "price * 0.9 + fee",
-    "price",
-    "fee");
-
-double result = formula.Invoke(100.0, 5.0);
-```
-
-## One-off execution with Evaluate
-
-Use `Evaluate` when a formula is executed rarely or when onboarding matters more than hot-path speed.
+## 30-second example
 
 ```csharp
 using UniversalToolchain.Wist;
 
-using var wist = WistEngine.CreateSafeFormulas();
+using var rules = WistEngine.CreateSafeFormulas();
 
-double result = wist.Evaluate<double>(
-    "price * 0.9 + fee",
-    new
-    {
-        price = 100.0,
-        fee = 5.0
-    });
+var rolloutScore = rules.Compile<Func<double, double, double, double>>(
+    "usage * 0.7 + reliability * 0.3 - incidents * 15.0",
+    "usage",
+    "reliability",
+    "incidents");
+
+double score = rolloutScore.CompiledDelegate(100.0, 90.0, 1.0);
+bool enableNewDashboard = score >= 80.0;
 ```
 
-`Evaluate` is intentionally convenient. It may inspect anonymous objects, map argument names, and run through the
-convenience execution path. It is not the primary performance path.
+The formula returns data. The host application performs the action.
 
 ## Validation without throwing
 
-Use `Validate` when a UI, import flow, or configuration pipeline needs to check a formula before execution.
+Use `Validate` before storing or executing user/admin/config-supplied formulas:
 
 ```csharp
 using UniversalToolchain.Wist;
 
-using var wist = WistEngine.CreateSafeFormulas();
+using var rules = WistEngine.CreateSafeFormulas();
 
-var validation = wist.Validate(
-    "price * 0.9 + fee",
+var validation = rules.Validate(
+    """
+    let score = usage * 0.7
+    score
+    """,
     new
     {
-        price = 100.0,
-        fee = 5.0
+        usage = 100.0,
+        reliability = 90.0,
+        incidents = 1.0
     });
 
 if (!validation.IsValid)
@@ -98,79 +74,44 @@ if (!validation.IsValid)
 }
 ```
 
-Use `TryCompile<TDelegate>` when compilation should return diagnostics-like result data instead of throwing:
+The current safe-formula preset starts narrow. Statement-style bindings such as `let` are rejected by that restricted surface.
+
+## Hot path vs convenience path
+
+Use `Evaluate<T>` for one-off previews, admin tools, tests, and non-hot paths:
 
 ```csharp
-var compiled = wist.TryCompile<Func<double, double>>(
-    "price *",
-    "price");
+double score = rules.Evaluate<double>(
+    "usage * 0.7 + reliability * 0.3",
+    new
+    {
+        usage = 100.0,
+        reliability = 90.0
+    });
+```
 
-if (!compiled.IsSuccess)
+Use `Compile<TDelegate>` when the same formula is invoked repeatedly:
+
+```csharp
+var formula = rules.Compile<Func<double, double, double>>(
+    "usage * weight",
+    "usage",
+    "weight");
+
+for (var i = 0; i < usages.Length; i++)
 {
-    Console.WriteLine(compiled.Message);
+    results[i] = formula.CompiledDelegate(usages[i], weights[i]);
 }
 ```
 
-## Rule of thumb
+Rule of thumb:
 
 ```text
 Use Evaluate for one-off execution.
 Use Compile<TDelegate> for hot paths.
 Compilation is expensive.
-Invocation is fast.
+Invocation is the performance-oriented path.
 ```
-
-Avoid this in production hot loops:
-
-```csharp
-for (var i = 0; i < prices.Length; i++)
-{
-    results[i] = wist.Evaluate<double>(
-        "price * 0.9 + fee",
-        new { price = prices[i], fee = fees[i] });
-}
-```
-
-Prefer this:
-
-```csharp
-var formula = wist.Compile<Func<double, double, double>>(
-    "price * 0.9 + fee",
-    "price",
-    "fee");
-
-for (var i = 0; i < prices.Length; i++)
-{
-    results[i] = formula.CompiledDelegate(prices[i], fees[i]);
-}
-```
-
-## Compiler backend and interpreter backend
-
-The compiler backend is the default performance-oriented path for `CompileFunc` and convenience evaluation. The
-interpreter backend remains important for diagnostics, debugging, fallback, education, semantic parity, and backend/module
-development.
-
-The interpreter is not the main performance claim.
-
-## Performance model
-
-Cold path:
-
-```text
-source -> parse -> bind -> runtime selection -> compile/execute
-```
-
-Hot path:
-
-```text
-compiled typed function -> Invoke(arg0, arg1, ...)
-```
-
-The performance claim belongs to compiled typed CIL-backed invocation. It does not apply to `Evaluate`, compile time,
-every possible dialect, every module combination, or every backend.
-
-Do not benchmark `Evaluate` inside a tight loop when evaluating runtime throughput. Benchmark compiled `Invoke`.
 
 ## Presets
 
@@ -184,40 +125,22 @@ WistEngine.CreateBusinessRules();
 WistEngine.CreateTrusted();
 ```
 
-`CreateRestrictedArithmetic` is the recommended first-contact preset for restricted formula scenarios. It maps to the
-shipped `pricing-restricted` profile in this preview.
+`CreateRestrictedArithmetic` is the recommended first-contact preset for restricted formulas. `CreateSafeFormulas` remains a compatibility alias for it.
 
-`CreateFullNativePreview` maps to the broad native Wist preview profile. It is useful for trusted full-language Wist
-experiments, not for untrusted input.
+`CreateFullNativePreview`, `CreateBusinessRules`, and `CreateTrusted` are broad trusted-preview entry points in this preview. Do not use them for arbitrary untrusted input.
 
-`CreateSafeFormulas` remains a compatibility alias for `CreateRestrictedArithmetic`.
+## Security and trust
 
-`CreateBusinessRules` and `CreateTrusted` remain compatibility aliases for `CreateFullNativePreview` in this preview.
-They do not represent a separate stable business-rules runtime or a hardened trust boundary.
-
-`Safe` means a restricted language/runtime surface. It does not mean arbitrary untrusted code is safe to execute inside
-the current process.
-
-## Security note
-
-Restricted presets limit the selected language surface. They are not a hardened sandbox for arbitrary untrusted code.
-Compiled execution is a performance feature, not a sandbox boundary. Treat untrusted script execution as high risk and
-isolate it at the process/environment level when needed.
+Restricted presets limit the selected language/runtime surface. They are not hardened sandboxes for arbitrary untrusted code. Compiled execution is a performance feature, not a sandbox boundary. Treat untrusted script execution as high risk and isolate it at the process/environment level when needed.
 
 ## Current preview scope
 
-This initial facade intentionally exposes only:
+This facade currently exposes:
 
 - convenience `Evaluate<T>`;
-- validation without throwing;
+- non-throwing `Validate`;
 - typed fast `Compile<TDelegate>` and `TryCompile<TDelegate>`;
 - typed fast `CompileFunc` compatibility overloads for one, two, and three arguments;
 - backend-neutral compiled program metadata.
 
-Current preview contracts may change. Reusable object/session-based compiled artifacts, richer diagnostics, custom
-function registration, dialect builder APIs, and lower-level pass authoring APIs can evolve after this facade shape is
-validated.
-
-
-Use `WistEngine` for application-level formula execution.
-Use `WistRuntimeFacadeBuilder` only when working with lower-level Wist runtime or dialect integration scenarios.
+The larger direction is controlled application DSLs for .NET. The current stable preview claim is restricted numeric/formula execution, validation, and typed compiled invocation for supported shapes.

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -17,10 +17,11 @@ const bookSidebar = [
         items: [
             { text: '1.1 Installation', link: '/start/installation' },
             { text: '1.2 First Program', link: '/start/first-program' },
-            { text: '1.3 CLI Reference', link: '/start/cli-reference' },
-            { text: '1.4 Wist Overview', link: '/wist/' },
-            { text: '1.5 Wist Syntax Tour', link: '/wist/syntax-tour' },
-            { text: '1.6 Examples', link: '/wist/examples' }
+            { text: '1.3 Showcase: controlled rules', link: '/start/showcase' },
+            { text: '1.4 CLI Reference', link: '/start/cli-reference' },
+            { text: '1.5 Wist Overview', link: '/wist/' },
+            { text: '1.6 Wist Syntax Tour', link: '/wist/syntax-tour' },
+            { text: '1.7 Examples', link: '/wist/examples' }
         ]
     },
     {

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,149 +1,91 @@
 # UniversalToolchain Documentation
 
-## UniversalToolchain
+## Do not execute AI-generated code. Execute tiny rules in a language your .NET app controls.
 
-Build restricted formulas and small DSL runtimes for .NET.
+UniversalToolchain is a compiler/runtime framework for restricted formulas and application DSLs.
 
-Use it when an expression evaluator is too small,
-C# scripting is too broad,
-and writing a compiler from scratch is too expensive.
+It is useful when configuration turns into logic, expression evaluators become too small, and C# scripting is too broad for the surface you want to expose.
+
+```text
+admin / config / LLM suggestion
+        -> tiny rule text
+        -> restricted Wist formula surface
+        -> validation or rejection
+        -> interpreter for diagnostics
+        -> CIL-backed typed delegate for hot paths
+        -> your application decides the side effect
+```
+
+Wist is the reference language. UniversalToolchain is the framework behind it.
 
 ## 30-second demo
 
 ```csharp
 using UniversalToolchain.Wist;
 
-using var wist = WistEngine.CreateSafeFormulas();
+using var rules = WistEngine.CreateSafeFormulas();
 
-var formula = wist.CompileFunc<double, double, double>(
-    "price * 0.9 + fee",
-    "price",
-    "fee");
+var rolloutScore = rules.Compile<Func<double, double, double, double>>(
+    "usage * 0.7 + reliability * 0.3 - incidents * 15.0",
+    "usage",
+    "reliability",
+    "incidents");
 
-double result = formula.Invoke(100.0, 5.0);
+double score = rolloutScore.CompiledDelegate(100.0, 90.0, 1.0);
+bool enableNewDashboard = score >= 80.0;
 ```
+
+The rule returns data. Your application performs the action.
+
+## Why developers should care
+
+Most apps grow through this path:
 
 ```text
-95
+hardcoded C# logic
+        -> configurable formulas
+        -> user/admin/LLM-suggested rules
+        -> restricted application DSL
+        -> compiled hot path
 ```
 
-<!-- langdev-2026-site:start -->
+UniversalToolchain gives you a middle ground between JSON-rule trees and broad scripting.
 
-## Featured technical story
+## What is stable enough to show in the preview
 
-### Build the Language, Then Make the Abstractions Disappear
+- `WistEngine` facade for application-level formula execution.
+- Restricted arithmetic/formula preset through `CreateSafeFormulas()` and `CreateRestrictedArithmetic()`.
+- One-off `Evaluate<T>()` for previews and non-hot paths.
+- `Validate()` and `TryCompile<TDelegate>()` for non-throwing validation flows.
+- `Compile<TDelegate>()` and `CompileFunc(...)` for typed compiled invocation.
+- Interpreter/compiler split for diagnostics, backend work, and parity checks.
 
-UniversalToolchain explores a practical form of extensible programming:
-language features are composed as modules during construction, then
-progressively lowered into concrete runtime or typed CIL operations
-before execution.
+The larger business-rule DSL direction is intentional, but the current public claim is scoped to supported formula shapes.
 
-The LangDev 2026 proposal demonstrates:
+## Start here
 
-- deterministic dialect and runtime-plan composition;
-- Bytecode → AIR → capability-gated specialization;
-- AIR interpreter and `DynamicMethod`-based CIL execution;
-- a real semantic-parity regression involving external bindings and local-variable shadowing;
-- reproducible regression tests and carefully scoped benchmark evidence.
-
-For supported compiled paths, the prepared hot invocation path does not
-perform per-operation language-module dispatch. The generated typed CIL
-is instead presented to the .NET JIT, while cross-backend tests protect
-the language semantics.
-
-[Read the talk proposal and reproducible demo](https://github.com/Misha1302/Wist2/tree/master/docs/talks/langdev-2026) ·
-[Follow the lowering walkthrough](https://github.com/Misha1302/Wist2/blob/master/docs/talks/langdev-2026/lowering-walkthrough.md) ·
-[Review benchmark evidence](https://github.com/Misha1302/Wist2/blob/master/docs/talks/langdev-2026/benchmark-evidence.md)
-
-<!-- langdev-2026-site:end -->
-
-## When to use / when not to use
-
-Use UniversalToolchain when:
-- you need controlled formulas/rules in a .NET app
-- you want to restrict available language features
-- you need a path from interpreter to compiled execution
-- you want reusable DSL infrastructure
-
-Do not use it when:
-- you only need one arithmetic expression
-- you need a hardened sandbox for untrusted code
-- you need a stable production API today
-- you need broad C# scripting
-
-## Preview status
-
-Current status:
-- Wist-first preview
-- .NET 10 baseline
-- compiler-first hot path + interpreter diagnostics/parity backend
-- restricted dialects are not hardened sandboxes
-- legacy text-log debugging has been removed; the redacted `trace.json` v2 artifact is implemented, while a full viewer and fine-grained stage dumps remain future work
-- APIs may change before stable release
-
-## I want to...
-
-- [embed formulas in .NET](/start/what-is-wist)
-- [build a restricted DSL](/build-dsls/)
-- [write a module](/write-modules/)
-- [study compiler/runtime internals](/internals/)
-
-
-
-UniversalToolchain is a Wist-first modular .NET DSL/runtime framework.
-
-It helps you build small embeddable languages for .NET applications when a plain expression evaluator is too limited, full C# scripting is too broad, and writing a compiler from scratch would be too expensive.
-
-Wist is the reference language built on top of UniversalToolchain. It is not the main product; it demonstrates how the framework pieces fit together.
-
-> This documentation is written as a developer manual. It is not a landing page, a project report, or a promotional overview.
-
-## In 60 seconds
-
-- **UniversalToolchain** is the framework.
-- **Wist** is the reference language used to validate the framework.
-- **Dialects** select modules, optimizers, security posture and execution backends.
-- **Modules** own reusable language features such as syntax, AST translation and bytecode behavior.
-- **Backends** execute the selected language surface through interpreter or compiled execution paths.
-- **Bytecode** and **AIR** keep frontend semantics separate from backend execution.
-
-A typical use case is a .NET application that needs configurable formulas or restricted business rules without exposing a full general-purpose language.
+| Goal | Start here |
+|---|---|
+| Install the package | [Installation](/start/installation) |
+| Run the first program | [First Program](/start/first-program) |
+| See the product showcase | [Showcase: controlled rules](/start/showcase) |
+| Understand Wist | [What is Wist?](/start/what-is-wist) |
+| Build a restricted DSL | [Building DSLs](/build-dsls/) |
+| Study internals | [Pipeline](/internals/pipeline) |
 
 ## What this is not
 
-UniversalToolchain is not a production-grade sandbox, not a replacement for C#, and not a finished general-purpose language workbench. Restricted dialects control language composition, but untrusted execution still needs external process or environment isolation.
+UniversalToolchain is not a hardened sandbox, not a replacement for C#, and not a finished general-purpose language workbench. Restricted dialects control the selected language/runtime surface, but untrusted execution still needs external process or environment isolation.
 
-See [Current Limitations](/limitations) for the current maturity boundaries.
+See [Current Limitations](/limitations) and [Restricted DSL Security](/build-dsls/restricted-dsl-security) before exposing user-authored formulas.
 
-## Entry points
-
-| Goal | Start here | Continue with |
-|---|---|---|
-| Run the reference language | [Start](/start/) | [Wist](/wist/) |
-| Compose a DSL | [Dialects](/build-dsls/) | [Module composition](/build-dsls/module-composition) |
-| Add a language feature | [Modules](/write-modules/) | [Bytecode generation](/write-modules/bytecode-generation) |
-| Study implementation details | [Internals](/internals/) | [Pipeline](/internals/pipeline) |
-| Check precise contracts | [Reference](/reference/) | [Backend contracts](/reference/backend-contracts) |
-| Track debug trace direction | [Debug Trace v2](/architecture/debug-trace-v2) | [Debug Trace Schema](/reference/debug-trace-schema) |
-
-## Recommended order
-
-1. [Start here](/start/)
-2. [Run the first Wist program](/start/first-program)
-3. [Read the mental model](/start/mental-model)
-4. [Build a minimal DSL](/build-dsls/minimal-dsl)
-5. [Write a module](/write-modules/)
-6. [Read the pipeline overview](/internals/pipeline)
-7. [Use the reference section](/reference/)
-
-## Pipeline
+## Architecture in one picture
 
 ```text
 .NET host application
   -> Wist or custom DSL source
   -> dialect-selected modules and backends
-  -> lexer modules
-  -> parser modules
+  -> lexer/parser modules
   -> AST
   -> bytecode + semantic tags
   -> AIR
@@ -162,9 +104,3 @@ See [Current Limitations](/limitations) for the current maturity boundaries.
 | [Modules](/write-modules/) | Extension points for adding language features. |
 | [Internals](/internals/) | Compiler pipeline, bytecode, AIR, optimizers, and backends. |
 | [Reference](/reference/) | Exact technical contracts and reference material. |
-
-## Project model
-
-UniversalToolchain is not a single monolithic compiler.
-
-The core idea is to make language features composable, testable, and reusable across dialects. Wist exists as the reference language that demonstrates how the framework pieces fit together.

--- a/docs/start/first-program.md
+++ b/docs/start/first-program.md
@@ -8,6 +8,7 @@ description: Run the smallest useful Wist program from a .NET host or through th
 This page shows the shortest practical checks for Wist:
 
 - package-first usage from a .NET console application;
+- validation before execution;
 - CLI execution from a repository checkout.
 
 ## Package-first .NET example
@@ -18,23 +19,52 @@ Install the package first:
 dotnet add package UniversalToolchain.Wist --version 0.1.0-preview.2
 ```
 
-Then run a simple formula through the public facade:
+Then compile a small controlled formula through the public facade:
 
 ```csharp
 using UniversalToolchain.Wist;
 
-using var wist = WistEngine.CreateSafeFormulas();
+using var rules = WistEngine.CreateSafeFormulas();
 
-var formula = wist.CompileFunc<double, double, double>(
-    "price * 0.9 + fee",
-    "price",
-    "fee");
+var rolloutScore = rules.Compile<Func<double, double, double, double>>(
+    "usage * 0.7 + reliability * 0.3 - incidents * 15.0",
+    "usage",
+    "reliability",
+    "incidents");
 
-double result = formula.Invoke(100.0, 5.0);
-Console.WriteLine(result); // 95
+double score = rolloutScore.CompiledDelegate(100.0, 90.0, 1.0);
+bool enableNewDashboard = score >= 80.0;
+
+Console.WriteLine(score);              // 82
+Console.WriteLine(enableNewDashboard); // True
 ```
 
-This is the normal first-contact path for application developers. `CompileFunc` compiles once and returns a typed function that can be invoked repeatedly.
+This is the normal first-contact path for application developers: compile once, keep the returned typed function, and call the compiled delegate from the hot path.
+
+## Validate before storing or executing rules
+
+```csharp
+using UniversalToolchain.Wist;
+
+using var rules = WistEngine.CreateSafeFormulas();
+
+var validation = rules.Validate(
+    """
+    let score = usage * 0.7
+    score
+    """,
+    new
+    {
+        usage = 100.0,
+        reliability = 90.0,
+        incidents = 1.0
+    });
+
+Console.WriteLine(validation.IsValid); // false
+Console.WriteLine(validation.Message);
+```
+
+The restricted safe-formula preset does not enable statement-style bindings such as `let`. If your application needs them, choose or build a dialect that explicitly includes those capabilities.
 
 ## Trusted C# interop example
 
@@ -90,13 +120,13 @@ Expected output:
 
 The interpreter path is useful when validating semantic parity. If a selected dialect does not expose `interpreter`, Wistc will reject that backend alias.
 
-### 3. Run the pricing demo
+### 3. Run the showcase demo
 
 ```bash
 dotnet run --project UniversalToolchain/Example/Example.csproj
 ```
 
-The pricing demo runs a pricing formula through hardcoded C# logic, the shipped `full-default-native` Wist preset and the shipped `pricing-restricted` dialect. It also demonstrates compiler, interpreter and fast native invocation paths.
+The showcase demo runs a user/LLM-suggested numeric decision formula through the safe Wist facade, compiles it into a typed delegate, and demonstrates restricted-surface rejection before execution.
 
 ## What happened internally
 
@@ -106,11 +136,11 @@ For the simple expression, the runtime path is:
 source -> parser -> AST -> bytecode/AIR -> selected backend -> result
 ```
 
-For `CompileFunc`, the important distinction is:
+For `Compile<TDelegate>`, the important distinction is:
 
 ```text
 cold path: source -> parse -> compile
-hot path: typed function -> Invoke(arg0, arg1, ...)
+hot path: typed delegate -> Invoke(arg0, arg1, ...)
 ```
 
 The same source should produce the same observable result in compiler and interpreter modes when both modes are available. This parity is one of the main correctness expectations for Wist backends.
@@ -127,4 +157,4 @@ The same source should produce the same observable result in compiler and interp
 
 ## Next
 
-Read the [CLI Reference](/start/cli-reference) if you want the command surface, or continue with the [Mental Model](/start/mental-model) and the [Wist Syntax Tour](/wist/syntax-tour).
+Read the [Showcase](/start/showcase), the [CLI Reference](/start/cli-reference), the [Mental Model](/start/mental-model), or the [Wist Syntax Tour](/wist/syntax-tour).

--- a/docs/start/first-program.md
+++ b/docs/start/first-program.md
@@ -49,10 +49,7 @@ using UniversalToolchain.Wist;
 using var rules = WistEngine.CreateSafeFormulas();
 
 var validation = rules.Validate(
-    """
-    let score = usage * 0.7
-    score
-    """,
+    "let score = usage * 0.7\nscore",
     new
     {
         usage = 100.0,

--- a/docs/start/showcase.md
+++ b/docs/start/showcase.md
@@ -1,5 +1,5 @@
 ---
-title: Showcase: controlled rules
+title: "Showcase: controlled rules"
 description: Show how UniversalToolchain turns tiny user, admin or AI-suggested formulas into validated and compiled .NET decisions.
 ---
 

--- a/docs/start/showcase.md
+++ b/docs/start/showcase.md
@@ -1,0 +1,104 @@
+---
+title: Showcase: controlled rules
+description: Show how UniversalToolchain turns tiny user, admin or AI-suggested formulas into validated and compiled .NET decisions.
+---
+
+# Showcase: controlled rules
+
+UniversalToolchain is easiest to understand as a controlled rule layer for .NET applications.
+
+A product manager, admin UI, config file or LLM can suggest a small numeric rule:
+
+```text
+usage * 0.7 + reliability * 0.3 - incidents * 15.0
+```
+
+The application owns the inputs, validates the rule against a restricted Wist formula surface, compiles the accepted rule once, and decides what the returned score means.
+
+## Full example
+
+```csharp
+using UniversalToolchain.Wist;
+
+using var rules = WistEngine.CreateSafeFormulas();
+
+var rolloutScore = rules.Compile<Func<double, double, double, double>>(
+    "usage * 0.7 + reliability * 0.3 - incidents * 15.0",
+    "usage",
+    "reliability",
+    "incidents");
+
+double score = rolloutScore.CompiledDelegate(100.0, 90.0, 1.0);
+bool enableNewDashboard = score >= 80.0;
+```
+
+The Wist formula does not enable the dashboard. It only computes a value. The host application owns the side effect.
+
+## Validation before execution
+
+The safe-formula preset intentionally starts narrow:
+
+```csharp
+using UniversalToolchain.Wist;
+
+using var rules = WistEngine.CreateSafeFormulas();
+
+var rejected = rules.Validate(
+    """
+    let score = usage * 0.7
+    score
+    """,
+    new
+    {
+        usage = 100.0,
+        reliability = 90.0,
+        incidents = 1.0
+    });
+
+Console.WriteLine(rejected.IsValid); // false
+Console.WriteLine(rejected.Message);
+```
+
+Statement-style bindings such as `let` are not enabled by the restricted safe-formula preset. This is the intended product model: the application controls which language features exist.
+
+## Why not just JSON?
+
+JSON is good for data. It becomes painful when the data structure is really a programming language:
+
+```json
+{
+  "subtract": [
+    {
+      "add": [
+        { "multiply": ["usage", 0.7] },
+        { "multiply": ["reliability", 0.3] }
+      ]
+    },
+    { "multiply": ["incidents", 15.0] }
+  ]
+}
+```
+
+The equivalent formula is easier to read, validate, review and explain:
+
+```text
+usage * 0.7 + reliability * 0.3 - incidents * 15.0
+```
+
+## Why not C# scripting?
+
+C# scripting is powerful, but often broader than the surface you want to expose to an admin, config file or AI-generated suggestion.
+
+UniversalToolchain is for the middle ground:
+
+```text
+not JSON-rule trees
+not arbitrary C# scripting
+but a small language surface your application owns
+```
+
+## Current preview boundary
+
+This page demonstrates the current safe numeric/formula path. Full object-shaped business rules, string targeting rules and hardened sandboxing are not claimed as stable 1.0 features in this preview.
+
+Restricted dialects reduce the available language/runtime surface. They are not process isolation or a hardened security boundary.

--- a/docs/start/showcase.md
+++ b/docs/start/showcase.md
@@ -44,10 +44,7 @@ using UniversalToolchain.Wist;
 using var rules = WistEngine.CreateSafeFormulas();
 
 var rejected = rules.Validate(
-    """
-    let score = usage * 0.7
-    score
-    """,
+    "let score = usage * 0.7\nscore",
     new
     {
         usage = 100.0,

--- a/readme.md
+++ b/readme.md
@@ -1,73 +1,147 @@
 # UniversalToolchain
 
-Build formulas, embeddable DSLs, and restricted mini-languages for .NET applications.
+**Do not execute AI-generated code. Execute tiny rules in a language your .NET app controls.**
 
-UniversalToolchain is an embeddable .NET DSL/runtime framework for the moment when a plain expression evaluator is no
-longer enough.
+UniversalToolchain is a compiler/runtime framework for restricted formulas and application DSLs.
 
-Wist is the reference language in this repository. `UniversalToolchain.Wist` is the intended first-contact facade for
-.NET developers who want formula execution without starting from the lower-level runtime contracts.
+Start with small numeric rules. Validate them before execution. Interpret them when diagnostics matter. Compile hot paths into typed .NET delegates when throughput matters.
 
-**Compiler-first. Interpreter-supported.**
+```text
+admin / config / LLM suggestion
+        -> tiny rule text
+        -> restricted Wist formula surface
+        -> validation or rejection
+        -> interpreter for diagnostics
+        -> CIL-backed typed delegate for hot paths
+        -> your application decides the side effect
+```
 
-Wist can compile selected formula code into typed CIL-backed execution paths. The performance-oriented path is
-compiled typed invocation, not full convenience evaluation.
+Wist is the reference language in this repository. `UniversalToolchain.Wist` is the first-contact facade for .NET developers.
 
-## Current release scope
+## 30-second demo
 
-This repository state is positioned as a scoped public preview of the Wist facade and runtime foundations, not as a
-finalized 1.0 platform. The releaseable claim is formula evaluation, validation, restricted/full shipped Wist presets,
-CLI smoke coverage, package smoke coverage, and typed compiled invocation for supported shapes.
+A product manager, admin UI, config file, or LLM can suggest a rollout score formula:
 
-Neutral runtime host extraction, structured JSON trace, FunctionCalls/SafeMath, and the SSA route are active foundations
-with documented preview limits. They are not advertised here as a stable standalone runtime package family, a full trace
-viewer, a complete function authoring system, or a production SSA optimizer/backend layer.
+```text
+usage * 0.7 + reliability * 0.3 - incidents * 15.0
+```
 
-<!-- langdev-2026:start -->
+Your application owns the inputs, compiles the approved formula once, and decides what the score means:
 
-> **Featured technical story — LangDev 2026 proposal**
->
-> **Build the Language, Then Make the Abstractions Disappear: Extensible Programming on .NET**
->
-> UniversalToolchain composes language features as independent modules,
-> progressively lowers selected semantics through Bytecode and AIR into
-> concrete runtime or typed CIL operations, and checks that interpreter
-> and compiled execution preserve one language.
->
-> [Read the proposal and run the reproducible demo](docs/talks/langdev-2026/README.md)
+```csharp
+using UniversalToolchain.Wist;
 
-### Why this is interesting
+using var rules = WistEngine.CreateSafeFormulas();
 
-- Language features remain modular while the language is being constructed.
-- For supported compiled paths, per-operation module dispatch is removed from the prepared hot invocation path.
-- Typed CIL is handed to the .NET JIT for further optimization.
-- Cross-backend parity tests guard against one DSL silently becoming two languages.
-- Current benchmarks are split into hot prepared execution, convenience `Evaluate`, and cold compilation stories; publish numbers only with raw BenchmarkDotNet artifacts and environment metadata.
+var rolloutScore = rules.Compile<Func<double, double, double, double>>(
+    "usage * 0.7 + reliability * 0.3 - incidents * 15.0",
+    "usage",
+    "reliability",
+    "incidents");
 
-**Conference evidence:** [one-command demo](docs/talks/langdev-2026/README.md#reproducible-command) · [module-to-CIL lowering](docs/talks/langdev-2026/lowering-walkthrough.md) · [semantic-parity regression](docs/talks/langdev-2026/parity-regression.md) · [benchmarks and limitations](docs/talks/langdev-2026/benchmark-evidence.md)
+double score = rolloutScore.CompiledDelegate(100.0, 90.0, 1.0);
+bool enableNewDashboard = score >= 80.0;
+```
 
-<!-- langdev-2026:end -->
+The rule returns data. Your .NET application performs the action.
 
-## Requirements
+## The important part: rejection before execution
 
-- .NET SDK `10.0.103` or a compatible prerelease SDK selected by `UniversalToolchain/global.json`.
-- Target framework: `net10.0`.
-- SDK policy: `rollForward: latestMajor`, `allowPrerelease: true`.
+The preview safe-formula profile intentionally starts narrow. Statement-style bindings are not part of that restricted surface:
 
-## Install from NuGet
+```csharp
+using UniversalToolchain.Wist;
 
-The package metadata in this repository is prepared for `UniversalToolchain.Wist` `0.1.0-preview.2`. The package-first
-command works when that version is available from NuGet.org or another configured package source:
+using var rules = WistEngine.CreateSafeFormulas();
+
+var validation = rules.Validate(
+    """
+    let score = usage * 0.7
+    score
+    """,
+    new
+    {
+        usage = 100.0,
+        reliability = 90.0,
+        incidents = 1.0
+    });
+
+Console.WriteLine(validation.IsValid); // false
+Console.WriteLine(validation.Message); // Feature 'let' is not enabled by this preset.
+```
+
+That is the core product idea: your app does not accept an arbitrary programming language just because somebody wants configurable logic.
+
+## Why this exists
+
+Most applications eventually move through this path:
+
+```text
+hardcoded C# logic
+        -> configurable formulas
+        -> user/admin/LLM-suggested rules
+        -> restricted application DSL
+        -> compiled hot path
+```
+
+Without a language/runtime layer, teams usually choose one of two bad extremes:
+
+- encode logic as unreadable JSON trees;
+- expose a broad scripting language and hope nothing surprising happens.
+
+UniversalToolchain is for the middle ground: a language surface your application can own.
+
+## What is real in this preview
+
+The current public preview is intentionally scoped:
+
+| Capability | Current status |
+|---|---|
+| `WistEngine` facade | available in `UniversalToolchain.Wist` |
+| Restricted arithmetic/formula preset | available through `CreateSafeFormulas()` / `CreateRestrictedArithmetic()` |
+| One-off evaluation | available through `Evaluate<T>()` |
+| Non-throwing validation | available through `Validate()` and `TryCompile<TDelegate>()` |
+| Typed compiled hot path | available through `Compile<TDelegate>()` and `CompileFunc(...)` |
+| Interpreter backend | available for diagnostics, fallback, and semantic parity work |
+| Dialect composition | available through shipped `.wistdialect` profiles and lower-level APIs |
+| Full business-rule DSL | direction, not a stable 1.0 claim |
+| Hardened sandboxing | not claimed |
+
+## Install
+
+The package metadata in this repository is prepared for `UniversalToolchain.Wist` `0.1.0-preview.2`.
 
 ```bash ci-run=false
 dotnet add package UniversalToolchain.Wist --version 0.1.0-preview.2
 ```
 
-For the current repository state, the source workflow below is the authoritative path.
+For the current repository state, source checkout is still the authoritative path.
+
+Requirements:
+
+- .NET SDK `10.0.103` or a compatible prerelease SDK selected by `UniversalToolchain/global.json`.
+- Target framework: `net10.0`.
+- SDK policy: `rollForward: latestMajor`, `allowPrerelease: true`.
+
+## Run the showcase demo
+
+From the repository root:
+
+```bash ci-timeout=240
+dotnet run --project UniversalToolchain/Example/Example.csproj
+```
+
+The demo shows:
+
+- a user/LLM-suggested numeric decision rule;
+- compilation into a typed CIL-backed delegate;
+- repeated invocation without reparsing;
+- app-owned side effects;
+- restricted-surface rejection before execution.
 
 ## Fast path: compile once, invoke many times
 
-Use `WistEngine.Compile<TDelegate>` for code that will be invoked repeatedly:
+Use `Compile<TDelegate>` when a formula is invoked repeatedly:
 
 ```csharp
 using UniversalToolchain.Wist;
@@ -75,22 +149,23 @@ using UniversalToolchain.Wist;
 using var wist = WistEngine.CreateSafeFormulas();
 
 var formula = wist.Compile<Func<double, double, double>>(
-    "price * 0.9 + fee",
-    "price",
-    "fee");
+    "usage * weight",
+    "usage",
+    "weight");
 
-double result = formula.CompiledDelegate(100.0, 5.0);
+double result = formula.CompiledDelegate(100.0, 0.7);
 ```
 
 This is the intended hot path:
 
 - compile once;
-- invoke many times;
+- keep the returned program;
+- invoke the typed delegate repeatedly;
 - benchmark compiled delegate invocation, not `Evaluate` in a tight loop.
 
 ## One-off Evaluate
 
-Use `Evaluate` for one-off execution, onboarding, tests, validation UI, admin tools, and non-hot paths:
+Use `Evaluate` for onboarding, admin previews, tests, validation UI, and non-hot paths:
 
 ```csharp
 using UniversalToolchain.Wist;
@@ -98,38 +173,15 @@ using UniversalToolchain.Wist;
 using var wist = WistEngine.CreateSafeFormulas();
 
 double result = wist.Evaluate<double>(
-    "price * 0.9 + fee",
+    "usage * 0.7 + reliability * 0.3",
     new
     {
-        price = 100.0,
-        fee = 5.0
+        usage = 100.0,
+        reliability = 90.0
     });
 ```
 
-`Evaluate` is for convenience. It is not the primary performance path.
-
-## Validation
-
-Use `Validate` when a UI, import flow, or configuration pipeline needs non-throwing validation before execution:
-
-```csharp
-using UniversalToolchain.Wist;
-
-using var wist = WistEngine.CreateSafeFormulas();
-
-var validation = wist.Validate(
-    "price * 0.9 + fee",
-    new
-    {
-        price = 100.0,
-        fee = 5.0
-    });
-
-if (!validation.IsValid)
-{
-    Console.WriteLine(validation.Message);
-}
-```
+`Evaluate` is a convenience path. It is not the primary performance claim.
 
 ## Presets
 
@@ -145,52 +197,68 @@ using var businessRules = WistEngine.CreateBusinessRules();
 using var trusted = WistEngine.CreateTrusted();
 ```
 
-`CreateRestrictedArithmetic` is the recommended first-contact preset. It maps to the shipped `pricing-restricted` profile.
+`CreateRestrictedArithmetic` is the recommended first-contact preset. It maps to the shipped `pricing-restricted` profile in this preview.
+
 `CreateFullNativePreview` maps to the broad native Wist preview profile and must not be used for untrusted input.
 
-`CreateSafeFormulas` remains a compatibility alias for `CreateRestrictedArithmetic`. `CreateBusinessRules` and
-`CreateTrusted` remain compatibility aliases for `CreateFullNativePreview`; they do not represent a separate stable
-business-rules runtime or a hardened trust boundary.
+`CreateSafeFormulas` remains a compatibility alias for `CreateRestrictedArithmetic`. `CreateBusinessRules` and `CreateTrusted` remain compatibility aliases for `CreateFullNativePreview`; they do not represent a separate stable business-rules runtime or a hardened trust boundary.
 
-`Safe` means a restricted language/runtime surface. It does not mean arbitrary untrusted code is safe to execute inside
-the current process.
+## What this is not
 
-## Interpreter backend
+UniversalToolchain is not:
 
-The interpreter is a correctness, diagnostics, debugging, fallback, and semantic parity backend. The performance-oriented
-path is compiled typed CIL-backed invocation.
+- a hardened sandbox for arbitrary untrusted code;
+- a replacement for C#;
+- a finished general-purpose language workbench;
+- only a calculator;
+- only a parser generator.
 
-## Security and trust
+Restricted presets and dialects limit selected language/runtime surface. They are not process isolation, resource isolation, or a security boundary by themselves. For untrusted execution, use process/environment isolation with appropriate OS permissions and resource limits. See [docs/SECURITY.md](docs/SECURITY.md).
 
-Restricted presets and dialects limit selected language/runtime surface. They are not hardened sandboxes, and compiled
-execution is a performance feature rather than a sandbox boundary. For untrusted code, use process/environment isolation
-with appropriate OS permissions and resource limits. See [docs/SECURITY.md](docs/SECURITY.md).
+## When to use UniversalToolchain
 
-## Run the pricing demo
+Use it when:
 
-```bash
-dotnet run --project UniversalToolchain/Example/Example.csproj
+- JSON configuration is starting to become logic;
+- expression evaluators are too small for the direction of your product;
+- C# scripting is too broad for the surface you want to expose;
+- you want user/admin/LLM-suggested formulas to pass through validation before execution;
+- you need both interpreter and compiler paths for the same language surface;
+- you want configurable .NET logic without hardcoding every formula into the application.
+
+Typical scenarios:
+
+- scoring and rollout formulas;
+- alerting and monitoring formulas;
+- workflow decision scores;
+- LMS/autograding scores;
+- pricing and commission formulas;
+- restricted DSL experiments inside .NET applications.
+
+## Architecture at a glance
+
+```text
+Source
+  -> Lexer / Parser
+  -> AST
+  -> Bytecode
+  -> AIR
+  -> Optimizers
+  -> Compiler / Interpreter
+  -> Execution
 ```
 
-This runs a pricing formula through hardcoded C#, the shipped `full-default-native` Wist preset, and the shipped
-`pricing-restricted` dialect. It shows the same calculation executed through compiler, interpreter, and fast native
-invocation paths, plus rejection of a formula that the restricted dialect composition does not allow.
+Key project ideas:
 
-Code: [UniversalToolchain/Example/Scenarios/PricingDiscountScenario.cs](UniversalToolchain/Example/Scenarios/PricingDiscountScenario.cs) and [UniversalToolchain/Example/Scenarios/DslPricingCalculator.cs](UniversalToolchain/Example/Scenarios/DslPricingCalculator.cs).
+- framework-first, composition-based pipeline design;
+- Wist as the reference language, not the only product direction;
+- dialect-driven runtime composition through `.wistdialect` files;
+- dual backend model: `compiler` and `interpreter`;
+- semantic parity checks so one DSL does not silently become two languages.
 
-## What this demo shows
+## CLI quick start
 
-The pricing demo compares three ways to own the same pricing calculation:
-
-- hardcoded C# pricing logic,
-- the shipped `full-default-native` Wist preset for the formula,
-- a restricted pricing dialect with a narrower runtime surface,
-- compiler, interpreter, and fast native invocation paths for the same calculation,
-- rejection of a formula shape that the restricted dialect composition does not allow.
-
-## Tiny CLI quick start
-
-```bash
+```bash ci-timeout=240
 dotnet run --project UniversalToolchain/Wistc/Wistc.csproj -- run --eval "(2 + 2) * 3" --backend compiler
 ```
 
@@ -198,187 +266,6 @@ Expected output:
 
 ```text
 12
-```
-
-## Advanced runtime integration example
-
-Use `WistRuntimeFacadeBuilder` only for advanced/lower-level Wist runtime and dialect integration scenarios.
-
-```csharp
-using UniversalToolchain.Dialects.Wist.Presets;
-
-using var wist = WistRuntimeFacadeBuilder
-    .CreateDefault()
-    .WithShippedDialectPreset(WistShippedDialectPresets.PricingRestricted)
-    .Build();
-
-var attempt = wist.TryCompile(
-    """
-    let discount = 0.9
-    price * discount + fee
-    """,
-    new Dictionary<string, Type>
-    {
-        ["price"] = typeof(double),
-        ["fee"] = typeof(double)
-    },
-    backend: "interpreter");
-```
-
-## When to use UniversalToolchain
-
-Use UniversalToolchain when:
-
-- a normal expression evaluator is too narrow for your formulas or DSL code,
-- users need a syntax that matches your domain instead of C# syntax,
-- you need a dialect profile that allows only selected language features,
-- the same language should support compiler and interpreter backend aliases,
-- you need an inspectable execution pipeline for validation, diagnostics, or backend work,
-- you want configurable business logic without hardcoding every formula or policy into the application.
-
-Typical scenarios include pricing formulas, routing policies, internal workflow calculations, and DSL experiments inside
-.NET applications.
-
-## When not to use UniversalToolchain
-
-Do not start here when:
-
-- you only need trivial arithmetic formulas,
-- you only need a subset of C# expressions,
-- you only need parser generation,
-- you do not need a DSL or runtime story,
-- a simple library call can already evaluate all formulas or policies you plan to support.
-
-For those cases, a smaller evaluator, a rules library, or a parser generator is usually easier to own.
-
-## Comparison
-
-For a practical positioning guide against the nearest alternatives, see [UniversalToolchain vs Nearby Alternatives](docs/alternatives.md).
-
-At a high level:
-
-- **NCalc / Dynamic Expresso** are strong when you only need expression evaluation.
-- **RulesEngine** is strong when you need JSON-defined business rules in a .NET application.
-- **ANTLR / csly / Irony** are strong when parser construction is the main problem.
-- **JetBrains MPS** is strong when the target is a full language workbench with richer tooling.
-- **UniversalToolchain** becomes relevant when you need a restricted, embeddable DSL/runtime stack for .NET rather than only a parser, evaluator, or workbench.
-
-## Why this project exists
-
-Many language projects repeatedly rebuild the same layers: parsing, AST/IR transforms, runtime composition, and execution. UniversalToolchain focuses on reusable composition so capabilities can be assembled from modules instead of hardcoded into one implementation path. See [Why this exists](docs/why-this-exists.md) for the longer product and architecture rationale.
-
-This repository contains:
-
-- **UniversalToolchain**: reusable framework infrastructure.
-- **Wist**: a reference language used to validate and evolve the framework architecture.
-
-For a stable project map, see [Global project overview](docs/global-project-overview.md). For a stricter boundary between framework, reference language, and current limitations, see [Project positioning](docs/project-positioning.md). For an external-style evaluative architecture review, see [Technical due diligence review](docs/reviews/technical-due-diligence.md).
-
-## Architecture at a glance
-
-At a high level:
-
-```text
-Source -> Lexer/Parser -> AST -> Bytecode -> AIR -> Optimization -> Compiler/Interpreter -> Execution
-```
-
-Key repository architecture concepts:
-
-- framework-first, composition-based pipeline design,
-- dual backends (`compiler`, `interpreter`),
-- dialect-driven runtime composition via `.wistdialect` files,
-- manifest-backed runtime selection before host creation,
-- bytecode/AIR as semantic pipeline layers,
-- CLI and programmatic entry points for validation and integration.
-
-## Canonical Wist runtime path
-
-Normal Wist dialect execution follows this path:
-
-```text
-dialect source -> dialect compilation -> build plan -> manifest-backed runtime selection -> host creation -> execution
-```
-
-Composition and host creation are separate stages. `ComposeText`/`ComposeFile` compile the dialect DSL, build a
-deterministic plan, and resolve selected modules, optimizers, and backends from runtime manifests. `CreateHost` then
-builds the runtime provider for that resolved selection and activates only the selected backend registrars.
-
-The selection-driven path is the main dialect execution story. Runtime activation in that path uses targeted, exact loading
-of selected runtime component and registrar types from manifests. Shipped profiles do not require explicit backend imports in
-normal CLI, facade, or example usage. Broad eager discovery and compatibility helpers still exist, but they are not the
-canonical path for running shipped dialect profiles.
-
-## How features plug into the pipeline
-
-Framework features are introduced through extension points instead of one monolithic compiler path.
-
-For example, a frontend module can participate in several stages:
-
-- text preprocessing,
-- lexer initialization,
-- lexeme post-processing,
-- parser initialization,
-- AST post-processing,
-- bytecode post-processing,
-- AST-to-bytecode translator initialization.
-
-Module authoring is convention-heavy. Before adding or changing modules, read [Module authoring guide](docs/guides/module-authoring.md) and [Module contracts](docs/contracts/module-contracts.md).
-
-## CLI usage (`Wistc`)
-
-Available verbs:
-
-- `run`
-- `repl`
-- `dialect-inspect`
-- `dialect-demo`
-- `features`
-
-Common options:
-
-- `--backend <compiler|interpreter>`
-- `--dialect-file <path>`
-- `--list-modules`
-
-`run` options:
-
-- `--file <path>`
-- `--eval`
-
-`dialect-demo` options:
-
-- `--file <path>`
-- `--scenario <valid|invalid-syntax|semantic-conflict|unresolved-module>`
-
-The user-facing `compiler` backend alias selects the canonical `cil` backend when a dialect declares `backend cil` or the
-`compiler` alias. `--eval` is a flag; the source expression itself is passed as the positional code argument.
-
-Examples:
-
-```bash ci-timeout=240
-# Run a .wist file with an explicit dialect definition
-dotnet run --project UniversalToolchain/Wistc/Wistc.csproj -- run --dialect-file UniversalToolchain/Dialects/examples/wist/full-default/dialect.wistdialect --file UniversalToolchain/Dialects/examples/wist/full-default/program.wist --backend interpreter
-
-# Evaluate one expression
-dotnet run --project UniversalToolchain/Wistc/Wistc.csproj -- run --eval "(2 + 2) * 3" --backend compiler
-```
-
-```bash ci-run=false
-# Start REPL
-dotnet run --project UniversalToolchain/Wistc/Wistc.csproj -- repl --backend compiler
-```
-
-## Dialect usage
-
-```bash ci-timeout=240
-# Run code with a dialect definition
-dotnet run --project UniversalToolchain/Wistc/Wistc.csproj -- run --dialect-file UniversalToolchain/Dialects/examples/wist/full-default/dialect.wistdialect --file UniversalToolchain/Dialects/examples/wist/full-default/program.wist --backend interpreter
-
-# Inspect a dialect file
-dotnet run --project UniversalToolchain/Wistc/Wistc.csproj -- dialect-inspect --file UniversalToolchain/Dialects/examples/wist/full-default/dialect.wistdialect
-
-# Run the dialect demo workflow
-dotnet run --project UniversalToolchain/Wistc/Wistc.csproj -- dialect-demo --file UniversalToolchain/Dialects/examples/wist/full-default/dialect.wistdialect
 ```
 
 ## Dialect examples
@@ -390,78 +277,43 @@ Located under `UniversalToolchain/Dialects/examples/wist`:
 - `function-calls-safe-math`: neutral FunctionCalls + SafeMath profile without rule declarations.
 - `minimal-arithmetic`: smallest interpreter arithmetic profile.
 - `minimal-arithmetic-native`: smallest native arithmetic profile over `cil`.
-- `pricing-restricted`: composition-constrained pricing profile with a restricted runtime surface.
+- `pricing-restricted`: composition-constrained formula profile with a restricted runtime surface.
 - `restricted-sandbox`: composition-constrained profile, not a hardened sandbox guarantee.
 
-These directories are runnable canonical references for the manifest-driven dialect path. Each README includes
-repository-root CLI commands, expected behavior, and the capabilities intentionally excluded by that profile.
+## Technical story
 
-Public dialect documentation should follow the `.wistdialect` shape used by these shipped profiles. Secondary parser experiments must not be treated as the runtime dialect contract unless the runtime path is intentionally migrated to them.
+UniversalToolchain also has a compiler/runtime research angle: language features are composed as modules, selected semantics lower through Bytecode and AIR, and supported hot paths become typed CIL operations handed to the .NET JIT.
 
-## Why .NET 10 right now?
+Conference-oriented material:
 
-The current validation baseline is .NET 10 (`net10.0`) with SDK `10.0.103`.
-Active runtime and backend work is being verified there first, so older target frameworks are not the current compatibility target.
+- [LangDev 2026 proposal](docs/talks/langdev-2026/README.md)
+- [Module-to-CIL lowering walkthrough](docs/talks/langdev-2026/lowering-walkthrough.md)
+- [Semantic parity regression](docs/talks/langdev-2026/parity-regression.md)
+- [Benchmark evidence and limitations](docs/talks/langdev-2026/benchmark-evidence.md)
 
 ## Build and test from source
 
 From repository root:
 
 ```bash ci-run=false
-dotnet restore UniversalToolchain/Wist.sln
-dotnet build UniversalToolchain/Wist.sln -c Release --no-restore
-dotnet test UniversalToolchain/Tests/Tests.csproj -c Release --no-build
-dotnet test UniversalToolchain/UniversalToolchain.Modules.Tests/UniversalToolchain.Modules.Tests.csproj -c Release --no-build
-dotnet test UniversalToolchain/UniversalToolchain.Dialects.Tests/UniversalToolchain.Dialects.Tests.csproj -c Release --no-build
+dotnet restore UniversalToolchain/Wist.sln -p:Platform="Any CPU"
+dotnet build UniversalToolchain/Wist.sln -c Release --no-restore -p:Platform="Any CPU"
+dotnet test UniversalToolchain/Wist.sln -c Release --no-build -p:Platform="Any CPU"
 ```
 
-## Security note
+## Documentation map
 
-The repository does **not** claim hardened sandboxing for untrusted code. Use process/environment isolation for
-untrusted execution scenarios.
-See [docs/SECURITY.md](docs/SECURITY.md) for the trust model.
-
-## Known limitations
-
-This repository is actively evolving, and some areas are intentionally treated as design-in-progress:
-
-- some bootstrap/runtime wiring is still concrete rather than fully descriptor-driven,
-- reflection-based interop/discovery helpers still exist for compatibility and bootstrap scenarios,
-- constrained dialect composition is not equivalent to hardened sandboxing,
-- bytecode tags and module authoring contracts are being formalized,
-- backend-agnostic artifact handling is still an active architecture area,
-- the reference language Wist is still the main proving ground for framework decisions.
-
-See [Current limitations](docs/limitations.md) for the explicit limitation and wording guide.
-
-## Canonical documentation map
-
-- Project overview: [readme.md](readme.md)
-- Global project overview: [docs/global-project-overview.md](docs/global-project-overview.md)
-- Project positioning and public wording: [docs/project-positioning.md](docs/project-positioning.md)
+- Start: [docs/index.md](docs/index.md)
+- Installation: [docs/start/installation.md](docs/start/installation.md)
+- First program: [docs/start/first-program.md](docs/start/first-program.md)
+- Project positioning: [docs/project-positioning.md](docs/project-positioning.md)
 - Performance model: [docs/public/performance-model.md](docs/public/performance-model.md)
 - Preview stability: [docs/public/what-is-stable-in-preview.md](docs/public/what-is-stable-in-preview.md)
 - Current limitations: [docs/limitations.md](docs/limitations.md)
-- Technical due diligence review: [docs/reviews/technical-due-diligence.md](docs/reviews/technical-due-diligence.md)
-- Current runtime pipeline: [docs/current-canonical-runtime-pipeline.md](docs/current-canonical-runtime-pipeline.md)
-- Runtime manifest activation model: [docs/runtime-manifest-activation-model.md](docs/runtime-manifest-activation-model.md)
-- Runtime manifest format: [docs/runtime-manifest-format.md](docs/runtime-manifest-format.md)
-- Bytecode and AIR architecture: [docs/architecture/bytecode-and-air.md](docs/architecture/bytecode-and-air.md)
-- Backend and semantic parity contracts: [docs/architecture/backends-and-parity.md](docs/architecture/backends-and-parity.md)
-- Module authoring guide: [docs/guides/module-authoring.md](docs/guides/module-authoring.md)
-- Module hidden contracts: [docs/contracts/module-contracts.md](docs/contracts/module-contracts.md)
 - Architecture guardrails: [docs/ARCHITECTURE_RULES.md](docs/ARCHITECTURE_RULES.md)
-- Why this exists: [docs/why-this-exists.md](docs/why-this-exists.md)
-- Nearby alternatives: [docs/alternatives.md](docs/alternatives.md)
-- Coding standards: [docs/PROJECT_RULES.md](docs/PROJECT_RULES.md)
 - Contribution workflow: [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md)
 - Security policy: [docs/SECURITY.md](docs/SECURITY.md)
 
 ## License
 
 Licensed under Apache License 2.0. See [LICENSE](LICENSE).
-
-
-## Development validation
-
-See [RELEASE_CHECKLIST.md](RELEASE_CHECKLIST.md) for required release commands and manual smoke checks.


### PR DESCRIPTION
## Summary

This PR rewrites the first-contact story around a stronger, more honest product wedge:

> Do not execute AI-generated code. Execute tiny rules in a language your .NET app controls.

Changes:

- rewrites the root README around controlled numeric decision rules instead of the older pricing-first framing;
- adds a runnable `ShowcaseRuleScenario` example using the public `UniversalToolchain.Wist` facade;
- updates the example app entry point to run the showcase by default;
- adds `docs/start/showcase.md` and links it from the VitePress sidebar;
- updates the docs landing page, first program page, and package README to align the first impression.

## Scope / honesty guardrails

- Keeps the claim scoped to current preview capabilities: restricted numeric/formula execution, validation, and typed compiled invocation.
- Does **not** claim stable object/string feature-rule DSLs yet.
- Does **not** claim hardened sandboxing.
- Keeps side effects app-owned: Wist computes a value; the host application decides what to do.

## Validation expected from CI

- .NET restore/build/test workflows
- docs build / markdown checks if configured
- example project build through solution validation

Local archive note: the uploaded `Wist2-ea428d9.tar.gz` was 172 bytes and unpacked as an empty archive, so this PR was prepared against the live GitHub repository state.