### PR TITLE
tests: cover SSA preview route optimizers

### DIFF
--- a/UniversalToolchain/Tests/Ssa/SsaRoundtripRouteTests.cs
+++ b/UniversalToolchain/Tests/Ssa/SsaRoundtripRouteTests.cs
@@ -55,7 +55,7 @@ public sealed class SsaRoundtripRouteTests
     }
 
     [Test]
-    public void Run_WhenPolicyIsDebugAndRouteIsSupported_ReturnsRoundtrippedAir()
+    public void Run_WhenPolicyIsDebugAndRouteIsSupported_ReturnsOptimizedRoundtrippedAir()
     {
         var source = new AbstractIR();
         source.Push(2);
@@ -70,6 +70,34 @@ public sealed class SsaRoundtripRouteTests
         {
             Assert.That(result.UsedSsa, Is.True);
             Assert.That(result.FellBackToInput, Is.False);
+            Assert.That(result.Diagnostics, Is.Empty);
+            Assert.That(result.Program.Instructions.Select(static x => x.UOpCode), Is.EqualTo(new[]
+            {
+                UOpCode.Label,
+                UOpCode.Push
+            }));
+            Assert.That(result.Program.Instructions[1].Operands.Single(), Is.EqualTo(5));
+        });
+    }
+
+    [Test]
+    public void Run_WhenUsingRawConvertersWithoutProfile_DoesNotRunOptimizationPasses()
+    {
+        var source = new AbstractIR();
+        source.Push(2);
+        source.Push(3);
+        source.Intrinsic(AirIntrinsicIds.AddInt32Unchecked);
+
+        var result = new SsaRoundtripRoute(
+                SsaRouteFactory.CreateLowerer(SsaPreviewRouteProfiles.Create(SsaRoutePolicy.Debug)),
+                SsaRouteFactory.CreateEmitter(SsaPreviewRouteProfiles.Create(SsaRoutePolicy.Debug)))
+            .Run(source, SsaRoutePolicy.Debug);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.UsedSsa, Is.True);
+            Assert.That(result.FellBackToInput, Is.False);
+            Assert.That(result.Diagnostics, Is.Empty);
             Assert.That(result.Program.Instructions.Select(static x => x.UOpCode), Is.EqualTo(new[]
             {
                 UOpCode.Label,

--- a/UniversalToolchain/UniversalToolchain.Ssa.Optimization/SsaRoundtripRoute.cs
+++ b/UniversalToolchain/UniversalToolchain.Ssa.Optimization/SsaRoundtripRoute.cs
@@ -57,7 +57,7 @@ public sealed class SsaRouteException : InvalidOperationException
 }
 
 /// <summary>
-/// Runs the verifier-gated AIR -> SSA -> AIR route without applying SSA optimization passes.
+/// Runs the verifier-gated AIR -> SSA -> optional profile optimization -> AIR route.
 /// </summary>
 public sealed class SsaRoundtripRoute
 {
@@ -116,11 +116,27 @@ public sealed class SsaRoundtripRoute
         {
             var loweringResult = _lowering.Run(new AirArtifact(input), context);
             var ssaArtifact = loweringResult.Artifact.As<SsaArtifact>();
-            var emissionResult = _emission.Run(ssaArtifact, new IrPipelineContext(context.Capabilities, loweringResult.Facts));
+            var ssaFacts = loweringResult.Facts;
+
+            if (_profile is not null)
+            {
+                var optimizationResult = SsaRouteFactory
+                    .CreateOptimizer(_profile)
+                    .Run(ssaArtifact, new IrPipelineContext(context.Capabilities, ssaFacts));
+                ssaArtifact = optimizationResult.Artifact.As<SsaArtifact>();
+                ssaFacts = optimizationResult.Facts;
+            }
+
+            var emissionResult = _emission.Run(ssaArtifact, new IrPipelineContext(context.Capabilities, ssaFacts));
             output = emissionResult.Artifact.As<AirArtifact>().Program;
             return true;
         }
         catch (AirToSsaConversionException exception)
+        {
+            diagnostics = ConvertDiagnostics(exception.Diagnostics);
+            return false;
+        }
+        catch (SsaOptimizationException exception)
         {
             diagnostics = ConvertDiagnostics(exception.Diagnostics);
             return false;

--- a/docs/testing/ssa-preview-route-tests.md
+++ b/docs/testing/ssa-preview-route-tests.md
@@ -1,0 +1,16 @@
+# SSA preview route tests
+
+The preview SSA route is expected to run profile-owned optimization passes between `AIR -> SSA` lowering and `SSA -> AIR` emission.
+
+The focused roundtrip tests protect two separate contracts:
+
+- `SsaRouteFactory.CreateRoundtripRoute(profile)` must use the profile optimizer pipeline before emission.
+- Raw `new SsaRoundtripRoute(lowerer, emitter)` remains a plain roundtrip path and does not run optimizers implicitly.
+
+This distinction matters because the preview arithmetic profile now owns the safe pass sequence:
+
+1. `SsaConstantFoldingPass`
+2. `SsaBranchFoldingAndCleanupPass`
+3. `SsaDeadPureInstructionEliminationPass`
+
+The route-level optimization test intentionally checks the emitted AIR shape for `2 3 add`: after SSA optimization it should emit a single `Push 5` after the entry label, not the original `Push 2`, `Push 3`, `Intrinsic add` sequence.


### PR DESCRIPTION
## What changed

This test-first follow-up strengthens SSA preview route coverage:

- adds a route-level test proving `SsaRouteFactory.CreateRoundtripRoute(profile)` actually runs profile-owned SSA optimization passes;
- keeps a separate raw-converter roundtrip test proving `new SsaRoundtripRoute(lowerer, emitter)` remains a plain non-optimizing route;
- updates `SsaRoundtripRoute` to run `SsaRouteFactory.CreateOptimizer(profile)` between AIR -> SSA lowering and SSA -> AIR emission when a profile is present;
- documents the route-level test invariant.

## Why

PR #262 wired safe passes into the preview arithmetic profile, but the route-level tests did not prove that the roundtrip route actually applied those pass lists. The new test checks a simple `2 3 add` program: with the profile route it must emit `Label, Push 5`, not the unoptimized `Label, Push 2`, `Push 3`, `Intrinsic add` shape.

## Safety

This keeps raw-converter construction behavior unchanged. Optimization is only enabled when the route was created with an `SsaRouteProfile`.

## Validation status

Validated on head `7fd0228a78eb235ae7cded60eeee311dbaaf275d`:

- `Docs Check`: success.
- `UniversalToolchain validation`: success, including restore, build, tests, and anti-hardcode checks.
- `.NET CI`: build, tests, package creation/check, package smoke test, docs dependency install, and docs build are successful; final markdown bash smoke step is still in progress at the time of this PR body update.

Keep this PR as draft until `.NET CI` fully completes.