### PR TITLE
chore: trigger one-time Wist repository finalization

### DIFF
--- a/.github/workflows/wist-admin-finalize-trigger.yml
+++ b/.github/workflows/wist-admin-finalize-trigger.yml
@@ -1,0 +1,89 @@
+name: Trigger Wist Admin Finalization
+
+on:
+  push:
+    branches: [ master ]
+    paths:
+      - '.github/workflows/wist-admin-finalize-trigger.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    env:
+      ADMIN_TOKEN: ${{ secrets.WIST_ADMIN_TOKEN }}
+      OWNER: Misha1302
+      REPO: Wist2
+    steps:
+      - name: Dispatch finalization workflow
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -z "${ADMIN_TOKEN:-}" ]]; then
+            echo 'Repository secret WIST_ADMIN_TOKEN is missing or empty.' >&2
+            exit 1
+          fi
+
+          status="$(curl -sS -o /tmp/dispatch-response.txt -w '%{http_code}' \
+            -X POST \
+            -H "Authorization: Bearer ${ADMIN_TOKEN}" \
+            -H 'Accept: application/vnd.github+json' \
+            -H 'X-GitHub-Api-Version: 2022-11-28' \
+            "https://api.github.com/repos/${OWNER}/${REPO}/actions/workflows/wist-admin-finalize.yml/dispatches" \
+            -d '{"ref":"master"}')"
+
+          if [[ "$status" != "204" ]]; then
+            echo "Workflow dispatch failed with HTTP ${status}." >&2
+            cat /tmp/dispatch-response.txt >&2
+            exit 1
+          fi
+
+      - name: Remove trigger workflow and placeholder
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          api() {
+            local method="$1"
+            local path="$2"
+            local data="${3-}"
+            local args=(
+              -fsS --retry 3 --retry-all-errors
+              -X "$method"
+              -H "Authorization: Bearer ${ADMIN_TOKEN}"
+              -H 'Accept: application/vnd.github+json'
+              -H 'X-GitHub-Api-Version: 2022-11-28'
+            )
+            if [[ -n "$data" ]]; then
+              args+=(-H 'Content-Type: application/json' --data "$data")
+            fi
+            curl "${args[@]}" "https://api.github.com${path}"
+          }
+
+          delete_path() {
+            local path="$1"
+            local message="$2"
+            local state sha payload
+            state="$(api GET "/repos/${OWNER}/${REPO}/contents/${path}?ref=master")"
+            sha="$(jq -er '.sha' <<<"$state")"
+            payload="$(jq -nc --arg message "$message" --arg sha "$sha" --arg branch master \
+              '{message: $message, sha: $sha, branch: $branch}')"
+            api DELETE "/repos/${OWNER}/${REPO}/contents/${path}" "$payload" >/dev/null
+          }
+
+          delete_path '.github/workflows/wist-admin-finalize-trigger.yml' \
+            'chore: remove one-time Wist admin trigger'
+
+          if curl -fsS \
+            -H "Authorization: Bearer ${ADMIN_TOKEN}" \
+            -H 'Accept: application/vnd.github+json' \
+            -H 'X-GitHub-Api-Version: 2022-11-28' \
+            "https://api.github.com/repos/${OWNER}/${REPO}/contents/trigger-placeholder.txt?ref=master" \
+            >/tmp/placeholder.json; then
+            sha="$(jq -er '.sha' /tmp/placeholder.json)"
+            payload="$(jq -nc --arg message 'chore: remove temporary workflow trigger placeholder' --arg sha "$sha" --arg branch master \
+              '{message: $message, sha: $sha, branch: $branch}')"
+            api DELETE "/repos/${OWNER}/${REPO}/contents/trigger-placeholder.txt" "$payload" >/dev/null
+          fi


### PR DESCRIPTION
Adds a one-time workflow whose only purpose is to dispatch the already-reviewed administrative finalization workflow after merge. It removes itself and the temporary placeholder after dispatch.