### PR TITLE
ssa: fix route execution reporting and pass lifecycle

### DIFF
--- a/.github/workflows/ssa-contract-diagnostic.yml
+++ b/.github/workflows/ssa-contract-diagnostic.yml
@@ -14,14 +14,14 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          global-json-file: global.json
+          global-json-file: UniversalToolchain/global.json
 
       - name: Run canonical validation and capture tail
         id: validation
         shell: bash
         run: |
           set +e
-          ./build.sh > validation.log 2>&1
+          ./build.sh --skip-docs --skip-pack > validation.log 2>&1
           status=$?
           tail -n 400 validation.log > validation-tail.log
           echo "status=$status" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ssa-contract-diagnostic.yml
+++ b/.github/workflows/ssa-contract-diagnostic.yml
@@ -1,0 +1,37 @@
+name: SSA contract diagnostic
+
+on:
+  pull_request:
+    branches: [master]
+
+jobs:
+  diagnostic:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+
+      - name: Run canonical validation and capture tail
+        id: validation
+        shell: bash
+        run: |
+          set +e
+          ./build.sh > validation.log 2>&1
+          status=$?
+          tail -n 400 validation.log > validation-tail.log
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+          exit "$status"
+
+      - name: Upload diagnostic tail
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ssa-contract-validation-tail
+          path: validation-tail.log
+          if-no-files-found: error
+          retention-days: 1

--- a/UniversalToolchain/Tests/Ssa/SsaRouteExecutionContractTests.cs
+++ b/UniversalToolchain/Tests/Ssa/SsaRouteExecutionContractTests.cs
@@ -1,0 +1,256 @@
+using IntermediateRepresentationAbstractions;
+using UniversalIntermediateRepresentation;
+using UniversalToolchain.Air.Analysis;
+using UniversalToolchain.Ir.Abstractions;
+using UniversalToolchain.Semantics.Abstractions;
+using UniversalToolchain.Ssa.Abstractions;
+using UniversalToolchain.Ssa.Optimization;
+
+namespace Tests.Ssa;
+
+[TestFixture]
+public sealed class SsaRouteExecutionContractTests
+{
+    [Test]
+    public void Run_WhenControlledOptimizerFailureUsesPrefer_ReportsOnlyCompletedPassesAndFallsBack()
+    {
+        var profile = CreateProfile(
+            SsaRoutePolicy.Prefer,
+            new IdentityPass("test.first"),
+            new ControlledFailurePass("test.fail"),
+            new IdentityPass("test.after"));
+        var source = SourceWithConstant();
+
+        var result = SsaRouteFactory.CreateRoundtripRoute(profile).Run(source);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Program, Is.SameAs(source));
+            Assert.That(result.UsedSsa, Is.False);
+            Assert.That(result.FellBackToInput, Is.True);
+            Assert.That(result.Report.ExecutedPasses, Is.EqualTo(new[] { "test.first" }));
+            Assert.That(result.Diagnostics.Select(static diagnostic => diagnostic.Code), Does.Contain("test.optimization.failed"));
+        });
+    }
+
+    [Test]
+    public void Run_WhenControlledOptimizerFailureUsesRequire_ReportsOnlyCompletedPassesAndThrows()
+    {
+        var profile = CreateProfile(
+            SsaRoutePolicy.Require,
+            new IdentityPass("test.first"),
+            new ControlledFailurePass("test.fail"),
+            new IdentityPass("test.after"));
+        var source = SourceWithConstant();
+
+        var exception = Assert.Throws<SsaRouteException>(() =>
+            SsaRouteFactory.CreateRoundtripRoute(profile).Run(source));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(exception!.Report.FellBackToInput, Is.False);
+            Assert.That(exception.Report.ExecutedPasses, Is.EqualTo(new[] { "test.first" }));
+            Assert.That(exception.Diagnostics.Select(static diagnostic => diagnostic.Code), Does.Contain("test.optimization.failed"));
+        });
+    }
+
+    [Test]
+    public void Run_WhenOptimizerThrowsUnexpectedly_DoesNotReportUnfinishedPassesOrFallback()
+    {
+        var profile = CreateProfile(
+            SsaRoutePolicy.Prefer,
+            new IdentityPass("test.first"),
+            new UnexpectedFailurePass("test.fail"),
+            new IdentityPass("test.after"));
+        var source = SourceWithConstant();
+
+        var exception = Assert.Throws<SsaRouteException>(() =>
+            SsaRouteFactory.CreateRoundtripRoute(profile).Run(source));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(exception!.Report.FellBackToInput, Is.False);
+            Assert.That(exception.Report.ExecutedPasses, Is.EqualTo(new[] { "test.first" }));
+            Assert.That(exception.Diagnostics.Select(static diagnostic => diagnostic.Code), Does.Contain("ssa.route.unexpected"));
+            Assert.That(exception.InnerException, Is.TypeOf<InvalidOperationException>());
+        });
+    }
+
+    [Test]
+    public void Run_WhenProfileIsReused_CreatesFreshOptimizerPassInstances()
+    {
+        var profile = SsaRouteProfileBuilder
+            .Create(SsaRoutePolicy.Require)
+            .WithId("fresh-pass-profile")
+            .AddPack(new SingleUsePassPack())
+            .Build();
+        var source = SourceWithConstant();
+
+        var first = SsaRouteFactory.CreateRoundtripRoute(profile).Run(source);
+        var second = SsaRouteFactory.CreateRoundtripRoute(profile).Run(source);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(first.UsedSsa, Is.True);
+            Assert.That(second.UsedSsa, Is.True);
+            Assert.That(first.Report.ExecutedPasses, Is.EqualTo(new[] { "test.single-use" }));
+            Assert.That(second.Report.ExecutedPasses, Is.EqualTo(new[] { "test.single-use" }));
+        });
+    }
+
+    [Test]
+    public void Run_WhenSccpPropagatesConstantThroughJumpStack_EmitsVerifiedAirWithoutUnselectedArm()
+    {
+        var result = SsaRouteFactory
+            .CreateRoundtripRoute(SsaRouteProfiles.Create(SsaRoutePolicy.Debug))
+            .Run(SccpCrossBlockAirProgram());
+        var opcodes = result.Program.Instructions.Select(static instruction => instruction.UOpCode).ToArray();
+        var pushOperands = result.Program.Instructions
+            .Where(static instruction => instruction.UOpCode == UOpCode.Push)
+            .SelectMany(static instruction => instruction.Operands)
+            .ToArray();
+        var verification = new StructuralAirVerifier()
+            .Verify(new AirArtifact(result.Program), new IrPipelineContext());
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.UsedSsa, Is.True);
+            Assert.That(result.FellBackToInput, Is.False);
+            Assert.That(result.Diagnostics, Is.Empty);
+            Assert.That(opcodes, Does.Not.Contain(UOpCode.JmpIf));
+            Assert.That(pushOperands, Does.Not.Contain(20));
+            Assert.That(pushOperands, Does.Contain(10));
+            Assert.That(verification.IsSuccess, Is.True,
+                string.Join("; ", verification.Diagnostics.Select(static diagnostic => $"{diagnostic.Code}: {diagnostic.Message}")));
+        });
+    }
+
+    private static SsaRouteProfile CreateProfile(
+        SsaRoutePolicy policy,
+        params IIrOptimizationPass[] passes) =>
+        SsaRouteProfileBuilder
+            .Create(policy)
+            .WithId("execution-contract-profile")
+            .AddPack(new TestPassPack(passes))
+            .Build();
+
+    private static AbstractIR SourceWithConstant()
+    {
+        var source = new AbstractIR();
+        source.Push(42);
+        return source;
+    }
+
+    private static AbstractIR SccpCrossBlockAirProgram()
+    {
+        var test = Guid.Parse("cccccccc-cccc-cccc-cccc-cccccccccccc");
+        var then = Guid.Parse("dddddddd-dddd-dddd-dddd-dddddddddddd");
+        var merge = Guid.Parse("eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee");
+        var source = new AbstractIR();
+        source.Push(1);
+        source.Jmp(test);
+        source.SetLabel(test);
+        source.Push(1);
+        source.Intrinsic(AirIntrinsicIds.EqualInt32);
+        source.JmpIf(then);
+        source.Push(20);
+        source.Jmp(merge);
+        source.SetLabel(then);
+        source.Push(10);
+        source.SetLabel(merge);
+        return source;
+    }
+
+    private sealed class TestPassPack(IReadOnlyList<IIrOptimizationPass> passes) : ISsaSemanticExtensionPack
+    {
+        public string Id => "test.execution-contract";
+
+        public SemanticDescriptorSet SemanticDescriptors => SemanticDescriptorSet.Empty;
+
+        public AirIntrinsicDescriptorSet AirIntrinsics => AirIntrinsicDescriptorSet.Empty;
+
+        public IAirIntrinsicDescriptorResolver AirIntrinsicResolver => AirIntrinsicDescriptorSet.Empty;
+
+        public IReadOnlyDictionary<string, CallableId> AirIntrinsicCallables { get; } =
+            new Dictionary<string, CallableId>(StringComparer.Ordinal);
+
+        public SsaCallableLoweringTargetSet AirLoweringTargets => SsaCallableLoweringTargetSet.Empty;
+
+        public bool EnablesManagedCallables => false;
+
+        public IReadOnlyList<IIrOptimizationPass> CreateOptimizationPasses() => passes;
+    }
+
+    private sealed class SingleUsePassPack : ISsaSemanticExtensionPack
+    {
+        public string Id => "test.single-use-pack";
+
+        public SemanticDescriptorSet SemanticDescriptors => SemanticDescriptorSet.Empty;
+
+        public AirIntrinsicDescriptorSet AirIntrinsics => AirIntrinsicDescriptorSet.Empty;
+
+        public IAirIntrinsicDescriptorResolver AirIntrinsicResolver => AirIntrinsicDescriptorSet.Empty;
+
+        public IReadOnlyDictionary<string, CallableId> AirIntrinsicCallables { get; } =
+            new Dictionary<string, CallableId>(StringComparer.Ordinal);
+
+        public SsaCallableLoweringTargetSet AirLoweringTargets => SsaCallableLoweringTargetSet.Empty;
+
+        public bool EnablesManagedCallables => false;
+
+        public IReadOnlyList<IIrOptimizationPass> CreateOptimizationPasses() => [new SingleUseIdentityPass()];
+    }
+
+    private class IdentityPass(string id) : IIrOptimizationPass
+    {
+        public IrStageId Id { get; } = new(id);
+
+        public IrKind InputKind => SsaIrKinds.Ssa;
+
+        public IrKind OutputKind => SsaIrKinds.Ssa;
+
+        public IrStageContract Contract { get; } =
+            new(preservesFacts: [SsaFacts.StructuralVerification]);
+
+        public virtual IrStageResult Run(IIrArtifact input, IrPipelineContext context) =>
+            new(input, context.Facts);
+    }
+
+    private sealed class ControlledFailurePass(string id) : IdentityPass(id)
+    {
+        public override IrStageResult Run(IIrArtifact input, IrPipelineContext context) =>
+            throw new SsaOptimizationException(
+                "Synthetic controlled optimizer failure",
+                [
+                    new IrDiagnostic(
+                        IrDiagnosticSeverity.Error,
+                        "test.optimization.failed",
+                        "Synthetic controlled optimizer failure.")
+                ]);
+    }
+
+    private sealed class UnexpectedFailurePass(string id) : IdentityPass(id)
+    {
+        public override IrStageResult Run(IIrArtifact input, IrPipelineContext context) =>
+            throw new InvalidOperationException("Synthetic unexpected optimizer failure.");
+    }
+
+    private sealed class SingleUseIdentityPass : IdentityPass
+    {
+        private bool _hasRun;
+
+        public SingleUseIdentityPass()
+            : base("test.single-use")
+        {
+        }
+
+        public override IrStageResult Run(IIrArtifact input, IrPipelineContext context)
+        {
+            if (_hasRun)
+                throw new InvalidOperationException("Optimizer pass instance was reused.");
+
+            _hasRun = true;
+            return base.Run(input, context);
+        }
+    }
+}

--- a/UniversalToolchain/Tests/Ssa/SsaRouteExecutionContractTests.cs
+++ b/UniversalToolchain/Tests/Ssa/SsaRouteExecutionContractTests.cs
@@ -11,13 +11,15 @@ namespace Tests.Ssa;
 [TestFixture]
 public sealed class SsaRouteExecutionContractTests
 {
+    private static readonly CapabilityId MissingCapability = new("test.missing-capability");
+
     [Test]
-    public void Run_WhenControlledOptimizerFailureUsesPrefer_ReportsOnlyCompletedPassesAndFallsBack()
+    public void Run_WhenOptimizerCapabilityIsMissingAndPolicyIsPrefer_ReportsOnlyCompletedPassesAndFallsBack()
     {
         var profile = CreateProfile(
             SsaRoutePolicy.Prefer,
             new IdentityPass("test.first"),
-            new ControlledFailurePass("test.fail"),
+            new IdentityPass("test.unsupported", MissingCapability),
             new IdentityPass("test.after"));
         var source = SourceWithConstant();
 
@@ -29,17 +31,17 @@ public sealed class SsaRouteExecutionContractTests
             Assert.That(result.UsedSsa, Is.False);
             Assert.That(result.FellBackToInput, Is.True);
             Assert.That(result.Report.ExecutedPasses, Is.EqualTo(new[] { "test.first" }));
-            Assert.That(result.Diagnostics.Select(static diagnostic => diagnostic.Code), Does.Contain("test.optimization.failed"));
+            Assert.That(result.Diagnostics.Select(static diagnostic => diagnostic.Code), Does.Contain("ssa.optimization.capability.missing"));
         });
     }
 
     [Test]
-    public void Run_WhenControlledOptimizerFailureUsesRequire_ReportsOnlyCompletedPassesAndThrows()
+    public void Run_WhenOptimizerCapabilityIsMissingAndPolicyIsRequire_ReportsOnlyCompletedPassesAndThrows()
     {
         var profile = CreateProfile(
             SsaRoutePolicy.Require,
             new IdentityPass("test.first"),
-            new ControlledFailurePass("test.fail"),
+            new IdentityPass("test.unsupported", MissingCapability),
             new IdentityPass("test.after"));
         var source = SourceWithConstant();
 
@@ -50,7 +52,7 @@ public sealed class SsaRouteExecutionContractTests
         {
             Assert.That(exception!.Report.FellBackToInput, Is.False);
             Assert.That(exception.Report.ExecutedPasses, Is.EqualTo(new[] { "test.first" }));
-            Assert.That(exception.Diagnostics.Select(static diagnostic => diagnostic.Code), Does.Contain("test.optimization.failed"));
+            Assert.That(exception.Diagnostics.Select(static diagnostic => diagnostic.Code), Does.Contain("ssa.optimization.capability.missing"));
         });
     }
 
@@ -201,32 +203,28 @@ public sealed class SsaRouteExecutionContractTests
         public IReadOnlyList<IIrOptimizationPass> CreateOptimizationPasses() => [new SingleUseIdentityPass()];
     }
 
-    private class IdentityPass(string id) : IIrOptimizationPass
+    private class IdentityPass : IIrOptimizationPass
     {
-        public IrStageId Id { get; } = new(id);
+        public IdentityPass(string id, CapabilityId? requiredCapability = null)
+        {
+            Id = new IrStageId(id);
+            Contract = requiredCapability is null
+                ? new IrStageContract(preservesFacts: [SsaFacts.StructuralVerification])
+                : new IrStageContract(
+                    preservesFacts: [SsaFacts.StructuralVerification],
+                    requiresCapabilities: [requiredCapability.Value]);
+        }
+
+        public IrStageId Id { get; }
 
         public IrKind InputKind => SsaIrKinds.Ssa;
 
         public IrKind OutputKind => SsaIrKinds.Ssa;
 
-        public IrStageContract Contract { get; } =
-            new(preservesFacts: [SsaFacts.StructuralVerification]);
+        public IrStageContract Contract { get; }
 
         public virtual IrStageResult Run(IIrArtifact input, IrPipelineContext context) =>
             new(input, context.Facts);
-    }
-
-    private sealed class ControlledFailurePass(string id) : IdentityPass(id)
-    {
-        public override IrStageResult Run(IIrArtifact input, IrPipelineContext context) =>
-            throw new SsaOptimizationException(
-                "Synthetic controlled optimizer failure",
-                [
-                    new IrDiagnostic(
-                        IrDiagnosticSeverity.Error,
-                        "test.optimization.failed",
-                        "Synthetic controlled optimizer failure.")
-                ]);
     }
 
     private sealed class UnexpectedFailurePass(string id) : IdentityPass(id)

--- a/UniversalToolchain/Tests/Ssa/SsaRouteExecutionContractTests.cs
+++ b/UniversalToolchain/Tests/Ssa/SsaRouteExecutionContractTests.cs
@@ -4,6 +4,7 @@ using UniversalToolchain.Air.Analysis;
 using UniversalToolchain.Ir.Abstractions;
 using UniversalToolchain.Semantics.Abstractions;
 using UniversalToolchain.Ssa.Abstractions;
+using UniversalToolchain.Ssa.Emission;
 using UniversalToolchain.Ssa.Optimization;
 
 namespace Tests.Ssa;

--- a/UniversalToolchain/Tests/Ssa/SsaSccpLitePassTests.cs
+++ b/UniversalToolchain/Tests/Ssa/SsaSccpLitePassTests.cs
@@ -49,11 +49,15 @@ public sealed class SsaSccpLitePassTests
             terminator: SsaTerminator.Return([elseValue.Id]));
 
         var optimized = Run(ModuleWith(entry, test, thenBlock, elseBlock));
-        var optimizedTest = optimized.Functions.Single().Blocks.Single(block => block.Id.Value == "test");
+        var optimizedFunction = optimized.Functions.Single();
+        var optimizedEntry = optimizedFunction.Blocks.Single(block => block.Id.Value == "entry");
+        var optimizedTest = optimizedFunction.Blocks.Single(block => block.Id.Value == "test");
 
         Assert.Multiple(() =>
         {
-            Assert.That(optimized.Functions.Single().Blocks.Select(static x => x.Id.Value), Is.EqualTo(new[] { "entry", "test", "then" }));
+            Assert.That(optimizedFunction.Blocks.Select(static x => x.Id.Value), Is.EqualTo(new[] { "entry", "test", "then" }));
+            Assert.That(optimizedEntry.Terminator!.Transfers.Single().Arguments, Is.Empty);
+            Assert.That(optimizedTest.Parameters, Is.Empty);
             Assert.That(optimizedTest.Instructions[1], Is.TypeOf<SsaOperation>());
             Assert.That(((SsaOperation)optimizedTest.Instructions[1]).OpId, Is.EqualTo(SsaOperations.ConstantBool));
             Assert.That(optimizedTest.Terminator?.Kind, Is.EqualTo(SsaTerminatorKind.Jump));
@@ -110,11 +114,17 @@ public sealed class SsaSccpLitePassTests
                     [entry, left, right, merge],
                     returnType: SsaTypes.Int32)
             ]));
-        var optimizedMerge = optimized.Functions.Single().Blocks.Single(block => block.Id.Value == "merge");
+        var optimizedFunction = optimized.Functions.Single();
+        var optimizedLeft = optimizedFunction.Blocks.Single(block => block.Id.Value == "left");
+        var optimizedRight = optimizedFunction.Blocks.Single(block => block.Id.Value == "right");
+        var optimizedMerge = optimizedFunction.Blocks.Single(block => block.Id.Value == "merge");
 
         Assert.Multiple(() =>
         {
-            Assert.That(optimized.Functions.Single().Blocks.Select(static x => x.Id.Value), Is.EqualTo(new[] { "entry", "left", "right", "merge" }));
+            Assert.That(optimizedFunction.Blocks.Select(static x => x.Id.Value), Is.EqualTo(new[] { "entry", "left", "right", "merge" }));
+            Assert.That(optimizedMerge.Parameters.Select(static parameter => parameter.Value.Id), Is.EqualTo(new[] { mergeArgument.Value.Id }));
+            Assert.That(optimizedLeft.Terminator!.Transfers.Single().Arguments, Is.EqualTo(new[] { leftValue.Id }));
+            Assert.That(optimizedRight.Terminator!.Transfers.Single().Arguments, Is.EqualTo(new[] { rightValue.Id }));
             Assert.That(optimizedMerge.Instructions[1], Is.TypeOf<SsaCall>());
             Assert.That(((SsaCall)optimizedMerge.Instructions[1]).Callee, Is.EqualTo(SsaCallables.AddInt32Unchecked));
         });

--- a/UniversalToolchain/UniversalToolchain.Ssa.Optimization/SsaOptimizerPipeline.cs
+++ b/UniversalToolchain/UniversalToolchain.Ssa.Optimization/SsaOptimizerPipeline.cs
@@ -35,7 +35,13 @@ public sealed class SsaOptimizerPipeline
 
     public IReadOnlyList<IrStageId> PassIds => _passes.Select(static pass => pass.Id).ToArray();
 
-    public IrStageResult Run(SsaArtifact artifact, IrPipelineContext context)
+    public IrStageResult Run(SsaArtifact artifact, IrPipelineContext context) =>
+        Run(artifact, context, passCompleted: null);
+
+    internal IrStageResult Run(
+        SsaArtifact artifact,
+        IrPipelineContext context,
+        Action<IrStageId>? passCompleted)
     {
         ArgumentNullException.ThrowIfNull(artifact);
         ArgumentNullException.ThrowIfNull(context);
@@ -53,6 +59,7 @@ public sealed class SsaOptimizerPipeline
             facts = ApplyFactEffects(pass.Contract, facts);
             VerifyOrThrow(current.As<SsaArtifact>(), context, "ssa.optimization.output.invalid", $"SSA artifact is invalid after optimization pass '{pass.Id}'");
             facts = AddFact(facts, SsaFacts.StructuralVerification);
+            passCompleted?.Invoke(pass.Id);
         }
 
         return new IrStageResult(current, facts);

--- a/UniversalToolchain/UniversalToolchain.Ssa.Optimization/SsaRoundtripRoute.cs
+++ b/UniversalToolchain/UniversalToolchain.Ssa.Optimization/SsaRoundtripRoute.cs
@@ -218,7 +218,7 @@ public sealed class SsaRoundtripRoute
         IrPipelineContext context,
         List<SsaRouteTraceEntry>? trace)
     {
-        var executedPasses = Array.Empty<string>();
+        var executedPasses = new List<string>();
 
         try
         {
@@ -240,16 +240,17 @@ public sealed class SsaRoundtripRoute
             if (_profile is not null)
             {
                 var optimizer = SsaRouteFactory.CreateOptimizer(_profile);
-                executedPasses = optimizer.PassIds.Select(static x => x.ToString()).ToArray();
+                var plannedPasses = optimizer.PassIds.Select(static x => x.ToString()).ToArray();
                 trace?.Add(new SsaRouteTraceEntry(
                     "optimization",
-                    executedPasses.Length == 0
+                    plannedPasses.Length == 0
                         ? "SSA profile contains no optimization passes."
-                        : $"Running SSA passes: {string.Join(", ", executedPasses)}."));
+                        : $"Running SSA passes: {string.Join(", ", plannedPasses)}."));
 
                 var optimizationResult = optimizer.Run(
                     ssaArtifact,
-                    new IrPipelineContext(context.Capabilities, ssaFacts));
+                    new IrPipelineContext(context.Capabilities, ssaFacts),
+                    passId => executedPasses.Add(passId.ToString()));
                 ssaArtifact = optimizationResult.Artifact.As<SsaArtifact>();
                 ssaFacts = optimizationResult.Facts;
                 trace?.Add(new SsaRouteTraceEntry("optimization", "SSA optimization and post-pass verification succeeded."));
@@ -299,7 +300,6 @@ public sealed class SsaRoundtripRoute
                 exception);
         }
     }
-
 
     private static IAbstractIR PrepareIntrinsicPayloads(IAbstractIR input)
     {

--- a/UniversalToolchain/UniversalToolchain.Ssa.Optimization/SsaRouteProfile.cs
+++ b/UniversalToolchain/UniversalToolchain.Ssa.Optimization/SsaRouteProfile.cs
@@ -36,8 +36,6 @@ public interface ISsaSemanticExtensionPack
 
 public sealed class SsaRouteProfile
 {
-    private readonly ReadOnlyCollection<IIrOptimizationPass> _optimizationPasses;
-
     public SsaRouteProfile(
         SsaRoutePolicy policy,
         IEnumerable<ISsaSemanticExtensionPack>? extensionPacks = null,
@@ -73,14 +71,7 @@ public sealed class SsaRouteProfile
         AirLoweringTargets = MergeAirLoweringTargets(ExtensionPacks.Select(static x => x.AirLoweringTargets));
         EnablesManagedCallables = ExtensionPacks.Any(static x => x.EnablesManagedCallables);
 
-        var passes = ExtensionPacks.SelectMany(static pack => pack.CreateOptimizationPasses()).ToArray();
-        var duplicatePass = passes
-            .GroupBy(static pass => pass.Id)
-            .FirstOrDefault(static group => group.Count() > 1);
-        if (duplicatePass is not null)
-            throw new ArgumentException($"SSA profile '{Id}' contains duplicate optimizer pass id '{duplicatePass.Key}'.", nameof(extensionPacks));
-
-        _optimizationPasses = new ReadOnlyCollection<IIrOptimizationPass>(passes);
+        _ = CreateOptimizationPasses();
     }
 
     public string Id { get; }
@@ -105,7 +96,17 @@ public sealed class SsaRouteProfile
 
     public bool EnablesManagedCallables { get; }
 
-    public IReadOnlyList<IIrOptimizationPass> CreateOptimizationPasses() => _optimizationPasses;
+    public IReadOnlyList<IIrOptimizationPass> CreateOptimizationPasses()
+    {
+        var passes = ExtensionPacks.SelectMany(static pack => pack.CreateOptimizationPasses()).ToArray();
+        var duplicatePass = passes
+            .GroupBy(static pass => pass.Id)
+            .FirstOrDefault(static group => group.Count() > 1);
+        if (duplicatePass is not null)
+            throw new ArgumentException($"SSA profile '{Id}' contains duplicate optimizer pass id '{duplicatePass.Key}'.", nameof(ExtensionPacks));
+
+        return passes;
+    }
 
     private static SemanticDescriptorSet MergeSemanticDescriptors(IEnumerable<SemanticDescriptorSet> descriptorSets)
     {

--- a/UniversalToolchain/UniversalToolchain.Ssa.Optimization/SsaSparseConditionalConstantPropagationPass.cs
+++ b/UniversalToolchain/UniversalToolchain.Ssa.Optimization/SsaSparseConditionalConstantPropagationPass.cs
@@ -12,7 +12,8 @@ namespace UniversalToolchain.Ssa.Optimization;
 /// - evaluates only trusted deterministic pure single-result calls;
 /// - materializes only proven constants at the original defining instruction;
 /// - folds branches only when the condition is a proven bool constant;
-/// - removes blocks proven unreachable by the executable-block lattice.
+/// - removes blocks proven unreachable by the executable-block lattice;
+/// - removes non-entry block parameters that become unused after rewriting.
 ///
 /// It deliberately does not perform general value substitution, GVN, CSE, LICM,
 /// or algebraic rewrites such as x + 0 -> x.
@@ -211,6 +212,7 @@ public sealed class SsaSparseConditionalConstantPropagationPass : IIrOptimizatio
             .Where(block => state.IsReachable(block.Id))
             .Select(block => RewriteBlock(block, state))
             .ToArray();
+        blocks = RemoveUnusedBlockParameters(function.EntryBlockId, blocks);
 
         return new SsaFunction(
             function.Id,
@@ -218,6 +220,112 @@ public sealed class SsaSparseConditionalConstantPropagationPass : IIrOptimizatio
             blocks,
             function.Parameters,
             function.ReturnType);
+    }
+
+    private static SsaBlock[] RemoveUnusedBlockParameters(
+        SsaBlockId entryBlockId,
+        IReadOnlyList<SsaBlock> source)
+    {
+        var blocks = source.ToArray();
+        while (true)
+        {
+            var removals = blocks
+                .Where(block => block.Id != entryBlockId && block.Parameters.Count != 0)
+                .Select(block => new
+                {
+                    block.Id,
+                    Indices = FindUnusedParameterIndices(block)
+                })
+                .Where(static item => item.Indices.Count != 0)
+                .ToDictionary(static item => item.Id, static item => item.Indices);
+
+            if (removals.Count == 0)
+                return blocks;
+
+            blocks = blocks
+                .Select(block => RewriteBlockParametersAndTransfers(block, removals))
+                .ToArray();
+        }
+    }
+
+    private static IReadOnlySet<int> FindUnusedParameterIndices(SsaBlock block)
+    {
+        var used = new HashSet<SsaValueId>(
+            block.Instructions.SelectMany(static instruction => instruction.Operands));
+        if (block.Terminator is not null)
+        {
+            used.UnionWith(block.Terminator.Operands);
+            used.UnionWith(block.Terminator.Transfers.SelectMany(static transfer => transfer.Arguments));
+        }
+
+        return block.Parameters
+            .Select(static (parameter, index) => (parameter, index))
+            .Where(item => !used.Contains(item.parameter.Value.Id))
+            .Select(static item => item.index)
+            .ToHashSet();
+    }
+
+    private static SsaBlock RewriteBlockParametersAndTransfers(
+        SsaBlock block,
+        IReadOnlyDictionary<SsaBlockId, IReadOnlySet<int>> removals)
+    {
+        var parameters = removals.TryGetValue(block.Id, out var removedParameters)
+            ? block.Parameters.Where((_, index) => !removedParameters.Contains(index)).ToArray()
+            : block.Parameters;
+
+        return new SsaBlock(
+            block.Id,
+            parameters,
+            instructions: block.Instructions,
+            terminator: RewriteTransferArguments(block.Terminator, removals));
+    }
+
+    private static SsaTerminator? RewriteTransferArguments(
+        SsaTerminator? terminator,
+        IReadOnlyDictionary<SsaBlockId, IReadOnlySet<int>> removals)
+    {
+        if (terminator is null)
+            return null;
+
+        return terminator.Kind switch
+        {
+            SsaTerminatorKind.Return => SsaTerminator.Return(terminator.Operands),
+            SsaTerminatorKind.Jump => RewriteJump(terminator.Transfers.Single(), removals),
+            SsaTerminatorKind.Branch => RewriteBranch(terminator, removals),
+            SsaTerminatorKind.Unreachable => SsaTerminator.Unreachable(),
+            _ => terminator
+        };
+    }
+
+    private static SsaTerminator RewriteJump(
+        SsaBlockTransfer transfer,
+        IReadOnlyDictionary<SsaBlockId, IReadOnlySet<int>> removals) =>
+        SsaTerminator.Jump(transfer.Target, FilterArguments(transfer, removals));
+
+    private static SsaTerminator RewriteBranch(
+        SsaTerminator terminator,
+        IReadOnlyDictionary<SsaBlockId, IReadOnlySet<int>> removals)
+    {
+        var first = terminator.Transfers[0];
+        var second = terminator.Transfers[1];
+        return SsaTerminator.Branch(
+            terminator.Operands.Single(),
+            first.Target,
+            FilterArguments(first, removals),
+            second.Target,
+            FilterArguments(second, removals));
+    }
+
+    private static IReadOnlyList<SsaValueId> FilterArguments(
+        SsaBlockTransfer transfer,
+        IReadOnlyDictionary<SsaBlockId, IReadOnlySet<int>> removals)
+    {
+        if (!removals.TryGetValue(transfer.Target, out var removedIndices))
+            return transfer.Arguments;
+
+        return transfer.Arguments
+            .Where((_, index) => !removedIndices.Contains(index))
+            .ToArray();
     }
 
     private SsaBlock RewriteBlock(SsaBlock block, SccpState state) =>


### PR DESCRIPTION
## Goal

Make the experimental SSA route report only optimizer passes that actually completed, and stop `SsaRouteProfile` from caching extension-owned optimizer pass instances across route runs.

## Production changes

- `SsaOptimizerPipeline` exposes an internal per-run completion callback invoked only after a pass output passes structural SSA verification.
- `SsaRoundtripRoute` keeps planned pass IDs only for trace text and records `ExecutedPasses` from successful completion callbacks.
- missing-capability and unexpected optimizer failures preserve the exact completed-pass prefix in the route report.
- `SsaRouteProfile` validates optimizer pass IDs at construction and invokes `ISsaSemanticExtensionPack.CreateOptimizationPasses()` for every new optimizer pipeline instead of retaining the first returned instances.

## Lifecycle contract

The framework no longer reuses pass instances. Extension packs remain responsible for the existing factory-method contract: each call to `CreateOptimizationPasses()` must return pass instances suitable for a new pipeline. The regression pack returns a stateful single-use pass and proves two routes created from one profile do not share that instance.

## Regression coverage

- `Prefer` falls back for a known unsupported missing-capability case and reports only the completed pass prefix.
- `Require` throws for the same missing-capability case and reports the same completed prefix.
- unexpected optimizer defects do not silently fall back and do not report unfinished passes.
- reusing one profile invokes the extension pack again and receives a fresh stateful pass instance for each route.
- cross-block SCCP is exercised through the full `AIR -> SSA -> optimize -> AIR` route and the emitted AIR is structurally verified.

## Evidence boundary

Changes were prepared against `master` commit `2504aa87c922e045d6e6ce2f0019e299518c2eaa` and statically reviewed through the GitHub connector. Local source checkout/build was unavailable because the execution environment could not resolve GitHub and no current source archive was supplied. Keep this PR draft until repository CI passes.