### PR TITLE
ssa: add preview-safe optimization passes

### DIFF
--- a/UniversalToolchain/Tests/Ssa/SsaPreviewSafeOptimizationPassTests.cs
+++ b/UniversalToolchain/Tests/Ssa/SsaPreviewSafeOptimizationPassTests.cs
@@ -1,0 +1,176 @@
+using UniversalToolchain.Ir.Abstractions;
+using UniversalToolchain.Semantics.Abstractions;
+using UniversalToolchain.Ssa.Abstractions;
+using UniversalToolchain.Ssa.Optimization;
+
+namespace Tests.Ssa;
+
+public sealed class SsaPreviewSafeOptimizationPassTests
+{
+    [Test]
+    public void ConstantMaterializerAndReaderRoundTripFloat64()
+    {
+        var result = new SsaValue(new SsaValueId("v0"), SsaTypes.Float64);
+        var operation = SsaConstantMaterializer.Float64(new SsaOperationId("op0"), result, 1.25d);
+
+        Assert.That(SsaConstantReader.TryRead(operation, out var constant), Is.True);
+        Assert.That(constant.Type, Is.EqualTo(SsaPreviewSemanticTypes.Float64));
+        Assert.That(constant.CanonicalValue, Is.EqualTo("1.25"));
+    }
+
+    [Test]
+    public void DeadPureInstructionEliminationRemovesUnusedConstants()
+    {
+        var dead = new SsaValue(new SsaValueId("dead"), SsaTypes.Int32);
+        var live = new SsaValue(new SsaValueId("live"), SsaTypes.Int32);
+        var block = new SsaBlock(
+            new SsaBlockId("entry"),
+            instructions:
+            [
+                SsaConstantMaterializer.Int32(new SsaOperationId("dead.op"), dead, 10),
+                SsaConstantMaterializer.Int32(new SsaOperationId("live.op"), live, 20)
+            ],
+            terminator: SsaTerminator.Return([live.Id]));
+
+        var optimized = Run(
+            new SsaDeadPureInstructionEliminationPass(),
+            ModuleWith(block));
+
+        var optimizedBlock = optimized.Functions.Single().Blocks.Single();
+        Assert.That(optimizedBlock.Instructions.Select(static x => x.Id.Value), Is.EqualTo(new[] { "live.op" }));
+    }
+
+    [Test]
+    public void DeadPureInstructionEliminationKeepsValuesUsedAcrossBlocks()
+    {
+        var transferred = new SsaValue(new SsaValueId("transferred"), SsaTypes.Int32);
+        var entry = new SsaBlock(
+            new SsaBlockId("entry"),
+            instructions:
+            [
+                SsaConstantMaterializer.Int32(new SsaOperationId("transferred.op"), transferred, 42)
+            ],
+            terminator: SsaTerminator.Jump(new SsaBlockId("exit"), [transferred.Id]));
+        var exitParameter = new SsaBlockParameter(new SsaValue(new SsaValueId("exit.arg"), SsaTypes.Int32));
+        var exit = new SsaBlock(
+            new SsaBlockId("exit"),
+            parameters: [exitParameter],
+            terminator: SsaTerminator.Return([exitParameter.Value.Id]));
+
+        var optimized = Run(
+            new SsaDeadPureInstructionEliminationPass(),
+            ModuleWith(entry, exit));
+
+        var optimizedEntry = optimized.Functions.Single().Blocks.Single(block => block.Id.Value == "entry");
+        Assert.That(optimizedEntry.Instructions.Select(static x => x.Id.Value), Is.EqualTo(new[] { "transferred.op" }));
+    }
+
+    [Test]
+    public void DeadPureInstructionEliminationKeepsUnknownCalls()
+    {
+        var result = new SsaValue(new SsaValueId("result"), SsaTypes.Int32);
+        var call = new SsaCall(
+            new SsaOperationId("call"),
+            new CallableId("unknown.call"),
+            results: [result]);
+        var block = new SsaBlock(
+            new SsaBlockId("entry"),
+            instructions: [call],
+            terminator: SsaTerminator.Return());
+
+        var optimized = Run(
+            new SsaDeadPureInstructionEliminationPass(),
+            ModuleWith(block));
+
+        Assert.That(optimized.Functions.Single().Blocks.Single().Instructions, Has.Count.EqualTo(1));
+    }
+
+    [Test]
+    public void DeadPureInstructionEliminationKeepsMayThrowCalls()
+    {
+        var descriptors = new SemanticDescriptorSet(
+            types:
+            [
+                new SemanticTypeDescriptor(SsaPreviewSemanticTypes.Int32)
+            ],
+            callables:
+            [
+                new CallableDescriptor(
+                    new CallableId("throwing.call"),
+                    new CallableSignature([], [SsaPreviewSemanticTypes.Int32]),
+                    effects: new SemanticEffectSummary([SemanticEffectKind.MayThrow]),
+                    determinism: Determinism.Deterministic,
+                    trustLevel: SemanticTrustLevel.BuiltInTrusted)
+            ]);
+        var result = new SsaValue(new SsaValueId("result"), SsaTypes.Int32);
+        var call = new SsaCall(
+            new SsaOperationId("call"),
+            new CallableId("throwing.call"),
+            results: [result]);
+        var block = new SsaBlock(
+            new SsaBlockId("entry"),
+            instructions: [call],
+            terminator: SsaTerminator.Return());
+
+        var optimized = Run(
+            new SsaDeadPureInstructionEliminationPass(SsaCoreDescriptors.ConstantMaterialization, descriptors),
+            ModuleWith(block));
+
+        Assert.That(optimized.Functions.Single().Blocks.Single().Instructions, Has.Count.EqualTo(1));
+    }
+
+    [Test]
+    public void BranchFoldingConvertsConstantBranchToJumpAndDropsUnreachableBlock()
+    {
+        var condition = new SsaValue(new SsaValueId("condition"), SsaTypes.Bool);
+        var result = new SsaValue(new SsaValueId("result"), SsaTypes.Int32);
+        var entry = new SsaBlock(
+            new SsaBlockId("entry"),
+            instructions:
+            [
+                SsaConstantMaterializer.Bool(new SsaOperationId("condition.op"), condition, true)
+            ],
+            terminator: SsaTerminator.Branch(
+                condition.Id,
+                new SsaBlockId("then"),
+                [],
+                new SsaBlockId("else"),
+                []));
+        var thenBlock = new SsaBlock(
+            new SsaBlockId("then"),
+            instructions:
+            [
+                SsaConstantMaterializer.Int32(new SsaOperationId("then.value"), result, 1)
+            ],
+            terminator: SsaTerminator.Return([result.Id]));
+        var elseBlock = new SsaBlock(
+            new SsaBlockId("else"),
+            terminator: SsaTerminator.Unreachable());
+
+        var optimized = Run(
+            new SsaBranchFoldingAndCleanupPass(),
+            ModuleWith(entry, thenBlock, elseBlock));
+
+        var blocks = optimized.Functions.Single().Blocks;
+        Assert.That(blocks.Select(static x => x.Id.Value), Is.EqualTo(new[] { "entry", "then" }));
+        Assert.That(blocks[0].Terminator?.Kind, Is.EqualTo(SsaTerminatorKind.Jump));
+        Assert.That(blocks[0].Terminator?.Transfers.Single().Target.Value, Is.EqualTo("then"));
+    }
+
+    private static SsaModule Run(IIrOptimizationPass pass, SsaModule module)
+    {
+        var result = pass.Run(new SsaArtifact(module), new IrPipelineContext());
+        return result.Artifact.As<SsaArtifact>().Module;
+    }
+
+    private static SsaModule ModuleWith(params SsaBlock[] blocks) =>
+        new(
+            new SsaModuleId("test.module"),
+            [
+                new SsaFunction(
+                    new SsaFunctionId("test.function"),
+                    new SsaBlockId("entry"),
+                    blocks,
+                    returnType: SsaTypes.Int32)
+            ]);
+}

--- a/UniversalToolchain/UniversalToolchain.Ssa.Optimization/SsaAnalysis.cs
+++ b/UniversalToolchain/UniversalToolchain.Ssa.Optimization/SsaAnalysis.cs
@@ -1,0 +1,151 @@
+using System.Collections.ObjectModel;
+using UniversalToolchain.Ssa.Abstractions;
+
+namespace UniversalToolchain.Ssa.Optimization;
+
+public sealed record SsaValueDefinition(
+    SsaValue Value,
+    SsaBlockId BlockId,
+    int InstructionIndex,
+    ISsaInstruction? Instruction);
+
+public sealed record SsaValueUse(
+    SsaValueId ValueId,
+    SsaBlockId BlockId,
+    int InstructionIndex,
+    ISsaInstruction? Instruction,
+    string UseKind);
+
+public sealed class SsaControlFlowGraph
+{
+    public SsaControlFlowGraph(SsaFunction function)
+    {
+        ArgumentNullException.ThrowIfNull(function);
+
+        Blocks = new ReadOnlyDictionary<SsaBlockId, SsaBlock>(
+            function.Blocks.ToDictionary(static x => x.Id));
+
+        var successors = new Dictionary<SsaBlockId, IReadOnlyList<SsaBlockId>>();
+        var predecessors = Blocks.Keys.ToDictionary(static x => x, static _ => new List<SsaBlockId>());
+
+        foreach (var block in function.Blocks)
+        {
+            var blockSuccessors = block.Terminator?.Transfers
+                .Select(static x => x.Target)
+                .Where(Blocks.ContainsKey)
+                .Distinct()
+                .Order()
+                .ToArray() ?? [];
+
+            successors[block.Id] = blockSuccessors;
+            foreach (var successor in blockSuccessors)
+                predecessors[successor].Add(block.Id);
+        }
+
+        Successors = new ReadOnlyDictionary<SsaBlockId, IReadOnlyList<SsaBlockId>>(successors);
+        Predecessors = new ReadOnlyDictionary<SsaBlockId, IReadOnlyList<SsaBlockId>>(
+            predecessors.ToDictionary(
+                static x => x.Key,
+                static x => (IReadOnlyList<SsaBlockId>)x.Value.Order().ToArray()));
+    }
+
+    public IReadOnlyDictionary<SsaBlockId, SsaBlock> Blocks { get; }
+
+    public IReadOnlyDictionary<SsaBlockId, IReadOnlyList<SsaBlockId>> Successors { get; }
+
+    public IReadOnlyDictionary<SsaBlockId, IReadOnlyList<SsaBlockId>> Predecessors { get; }
+}
+
+public sealed class SsaUseDefMap
+{
+    private SsaUseDefMap(
+        IReadOnlyDictionary<SsaValueId, SsaValueDefinition> definitions,
+        IReadOnlyDictionary<SsaValueId, IReadOnlyList<SsaValueUse>> uses)
+    {
+        Definitions = definitions;
+        Uses = uses;
+    }
+
+    public IReadOnlyDictionary<SsaValueId, SsaValueDefinition> Definitions { get; }
+
+    public IReadOnlyDictionary<SsaValueId, IReadOnlyList<SsaValueUse>> Uses { get; }
+
+    public static SsaUseDefMap Build(SsaFunction function)
+    {
+        ArgumentNullException.ThrowIfNull(function);
+
+        var definitions = new Dictionary<SsaValueId, SsaValueDefinition>();
+        var uses = new Dictionary<SsaValueId, List<SsaValueUse>>();
+
+        foreach (var parameter in function.Parameters)
+        {
+            definitions[parameter.Value.Id] = new SsaValueDefinition(
+                parameter.Value,
+                function.EntryBlockId,
+                InstructionIndex: -1,
+                Instruction: null);
+        }
+
+        foreach (var block in function.Blocks)
+        {
+            foreach (var parameter in block.Parameters)
+            {
+                definitions[parameter.Value.Id] = new SsaValueDefinition(
+                    parameter.Value,
+                    block.Id,
+                    InstructionIndex: -1,
+                    Instruction: null);
+            }
+
+            for (var index = 0; index < block.Instructions.Count; index++)
+            {
+                var instruction = block.Instructions[index];
+                foreach (var result in instruction.Results)
+                {
+                    definitions[result.Id] = new SsaValueDefinition(
+                        result,
+                        block.Id,
+                        index,
+                        instruction);
+                }
+
+                foreach (var operand in instruction.Operands)
+                    AddUse(uses, operand, block.Id, index, instruction, "instruction.operand");
+            }
+
+            if (block.Terminator is null)
+                continue;
+
+            foreach (var operand in block.Terminator.Operands)
+                AddUse(uses, operand, block.Id, int.MaxValue, null, "terminator.operand");
+
+            foreach (var transfer in block.Terminator.Transfers)
+            foreach (var argument in transfer.Arguments)
+                AddUse(uses, argument, block.Id, int.MaxValue, null, "terminator.transfer.argument");
+        }
+
+        return new SsaUseDefMap(
+            new ReadOnlyDictionary<SsaValueId, SsaValueDefinition>(definitions),
+            new ReadOnlyDictionary<SsaValueId, IReadOnlyList<SsaValueUse>>(
+                uses.ToDictionary(
+                    static x => x.Key,
+                    static x => (IReadOnlyList<SsaValueUse>)x.Value.ToArray())));
+    }
+
+    private static void AddUse(
+        IDictionary<SsaValueId, List<SsaValueUse>> uses,
+        SsaValueId valueId,
+        SsaBlockId blockId,
+        int instructionIndex,
+        ISsaInstruction? instruction,
+        string useKind)
+    {
+        if (!uses.TryGetValue(valueId, out var valueUses))
+        {
+            valueUses = [];
+            uses[valueId] = valueUses;
+        }
+
+        valueUses.Add(new SsaValueUse(valueId, blockId, instructionIndex, instruction, useKind));
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Ssa.Optimization/SsaBranchFoldingAndCleanupPass.cs
+++ b/UniversalToolchain/UniversalToolchain.Ssa.Optimization/SsaBranchFoldingAndCleanupPass.cs
@@ -1,0 +1,136 @@
+using UniversalToolchain.Ir.Abstractions;
+using UniversalToolchain.Ssa.Abstractions;
+
+namespace UniversalToolchain.Ssa.Optimization;
+
+public sealed class SsaBranchFoldingAndCleanupPass : IIrOptimizationPass
+{
+    public IrStageId Id { get; } = new("ssa.optimization.branch-folding-and-cleanup");
+
+    public IrKind InputKind => SsaIrKinds.Ssa;
+
+    public IrKind OutputKind => SsaIrKinds.Ssa;
+
+    public IrStageContract Contract { get; } = new(
+        requiresFacts: [SsaFacts.StructuralVerification],
+        producesFacts:
+        [
+            SsaOptimizationFacts.BranchesFolded,
+            SsaOptimizationFacts.UnreachableBlocksEliminated
+        ],
+        preservesFacts: [SsaFacts.StructuralVerification]);
+
+    public IrStageResult Run(IIrArtifact input, IrPipelineContext context)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+        ArgumentNullException.ThrowIfNull(context);
+
+        var artifact = input.As<SsaArtifact>();
+        var module = new SsaModule(artifact.Module.Id, artifact.Module.Functions.Select(RewriteFunction));
+        return new IrStageResult(new SsaArtifact(module));
+    }
+
+    private static SsaFunction RewriteFunction(SsaFunction function)
+    {
+        var foldedBlocks = function.Blocks
+            .Select(RewriteBlockTerminator)
+            .ToArray();
+
+        var foldedFunction = new SsaFunction(
+            function.Id,
+            function.EntryBlockId,
+            foldedBlocks,
+            function.Parameters,
+            function.ReturnType);
+
+        return RemoveUnreachableBlocks(foldedFunction);
+    }
+
+    private static SsaBlock RewriteBlockTerminator(SsaBlock block)
+    {
+        if (block.Terminator is not { Kind: SsaTerminatorKind.Branch } terminator ||
+            terminator.Operands.Count != 1 ||
+            terminator.Transfers.Count != 2 ||
+            !TryReadLocalBoolConstant(block, terminator.Operands[0], out var condition))
+        {
+            return block;
+        }
+
+        var selectedTransfer = condition ? terminator.Transfers[0] : terminator.Transfers[1];
+        return new SsaBlock(
+            block.Id,
+            block.Parameters,
+            terminator: SsaTerminator.Jump(selectedTransfer.Target, selectedTransfer.Arguments),
+            instructions: block.Instructions);
+    }
+
+    private static bool TryReadLocalBoolConstant(SsaBlock block, SsaValueId valueId, out bool value)
+    {
+        value = default;
+        for (var index = block.Instructions.Count - 1; index >= 0; index--)
+        {
+            var instruction = block.Instructions[index];
+            if (instruction.Results.Count != 1 ||
+                instruction.Results[0].Id != valueId)
+            {
+                continue;
+            }
+
+            if (!SsaConstantReader.TryRead(instruction, out var constant) ||
+                constant.Type != SsaPreviewSemanticTypes.Bool)
+            {
+                return false;
+            }
+
+            return bool.TryParse(constant.CanonicalValue, out value);
+        }
+
+        return false;
+    }
+
+    private static SsaFunction RemoveUnreachableBlocks(SsaFunction function)
+    {
+        var blocks = function.Blocks.ToDictionary(static x => x.Id);
+        if (!blocks.ContainsKey(function.EntryBlockId))
+            return function;
+
+        var reachable = ComputeReachable(function.EntryBlockId, blocks);
+        if (reachable.Count == blocks.Count)
+            return function;
+
+        return new SsaFunction(
+            function.Id,
+            function.EntryBlockId,
+            function.Blocks.Where(block => reachable.Contains(block.Id)),
+            function.Parameters,
+            function.ReturnType);
+    }
+
+    private static HashSet<SsaBlockId> ComputeReachable(
+        SsaBlockId entryBlockId,
+        IReadOnlyDictionary<SsaBlockId, SsaBlock> blocks)
+    {
+        var reachable = new HashSet<SsaBlockId>();
+        var worklist = new Queue<SsaBlockId>();
+        worklist.Enqueue(entryBlockId);
+
+        while (worklist.Count != 0)
+        {
+            var current = worklist.Dequeue();
+            if (!reachable.Add(current) ||
+                !blocks.TryGetValue(current, out var block) ||
+                block.Terminator is null)
+            {
+                continue;
+            }
+
+            foreach (var transfer in block.Terminator.Transfers)
+            {
+                if (blocks.ContainsKey(transfer.Target))
+                    worklist.Enqueue(transfer.Target);
+            }
+        }
+
+        return reachable;
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Ssa.Optimization/SsaConstantFoldingPass.cs
+++ b/UniversalToolchain/UniversalToolchain.Ssa.Optimization/SsaConstantFoldingPass.cs
@@ -1,4 +1,3 @@
-using System.Globalization;
 using UniversalToolchain.Ir.Abstractions;
 using UniversalToolchain.Semantics.Abstractions;
 using UniversalToolchain.Ssa.Abstractions;
@@ -88,7 +87,7 @@ public sealed class SsaConstantFoldingPass : IIrOptimizationPass
             return null;
         }
 
-        return CreateConstantInstruction(instruction, result);
+        return SsaConstantMaterializer.TryCreate(instruction, result);
     }
 
     private bool TryGetDescriptor(ISsaInstruction instruction, out CallableDescriptor descriptor)
@@ -125,72 +124,15 @@ public sealed class SsaConstantFoldingPass : IIrOptimizationPass
         return true;
     }
 
-    private static SsaOperation? CreateConstantInstruction(ISsaInstruction source, ConstantValue value)
-    {
-        if (source.Results.Count != 1 ||
-            !SameType(source.Results[0].Type, value.Type))
-        {
-            return null;
-        }
-
-        if (source.Results[0].Type == SsaTypes.Int32 &&
-            int.TryParse(value.CanonicalValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out var intValue))
-        {
-            return ConstantInt32(source, intValue);
-        }
-
-        if (source.Results[0].Type == SsaTypes.Bool &&
-            bool.TryParse(value.CanonicalValue, out var boolValue))
-        {
-            return ConstantBool(source, boolValue);
-        }
-
-        return null;
-    }
-
-    private static SsaOperation ConstantInt32(ISsaInstruction source, int value) =>
-        new(
-            source.Id,
-            SsaOperations.ConstantInt32,
-            results: source.Results,
-            attributes: new SsaAttributeBag([new SsaAttribute(SsaAttributeKeys.ConstantValue, value.ToString(CultureInfo.InvariantCulture))]));
-
-    private static SsaOperation ConstantBool(ISsaInstruction source, bool value) =>
-        new(
-            source.Id,
-            SsaOperations.ConstantBool,
-            results: source.Results,
-            attributes: new SsaAttributeBag([new SsaAttribute(SsaAttributeKeys.ConstantValue, value.ToString())]));
-
     private static void RecordResultConstants(ISsaInstruction instruction, IDictionary<SsaValueId, ConstantValue> constants)
     {
         foreach (var result in instruction.Results)
             constants.Remove(result.Id);
 
-        if (instruction is not SsaOperation operation ||
-            operation.Results.Count != 1 ||
-            !operation.Attributes.TryGet(SsaAttributeKeys.ConstantValue, out var attribute))
+        if (instruction.Results.Count == 1 &&
+            SsaConstantReader.TryRead(instruction, out var constant))
         {
-            return;
-        }
-
-        var resultValue = operation.Results[0];
-        if (operation.OpId == SsaOperations.ConstantInt32 &&
-            resultValue.Type == SsaTypes.Int32 &&
-            int.TryParse(attribute.Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out _))
-        {
-            constants[resultValue.Id] = new ConstantValue(SsaPreviewSemanticTypes.Int32, attribute.Value);
-            return;
-        }
-
-        if (operation.OpId == SsaOperations.ConstantBool &&
-            resultValue.Type == SsaTypes.Bool &&
-            bool.TryParse(attribute.Value, out _))
-        {
-            constants[resultValue.Id] = new ConstantValue(SsaPreviewSemanticTypes.Bool, attribute.Value);
+            constants[instruction.Results[0].Id] = constant;
         }
     }
-
-    private static bool SameType(SsaTypeId ssaType, SemanticTypeId semanticType) =>
-        string.Equals(ssaType.Value, semanticType.Value, StringComparison.Ordinal);
 }

--- a/UniversalToolchain/UniversalToolchain.Ssa.Optimization/SsaConstantMaterializer.cs
+++ b/UniversalToolchain/UniversalToolchain.Ssa.Optimization/SsaConstantMaterializer.cs
@@ -1,0 +1,68 @@
+using System.Globalization;
+using UniversalToolchain.Semantics.Abstractions;
+using UniversalToolchain.Ssa.Abstractions;
+
+namespace UniversalToolchain.Ssa.Optimization;
+
+public static class SsaConstantMaterializer
+{
+    public static SsaOperation? TryCreate(ISsaInstruction source, ConstantValue value)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+
+        if (source.Results.Count != 1 ||
+            !SameType(source.Results[0].Type, value.Type))
+        {
+            return null;
+        }
+
+        if (source.Results[0].Type == SsaTypes.Int32 &&
+            int.TryParse(value.CanonicalValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out var intValue))
+        {
+            return Create(source, SsaOperations.ConstantInt32, intValue.ToString(CultureInfo.InvariantCulture));
+        }
+
+        if (source.Results[0].Type == SsaTypes.Bool &&
+            bool.TryParse(value.CanonicalValue, out var boolValue))
+        {
+            return Create(source, SsaOperations.ConstantBool, boolValue.ToString());
+        }
+
+        if (source.Results[0].Type == SsaTypes.Float64 &&
+            double.TryParse(value.CanonicalValue, NumberStyles.Float, CultureInfo.InvariantCulture, out var floatValue))
+        {
+            return Create(source, SsaOperations.ConstantFloat64, floatValue.ToString("R", CultureInfo.InvariantCulture));
+        }
+
+        return null;
+    }
+
+    public static SsaOperation Int32(SsaOperationId id, SsaValue result, int value) =>
+        Create(id, SsaOperations.ConstantInt32, [result], value.ToString(CultureInfo.InvariantCulture));
+
+    public static SsaOperation Bool(SsaOperationId id, SsaValue result, bool value) =>
+        Create(id, SsaOperations.ConstantBool, [result], value.ToString());
+
+    public static SsaOperation Float64(SsaOperationId id, SsaValue result, double value) =>
+        Create(id, SsaOperations.ConstantFloat64, [result], value.ToString("R", CultureInfo.InvariantCulture));
+
+    private static SsaOperation Create(ISsaInstruction source, SsaOpId opId, string canonicalValue) =>
+        Create(source.Id, opId, source.Results, canonicalValue);
+
+    private static SsaOperation Create(
+        SsaOperationId id,
+        SsaOpId opId,
+        IEnumerable<SsaValue> results,
+        string canonicalValue) =>
+        new(
+            id,
+            opId,
+            results: results,
+            attributes: new SsaAttributeBag(
+            [
+                new SsaAttribute(SsaAttributeKeys.ConstantValue, canonicalValue)
+            ]));
+
+    private static bool SameType(SsaTypeId ssaType, SemanticTypeId semanticType) =>
+        string.Equals(ssaType.Value, semanticType.Value, StringComparison.Ordinal);
+}

--- a/UniversalToolchain/UniversalToolchain.Ssa.Optimization/SsaConstantReader.cs
+++ b/UniversalToolchain/UniversalToolchain.Ssa.Optimization/SsaConstantReader.cs
@@ -1,0 +1,48 @@
+using System.Globalization;
+using UniversalToolchain.Semantics.Abstractions;
+using UniversalToolchain.Ssa.Abstractions;
+
+namespace UniversalToolchain.Ssa.Optimization;
+
+public static class SsaConstantReader
+{
+    public static bool TryRead(ISsaInstruction instruction, out ConstantValue constant)
+    {
+        ArgumentNullException.ThrowIfNull(instruction);
+
+        constant = default!;
+        if (instruction is not SsaOperation operation ||
+            operation.Results.Count != 1 ||
+            !operation.Attributes.TryGet(SsaAttributeKeys.ConstantValue, out var attribute))
+        {
+            return false;
+        }
+
+        var result = operation.Results[0];
+        if (operation.OpId == SsaOperations.ConstantInt32 &&
+            result.Type == SsaTypes.Int32 &&
+            int.TryParse(attribute.Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out _))
+        {
+            constant = new ConstantValue(SsaPreviewSemanticTypes.Int32, attribute.Value);
+            return true;
+        }
+
+        if (operation.OpId == SsaOperations.ConstantBool &&
+            result.Type == SsaTypes.Bool &&
+            bool.TryParse(attribute.Value, out _))
+        {
+            constant = new ConstantValue(SsaPreviewSemanticTypes.Bool, attribute.Value);
+            return true;
+        }
+
+        if (operation.OpId == SsaOperations.ConstantFloat64 &&
+            result.Type == SsaTypes.Float64 &&
+            double.TryParse(attribute.Value, NumberStyles.Float, CultureInfo.InvariantCulture, out _))
+        {
+            constant = new ConstantValue(SsaPreviewSemanticTypes.Float64, attribute.Value);
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Ssa.Optimization/SsaDeadPureInstructionEliminationPass.cs
+++ b/UniversalToolchain/UniversalToolchain.Ssa.Optimization/SsaDeadPureInstructionEliminationPass.cs
@@ -1,0 +1,147 @@
+using UniversalToolchain.Ir.Abstractions;
+using UniversalToolchain.Semantics.Abstractions;
+using UniversalToolchain.Ssa.Abstractions;
+
+namespace UniversalToolchain.Ssa.Optimization;
+
+public sealed class SsaDeadPureInstructionEliminationPass : IIrOptimizationPass
+{
+    private readonly SsaDescriptorSet _descriptors;
+    private readonly SemanticDescriptorSet _semanticDescriptors;
+
+    public SsaDeadPureInstructionEliminationPass()
+        : this(SsaCoreDescriptors.ConstantMaterialization, SemanticDescriptorSet.Empty)
+    {
+    }
+
+    public SsaDeadPureInstructionEliminationPass(
+        SsaDescriptorSet descriptors,
+        SemanticDescriptorSet? semanticDescriptors = null)
+    {
+        _descriptors = descriptors ?? throw new ArgumentNullException(nameof(descriptors));
+        _semanticDescriptors = semanticDescriptors ?? SemanticDescriptorSet.Empty;
+    }
+
+    public IrStageId Id { get; } = new("ssa.optimization.dce.dead-pure-instructions");
+
+    public IrKind InputKind => SsaIrKinds.Ssa;
+
+    public IrKind OutputKind => SsaIrKinds.Ssa;
+
+    public IrStageContract Contract { get; } = new(
+        requiresFacts: [SsaFacts.StructuralVerification],
+        producesFacts: [SsaOptimizationFacts.DeadPureInstructionsEliminated],
+        preservesFacts: [SsaFacts.StructuralVerification]);
+
+    public IrStageResult Run(IIrArtifact input, IrPipelineContext context)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+        ArgumentNullException.ThrowIfNull(context);
+
+        var artifact = input.As<SsaArtifact>();
+        return new IrStageResult(new SsaArtifact(RewriteModule(artifact.Module)));
+    }
+
+    private SsaModule RewriteModule(SsaModule module) =>
+        new(module.Id, module.Functions.Select(RewriteFunction));
+
+    private SsaFunction RewriteFunction(SsaFunction function)
+    {
+        var useDef = SsaUseDefMap.Build(function);
+        var liveInstructions = ComputeLiveInstructions(function, useDef);
+
+        return new SsaFunction(
+            function.Id,
+            function.EntryBlockId,
+            function.Blocks.Select(block => RewriteBlock(block, liveInstructions)),
+            function.Parameters,
+            function.ReturnType);
+    }
+
+    private SsaBlock RewriteBlock(SsaBlock block, IReadOnlySet<SsaOperationId> liveInstructions)
+    {
+        var instructions = block.Instructions
+            .Where(instruction => liveInstructions.Contains(instruction.Id))
+            .ToArray();
+
+        return new SsaBlock(block.Id, block.Parameters, terminator: block.Terminator, instructions: instructions);
+    }
+
+    private HashSet<SsaOperationId> ComputeLiveInstructions(SsaFunction function, SsaUseDefMap useDef)
+    {
+        var liveValues = new HashSet<SsaValueId>();
+        var liveInstructions = new HashSet<SsaOperationId>();
+        var worklist = new Queue<SsaValueId>();
+
+        void MarkValue(SsaValueId valueId)
+        {
+            if (liveValues.Add(valueId))
+                worklist.Enqueue(valueId);
+        }
+
+        foreach (var block in function.Blocks)
+        {
+            if (block.Terminator is not null)
+            {
+                foreach (var operand in block.Terminator.Operands)
+                    MarkValue(operand);
+
+                foreach (var transfer in block.Terminator.Transfers)
+                foreach (var argument in transfer.Arguments)
+                    MarkValue(argument);
+            }
+
+            foreach (var instruction in block.Instructions)
+            {
+                if (!HasObservableEffects(instruction))
+                    continue;
+
+                liveInstructions.Add(instruction.Id);
+                foreach (var operand in instruction.Operands)
+                    MarkValue(operand);
+            }
+        }
+
+        while (worklist.Count != 0)
+        {
+            var valueId = worklist.Dequeue();
+            if (!useDef.Definitions.TryGetValue(valueId, out var definition) ||
+                definition.Instruction is null ||
+                !liveInstructions.Add(definition.Instruction.Id))
+            {
+                continue;
+            }
+
+            foreach (var operand in definition.Instruction.Operands)
+                MarkValue(operand);
+        }
+
+        return liveInstructions;
+    }
+
+    private bool HasObservableEffects(ISsaInstruction instruction) =>
+        instruction switch
+        {
+            SsaOperation operation => HasObservableEffects(operation),
+            SsaCall call => HasObservableEffects(call),
+            _ => true
+        };
+
+    private bool HasObservableEffects(SsaOperation operation)
+    {
+        if (!_descriptors.TryGet(operation.OpId, out var descriptor))
+            return true;
+
+        return !descriptor.Effects.IsPure;
+    }
+
+    private bool HasObservableEffects(SsaCall call)
+    {
+        if (!_semanticDescriptors.TryGetCallable(call.Callee, out var descriptor))
+            return true;
+
+        return !descriptor.Effects.IsPure ||
+               descriptor.Effects.Contains(SemanticEffectKind.MayThrow) ||
+               descriptor.TrustLevel is not (SemanticTrustLevel.BuiltInTrusted or SemanticTrustLevel.VerifiedPlugin);
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Ssa.Optimization/SsaOptimizationFacts.cs
+++ b/UniversalToolchain/UniversalToolchain.Ssa.Optimization/SsaOptimizationFacts.cs
@@ -8,4 +8,10 @@ public static class SsaOptimizationFacts
     public static FactId StructurallyVerifiedSsa => SsaFacts.StructuralVerification;
 
     public static FactId LocallyConstantFolded { get; } = new("ssa.optimization.constant-folded.local");
+
+    public static FactId DeadPureInstructionsEliminated { get; } = new("ssa.optimization.dead-pure-instructions-eliminated");
+
+    public static FactId BranchesFolded { get; } = new("ssa.optimization.branches-folded");
+
+    public static FactId UnreachableBlocksEliminated { get; } = new("ssa.optimization.unreachable-blocks-eliminated");
 }

--- a/UniversalToolchain/UniversalToolchain.Ssa.Optimization/SsaRouteProfile.cs
+++ b/UniversalToolchain/UniversalToolchain.Ssa.Optimization/SsaRouteProfile.cs
@@ -193,7 +193,11 @@ public sealed class SsaPreviewArithmeticInt32Pack : ISsaSemanticExtensionPack
     public bool EnablesManagedCallables => false;
 
     public IReadOnlyList<IIrOptimizationPass> CreateOptimizationPasses() =>
-        [new SsaConstantFoldingPass(SemanticDescriptors, new SsaPreviewInt32ConstantEvaluator())];
+    [
+        new SsaConstantFoldingPass(SemanticDescriptors, new SsaPreviewInt32ConstantEvaluator()),
+        new SsaBranchFoldingAndCleanupPass(),
+        new SsaDeadPureInstructionEliminationPass(SsaCoreDescriptors.ConstantMaterialization, SemanticDescriptors)
+    ];
 }
 
 public sealed class SsaManagedCallablePack : ISsaSemanticExtensionPack


### PR DESCRIPTION
## What changed

This PR implements the preview-safe SSA optimization slice and wires it into the preview arithmetic SSA route:

- adds shared `SsaConstantReader` / `SsaConstantMaterializer` helpers;
- updates `SsaConstantFoldingPass` to use those helpers and preserve result identity while adding the `f64` materialization path;
- adds lightweight `SsaControlFlowGraph` and `SsaUseDefMap` helpers inside the SSA optimization package;
- adds conservative `SsaDeadPureInstructionEliminationPass` with function-level liveness;
- adds `SsaBranchFoldingAndCleanupPass` for local `branch const_bool -> jump` plus unreachable block cleanup;
- wires the preview arithmetic route as: `SsaConstantFoldingPass` -> `SsaBranchFoldingAndCleanupPass` -> `SsaDeadPureInstructionEliminationPass`;
- adds focused NUnit tests for the new preview-safe behavior.

## Safety model

This intentionally does not implement GVN, CSE, LICM, arbitrary value substitution, or `x + 0 -> x`-style rewrites. Those can create SSA value reuse patterns that the current preview `SSA -> AIR` path may not lower safely into stack-shaped AIR.

DCE is conservative:

- unknown operations are kept;
- unknown calls are kept;
- calls with observable effects or `MayThrow` are kept;
- only known pure trusted dead instructions can be removed;
- liveness is computed at function scope, so values used across block transfers are preserved.

## Validation status

Validated after wiring on head `9b76a1acd6a0a209fdeb7bee2090fb912fefc7bb`:

- `UniversalToolchain validation`: success, including restore, build, tests, and anti-hardcode checks.
- `.NET CI`: build, tests, package creation/check, package smoke test, docs dependency install, and docs build are successful; final markdown bash smoke step is still in progress at the time of this PR body update.

Keep this PR as draft until `.NET CI` fully completes.

## Next step after merge

Proceed to SCCP-lite. Keep GVN/CSE/LICM postponed until out-of-SSA/scheduler or SSA-native backend support is explicit.