### PR TITLE
docs: make README and package first impression product-first

### DIFF
--- a/.github/workflows/benchmark-full.yml
+++ b/.github/workflows/benchmark-full.yml
@@ -22,10 +22,10 @@ jobs:
           global-json-file: UniversalToolchain/global.json
 
       - name: Restore benchmark project
-        run: dotnet restore UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/UniversalToolchain.Benchmarks.csproj -p:Platform="Any CPU"
+        run: dotnet restore UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/UniversalToolchain.Benchmarks.csproj
 
       - name: Build benchmark project
-        run: dotnet build UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/UniversalToolchain.Benchmarks.csproj -c Release --no-restore -p:Platform="Any CPU"
+        run: dotnet build UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/UniversalToolchain.Benchmarks.csproj -c Release --no-restore
 
       - name: Run benchmarks
         run: >

--- a/.github/workflows/benchmark-smoke.yml
+++ b/.github/workflows/benchmark-smoke.yml
@@ -5,8 +5,10 @@ on:
   pull_request:
     paths:
       - "UniversalToolchain/Benchmarks/**"
-      - "UniversalToolchain/UniversalToolchain.Wist/**"
-      - "UniversalToolchain/UniversalToolchain.Dialects.Wist/**"
+      - "UniversalToolchain/UniversalToolchain.Wist/**/*.cs"
+      - "UniversalToolchain/UniversalToolchain.Wist/**/*.csproj"
+      - "UniversalToolchain/UniversalToolchain.Dialects.Wist/**/*.cs"
+      - "UniversalToolchain/UniversalToolchain.Dialects.Wist/**/*.csproj"
       - ".github/workflows/benchmark-smoke.yml"
 
 jobs:
@@ -23,10 +25,10 @@ jobs:
           global-json-file: UniversalToolchain/global.json
 
       - name: Restore benchmark project
-        run: dotnet restore UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/UniversalToolchain.Benchmarks.csproj -p:Platform="Any CPU"
+        run: dotnet restore UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/UniversalToolchain.Benchmarks.csproj
 
       - name: Build benchmark project
-        run: dotnet build UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/UniversalToolchain.Benchmarks.csproj -c Release --no-restore -p:Platform="Any CPU"
+        run: dotnet build UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/UniversalToolchain.Benchmarks.csproj -c Release --no-restore
 
       - name: Benchmark self-test
         run: >

--- a/.github/workflows/dotnet-ci.yml
+++ b/.github/workflows/dotnet-ci.yml
@@ -69,16 +69,28 @@ jobs:
 
           using var safe = WistEngine.CreateSafeFormulas();
 
-          var formula = safe.CompileFunc<double, double, double>(
+          var compiledProgram = safe.Compile<Func<double, double, double>>(
               "price * 0.9 + fee",
               "price",
               "fee");
 
-          double compiledResult = formula.Invoke(100.0, 5.0);
+          double compiledResult = compiledProgram.CompiledDelegate(100.0, 5.0);
 
           if (Math.Abs(compiledResult - 95.0) > 1e-9)
           {
               throw new InvalidOperationException($"Expected 95, got {compiledResult}.");
+          }
+
+          var compatibilityFunction = safe.CompileFunc<double, double, double>(
+              "price * 0.9 + fee",
+              "price",
+              "fee");
+
+          double compatibilityResult = compatibilityFunction.Invoke(100.0, 5.0);
+
+          if (Math.Abs(compatibilityResult - 95.0) > 1e-9)
+          {
+              throw new InvalidOperationException($"Expected 95, got {compatibilityResult}.");
           }
 
           double evaluatedResult = safe.Evaluate<double>(

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -13,7 +13,8 @@
 - site examples match README
 - SECURITY limitations are visible
 - version updated
-- root README first public API example uses CompileFunc, not Evaluate
+- root README first public API example uses `Compile<TDelegate>`, not `Evaluate`
+- `CompileFunc` is documented only as a compatibility convenience for small examples
 - NuGet/package README presents fast execution before one-off execution
 - performance model doc exists
 - preview stability doc exists
@@ -21,7 +22,7 @@
 - docs do not advertise Evaluate as the performance path
 - docs do not claim hardened sandboxing
 - security note is visible near compiled/restricted execution docs
-- package smoke validates CompileFunc, Evaluate, and Validate
+- package smoke validates `Compile<TDelegate>`, `CompileFunc`, `Evaluate`, and `Validate`
 - CLI smoke validates compiler backend, interpreter backend, and restricted dialect rejection
 - benchmark dry smoke genuinely executes at least one benchmark or is replaced by a meaningful benchmark contract smoke
 
@@ -29,10 +30,10 @@
 
 ```bash ci-run=false
 unset PLATFORM
-dotnet restore UniversalToolchain/Wist.sln -p:Platform="Any CPU"
-dotnet build UniversalToolchain/Wist.sln -c Release --no-restore -p:Platform="Any CPU"
-dotnet test UniversalToolchain/Wist.sln -c Release --no-build -p:Platform="Any CPU"
-dotnet pack UniversalToolchain/UniversalToolchain.Wist/UniversalToolchain.Wist.csproj -c Release -o artifacts/packages -p:Platform="Any CPU" /p:WarningsAsErrors=NU5118
+dotnet restore UniversalToolchain/Wist.sln
+dotnet build UniversalToolchain/Wist.sln -c Release --no-restore -m:1 -p:BuildInParallel=false
+dotnet test UniversalToolchain/Wist.sln -c Release --no-build
+dotnet pack UniversalToolchain/UniversalToolchain.Wist/UniversalToolchain.Wist.csproj -c Release -o artifacts/packages /p:WarningsAsErrors=NU5118
 ls -la artifacts/packages
 unzip -l artifacts/packages/UniversalToolchain.Wist.0.1.0-preview.2.nupkg
 npm install --no-audit --no-fund
@@ -59,7 +60,8 @@ python3 .github/scripts/run-markdown-bash-blocks.py
 
 ## Manual smoke
 - run simple formula through WistEngine
-- run compiled formula through WistEngine.CompileFunc
+- run compiled formula through `WistEngine.Compile<TDelegate>`
+- run compatibility compiled formula through `WistEngine.CompileFunc`
 - validate a simple formula through WistEngine.Validate
 - run CLI compiler backend
 - run CLI interpreter backend

--- a/UniversalToolchain/AssemblyFinder/TypesFinder.cs
+++ b/UniversalToolchain/AssemblyFinder/TypesFinder.cs
@@ -88,6 +88,11 @@ public static class TypesFinder
             _badAssemblies.Add(Path.GetFileName(path));
             return false;
         }
+        catch (FileLoadException)
+        {
+            _badAssemblies.Add(Path.GetFileName(path));
+            return false;
+        }
         catch (UnauthorizedAccessException)
         {
             return false;
@@ -134,15 +139,19 @@ public static class TypesFinder
                 _badAssemblies.Add(fullName);
                 return false;
             }
-            catch (FileLoadException ex) when (ex.Message.Contains("administrator") || ex.Message.Contains("elevated"))
+            catch (FileLoadException)
             {
+                // Assembly discovery is best-effort. Test runners and optional tooling can place
+                // incompatible assemblies or mismatched dependency identities in the output directory.
+                // Such assemblies must not prevent C# interop from finding usable application types.
                 _badAssemblies.Add(fullName);
                 return false;
             }
             catch (Exception ex) when (ex is FileNotFoundException or
                                            DirectoryNotFoundException or
                                            UnauthorizedAccessException or
-                                           PathTooLongException)
+                                           PathTooLongException or
+                                           InvalidOperationException)
             {
                 _badAssemblies.Add(fullName);
                 return false;

--- a/UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/README.md
+++ b/UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/README.md
@@ -23,8 +23,8 @@ This project is a measurement surface, not marketing proof.
 ```bash
 unset PLATFORM
 export DOTNET_CLI_HOME="$PWD/.dotnet-home"
-dotnet restore UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/UniversalToolchain.Benchmarks.csproj -p:Platform="Any CPU"
-dotnet build UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/UniversalToolchain.Benchmarks.csproj -c Release --no-restore -p:Platform="Any CPU"
+dotnet restore UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/UniversalToolchain.Benchmarks.csproj
+dotnet build UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/UniversalToolchain.Benchmarks.csproj -c Release --no-restore
 dotnet run -c Release --no-build \
   --project UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/UniversalToolchain.Benchmarks.csproj \
   -- \

--- a/UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/README.md
+++ b/UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/README.md
@@ -20,7 +20,10 @@ This project is a measurement surface, not marketing proof.
 
 ## Smoke
 
-```bash
+The smoke command performs restore, Release build, benchmark self-test, and a BenchmarkDotNet dry job. It is intentionally
+slower than ordinary documentation snippets, so the markdown checker gives this fenced block an explicit timeout.
+
+```bash ci-timeout=240s
 unset PLATFORM
 export DOTNET_CLI_HOME="$PWD/.dotnet-home"
 dotnet restore UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/UniversalToolchain.Benchmarks.csproj
@@ -39,7 +42,7 @@ dotnet run -c Release --no-build \
 
 ## Full run
 
-```bash
+```bash ci-run=false
 unset PLATFORM
 export DOTNET_CLI_HOME="$PWD/.dotnet-home"
 dotnet run -c Release \

--- a/UniversalToolchain/UniversalToolchain.Dialects.Integration/DefaultRuntimeAssemblyLoadStrategy.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Integration/DefaultRuntimeAssemblyLoadStrategy.cs
@@ -22,8 +22,6 @@ public sealed class DefaultRuntimeAssemblyLoadStrategy : IRuntimeAssemblyLoadStr
         if (string.IsNullOrWhiteSpace(assemblySimpleName))
             Thrower.Argument(nameof(assemblySimpleName), "Assembly simple name must not be empty.");
 
-        EnsureResolvingHandlerRegistered();
-
         return TryGetAlreadyLoadedAssembly(assemblySimpleName)
                ?? TryLoadBySimpleName(assemblySimpleName)
                ?? LoadAssemblyFromResolvedPath(assemblySimpleName);
@@ -109,6 +107,8 @@ public sealed class DefaultRuntimeAssemblyLoadStrategy : IRuntimeAssemblyLoadStr
 
         if (!Path.IsPathRooted(absolutePath))
             Thrower.Argument(nameof(absolutePath), $"Assembly locator returned non-absolute path '{absolutePath}'.");
+
+        EnsureResolvingHandlerRegistered();
 
         return AssemblyLoadContext.Default.LoadFromAssemblyPath(absolutePath);
     }

--- a/UniversalToolchain/UniversalToolchain.Wist/README.md
+++ b/UniversalToolchain/UniversalToolchain.Wist/README.md
@@ -1,95 +1,68 @@
 # UniversalToolchain.Wist
 
-A compiler-first Wist facade for .NET formula execution.
+**Tiny controlled rules for .NET applications.**
 
-This package is the intended first-contact API for .NET developers. It hides the compiler pipeline, dialect runtime host,
-manifests, `DynamicMethod`, `IAbstractIR`, and session APIs behind a small facade.
+`UniversalToolchain.Wist` is the first-contact package for UniversalToolchain. It gives .NET applications a small facade for restricted formula execution without exposing the lower-level compiler pipeline, dialect host, manifests, `DynamicMethod`, AIR, or session APIs.
 
-Compiler-first. Interpreter-supported. `Compile<TDelegate>` is the primary hot-path API. `CompileFunc` remains as a
-small compatibility convenience for one, two, and three arguments. `Evaluate` is the convenience one-off API.
+Use it when configuration starts turning into logic:
 
-## Requirements
-
-- .NET SDK `10.0.103` or a compatible prerelease SDK selected by the repository `global.json`.
-- Target framework: `net10.0`.
+```text
+admin / config / LLM suggestion
+        -> tiny rule text
+        -> restricted formula surface
+        -> validation or rejection
+        -> typed compiled delegate for hot paths
+        -> your application decides the side effect
+```
 
 ## Install
 
-The package metadata in this repository is prepared for `UniversalToolchain.Wist` `0.1.0-preview.2`. This package-first
-command works when that version is available from NuGet.org or another configured package source:
+The package metadata in this repository is prepared for `UniversalToolchain.Wist` `0.1.0-preview.2`.
 
 ```bash ci-run=false
 dotnet add package UniversalToolchain.Wist --version 0.1.0-preview.2
 ```
 
-## Fast execution: compile once, invoke many times
+Requirements:
 
-Use `Compile<TDelegate>` when the same formula is executed many times.
+- target framework: `net10.0`;
+- .NET SDK `10.0.103` or a compatible prerelease SDK accepted by the repository `global.json`.
 
-```csharp
-using UniversalToolchain.Wist;
-
-using var wist = WistEngine.CreateSafeFormulas();
-
-var formula = wist.Compile<Func<double, double, double>>(
-    "price * 0.9 + fee",
-    "price",
-    "fee");
-
-double result = formula.CompiledDelegate(100.0, 5.0);
-```
-
-`Compile<TDelegate>` compiles once and returns a typed program with backend-neutral metadata. The hot delegate path does
-not use dictionaries, anonymous-object reflection, session setup, backend strings, or boxing for typed primitive
-arguments.
-
-`CompileFunc` remains available for compatibility and small examples:
-
-```csharp
-var formula = wist.CompileFunc<double, double, double>(
-    "price * 0.9 + fee",
-    "price",
-    "fee");
-
-double result = formula.Invoke(100.0, 5.0);
-```
-
-## One-off execution with Evaluate
-
-Use `Evaluate` when a formula is executed rarely or when onboarding matters more than hot-path speed.
+## 30-second example
 
 ```csharp
 using UniversalToolchain.Wist;
 
-using var wist = WistEngine.CreateSafeFormulas();
+using var rules = WistEngine.CreateSafeFormulas();
 
-double result = wist.Evaluate<double>(
-    "price * 0.9 + fee",
-    new
-    {
-        price = 100.0,
-        fee = 5.0
-    });
+var rolloutScore = rules.Compile<Func<double, double, double, double>>(
+    "usage * 0.7 + reliability * 0.3 - incidents * 15.0",
+    "usage",
+    "reliability",
+    "incidents");
+
+double score = rolloutScore.CompiledDelegate(100.0, 90.0, 1.0);
+bool enableNewDashboard = score >= 80.0;
 ```
 
-`Evaluate` is intentionally convenient. It may inspect anonymous objects, map argument names, and run through the
-convenience execution path. It is not the primary performance path.
+The formula returns data. The host application performs the action.
 
 ## Validation without throwing
 
-Use `Validate` when a UI, import flow, or configuration pipeline needs to check a formula before execution.
+Use `Validate` before storing or executing user/admin/config-supplied formulas:
 
 ```csharp
 using UniversalToolchain.Wist;
 
-using var wist = WistEngine.CreateSafeFormulas();
+using var rules = WistEngine.CreateSafeFormulas();
 
-var validation = wist.Validate(
-    "price * 0.9 + fee",
+var validation = rules.Validate(
+    "let score = usage * 0.7\nscore",
     new
     {
-        price = 100.0,
-        fee = 5.0
+        usage = 100.0,
+        reliability = 90.0,
+        incidents = 1.0
     });
 
 if (!validation.IsValid)
@@ -98,79 +71,44 @@ if (!validation.IsValid)
 }
 ```
 
-Use `TryCompile<TDelegate>` when compilation should return diagnostics-like result data instead of throwing:
+The current safe-formula preset starts narrow. Statement-style bindings such as `let` are rejected by that restricted surface.
+
+## Hot path vs convenience path
+
+Use `Evaluate<T>` for one-off previews, admin tools, tests, and non-hot paths:
 
 ```csharp
-var compiled = wist.TryCompile<Func<double, double>>(
-    "price *",
-    "price");
+double score = rules.Evaluate<double>(
+    "usage * 0.7 + reliability * 0.3",
+    new
+    {
+        usage = 100.0,
+        reliability = 90.0
+    });
+```
 
-if (!compiled.IsSuccess)
+Use `Compile<TDelegate>` when the same formula is invoked repeatedly:
+
+```csharp
+var formula = rules.Compile<Func<double, double, double>>(
+    "usage * weight",
+    "usage",
+    "weight");
+
+for (var i = 0; i < usages.Length; i++)
 {
-    Console.WriteLine(compiled.Message);
+    results[i] = formula.CompiledDelegate(usages[i], weights[i]);
 }
 ```
 
-## Rule of thumb
+Rule of thumb:
 
 ```text
 Use Evaluate for one-off execution.
 Use Compile<TDelegate> for hot paths.
 Compilation is expensive.
-Invocation is fast.
+Invocation is the performance-oriented path.
 ```
-
-Avoid this in production hot loops:
-
-```csharp
-for (var i = 0; i < prices.Length; i++)
-{
-    results[i] = wist.Evaluate<double>(
-        "price * 0.9 + fee",
-        new { price = prices[i], fee = fees[i] });
-}
-```
-
-Prefer this:
-
-```csharp
-var formula = wist.Compile<Func<double, double, double>>(
-    "price * 0.9 + fee",
-    "price",
-    "fee");
-
-for (var i = 0; i < prices.Length; i++)
-{
-    results[i] = formula.CompiledDelegate(prices[i], fees[i]);
-}
-```
-
-## Compiler backend and interpreter backend
-
-The compiler backend is the default performance-oriented path for `CompileFunc` and convenience evaluation. The
-interpreter backend remains important for diagnostics, debugging, fallback, education, semantic parity, and backend/module
-development.
-
-The interpreter is not the main performance claim.
-
-## Performance model
-
-Cold path:
-
-```text
-source -> parse -> bind -> runtime selection -> compile/execute
-```
-
-Hot path:
-
-```text
-compiled typed function -> Invoke(arg0, arg1, ...)
-```
-
-The performance claim belongs to compiled typed CIL-backed invocation. It does not apply to `Evaluate`, compile time,
-every possible dialect, every module combination, or every backend.
-
-Do not benchmark `Evaluate` inside a tight loop when evaluating runtime throughput. Benchmark compiled `Invoke`.
 
 ## Presets
 
@@ -184,40 +122,22 @@ WistEngine.CreateBusinessRules();
 WistEngine.CreateTrusted();
 ```
 
-`CreateRestrictedArithmetic` is the recommended first-contact preset for restricted formula scenarios. It maps to the
-shipped `pricing-restricted` profile in this preview.
+`CreateRestrictedArithmetic` is the recommended first-contact preset for restricted formulas. `CreateSafeFormulas` remains a compatibility alias for it.
 
-`CreateFullNativePreview` maps to the broad native Wist preview profile. It is useful for trusted full-language Wist
-experiments, not for untrusted input.
+`CreateFullNativePreview`, `CreateBusinessRules`, and `CreateTrusted` are broad trusted-preview entry points in this preview. Do not use them for arbitrary untrusted input.
 
-`CreateSafeFormulas` remains a compatibility alias for `CreateRestrictedArithmetic`.
+## Security and trust
 
-`CreateBusinessRules` and `CreateTrusted` remain compatibility aliases for `CreateFullNativePreview` in this preview.
-They do not represent a separate stable business-rules runtime or a hardened trust boundary.
-
-`Safe` means a restricted language/runtime surface. It does not mean arbitrary untrusted code is safe to execute inside
-the current process.
-
-## Security note
-
-Restricted presets limit the selected language surface. They are not a hardened sandbox for arbitrary untrusted code.
-Compiled execution is a performance feature, not a sandbox boundary. Treat untrusted script execution as high risk and
-isolate it at the process/environment level when needed.
+Restricted presets limit the selected language/runtime surface. They are not hardened sandboxes for arbitrary untrusted code. Compiled execution is a performance feature, not a sandbox boundary. Treat untrusted script execution as high risk and isolate it at the process/environment level when needed.
 
 ## Current preview scope
 
-This initial facade intentionally exposes only:
+This facade currently exposes:
 
 - convenience `Evaluate<T>`;
-- validation without throwing;
+- non-throwing `Validate`;
 - typed fast `Compile<TDelegate>` and `TryCompile<TDelegate>`;
 - typed fast `CompileFunc` compatibility overloads for one, two, and three arguments;
 - backend-neutral compiled program metadata.
 
-Current preview contracts may change. Reusable object/session-based compiled artifacts, richer diagnostics, custom
-function registration, dialect builder APIs, and lower-level pass authoring APIs can evolve after this facade shape is
-validated.
-
-
-Use `WistEngine` for application-level formula execution.
-Use `WistRuntimeFacadeBuilder` only when working with lower-level Wist runtime or dialect integration scenarios.
+The larger direction is controlled application DSLs for .NET. The current stable preview claim is restricted numeric/formula execution, validation, and typed compiled invocation for supported shapes.

--- a/docs/reference/runtime-profiles.md
+++ b/docs/reference/runtime-profiles.md
@@ -42,11 +42,11 @@ Profiles can provide:
 
 | Default | Dialect directive emitted when missing |
 |---|---|
-| modules | `use <module>` |
-| backends | `backend <backend>` |
-| optimizers | `enable optimizer <optimizer> for any` |
-| security | `security <profile>` |
-| capabilities | `capability <name> = <true|false>` |
+| modules | `use {module}` |
+| backends | `backend {backend}` |
+| optimizers | `enable optimizer {optimizer} for any` |
+| security | `security {profile}` |
+| capabilities | `capability {name} = true/false` |
 
 The applicator records provenance for every source and profile directive. Strict mode reports conflicts such as a source
 excluding a module that the selected profile would add.

--- a/readme.md
+++ b/readme.md
@@ -1,73 +1,138 @@
 # UniversalToolchain
 
-Build formulas, embeddable DSLs, and restricted mini-languages for .NET applications.
+**Do not execute AI-generated code. Execute tiny rules in a language your .NET app controls.**
 
-UniversalToolchain is an embeddable .NET DSL/runtime framework for the moment when a plain expression evaluator is no
-longer enough.
+UniversalToolchain is a compiler/runtime framework for restricted formulas and application DSLs.
 
-Wist is the reference language in this repository. `UniversalToolchain.Wist` is the intended first-contact facade for
-.NET developers who want formula execution without starting from the lower-level runtime contracts.
+Start with small numeric rules. Validate them before execution. Interpret them when diagnostics matter. Compile hot paths into typed .NET delegates when throughput matters.
 
-**Compiler-first. Interpreter-supported.**
+```text
+admin / config / LLM suggestion
+        -> tiny rule text
+        -> restricted Wist formula surface
+        -> validation or rejection
+        -> interpreter for diagnostics
+        -> CIL-backed typed delegate for hot paths
+        -> your application decides the side effect
+```
 
-Wist can compile selected formula code into typed CIL-backed execution paths. The performance-oriented path is
-compiled typed invocation, not full convenience evaluation.
+Wist is the reference language in this repository. `UniversalToolchain.Wist` is the first-contact facade for .NET developers.
 
-## Current release scope
+## 30-second demo
 
-This repository state is positioned as a scoped public preview of the Wist facade and runtime foundations, not as a
-finalized 1.0 platform. The releaseable claim is formula evaluation, validation, restricted/full shipped Wist presets,
-CLI smoke coverage, package smoke coverage, and typed compiled invocation for supported shapes.
+A product manager, admin UI, config file, or LLM can suggest a rollout score formula:
 
-Neutral runtime host extraction, structured JSON trace, FunctionCalls/SafeMath, and the SSA route are active foundations
-with documented preview limits. They are not advertised here as a stable standalone runtime package family, a full trace
-viewer, a complete function authoring system, or a production SSA optimizer/backend layer.
+```text
+usage * 0.7 + reliability * 0.3 - incidents * 15.0
+```
 
-<!-- langdev-2026:start -->
+Your application owns the inputs, compiles the approved formula once, and decides what the score means:
 
-> **Featured technical story — LangDev 2026 proposal**
->
-> **Build the Language, Then Make the Abstractions Disappear: Extensible Programming on .NET**
->
-> UniversalToolchain composes language features as independent modules,
-> progressively lowers selected semantics through Bytecode and AIR into
-> concrete runtime or typed CIL operations, and checks that interpreter
-> and compiled execution preserve one language.
->
-> [Read the proposal and run the reproducible demo](docs/talks/langdev-2026/README.md)
+```csharp
+using UniversalToolchain.Wist;
 
-### Why this is interesting
+using var rules = WistEngine.CreateSafeFormulas();
 
-- Language features remain modular while the language is being constructed.
-- For supported compiled paths, per-operation module dispatch is removed from the prepared hot invocation path.
-- Typed CIL is handed to the .NET JIT for further optimization.
-- Cross-backend parity tests guard against one DSL silently becoming two languages.
-- Current benchmarks are split into hot prepared execution, convenience `Evaluate`, and cold compilation stories; publish numbers only with raw BenchmarkDotNet artifacts and environment metadata.
+var rolloutScore = rules.Compile<Func<double, double, double, double>>(
+    "usage * 0.7 + reliability * 0.3 - incidents * 15.0",
+    "usage",
+    "reliability",
+    "incidents");
 
-**Conference evidence:** [one-command demo](docs/talks/langdev-2026/README.md#reproducible-command) · [module-to-CIL lowering](docs/talks/langdev-2026/lowering-walkthrough.md) · [semantic-parity regression](docs/talks/langdev-2026/parity-regression.md) · [benchmarks and limitations](docs/talks/langdev-2026/benchmark-evidence.md)
+double score = rolloutScore.CompiledDelegate(100.0, 90.0, 1.0);
+bool enableNewDashboard = score >= 80.0;
+```
 
-<!-- langdev-2026:end -->
+The rule returns data. Your .NET application performs the action.
 
-## Requirements
+## The important part: rejection before execution
 
-- .NET SDK `10.0.103` or a compatible prerelease SDK selected by `UniversalToolchain/global.json`.
-- Target framework: `net10.0`.
-- SDK policy: `rollForward: latestMajor`, `allowPrerelease: true`.
+The preview safe-formula profile intentionally starts narrow. Statement-style bindings are not part of that restricted surface:
 
-## Install from NuGet
+```csharp
+using UniversalToolchain.Wist;
 
-The package metadata in this repository is prepared for `UniversalToolchain.Wist` `0.1.0-preview.2`. The package-first
-command works when that version is available from NuGet.org or another configured package source:
+using var rules = WistEngine.CreateSafeFormulas();
+
+var validation = rules.Validate(
+    "let score = usage * 0.7\nscore",
+    new
+    {
+        usage = 100.0,
+        reliability = 90.0,
+        incidents = 1.0
+    });
+
+Console.WriteLine(validation.IsValid); // false
+Console.WriteLine(validation.Message); // Feature 'let' is not enabled by this preset.
+```
+
+That is the core product idea: your app does not accept an arbitrary programming language just because somebody wants configurable logic.
+
+## Why this exists
+
+Most applications eventually move through this path:
+
+```text
+hardcoded C# logic
+        -> configurable formulas
+        -> user/admin/LLM-suggested rules
+        -> restricted application DSL
+        -> compiled hot path
+```
+
+Without a language/runtime layer, teams usually choose one of two bad extremes:
+
+- encode logic as unreadable JSON trees;
+- expose a broad scripting language and hope nothing surprising happens.
+
+UniversalToolchain is for the middle ground: a language surface your application can own.
+
+## What is real in this preview
+
+The current public preview is intentionally scoped:
+
+| Capability | Current status |
+|---|---|
+| `WistEngine` facade | available in `UniversalToolchain.Wist` |
+| Restricted arithmetic/formula preset | available through `CreateSafeFormulas()` / `CreateRestrictedArithmetic()` |
+| One-off evaluation | available through `Evaluate<T>()` |
+| Non-throwing validation | available through `Validate()` and `TryCompile<TDelegate>()` |
+| Typed compiled hot path | available through `Compile<TDelegate>()` and `CompileFunc(...)` |
+| Interpreter backend | available for diagnostics, fallback, and semantic parity work |
+| Dialect composition | available through shipped `.wistdialect` profiles and lower-level APIs |
+| Full business-rule DSL | direction, not a stable 1.0 claim |
+| Hardened sandboxing | not claimed |
+
+## Install
+
+The package metadata in this repository is prepared for `UniversalToolchain.Wist` `0.1.0-preview.2`.
 
 ```bash ci-run=false
 dotnet add package UniversalToolchain.Wist --version 0.1.0-preview.2
 ```
 
-For the current repository state, the source workflow below is the authoritative path.
+For the current repository state, source checkout is still the authoritative path.
+
+Requirements:
+
+- .NET SDK `10.0.103` or a compatible prerelease SDK selected by `UniversalToolchain/global.json`.
+- Target framework: `net10.0`.
+- SDK policy: `rollForward: latestMajor`, `allowPrerelease: true`.
+
+## Run the included formula demo
+
+From the repository root:
+
+```bash ci-timeout=240
+dotnet run --project UniversalToolchain/Example/Example.csproj
+```
+
+The current demo exercises formula execution through shipped Wist profiles. It shows compiler, interpreter and fast native invocation paths plus rejection of a formula shape that the restricted dialect composition does not allow.
 
 ## Fast path: compile once, invoke many times
 
-Use `WistEngine.Compile<TDelegate>` for code that will be invoked repeatedly:
+Use `Compile<TDelegate>` when a formula is invoked repeatedly:
 
 ```csharp
 using UniversalToolchain.Wist;
@@ -75,22 +140,23 @@ using UniversalToolchain.Wist;
 using var wist = WistEngine.CreateSafeFormulas();
 
 var formula = wist.Compile<Func<double, double, double>>(
-    "price * 0.9 + fee",
-    "price",
-    "fee");
+    "usage * weight",
+    "usage",
+    "weight");
 
-double result = formula.CompiledDelegate(100.0, 5.0);
+double result = formula.CompiledDelegate(100.0, 0.7);
 ```
 
 This is the intended hot path:
 
 - compile once;
-- invoke many times;
+- keep the returned program;
+- invoke the typed delegate repeatedly;
 - benchmark compiled delegate invocation, not `Evaluate` in a tight loop.
 
 ## One-off Evaluate
 
-Use `Evaluate` for one-off execution, onboarding, tests, validation UI, admin tools, and non-hot paths:
+Use `Evaluate` for onboarding, admin previews, tests, validation UI, and non-hot paths:
 
 ```csharp
 using UniversalToolchain.Wist;
@@ -98,38 +164,15 @@ using UniversalToolchain.Wist;
 using var wist = WistEngine.CreateSafeFormulas();
 
 double result = wist.Evaluate<double>(
-    "price * 0.9 + fee",
+    "usage * 0.7 + reliability * 0.3",
     new
     {
-        price = 100.0,
-        fee = 5.0
+        usage = 100.0,
+        reliability = 90.0
     });
 ```
 
-`Evaluate` is for convenience. It is not the primary performance path.
-
-## Validation
-
-Use `Validate` when a UI, import flow, or configuration pipeline needs non-throwing validation before execution:
-
-```csharp
-using UniversalToolchain.Wist;
-
-using var wist = WistEngine.CreateSafeFormulas();
-
-var validation = wist.Validate(
-    "price * 0.9 + fee",
-    new
-    {
-        price = 100.0,
-        fee = 5.0
-    });
-
-if (!validation.IsValid)
-{
-    Console.WriteLine(validation.Message);
-}
-```
+`Evaluate` is a convenience path. It is not the primary performance claim.
 
 ## Presets
 
@@ -145,52 +188,68 @@ using var businessRules = WistEngine.CreateBusinessRules();
 using var trusted = WistEngine.CreateTrusted();
 ```
 
-`CreateRestrictedArithmetic` is the recommended first-contact preset. It maps to the shipped `pricing-restricted` profile.
+`CreateRestrictedArithmetic` is the recommended first-contact preset. It maps to the shipped `pricing-restricted` profile in this preview.
+
 `CreateFullNativePreview` maps to the broad native Wist preview profile and must not be used for untrusted input.
 
-`CreateSafeFormulas` remains a compatibility alias for `CreateRestrictedArithmetic`. `CreateBusinessRules` and
-`CreateTrusted` remain compatibility aliases for `CreateFullNativePreview`; they do not represent a separate stable
-business-rules runtime or a hardened trust boundary.
+`CreateSafeFormulas` remains a compatibility alias for `CreateRestrictedArithmetic`. `CreateBusinessRules` and `CreateTrusted` remain compatibility aliases for `CreateFullNativePreview`; they do not represent a separate stable business-rules runtime or a hardened trust boundary.
 
-`Safe` means a restricted language/runtime surface. It does not mean arbitrary untrusted code is safe to execute inside
-the current process.
+## What this is not
 
-## Interpreter backend
+UniversalToolchain is not:
 
-The interpreter is a correctness, diagnostics, debugging, fallback, and semantic parity backend. The performance-oriented
-path is compiled typed CIL-backed invocation.
+- a hardened sandbox for arbitrary untrusted code;
+- a replacement for C#;
+- a finished general-purpose language workbench;
+- only a calculator;
+- only a parser generator.
 
-## Security and trust
+Restricted presets and dialects limit selected language/runtime surface. They are not process isolation, resource isolation, or a security boundary by themselves. For untrusted execution, use process/environment isolation with appropriate OS permissions and resource limits. See [docs/SECURITY.md](docs/SECURITY.md).
 
-Restricted presets and dialects limit selected language/runtime surface. They are not hardened sandboxes, and compiled
-execution is a performance feature rather than a sandbox boundary. For untrusted code, use process/environment isolation
-with appropriate OS permissions and resource limits. See [docs/SECURITY.md](docs/SECURITY.md).
+## When to use UniversalToolchain
 
-## Run the pricing demo
+Use it when:
 
-```bash
-dotnet run --project UniversalToolchain/Example/Example.csproj
+- JSON configuration is starting to become logic;
+- expression evaluators are too small for the direction of your product;
+- C# scripting is too broad for the surface you want to expose;
+- you want user/admin/LLM-suggested formulas to pass through validation before execution;
+- you need both interpreter and compiler paths for the same language surface;
+- you want configurable .NET logic without hardcoding every formula into the application.
+
+Typical scenarios:
+
+- scoring and rollout formulas;
+- alerting and monitoring formulas;
+- workflow decision scores;
+- LMS/autograding scores;
+- pricing and commission formulas;
+- restricted DSL experiments inside .NET applications.
+
+## Architecture at a glance
+
+```text
+Source
+  -> Lexer / Parser
+  -> AST
+  -> Bytecode
+  -> AIR
+  -> Optimizers
+  -> Compiler / Interpreter
+  -> Execution
 ```
 
-This runs a pricing formula through hardcoded C#, the shipped `full-default-native` Wist preset, and the shipped
-`pricing-restricted` dialect. It shows the same calculation executed through compiler, interpreter, and fast native
-invocation paths, plus rejection of a formula that the restricted dialect composition does not allow.
+Key project ideas:
 
-Code: [UniversalToolchain/Example/Scenarios/PricingDiscountScenario.cs](UniversalToolchain/Example/Scenarios/PricingDiscountScenario.cs) and [UniversalToolchain/Example/Scenarios/DslPricingCalculator.cs](UniversalToolchain/Example/Scenarios/DslPricingCalculator.cs).
+- framework-first, composition-based pipeline design;
+- Wist as the reference language, not the only product direction;
+- dialect-driven runtime composition through `.wistdialect` files;
+- dual backend model: `compiler` and `interpreter`;
+- semantic parity checks so one DSL does not silently become two languages.
 
-## What this demo shows
+## CLI quick start
 
-The pricing demo compares three ways to own the same pricing calculation:
-
-- hardcoded C# pricing logic,
-- the shipped `full-default-native` Wist preset for the formula,
-- a restricted pricing dialect with a narrower runtime surface,
-- compiler, interpreter, and fast native invocation paths for the same calculation,
-- rejection of a formula shape that the restricted dialect composition does not allow.
-
-## Tiny CLI quick start
-
-```bash
+```bash ci-timeout=240
 dotnet run --project UniversalToolchain/Wistc/Wistc.csproj -- run --eval "(2 + 2) * 3" --backend compiler
 ```
 
@@ -198,187 +257,6 @@ Expected output:
 
 ```text
 12
-```
-
-## Advanced runtime integration example
-
-Use `WistRuntimeFacadeBuilder` only for advanced/lower-level Wist runtime and dialect integration scenarios.
-
-```csharp
-using UniversalToolchain.Dialects.Wist.Presets;
-
-using var wist = WistRuntimeFacadeBuilder
-    .CreateDefault()
-    .WithShippedDialectPreset(WistShippedDialectPresets.PricingRestricted)
-    .Build();
-
-var attempt = wist.TryCompile(
-    """
-    let discount = 0.9
-    price * discount + fee
-    """,
-    new Dictionary<string, Type>
-    {
-        ["price"] = typeof(double),
-        ["fee"] = typeof(double)
-    },
-    backend: "interpreter");
-```
-
-## When to use UniversalToolchain
-
-Use UniversalToolchain when:
-
-- a normal expression evaluator is too narrow for your formulas or DSL code,
-- users need a syntax that matches your domain instead of C# syntax,
-- you need a dialect profile that allows only selected language features,
-- the same language should support compiler and interpreter backend aliases,
-- you need an inspectable execution pipeline for validation, diagnostics, or backend work,
-- you want configurable business logic without hardcoding every formula or policy into the application.
-
-Typical scenarios include pricing formulas, routing policies, internal workflow calculations, and DSL experiments inside
-.NET applications.
-
-## When not to use UniversalToolchain
-
-Do not start here when:
-
-- you only need trivial arithmetic formulas,
-- you only need a subset of C# expressions,
-- you only need parser generation,
-- you do not need a DSL or runtime story,
-- a simple library call can already evaluate all formulas or policies you plan to support.
-
-For those cases, a smaller evaluator, a rules library, or a parser generator is usually easier to own.
-
-## Comparison
-
-For a practical positioning guide against the nearest alternatives, see [UniversalToolchain vs Nearby Alternatives](docs/alternatives.md).
-
-At a high level:
-
-- **NCalc / Dynamic Expresso** are strong when you only need expression evaluation.
-- **RulesEngine** is strong when you need JSON-defined business rules in a .NET application.
-- **ANTLR / csly / Irony** are strong when parser construction is the main problem.
-- **JetBrains MPS** is strong when the target is a full language workbench with richer tooling.
-- **UniversalToolchain** becomes relevant when you need a restricted, embeddable DSL/runtime stack for .NET rather than only a parser, evaluator, or workbench.
-
-## Why this project exists
-
-Many language projects repeatedly rebuild the same layers: parsing, AST/IR transforms, runtime composition, and execution. UniversalToolchain focuses on reusable composition so capabilities can be assembled from modules instead of hardcoded into one implementation path. See [Why this exists](docs/why-this-exists.md) for the longer product and architecture rationale.
-
-This repository contains:
-
-- **UniversalToolchain**: reusable framework infrastructure.
-- **Wist**: a reference language used to validate and evolve the framework architecture.
-
-For a stable project map, see [Global project overview](docs/global-project-overview.md). For a stricter boundary between framework, reference language, and current limitations, see [Project positioning](docs/project-positioning.md). For an external-style evaluative architecture review, see [Technical due diligence review](docs/reviews/technical-due-diligence.md).
-
-## Architecture at a glance
-
-At a high level:
-
-```text
-Source -> Lexer/Parser -> AST -> Bytecode -> AIR -> Optimization -> Compiler/Interpreter -> Execution
-```
-
-Key repository architecture concepts:
-
-- framework-first, composition-based pipeline design,
-- dual backends (`compiler`, `interpreter`),
-- dialect-driven runtime composition via `.wistdialect` files,
-- manifest-backed runtime selection before host creation,
-- bytecode/AIR as semantic pipeline layers,
-- CLI and programmatic entry points for validation and integration.
-
-## Canonical Wist runtime path
-
-Normal Wist dialect execution follows this path:
-
-```text
-dialect source -> dialect compilation -> build plan -> manifest-backed runtime selection -> host creation -> execution
-```
-
-Composition and host creation are separate stages. `ComposeText`/`ComposeFile` compile the dialect DSL, build a
-deterministic plan, and resolve selected modules, optimizers, and backends from runtime manifests. `CreateHost` then
-builds the runtime provider for that resolved selection and activates only the selected backend registrars.
-
-The selection-driven path is the main dialect execution story. Runtime activation in that path uses targeted, exact loading
-of selected runtime component and registrar types from manifests. Shipped profiles do not require explicit backend imports in
-normal CLI, facade, or example usage. Broad eager discovery and compatibility helpers still exist, but they are not the
-canonical path for running shipped dialect profiles.
-
-## How features plug into the pipeline
-
-Framework features are introduced through extension points instead of one monolithic compiler path.
-
-For example, a frontend module can participate in several stages:
-
-- text preprocessing,
-- lexer initialization,
-- lexeme post-processing,
-- parser initialization,
-- AST post-processing,
-- bytecode post-processing,
-- AST-to-bytecode translator initialization.
-
-Module authoring is convention-heavy. Before adding or changing modules, read [Module authoring guide](docs/guides/module-authoring.md) and [Module contracts](docs/contracts/module-contracts.md).
-
-## CLI usage (`Wistc`)
-
-Available verbs:
-
-- `run`
-- `repl`
-- `dialect-inspect`
-- `dialect-demo`
-- `features`
-
-Common options:
-
-- `--backend <compiler|interpreter>`
-- `--dialect-file <path>`
-- `--list-modules`
-
-`run` options:
-
-- `--file <path>`
-- `--eval`
-
-`dialect-demo` options:
-
-- `--file <path>`
-- `--scenario <valid|invalid-syntax|semantic-conflict|unresolved-module>`
-
-The user-facing `compiler` backend alias selects the canonical `cil` backend when a dialect declares `backend cil` or the
-`compiler` alias. `--eval` is a flag; the source expression itself is passed as the positional code argument.
-
-Examples:
-
-```bash ci-timeout=240
-# Run a .wist file with an explicit dialect definition
-dotnet run --project UniversalToolchain/Wistc/Wistc.csproj -- run --dialect-file UniversalToolchain/Dialects/examples/wist/full-default/dialect.wistdialect --file UniversalToolchain/Dialects/examples/wist/full-default/program.wist --backend interpreter
-
-# Evaluate one expression
-dotnet run --project UniversalToolchain/Wistc/Wistc.csproj -- run --eval "(2 + 2) * 3" --backend compiler
-```
-
-```bash ci-run=false
-# Start REPL
-dotnet run --project UniversalToolchain/Wistc/Wistc.csproj -- repl --backend compiler
-```
-
-## Dialect usage
-
-```bash ci-timeout=240
-# Run code with a dialect definition
-dotnet run --project UniversalToolchain/Wistc/Wistc.csproj -- run --dialect-file UniversalToolchain/Dialects/examples/wist/full-default/dialect.wistdialect --file UniversalToolchain/Dialects/examples/wist/full-default/program.wist --backend interpreter
-
-# Inspect a dialect file
-dotnet run --project UniversalToolchain/Wistc/Wistc.csproj -- dialect-inspect --file UniversalToolchain/Dialects/examples/wist/full-default/dialect.wistdialect
-
-# Run the dialect demo workflow
-dotnet run --project UniversalToolchain/Wistc/Wistc.csproj -- dialect-demo --file UniversalToolchain/Dialects/examples/wist/full-default/dialect.wistdialect
 ```
 
 ## Dialect examples
@@ -390,78 +268,43 @@ Located under `UniversalToolchain/Dialects/examples/wist`:
 - `function-calls-safe-math`: neutral FunctionCalls + SafeMath profile without rule declarations.
 - `minimal-arithmetic`: smallest interpreter arithmetic profile.
 - `minimal-arithmetic-native`: smallest native arithmetic profile over `cil`.
-- `pricing-restricted`: composition-constrained pricing profile with a restricted runtime surface.
+- `pricing-restricted`: composition-constrained formula profile with a restricted runtime surface.
 - `restricted-sandbox`: composition-constrained profile, not a hardened sandbox guarantee.
 
-These directories are runnable canonical references for the manifest-driven dialect path. Each README includes
-repository-root CLI commands, expected behavior, and the capabilities intentionally excluded by that profile.
+## Technical story
 
-Public dialect documentation should follow the `.wistdialect` shape used by these shipped profiles. Secondary parser experiments must not be treated as the runtime dialect contract unless the runtime path is intentionally migrated to them.
+UniversalToolchain also has a compiler/runtime research angle: language features are composed as modules, selected semantics lower through Bytecode and AIR, and supported hot paths become typed CIL operations handed to the .NET JIT.
 
-## Why .NET 10 right now?
+Conference-oriented material:
 
-The current validation baseline is .NET 10 (`net10.0`) with SDK `10.0.103`.
-Active runtime and backend work is being verified there first, so older target frameworks are not the current compatibility target.
+- [LangDev 2026 proposal](docs/talks/langdev-2026/README.md)
+- [Module-to-CIL lowering walkthrough](docs/talks/langdev-2026/lowering-walkthrough.md)
+- [Semantic parity regression](docs/talks/langdev-2026/parity-regression.md)
+- [Benchmark evidence and limitations](docs/talks/langdev-2026/benchmark-evidence.md)
 
 ## Build and test from source
 
 From repository root:
 
 ```bash ci-run=false
-dotnet restore UniversalToolchain/Wist.sln
-dotnet build UniversalToolchain/Wist.sln -c Release --no-restore
-dotnet test UniversalToolchain/Tests/Tests.csproj -c Release --no-build
-dotnet test UniversalToolchain/UniversalToolchain.Modules.Tests/UniversalToolchain.Modules.Tests.csproj -c Release --no-build
-dotnet test UniversalToolchain/UniversalToolchain.Dialects.Tests/UniversalToolchain.Dialects.Tests.csproj -c Release --no-build
+dotnet restore UniversalToolchain/Wist.sln -p:Platform="Any CPU"
+dotnet build UniversalToolchain/Wist.sln -c Release --no-restore -p:Platform="Any CPU"
+dotnet test UniversalToolchain/Wist.sln -c Release --no-build -p:Platform="Any CPU"
 ```
 
-## Security note
+## Documentation map
 
-The repository does **not** claim hardened sandboxing for untrusted code. Use process/environment isolation for
-untrusted execution scenarios.
-See [docs/SECURITY.md](docs/SECURITY.md) for the trust model.
-
-## Known limitations
-
-This repository is actively evolving, and some areas are intentionally treated as design-in-progress:
-
-- some bootstrap/runtime wiring is still concrete rather than fully descriptor-driven,
-- reflection-based interop/discovery helpers still exist for compatibility and bootstrap scenarios,
-- constrained dialect composition is not equivalent to hardened sandboxing,
-- bytecode tags and module authoring contracts are being formalized,
-- backend-agnostic artifact handling is still an active architecture area,
-- the reference language Wist is still the main proving ground for framework decisions.
-
-See [Current limitations](docs/limitations.md) for the explicit limitation and wording guide.
-
-## Canonical documentation map
-
-- Project overview: [readme.md](readme.md)
-- Global project overview: [docs/global-project-overview.md](docs/global-project-overview.md)
-- Project positioning and public wording: [docs/project-positioning.md](docs/project-positioning.md)
+- Start: [docs/index.md](docs/index.md)
+- Installation: [docs/start/installation.md](docs/start/installation.md)
+- First program: [docs/start/first-program.md](docs/start/first-program.md)
+- Project positioning: [docs/project-positioning.md](docs/project-positioning.md)
 - Performance model: [docs/public/performance-model.md](docs/public/performance-model.md)
 - Preview stability: [docs/public/what-is-stable-in-preview.md](docs/public/what-is-stable-in-preview.md)
 - Current limitations: [docs/limitations.md](docs/limitations.md)
-- Technical due diligence review: [docs/reviews/technical-due-diligence.md](docs/reviews/technical-due-diligence.md)
-- Current runtime pipeline: [docs/current-canonical-runtime-pipeline.md](docs/current-canonical-runtime-pipeline.md)
-- Runtime manifest activation model: [docs/runtime-manifest-activation-model.md](docs/runtime-manifest-activation-model.md)
-- Runtime manifest format: [docs/runtime-manifest-format.md](docs/runtime-manifest-format.md)
-- Bytecode and AIR architecture: [docs/architecture/bytecode-and-air.md](docs/architecture/bytecode-and-air.md)
-- Backend and semantic parity contracts: [docs/architecture/backends-and-parity.md](docs/architecture/backends-and-parity.md)
-- Module authoring guide: [docs/guides/module-authoring.md](docs/guides/module-authoring.md)
-- Module hidden contracts: [docs/contracts/module-contracts.md](docs/contracts/module-contracts.md)
 - Architecture guardrails: [docs/ARCHITECTURE_RULES.md](docs/ARCHITECTURE_RULES.md)
-- Why this exists: [docs/why-this-exists.md](docs/why-this-exists.md)
-- Nearby alternatives: [docs/alternatives.md](docs/alternatives.md)
-- Coding standards: [docs/PROJECT_RULES.md](docs/PROJECT_RULES.md)
 - Contribution workflow: [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md)
 - Security policy: [docs/SECURITY.md](docs/SECURITY.md)
 
 ## License
 
 Licensed under Apache License 2.0. See [LICENSE](LICENSE).
-
-
-## Development validation
-
-See [RELEASE_CHECKLIST.md](RELEASE_CHECKLIST.md) for required release commands and manual smoke checks.


### PR DESCRIPTION
## Summary

This PR keeps the first-impression rewrite focused on the two public surfaces that matter most before broader docs work:

- root `readme.md`;
- `UniversalToolchain/UniversalToolchain.Wist/README.md` for package/NuGet first contact.

New positioning:

> Do not execute AI-generated code. Execute tiny rules in a language your .NET app controls.

## Scope / guardrails

- Claims stay scoped to current preview capabilities: restricted numeric/formula execution, validation, and typed compiled invocation.
- Does not claim stable object/string feature-rule DSLs yet.
- Does not claim hardened sandboxing.
- Keeps side effects app-owned: Wist computes a value; the host application decides what to do.

## Why this PR is small

A broader PR with VitePress docs and runnable example changes was closed because Docs Check failed and the available connector logs did not expose the tail needed for precise VitePress diagnosis. This version avoids `docs/**` changes and keeps the GitHub/NuGet first-contact copy aligned without blocking on the docs site.