### PR TITLE
tests: cover SSA route optimizer failure policies

### DIFF
--- a/UniversalToolchain/Tests/Ssa/SsaRoundtripRouteTests.cs
+++ b/UniversalToolchain/Tests/Ssa/SsaRoundtripRouteTests.cs
@@ -1,10 +1,6 @@
 using IntermediateRepresentationAbstractions;
 using UniversalIntermediateRepresentation;
 using UniversalToolchain.Air.Analysis;
-using UniversalToolchain.Ir.Abstractions;
-using UniversalToolchain.Semantics.Abstractions;
-using UniversalToolchain.Ssa.Abstractions;
-using UniversalToolchain.Ssa.Emission;
 using UniversalToolchain.Ssa.Optimization;
 
 namespace Tests.Ssa;
@@ -59,6 +55,18 @@ public sealed class SsaRoundtripRouteTests
     }
 
     [Test]
+    public void Run_WhenPolicyIsDebugAndRouteIsUnsupported_ThrowsDiagnosticException()
+    {
+        var source = new AbstractIR();
+        source.Intrinsic("custom.intrinsic");
+
+        var exception = Assert.Throws<SsaRouteException>(() =>
+            new SsaRoundtripRoute().Run(source, SsaRoutePolicy.Debug));
+
+        Assert.That(exception!.Diagnostics.Select(static x => x.Code), Does.Contain("air.stack.invalid"));
+    }
+
+    [Test]
     public void Run_WhenPolicyIsDebugAndRouteIsSupported_ReturnsOptimizedRoundtrippedAir()
     {
         var source = new AbstractIR();
@@ -82,39 +90,6 @@ public sealed class SsaRoundtripRouteTests
             }));
             Assert.That(result.Program.Instructions[1].Operands.Single(), Is.EqualTo(5));
         });
-    }
-
-    [Test]
-    public void Run_WhenProfileOptimizerFailsAndPolicyIsPrefer_FallsBackToInputWithDiagnostics()
-    {
-        var source = new AbstractIR();
-        source.Push(1);
-
-        var result = SsaRouteFactory
-            .CreateRoundtripRoute(ProfileWithInvalidOptimizer(SsaRoutePolicy.Prefer))
-            .Run(source);
-
-        Assert.Multiple(() =>
-        {
-            Assert.That(result.Program, Is.SameAs(source));
-            Assert.That(result.UsedSsa, Is.False);
-            Assert.That(result.FellBackToInput, Is.True);
-            Assert.That(result.Diagnostics.Select(static x => x.Code), Does.Contain("ssa.optimization.output.invalid"));
-        });
-    }
-
-    [Test]
-    public void Run_WhenProfileOptimizerFailsAndPolicyIsRequire_ThrowsDiagnosticException()
-    {
-        var source = new AbstractIR();
-        source.Push(1);
-
-        var exception = Assert.Throws<SsaRouteException>(() =>
-            SsaRouteFactory
-                .CreateRoundtripRoute(ProfileWithInvalidOptimizer(SsaRoutePolicy.Require))
-                .Run(source));
-
-        Assert.That(exception!.Diagnostics.Select(static x => x.Code), Does.Contain("ssa.optimization.output.invalid"));
     }
 
     [Test]
@@ -143,69 +118,5 @@ public sealed class SsaRoundtripRouteTests
                 UOpCode.Intrinsic
             }));
         });
-    }
-
-    private static SsaRouteProfile ProfileWithInvalidOptimizer(SsaRoutePolicy policy) =>
-        new(
-            policy,
-            new ISsaSemanticExtensionPack[]
-            {
-                SsaPreviewArithmeticInt32Pack.Instance,
-                InvalidOptimizerPack.Instance
-            });
-
-    private sealed class InvalidOptimizerPack : ISsaSemanticExtensionPack
-    {
-        public static InvalidOptimizerPack Instance { get; } = new();
-
-        public string Id => "InvalidOptimizer";
-
-        public SemanticDescriptorSet SemanticDescriptors => SemanticDescriptorSet.Empty;
-
-        public AirIntrinsicDescriptorSet AirIntrinsics => AirIntrinsicDescriptorSet.Empty;
-
-        public IAirIntrinsicDescriptorResolver AirIntrinsicResolver => AirIntrinsicDescriptorSet.Empty;
-
-        public IReadOnlyDictionary<string, CallableId> AirIntrinsicCallables { get; } =
-            new Dictionary<string, CallableId>(StringComparer.Ordinal);
-
-        public SsaCallableLoweringTargetSet AirLoweringTargets => SsaCallableLoweringTargetSet.Empty;
-
-        public bool EnablesManagedCallables => false;
-
-        public IReadOnlyList<IIrOptimizationPass> CreateOptimizationPasses() =>
-            new IIrOptimizationPass[] { new InvalidReturnOperandPass() };
-    }
-
-    private sealed class InvalidReturnOperandPass : IIrOptimizationPass
-    {
-        public IrStageId Id { get; } = new("ssa.test.invalid-return-operand");
-
-        public IrKind InputKind => SsaIrKinds.Ssa;
-
-        public IrKind OutputKind => SsaIrKinds.Ssa;
-
-        public IrStageContract Contract { get; } = IrStageContract.Empty;
-
-        public IrStageResult Run(IIrArtifact input, IrPipelineContext context)
-        {
-            var artifact = input.As<SsaArtifact>();
-            var invalid = new SsaModule(
-                artifact.Module.Id,
-                artifact.Module.Functions.Select(static function => new SsaFunction(
-                    function.Id,
-                    function.EntryBlockId,
-                    function.Blocks.Select(static block => block.Id == function.EntryBlockId
-                        ? new SsaBlock(
-                            block.Id,
-                            block.Parameters,
-                            instructions: block.Instructions,
-                            terminator: SsaTerminator.Return([new SsaValueId("%missing.after.pass")]))
-                        : block),
-                    function.Parameters,
-                    function.ReturnType)));
-
-            return new IrStageResult(new SsaArtifact(invalid));
-        }
     }
 }

--- a/UniversalToolchain/Tests/Ssa/SsaRoundtripRouteTests.cs
+++ b/UniversalToolchain/Tests/Ssa/SsaRoundtripRouteTests.cs
@@ -1,6 +1,10 @@
 using IntermediateRepresentationAbstractions;
 using UniversalIntermediateRepresentation;
 using UniversalToolchain.Air.Analysis;
+using UniversalToolchain.Ir.Abstractions;
+using UniversalToolchain.Semantics.Abstractions;
+using UniversalToolchain.Ssa.Abstractions;
+using UniversalToolchain.Ssa.Emission;
 using UniversalToolchain.Ssa.Optimization;
 
 namespace Tests.Ssa;
@@ -81,6 +85,39 @@ public sealed class SsaRoundtripRouteTests
     }
 
     [Test]
+    public void Run_WhenProfileOptimizerFailsAndPolicyIsPrefer_FallsBackToInputWithDiagnostics()
+    {
+        var source = new AbstractIR();
+        source.Push(1);
+
+        var result = SsaRouteFactory
+            .CreateRoundtripRoute(ProfileWithInvalidOptimizer(SsaRoutePolicy.Prefer))
+            .Run(source);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Program, Is.SameAs(source));
+            Assert.That(result.UsedSsa, Is.False);
+            Assert.That(result.FellBackToInput, Is.True);
+            Assert.That(result.Diagnostics.Select(static x => x.Code), Does.Contain("ssa.optimization.output.invalid"));
+        });
+    }
+
+    [Test]
+    public void Run_WhenProfileOptimizerFailsAndPolicyIsRequire_ThrowsDiagnosticException()
+    {
+        var source = new AbstractIR();
+        source.Push(1);
+
+        var exception = Assert.Throws<SsaRouteException>(() =>
+            SsaRouteFactory
+                .CreateRoundtripRoute(ProfileWithInvalidOptimizer(SsaRoutePolicy.Require))
+                .Run(source));
+
+        Assert.That(exception!.Diagnostics.Select(static x => x.Code), Does.Contain("ssa.optimization.output.invalid"));
+    }
+
+    [Test]
     public void Run_WhenUsingRawConvertersWithoutProfile_DoesNotRunOptimizationPasses()
     {
         var source = new AbstractIR();
@@ -106,5 +143,69 @@ public sealed class SsaRoundtripRouteTests
                 UOpCode.Intrinsic
             }));
         });
+    }
+
+    private static SsaRouteProfile ProfileWithInvalidOptimizer(SsaRoutePolicy policy) =>
+        new(
+            policy,
+            new ISsaSemanticExtensionPack[]
+            {
+                SsaPreviewArithmeticInt32Pack.Instance,
+                InvalidOptimizerPack.Instance
+            });
+
+    private sealed class InvalidOptimizerPack : ISsaSemanticExtensionPack
+    {
+        public static InvalidOptimizerPack Instance { get; } = new();
+
+        public string Id => "InvalidOptimizer";
+
+        public SemanticDescriptorSet SemanticDescriptors => SemanticDescriptorSet.Empty;
+
+        public AirIntrinsicDescriptorSet AirIntrinsics => AirIntrinsicDescriptorSet.Empty;
+
+        public IAirIntrinsicDescriptorResolver AirIntrinsicResolver => AirIntrinsicDescriptorSet.Empty;
+
+        public IReadOnlyDictionary<string, CallableId> AirIntrinsicCallables { get; } =
+            new Dictionary<string, CallableId>(StringComparer.Ordinal);
+
+        public SsaCallableLoweringTargetSet AirLoweringTargets => SsaCallableLoweringTargetSet.Empty;
+
+        public bool EnablesManagedCallables => false;
+
+        public IReadOnlyList<IIrOptimizationPass> CreateOptimizationPasses() =>
+            new IIrOptimizationPass[] { new InvalidReturnOperandPass() };
+    }
+
+    private sealed class InvalidReturnOperandPass : IIrOptimizationPass
+    {
+        public IrStageId Id { get; } = new("ssa.test.invalid-return-operand");
+
+        public IrKind InputKind => SsaIrKinds.Ssa;
+
+        public IrKind OutputKind => SsaIrKinds.Ssa;
+
+        public IrStageContract Contract { get; } = IrStageContract.Empty;
+
+        public IrStageResult Run(IIrArtifact input, IrPipelineContext context)
+        {
+            var artifact = input.As<SsaArtifact>();
+            var invalid = new SsaModule(
+                artifact.Module.Id,
+                artifact.Module.Functions.Select(static function => new SsaFunction(
+                    function.Id,
+                    function.EntryBlockId,
+                    function.Blocks.Select(static block => block.Id == function.EntryBlockId
+                        ? new SsaBlock(
+                            block.Id,
+                            block.Parameters,
+                            instructions: block.Instructions,
+                            terminator: SsaTerminator.Return([new SsaValueId("%missing.after.pass")]))
+                        : block),
+                    function.Parameters,
+                    function.ReturnType)));
+
+            return new IrStageResult(new SsaArtifact(invalid));
+        }
     }
 }


### PR DESCRIPTION
## What changed

This adds route-level tests for optimizer-stage failures inside `SsaRoundtripRoute`:

- `Prefer` policy falls back to the original AIR when the profile optimizer pipeline fails;
- `Require` policy throws `SsaRouteException` and surfaces optimizer diagnostics;
- failures are injected through a test-only semantic extension pack whose pass intentionally returns invalid SSA after lowering.

## Why

Existing route fallback tests covered unsupported lowering/emission cases. This closes the policy gap introduced by profile-owned optimizer passes running between `AIR -> SSA` and `SSA -> AIR`.

## Safety

Test-only PR. No production code changes.

## Validation

Awaiting GitHub Actions.