### PR TITLE
tests: strengthen SSA preview safe pass regressions

### DIFF
--- a/UniversalToolchain/Tests/Ssa/SsaPreviewSafeOptimizationPassTests.cs
+++ b/UniversalToolchain/Tests/Ssa/SsaPreviewSafeOptimizationPassTests.cs
@@ -66,6 +66,78 @@ public sealed class SsaPreviewSafeOptimizationPassTests
     }
 
     [Test]
+    public void DeadPureInstructionEliminationKeepsOperandProducersForLivePureCall()
+    {
+        var callable = new CallableId("test.pure.add");
+        var left = new SsaValue(new SsaValueId("left"), SsaTypes.Int32);
+        var right = new SsaValue(new SsaValueId("right"), SsaTypes.Int32);
+        var result = new SsaValue(new SsaValueId("result"), SsaTypes.Int32);
+        var block = new SsaBlock(
+            new SsaBlockId("entry"),
+            instructions:
+            [
+                SsaConstantMaterializer.Int32(new SsaOperationId("left.op"), left, 2),
+                SsaConstantMaterializer.Int32(new SsaOperationId("right.op"), right, 3),
+                new SsaCall(new SsaOperationId("call.add"), callable, [left.Id, right.Id], [result])
+            ],
+            terminator: SsaTerminator.Return([result.Id]));
+
+        var optimized = Run(
+            new SsaDeadPureInstructionEliminationPass(SsaCoreDescriptors.ConstantMaterialization, PureCallableDescriptors(callable)),
+            ModuleWith(block));
+
+        Assert.That(
+            optimized.Functions.Single().Blocks.Single().Instructions.Select(static x => x.Id.Value),
+            Is.EqualTo(new[] { "left.op", "right.op", "call.add" }));
+    }
+
+    [Test]
+    public void DeadPureInstructionEliminationRemovesDeadTrustedPureCallAndItsOperands()
+    {
+        var callable = new CallableId("test.pure.dead");
+        var left = new SsaValue(new SsaValueId("left"), SsaTypes.Int32);
+        var right = new SsaValue(new SsaValueId("right"), SsaTypes.Int32);
+        var result = new SsaValue(new SsaValueId("result"), SsaTypes.Int32);
+        var block = new SsaBlock(
+            new SsaBlockId("entry"),
+            instructions:
+            [
+                SsaConstantMaterializer.Int32(new SsaOperationId("left.op"), left, 2),
+                SsaConstantMaterializer.Int32(new SsaOperationId("right.op"), right, 3),
+                new SsaCall(new SsaOperationId("call.dead"), callable, [left.Id, right.Id], [result])
+            ],
+            terminator: SsaTerminator.Return());
+
+        var optimized = Run(
+            new SsaDeadPureInstructionEliminationPass(SsaCoreDescriptors.ConstantMaterialization, PureCallableDescriptors(callable)),
+            ModuleWith(block));
+
+        Assert.That(optimized.Functions.Single().Blocks.Single().Instructions, Is.Empty);
+    }
+
+    [Test]
+    public void DeadPureInstructionEliminationKeepsUntrustedPureCalls()
+    {
+        var callable = new CallableId("plugin.untrusted.pure");
+        var result = new SsaValue(new SsaValueId("result"), SsaTypes.Int32);
+        var block = new SsaBlock(
+            new SsaBlockId("entry"),
+            instructions:
+            [
+                new SsaCall(new SsaOperationId("call.untrusted"), callable, results: [result])
+            ],
+            terminator: SsaTerminator.Return());
+
+        var optimized = Run(
+            new SsaDeadPureInstructionEliminationPass(
+                SsaCoreDescriptors.ConstantMaterialization,
+                PureCallableDescriptors(callable, SemanticTrustLevel.UserProvidedUnchecked)),
+            ModuleWith(block));
+
+        Assert.That(optimized.Functions.Single().Blocks.Single().Instructions.Select(static x => x.Id.Value), Is.EqualTo(new[] { "call.untrusted" }));
+    }
+
+    [Test]
     public void DeadPureInstructionEliminationKeepsUnknownCalls()
     {
         var result = new SsaValue(new SsaValueId("result"), SsaTypes.Int32);
@@ -157,11 +229,124 @@ public sealed class SsaPreviewSafeOptimizationPassTests
         Assert.That(blocks[0].Terminator?.Transfers.Single().Target.Value, Is.EqualTo("then"));
     }
 
+    [Test]
+    public void BranchFoldingPreservesSelectedFalseTransferArguments()
+    {
+        var condition = new SsaValue(new SsaValueId("condition"), SsaTypes.Bool);
+        var payload = new SsaValue(new SsaValueId("payload"), SsaTypes.Int32);
+        var exitArgument = new SsaBlockParameter(new SsaValue(new SsaValueId("exit.arg"), SsaTypes.Int32));
+        var entry = new SsaBlock(
+            new SsaBlockId("entry"),
+            instructions:
+            [
+                SsaConstantMaterializer.Bool(new SsaOperationId("condition.op"), condition, false),
+                SsaConstantMaterializer.Int32(new SsaOperationId("payload.op"), payload, 11)
+            ],
+            terminator: SsaTerminator.Branch(
+                condition.Id,
+                new SsaBlockId("then"),
+                [],
+                new SsaBlockId("else"),
+                [payload.Id]));
+        var thenBlock = new SsaBlock(new SsaBlockId("then"), terminator: SsaTerminator.Unreachable());
+        var elseBlock = new SsaBlock(
+            new SsaBlockId("else"),
+            parameters: [exitArgument],
+            terminator: SsaTerminator.Return([exitArgument.Value.Id]));
+
+        var optimized = Run(new SsaBranchFoldingAndCleanupPass(), ModuleWith(entry, thenBlock, elseBlock));
+        var optimizedEntry = optimized.Functions.Single().Blocks.Single(block => block.Id.Value == "entry");
+        var transfer = optimizedEntry.Terminator!.Transfers.Single();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(optimized.Functions.Single().Blocks.Select(static x => x.Id.Value), Is.EqualTo(new[] { "entry", "else" }));
+            Assert.That(optimizedEntry.Terminator.Kind, Is.EqualTo(SsaTerminatorKind.Jump));
+            Assert.That(transfer.Target.Value, Is.EqualTo("else"));
+            Assert.That(transfer.Arguments, Is.EqualTo(new[] { payload.Id }));
+        });
+    }
+
+    [Test]
+    public void BranchFoldingDoesNotFoldNonLocalBoolConditions()
+    {
+        var conditionParameter = new SsaBlockParameter(new SsaValue(new SsaValueId("condition.arg"), SsaTypes.Bool));
+        var result = new SsaValue(new SsaValueId("result"), SsaTypes.Int32);
+        var entry = new SsaBlock(
+            new SsaBlockId("entry"),
+            parameters: [conditionParameter],
+            terminator: SsaTerminator.Branch(
+                conditionParameter.Value.Id,
+                new SsaBlockId("then"),
+                [],
+                new SsaBlockId("else"),
+                []));
+        var thenBlock = new SsaBlock(
+            new SsaBlockId("then"),
+            instructions: [SsaConstantMaterializer.Int32(new SsaOperationId("then.value"), result, 1)],
+            terminator: SsaTerminator.Return([result.Id]));
+        var elseBlock = new SsaBlock(new SsaBlockId("else"), terminator: SsaTerminator.Unreachable());
+
+        var optimized = Run(new SsaBranchFoldingAndCleanupPass(), ModuleWith(entry, thenBlock, elseBlock));
+        var optimizedEntry = optimized.Functions.Single().Blocks.Single(block => block.Id.Value == "entry");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(optimized.Functions.Single().Blocks.Select(static x => x.Id.Value), Is.EqualTo(new[] { "entry", "then", "else" }));
+            Assert.That(optimizedEntry.Terminator?.Kind, Is.EqualTo(SsaTerminatorKind.Branch));
+        });
+    }
+
+    [Test]
+    public void BranchFoldingDropsUnreachableChainsAfterSelectingConstantBranch()
+    {
+        var condition = new SsaValue(new SsaValueId("condition"), SsaTypes.Bool);
+        var result = new SsaValue(new SsaValueId("result"), SsaTypes.Int32);
+        var entry = new SsaBlock(
+            new SsaBlockId("entry"),
+            instructions: [SsaConstantMaterializer.Bool(new SsaOperationId("condition.op"), condition, true)],
+            terminator: SsaTerminator.Branch(
+                condition.Id,
+                new SsaBlockId("then"),
+                [],
+                new SsaBlockId("dead.1"),
+                []));
+        var thenBlock = new SsaBlock(
+            new SsaBlockId("then"),
+            instructions: [SsaConstantMaterializer.Int32(new SsaOperationId("then.value"), result, 1)],
+            terminator: SsaTerminator.Return([result.Id]));
+        var dead1 = new SsaBlock(
+            new SsaBlockId("dead.1"),
+            terminator: SsaTerminator.Jump(new SsaBlockId("dead.2"), []));
+        var dead2 = new SsaBlock(
+            new SsaBlockId("dead.2"),
+            terminator: SsaTerminator.Unreachable());
+
+        var optimized = Run(new SsaBranchFoldingAndCleanupPass(), ModuleWith(entry, thenBlock, dead1, dead2));
+
+        Assert.That(optimized.Functions.Single().Blocks.Select(static x => x.Id.Value), Is.EqualTo(new[] { "entry", "then" }));
+    }
+
     private static SsaModule Run(IIrOptimizationPass pass, SsaModule module)
     {
         var result = pass.Run(new SsaArtifact(module), new IrPipelineContext());
         return result.Artifact.As<SsaArtifact>().Module;
     }
+
+    private static SemanticDescriptorSet PureCallableDescriptors(
+        CallableId callable,
+        SemanticTrustLevel trustLevel = SemanticTrustLevel.BuiltInTrusted) =>
+        new(
+            types: [new SemanticTypeDescriptor(SsaPreviewSemanticTypes.Int32)],
+            callables:
+            [
+                new CallableDescriptor(
+                    callable,
+                    new CallableSignature([SsaPreviewSemanticTypes.Int32, SsaPreviewSemanticTypes.Int32], [SsaPreviewSemanticTypes.Int32]),
+                    effects: SemanticEffectSummary.Pure,
+                    determinism: Determinism.Deterministic,
+                    trustLevel: trustLevel)
+            ]);
 
     private static SsaModule ModuleWith(params SsaBlock[] blocks) =>
         new(


### PR DESCRIPTION
## What changed

This is a test-only follow-up for the preview-safe SSA optimization work.

It adds regression coverage for hidden invariants that were not covered by the first safe-pass tests:

- DCE keeps operand producers for a live trusted pure call result;
- DCE removes a dead trusted pure call and its now-dead operand constants;
- DCE keeps untrusted pure calls even if their result is unused;
- branch folding preserves selected false-edge transfer arguments;
- branch folding does not fold non-local bool conditions;
- branch folding removes an unreachable chain after selecting a constant branch.

## Safety

No production code changes. Only `UniversalToolchain/Tests/Ssa/SsaPreviewSafeOptimizationPassTests.cs` is modified.

## Validation

Awaiting GitHub Actions.