### PR TITLE
ssa: add SCCP-lite preview pass

### DIFF
--- a/UniversalToolchain/Tests/Ssa/SsaSccpLitePassTests.cs
+++ b/UniversalToolchain/Tests/Ssa/SsaSccpLitePassTests.cs
@@ -1,0 +1,178 @@
+using UniversalToolchain.Ir.Abstractions;
+using UniversalToolchain.Semantics.Abstractions;
+using UniversalToolchain.Ssa.Abstractions;
+using UniversalToolchain.Ssa.Optimization;
+
+namespace Tests.Ssa;
+
+[TestFixture]
+public sealed class SsaSccpLitePassTests
+{
+    [Test]
+    public void Run_PropagatesConstantThroughBlockArgumentAndFoldsReachableBranch()
+    {
+        var entryValue = new SsaValue(new SsaValueId("%entry.value"), SsaTypes.Int32);
+        var testArgument = new SsaBlockParameter(new SsaValue(new SsaValueId("%test.arg"), SsaTypes.Int32));
+        var one = new SsaValue(new SsaValueId("%one"), SsaTypes.Int32);
+        var condition = new SsaValue(new SsaValueId("%condition"), SsaTypes.Bool);
+        var thenValue = new SsaValue(new SsaValueId("%then.value"), SsaTypes.Int32);
+        var elseValue = new SsaValue(new SsaValueId("%else.value"), SsaTypes.Int32);
+        var entry = new SsaBlock(
+            new SsaBlockId("entry"),
+            instructions: [SsaConstantMaterializer.Int32(new SsaOperationId("entry.value"), entryValue, 1)],
+            terminator: SsaTerminator.Jump(new SsaBlockId("test"), [entryValue.Id]));
+        var test = new SsaBlock(
+            new SsaBlockId("test"),
+            parameters: [testArgument],
+            instructions:
+            [
+                SsaConstantMaterializer.Int32(new SsaOperationId("one"), one, 1),
+                new SsaCall(
+                    new SsaOperationId("equals"),
+                    SsaPreviewCallables.EqualInt32,
+                    [testArgument.Value.Id, one.Id],
+                    [condition])
+            ],
+            terminator: SsaTerminator.Branch(
+                condition.Id,
+                new SsaBlockId("then"),
+                [],
+                new SsaBlockId("else"),
+                []));
+        var thenBlock = new SsaBlock(
+            new SsaBlockId("then"),
+            instructions: [SsaConstantMaterializer.Int32(new SsaOperationId("then.value"), thenValue, 10)],
+            terminator: SsaTerminator.Return([thenValue.Id]));
+        var elseBlock = new SsaBlock(
+            new SsaBlockId("else"),
+            instructions: [SsaConstantMaterializer.Int32(new SsaOperationId("else.value"), elseValue, 20)],
+            terminator: SsaTerminator.Return([elseValue.Id]));
+
+        var optimized = Run(ModuleWith(entry, test, thenBlock, elseBlock));
+        var optimizedTest = optimized.Functions.Single().Blocks.Single(block => block.Id.Value == "test");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(optimized.Functions.Single().Blocks.Select(static x => x.Id.Value), Is.EqualTo(new[] { "entry", "test", "then" }));
+            Assert.That(optimizedTest.Instructions[1], Is.TypeOf<SsaOperation>());
+            Assert.That(((SsaOperation)optimizedTest.Instructions[1]).OpId, Is.EqualTo(SsaOperations.ConstantBool));
+            Assert.That(optimizedTest.Terminator?.Kind, Is.EqualTo(SsaTerminatorKind.Jump));
+            Assert.That(optimizedTest.Terminator?.Transfers.Single().Target.Value, Is.EqualTo("then"));
+        });
+    }
+
+    [Test]
+    public void Run_WhenIncomingConstantsDisagree_MarksBlockArgumentOverdefinedAndDoesNotFoldCall()
+    {
+        var selector = new SsaBlockParameter(new SsaValue(new SsaValueId("%selector"), SsaTypes.Bool));
+        var leftValue = new SsaValue(new SsaValueId("%left.value"), SsaTypes.Int32);
+        var rightValue = new SsaValue(new SsaValueId("%right.value"), SsaTypes.Int32);
+        var mergeArgument = new SsaBlockParameter(new SsaValue(new SsaValueId("%merge.arg"), SsaTypes.Int32));
+        var one = new SsaValue(new SsaValueId("%one"), SsaTypes.Int32);
+        var result = new SsaValue(new SsaValueId("%result"), SsaTypes.Int32);
+        var entry = new SsaBlock(
+            new SsaBlockId("entry"),
+            parameters: [selector],
+            terminator: SsaTerminator.Branch(
+                selector.Value.Id,
+                new SsaBlockId("left"),
+                [],
+                new SsaBlockId("right"),
+                []));
+        var left = new SsaBlock(
+            new SsaBlockId("left"),
+            instructions: [SsaConstantMaterializer.Int32(new SsaOperationId("left.value"), leftValue, 1)],
+            terminator: SsaTerminator.Jump(new SsaBlockId("merge"), [leftValue.Id]));
+        var right = new SsaBlock(
+            new SsaBlockId("right"),
+            instructions: [SsaConstantMaterializer.Int32(new SsaOperationId("right.value"), rightValue, 2)],
+            terminator: SsaTerminator.Jump(new SsaBlockId("merge"), [rightValue.Id]));
+        var merge = new SsaBlock(
+            new SsaBlockId("merge"),
+            parameters: [mergeArgument],
+            instructions:
+            [
+                SsaConstantMaterializer.Int32(new SsaOperationId("one"), one, 1),
+                new SsaCall(
+                    new SsaOperationId("add"),
+                    SsaPreviewCallables.AddInt32Unchecked,
+                    [mergeArgument.Value.Id, one.Id],
+                    [result])
+            ],
+            terminator: SsaTerminator.Return([result.Id]));
+
+        var optimized = Run(new SsaModule(
+            new SsaModuleId("test.module"),
+            [
+                new SsaFunction(
+                    new SsaFunctionId("test.function"),
+                    new SsaBlockId("entry"),
+                    [entry, left, right, merge],
+                    returnType: SsaTypes.Int32)
+            ]));
+        var optimizedMerge = optimized.Functions.Single().Blocks.Single(block => block.Id.Value == "merge");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(optimized.Functions.Single().Blocks.Select(static x => x.Id.Value), Is.EqualTo(new[] { "entry", "left", "right", "merge" }));
+            Assert.That(optimizedMerge.Instructions[1], Is.TypeOf<SsaCall>());
+            Assert.That(((SsaCall)optimizedMerge.Instructions[1]).Callee, Is.EqualTo(SsaPreviewCallables.AddInt32Unchecked));
+        });
+    }
+
+    [Test]
+    public void Run_DoesNotEvaluateUntrustedPureCall()
+    {
+        var callable = new CallableId("test.untrusted.add");
+        var left = new SsaValue(new SsaValueId("%left"), SsaTypes.Int32);
+        var right = new SsaValue(new SsaValueId("%right"), SsaTypes.Int32);
+        var result = new SsaValue(new SsaValueId("%result"), SsaTypes.Int32);
+        var block = new SsaBlock(
+            new SsaBlockId("entry"),
+            instructions:
+            [
+                SsaConstantMaterializer.Int32(new SsaOperationId("left"), left, 2),
+                SsaConstantMaterializer.Int32(new SsaOperationId("right"), right, 3),
+                new SsaCall(new SsaOperationId("call"), callable, [left.Id, right.Id], [result])
+            ],
+            terminator: SsaTerminator.Return([result.Id]));
+
+        var optimized = Run(
+            ModuleWith(block),
+            new SemanticDescriptorSet(
+                types: [new SemanticTypeDescriptor(SsaPreviewSemanticTypes.Int32)],
+                callables:
+                [
+                    new CallableDescriptor(
+                        callable,
+                        new CallableSignature([SsaPreviewSemanticTypes.Int32, SsaPreviewSemanticTypes.Int32], [SsaPreviewSemanticTypes.Int32]),
+                        effects: SemanticEffectSummary.Pure,
+                        determinism: Determinism.Deterministic,
+                        trustLevel: SemanticTrustLevel.UserProvidedUnchecked)
+                ]));
+
+        var optimizedBlock = optimized.Functions.Single().Blocks.Single();
+        Assert.That(optimizedBlock.Instructions[2], Is.TypeOf<SsaCall>());
+    }
+
+    private static SsaModule Run(SsaModule module, SemanticDescriptorSet? descriptors = null)
+    {
+        var result = new SsaSparseConditionalConstantPropagationPass(
+                descriptors ?? SsaPreviewSemanticDescriptors.ArithmeticInt32,
+                new SsaPreviewInt32ConstantEvaluator())
+            .Run(new SsaArtifact(module), new IrPipelineContext());
+
+        return result.Artifact.As<SsaArtifact>().Module;
+    }
+
+    private static SsaModule ModuleWith(params SsaBlock[] blocks) =>
+        new(
+            new SsaModuleId("test.module"),
+            [
+                new SsaFunction(
+                    new SsaFunctionId("test.function"),
+                    new SsaBlockId("entry"),
+                    blocks,
+                    returnType: SsaTypes.Int32)
+            ]);
+}

--- a/UniversalToolchain/UniversalToolchain.Ssa.Optimization/SsaOptimizationFacts.cs
+++ b/UniversalToolchain/UniversalToolchain.Ssa.Optimization/SsaOptimizationFacts.cs
@@ -9,6 +9,8 @@ public static class SsaOptimizationFacts
 
     public static FactId LocallyConstantFolded { get; } = new("ssa.optimization.constant-folded.local");
 
+    public static FactId SparseConditionalConstantPropagated { get; } = new("ssa.optimization.sccp-lite");
+
     public static FactId DeadPureInstructionsEliminated { get; } = new("ssa.optimization.dead-pure-instructions-eliminated");
 
     public static FactId BranchesFolded { get; } = new("ssa.optimization.branches-folded");

--- a/UniversalToolchain/UniversalToolchain.Ssa.Optimization/SsaRouteProfile.cs
+++ b/UniversalToolchain/UniversalToolchain.Ssa.Optimization/SsaRouteProfile.cs
@@ -195,6 +195,7 @@ public sealed class SsaPreviewArithmeticInt32Pack : ISsaSemanticExtensionPack
     public IReadOnlyList<IIrOptimizationPass> CreateOptimizationPasses() =>
     [
         new SsaConstantFoldingPass(SemanticDescriptors, new SsaPreviewInt32ConstantEvaluator()),
+        new SsaSparseConditionalConstantPropagationPass(SemanticDescriptors, new SsaPreviewInt32ConstantEvaluator()),
         new SsaBranchFoldingAndCleanupPass(),
         new SsaDeadPureInstructionEliminationPass(SsaCoreDescriptors.ConstantMaterialization, SemanticDescriptors)
     ];

--- a/UniversalToolchain/UniversalToolchain.Ssa.Optimization/SsaSparseConditionalConstantPropagationPass.cs
+++ b/UniversalToolchain/UniversalToolchain.Ssa.Optimization/SsaSparseConditionalConstantPropagationPass.cs
@@ -1,0 +1,350 @@
+using UniversalToolchain.Ir.Abstractions;
+using UniversalToolchain.Semantics.Abstractions;
+using UniversalToolchain.Ssa.Abstractions;
+
+namespace UniversalToolchain.Ssa.Optimization;
+
+/// <summary>
+/// Conservative sparse conditional constant propagation for preview SSA.
+///
+/// This pass intentionally keeps the first slice small:
+/// - tracks executable blocks and constants at SSA value granularity;
+/// - evaluates only trusted deterministic pure single-result calls;
+/// - materializes only proven constants at the original defining instruction;
+/// - folds branches only when the condition is a proven bool constant;
+/// - removes blocks proven unreachable by the executable-block lattice.
+///
+/// It deliberately does not perform general value substitution, GVN, CSE, LICM,
+/// or algebraic rewrites such as x + 0 -> x.
+/// </summary>
+public sealed class SsaSparseConditionalConstantPropagationPass : IIrOptimizationPass
+{
+    private readonly SemanticDescriptorSet _descriptors;
+    private readonly IConstantEvaluator _constantEvaluator;
+
+    public SsaSparseConditionalConstantPropagationPass()
+        : this(
+            SemanticDescriptorSet.Empty,
+            new SsaPreviewInt32ConstantEvaluator())
+    {
+    }
+
+    public SsaSparseConditionalConstantPropagationPass(
+        SemanticDescriptorSet descriptors,
+        IConstantEvaluator constantEvaluator)
+    {
+        _descriptors = descriptors ?? throw new ArgumentNullException(nameof(descriptors));
+        _constantEvaluator = constantEvaluator ?? throw new ArgumentNullException(nameof(constantEvaluator));
+    }
+
+    public IrStageId Id { get; } = new("ssa.optimization.sccp-lite");
+
+    public IrKind InputKind => SsaIrKinds.Ssa;
+
+    public IrKind OutputKind => SsaIrKinds.Ssa;
+
+    public IrStageContract Contract { get; } = new(
+        requiresFacts: [SsaFacts.StructuralVerification],
+        producesFacts:
+        [
+            SsaOptimizationFacts.SparseConditionalConstantPropagated,
+            SsaOptimizationFacts.BranchesFolded,
+            SsaOptimizationFacts.UnreachableBlocksEliminated
+        ],
+        preservesFacts: [SsaFacts.StructuralVerification]);
+
+    public IrStageResult Run(IIrArtifact input, IrPipelineContext context)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+        ArgumentNullException.ThrowIfNull(context);
+
+        var artifact = input.As<SsaArtifact>();
+        var module = new SsaModule(artifact.Module.Id, artifact.Module.Functions.Select(RewriteFunction));
+        return new IrStageResult(new SsaArtifact(module));
+    }
+
+    private SsaFunction RewriteFunction(SsaFunction function)
+    {
+        if (!function.Blocks.Any(static x => x.Id == x.Id) ||
+            !function.Blocks.Any(block => block.Id == function.EntryBlockId))
+        {
+            return function;
+        }
+
+        var state = Analyze(function);
+        return RewriteFunction(function, state);
+    }
+
+    private SccpState Analyze(SsaFunction function)
+    {
+        var state = new SccpState(function);
+        state.MarkReachable(function.EntryBlockId);
+
+        foreach (var parameter in function.Parameters)
+            state.SetValue(parameter.Value.Id, SccpValue.Overdefined);
+
+        var changed = true;
+        while (changed)
+        {
+            changed = false;
+            foreach (var block in function.Blocks)
+            {
+                if (!state.IsReachable(block.Id))
+                    continue;
+
+                foreach (var parameter in block.Parameters)
+                {
+                    if (block.Id == function.EntryBlockId)
+                        changed |= state.SetValue(parameter.Value.Id, SccpValue.Overdefined);
+                }
+
+                foreach (var instruction in block.Instructions)
+                    changed |= VisitInstruction(instruction, state);
+
+                changed |= VisitTerminator(block, state);
+            }
+        }
+
+        return state;
+    }
+
+    private bool VisitInstruction(ISsaInstruction instruction, SccpState state)
+    {
+        if (instruction.Results.Count == 0)
+            return false;
+
+        if (instruction.Results.Count == 1 &&
+            SsaConstantReader.TryRead(instruction, out var constant))
+        {
+            return state.SetValue(instruction.Results[0].Id, SccpValue.Constant(constant));
+        }
+
+        var evaluation = EvaluateInstruction(instruction, state);
+        if (evaluation.Kind == InstructionEvaluationKind.Wait)
+            return false;
+
+        if (evaluation.Kind == InstructionEvaluationKind.Constant)
+            return state.SetValue(instruction.Results[0].Id, SccpValue.Constant(evaluation.Constant!));
+
+        var changed = false;
+        foreach (var result in instruction.Results)
+            changed |= state.SetValue(result.Id, SccpValue.Overdefined);
+        return changed;
+    }
+
+    private InstructionEvaluation EvaluateInstruction(ISsaInstruction instruction, SccpState state)
+    {
+        if (instruction is not SsaCall call ||
+            instruction.Results.Count != 1 ||
+            !_descriptors.TryGetCallable(call.Callee, out var descriptor) ||
+            !CanEvaluateSafely(descriptor))
+        {
+            return InstructionEvaluation.Overdefined;
+        }
+
+        var arguments = new List<ConstantValue>(instruction.Operands.Count);
+        foreach (var operand in instruction.Operands)
+        {
+            var lattice = state.GetValue(operand);
+            if (lattice.Kind == SccpValueKind.Unknown)
+                return InstructionEvaluation.Wait;
+
+            if (lattice.Kind == SccpValueKind.Overdefined || lattice.Constant is null)
+                return InstructionEvaluation.Overdefined;
+
+            arguments.Add(lattice.Constant);
+        }
+
+        return _constantEvaluator.TryEvaluate(descriptor, arguments, out var result)
+            ? InstructionEvaluation.Constant(result)
+            : InstructionEvaluation.Overdefined;
+    }
+
+    private bool VisitTerminator(SsaBlock block, SccpState state)
+    {
+        if (block.Terminator is null)
+            return false;
+
+        if (block.Terminator.Kind == SsaTerminatorKind.Jump && block.Terminator.Transfers.Count == 1)
+            return VisitTransfer(block.Terminator.Transfers[0], state);
+
+        if (block.Terminator.Kind != SsaTerminatorKind.Branch ||
+            block.Terminator.Operands.Count != 1 ||
+            block.Terminator.Transfers.Count != 2)
+        {
+            return false;
+        }
+
+        var condition = state.GetValue(block.Terminator.Operands[0]);
+        if (TryReadBool(condition, out var boolValue))
+        {
+            var selected = boolValue ? block.Terminator.Transfers[0] : block.Terminator.Transfers[1];
+            return VisitTransfer(selected, state);
+        }
+
+        if (condition.Kind != SccpValueKind.Overdefined)
+            return false;
+
+        return VisitTransfer(block.Terminator.Transfers[0], state) |
+               VisitTransfer(block.Terminator.Transfers[1], state);
+    }
+
+    private bool VisitTransfer(SsaBlockTransfer transfer, SccpState state)
+    {
+        var changed = state.MarkReachable(transfer.Target);
+        if (!state.Blocks.TryGetValue(transfer.Target, out var target))
+            return changed;
+
+        var count = Math.Min(target.Parameters.Count, transfer.Arguments.Count);
+        for (var index = 0; index < count; index++)
+        {
+            var argumentValue = state.GetValue(transfer.Arguments[index]);
+            changed |= state.JoinValue(target.Parameters[index].Value.Id, argumentValue);
+        }
+
+        return changed;
+    }
+
+    private SsaFunction RewriteFunction(SsaFunction function, SccpState state)
+    {
+        var blocks = function.Blocks
+            .Where(block => state.IsReachable(block.Id))
+            .Select(block => RewriteBlock(block, state))
+            .ToArray();
+
+        return new SsaFunction(
+            function.Id,
+            function.EntryBlockId,
+            blocks,
+            function.Parameters,
+            function.ReturnType);
+    }
+
+    private SsaBlock RewriteBlock(SsaBlock block, SccpState state) =>
+        new(
+            block.Id,
+            block.Parameters,
+            instructions: block.Instructions.Select(instruction => RewriteInstruction(instruction, state)),
+            terminator: RewriteTerminator(block.Terminator, state));
+
+    private static ISsaInstruction RewriteInstruction(ISsaInstruction instruction, SccpState state)
+    {
+        if (instruction.Results.Count != 1)
+            return instruction;
+
+        var value = state.GetValue(instruction.Results[0].Id);
+        if (value.Kind != SccpValueKind.Constant || value.Constant is null)
+            return instruction;
+
+        return SsaConstantMaterializer.TryCreate(instruction, value.Constant) ?? instruction;
+    }
+
+    private static SsaTerminator? RewriteTerminator(SsaTerminator? terminator, SccpState state)
+    {
+        if (terminator is not { Kind: SsaTerminatorKind.Branch } ||
+            terminator.Operands.Count != 1 ||
+            terminator.Transfers.Count != 2 ||
+            !TryReadBool(state.GetValue(terminator.Operands[0]), out var condition))
+        {
+            return terminator;
+        }
+
+        var selected = condition ? terminator.Transfers[0] : terminator.Transfers[1];
+        return SsaTerminator.Jump(selected.Target, selected.Arguments);
+    }
+
+    private static bool CanEvaluateSafely(CallableDescriptor descriptor) =>
+        descriptor.Effects.IsPure &&
+        descriptor.Determinism == Determinism.Deterministic &&
+        descriptor.TrustLevel is SemanticTrustLevel.BuiltInTrusted or SemanticTrustLevel.VerifiedPlugin;
+
+    private static bool TryReadBool(SccpValue value, out bool result)
+    {
+        result = default;
+        return value.Kind == SccpValueKind.Constant &&
+               value.Constant is not null &&
+               value.Constant.Type == SsaPreviewSemanticTypes.Bool &&
+               bool.TryParse(value.Constant.CanonicalValue, out result);
+    }
+
+    private sealed class SccpState
+    {
+        private readonly HashSet<SsaBlockId> _reachableBlocks = [];
+        private readonly Dictionary<SsaValueId, SccpValue> _values = [];
+
+        public SccpState(SsaFunction function)
+        {
+            Blocks = function.Blocks.ToDictionary(static x => x.Id);
+        }
+
+        public IReadOnlyDictionary<SsaBlockId, SsaBlock> Blocks { get; }
+
+        public bool IsReachable(SsaBlockId blockId) => _reachableBlocks.Contains(blockId);
+
+        public bool MarkReachable(SsaBlockId blockId) =>
+            Blocks.ContainsKey(blockId) && _reachableBlocks.Add(blockId);
+
+        public SccpValue GetValue(SsaValueId valueId) =>
+            _values.TryGetValue(valueId, out var value) ? value : SccpValue.Unknown;
+
+        public bool SetValue(SsaValueId valueId, SccpValue value)
+        {
+            var joined = SccpValue.Join(GetValue(valueId), value);
+            if (joined.Equals(GetValue(valueId)))
+                return false;
+
+            _values[valueId] = joined;
+            return true;
+        }
+
+        public bool JoinValue(SsaValueId valueId, SccpValue value) => SetValue(valueId, value);
+    }
+
+    private enum SccpValueKind
+    {
+        Unknown,
+        Constant,
+        Overdefined
+    }
+
+    private readonly record struct SccpValue(SccpValueKind Kind, ConstantValue? Constant)
+    {
+        public static SccpValue Unknown { get; } = new(SccpValueKind.Unknown, null);
+
+        public static SccpValue Overdefined { get; } = new(SccpValueKind.Overdefined, null);
+
+        public static SccpValue Constant(ConstantValue constant) =>
+            new(SccpValueKind.Constant, constant ?? throw new ArgumentNullException(nameof(constant)));
+
+        public static SccpValue Join(SccpValue current, SccpValue incoming)
+        {
+            if (incoming.Kind == SccpValueKind.Unknown)
+                return current;
+
+            if (current.Kind == SccpValueKind.Unknown)
+                return incoming;
+
+            if (current.Kind == SccpValueKind.Overdefined || incoming.Kind == SccpValueKind.Overdefined)
+                return Overdefined;
+
+            return Equals(current.Constant, incoming.Constant) ? current : Overdefined;
+        }
+    }
+
+    private enum InstructionEvaluationKind
+    {
+        Wait,
+        Constant,
+        Overdefined
+    }
+
+    private readonly record struct InstructionEvaluation(InstructionEvaluationKind Kind, ConstantValue? Constant)
+    {
+        public static InstructionEvaluation Wait { get; } = new(InstructionEvaluationKind.Wait, null);
+
+        public static InstructionEvaluation Overdefined { get; } = new(InstructionEvaluationKind.Overdefined, null);
+
+        public static InstructionEvaluation Constant(ConstantValue constant) =>
+            new(InstructionEvaluationKind.Constant, constant ?? throw new ArgumentNullException(nameof(constant)));
+    }
+}

--- a/UniversalToolchain/UniversalToolchain.Ssa.Optimization/SsaSparseConditionalConstantPropagationPass.cs
+++ b/UniversalToolchain/UniversalToolchain.Ssa.Optimization/SsaSparseConditionalConstantPropagationPass.cs
@@ -65,7 +65,7 @@ public sealed class SsaSparseConditionalConstantPropagationPass : IIrOptimizatio
 
     private SsaFunction RewriteFunction(SsaFunction function)
     {
-        if (!function.Blocks.Any(static x => x.Id == x.Id) ||
+        if (function.Blocks.Count == 0 ||
             !function.Blocks.Any(block => block.Id == function.EntryBlockId))
         {
             return function;
@@ -116,7 +116,7 @@ public sealed class SsaSparseConditionalConstantPropagationPass : IIrOptimizatio
         if (instruction.Results.Count == 1 &&
             SsaConstantReader.TryRead(instruction, out var constant))
         {
-            return state.SetValue(instruction.Results[0].Id, SccpValue.Constant(constant));
+            return state.SetValue(instruction.Results[0].Id, SccpValue.ForConstant(constant));
         }
 
         var evaluation = EvaluateInstruction(instruction, state);
@@ -124,7 +124,7 @@ public sealed class SsaSparseConditionalConstantPropagationPass : IIrOptimizatio
             return false;
 
         if (evaluation.Kind == InstructionEvaluationKind.Constant)
-            return state.SetValue(instruction.Results[0].Id, SccpValue.Constant(evaluation.Constant!));
+            return state.SetValue(instruction.Results[0].Id, SccpValue.ForConstant(evaluation.Value!));
 
         var changed = false;
         foreach (var result in instruction.Results)
@@ -149,14 +149,14 @@ public sealed class SsaSparseConditionalConstantPropagationPass : IIrOptimizatio
             if (lattice.Kind == SccpValueKind.Unknown)
                 return InstructionEvaluation.Wait;
 
-            if (lattice.Kind == SccpValueKind.Overdefined || lattice.Constant is null)
+            if (lattice.Kind == SccpValueKind.Overdefined || lattice.Value is null)
                 return InstructionEvaluation.Overdefined;
 
-            arguments.Add(lattice.Constant);
+            arguments.Add(lattice.Value);
         }
 
         return _constantEvaluator.TryEvaluate(descriptor, arguments, out var result)
-            ? InstructionEvaluation.Constant(result)
+            ? InstructionEvaluation.ForConstant(result)
             : InstructionEvaluation.Overdefined;
     }
 
@@ -233,10 +233,10 @@ public sealed class SsaSparseConditionalConstantPropagationPass : IIrOptimizatio
             return instruction;
 
         var value = state.GetValue(instruction.Results[0].Id);
-        if (value.Kind != SccpValueKind.Constant || value.Constant is null)
+        if (value.Kind != SccpValueKind.Constant || value.Value is null)
             return instruction;
 
-        return SsaConstantMaterializer.TryCreate(instruction, value.Constant) ?? instruction;
+        return SsaConstantMaterializer.TryCreate(instruction, value.Value) ?? instruction;
     }
 
     private static SsaTerminator? RewriteTerminator(SsaTerminator? terminator, SccpState state)
@@ -262,9 +262,9 @@ public sealed class SsaSparseConditionalConstantPropagationPass : IIrOptimizatio
     {
         result = default;
         return value.Kind == SccpValueKind.Constant &&
-               value.Constant is not null &&
-               value.Constant.Type == SsaPreviewSemanticTypes.Bool &&
-               bool.TryParse(value.Constant.CanonicalValue, out result);
+               value.Value is not null &&
+               value.Value.Type == SsaPreviewSemanticTypes.Bool &&
+               bool.TryParse(value.Value.CanonicalValue, out result);
     }
 
     private sealed class SccpState
@@ -289,8 +289,9 @@ public sealed class SsaSparseConditionalConstantPropagationPass : IIrOptimizatio
 
         public bool SetValue(SsaValueId valueId, SccpValue value)
         {
-            var joined = SccpValue.Join(GetValue(valueId), value);
-            if (joined.Equals(GetValue(valueId)))
+            var current = GetValue(valueId);
+            var joined = SccpValue.Join(current, value);
+            if (joined.Equals(current))
                 return false;
 
             _values[valueId] = joined;
@@ -307,14 +308,14 @@ public sealed class SsaSparseConditionalConstantPropagationPass : IIrOptimizatio
         Overdefined
     }
 
-    private readonly record struct SccpValue(SccpValueKind Kind, ConstantValue? Constant)
+    private readonly record struct SccpValue(SccpValueKind Kind, ConstantValue? Value)
     {
         public static SccpValue Unknown { get; } = new(SccpValueKind.Unknown, null);
 
         public static SccpValue Overdefined { get; } = new(SccpValueKind.Overdefined, null);
 
-        public static SccpValue Constant(ConstantValue constant) =>
-            new(SccpValueKind.Constant, constant ?? throw new ArgumentNullException(nameof(constant)));
+        public static SccpValue ForConstant(ConstantValue value) =>
+            new(SccpValueKind.Constant, value ?? throw new ArgumentNullException(nameof(value)));
 
         public static SccpValue Join(SccpValue current, SccpValue incoming)
         {
@@ -327,7 +328,7 @@ public sealed class SsaSparseConditionalConstantPropagationPass : IIrOptimizatio
             if (current.Kind == SccpValueKind.Overdefined || incoming.Kind == SccpValueKind.Overdefined)
                 return Overdefined;
 
-            return Equals(current.Constant, incoming.Constant) ? current : Overdefined;
+            return Equals(current.Value, incoming.Value) ? current : Overdefined;
         }
     }
 
@@ -338,13 +339,13 @@ public sealed class SsaSparseConditionalConstantPropagationPass : IIrOptimizatio
         Overdefined
     }
 
-    private readonly record struct InstructionEvaluation(InstructionEvaluationKind Kind, ConstantValue? Constant)
+    private readonly record struct InstructionEvaluation(InstructionEvaluationKind Kind, ConstantValue? Value)
     {
         public static InstructionEvaluation Wait { get; } = new(InstructionEvaluationKind.Wait, null);
 
         public static InstructionEvaluation Overdefined { get; } = new(InstructionEvaluationKind.Overdefined, null);
 
-        public static InstructionEvaluation Constant(ConstantValue constant) =>
-            new(InstructionEvaluationKind.Constant, constant ?? throw new ArgumentNullException(nameof(constant)));
+        public static InstructionEvaluation ForConstant(ConstantValue value) =>
+            new(InstructionEvaluationKind.Constant, value ?? throw new ArgumentNullException(nameof(value)));
     }
 }


### PR DESCRIPTION
## What changed

This starts SCCP-lite for preview SSA:

- adds `SsaSparseConditionalConstantPropagationPass`;
- tracks executable blocks and SSA value constants with a small monotone lattice: `Unknown`, `Constant`, `Overdefined`;
- evaluates only trusted deterministic pure single-result calls;
- materializes only proven constants at their original defining instruction through `SsaConstantMaterializer`;
- folds branch terminators only when the condition is a proven bool constant;
- removes blocks proven unreachable by the executable-block lattice;
- wires the pass into the preview arithmetic route after local constant folding and before branch cleanup/DCE;
- adds focused tests for cross-block constants, overdefined merges, and untrusted callable safety.

## Safety boundaries

This intentionally does not implement GVN, CSE, LICM, general value substitution, or algebraic rewrites. The first SCCP-lite slice only creates materialized constants and selected jumps where the lattice proves them.

## Validation

Validated on head `283d70484478bab60494773dcef309d953cf0372`:

- `.NET CI`: success;
- `UniversalToolchain validation`: success.