### PR TITLE
docs: add REBASE 2026 talk proposal materials

### DIFF
--- a/docs/talks/langdev-2026/README.md
+++ b/docs/talks/langdev-2026/README.md
@@ -4,6 +4,8 @@
 
 **Extensible Programming on .NET**
 
+> The REBASE 2026 adaptation has a separate [reviewer landing page, submission, and 30-minute outline](../rebase-2026/README.md). This directory remains the original LangDev-specific evidence packet and shared reproducible demonstration.
+
 UniversalToolchain explores a practical form of extensible programming: language features are authored as independent modules, composed into a restricted dialect, progressively lowered through Bytecode and Abstract IR, and executed either by an AIR interpreter or by a CIL backend built on `DynamicMethod`.
 
 The central question of the talk is:
@@ -81,10 +83,10 @@ Expected high-level result:
 ```text
 Pricing results match.
 The restricted dialect rejects the unsupported binding shape.
-Focused parity suites: 30 tests passed, 0 failed.
+All focused interpreter/CIL parity and restricted-dialect suites pass.
 ```
 
-The exact console shape produced by the current pricing demonstration is recorded in [expected-output.txt](expected-output.txt).
+The exact console shape produced by the current pricing demonstration is recorded in [expected-output.txt](expected-output.txt). The test runner reports the currently discovered test count; the documentation intentionally does not hard-code a count that may change as regression coverage grows.
 
 ## Talk structure
 

--- a/docs/talks/langdev-2026/run-demo.sh
+++ b/docs/talks/langdev-2026/run-demo.sh
@@ -85,4 +85,4 @@ dotnet test \
     --filter "FullyQualifiedName~PricingRestrictedDialectExecutionTests|FullyQualifiedName~WistDialectExecutionParityTests"
 
 echo
-echo "LangDev 2026 demonstration verification completed successfully."
+echo "Talk demonstration verification completed successfully."

--- a/docs/talks/langdev-2026/talk-outline.md
+++ b/docs/talks/langdev-2026/talk-outline.md
@@ -51,7 +51,7 @@ module-owned syntax/semantics
 
 Clarify that the module/plugin abstraction is primarily a construction-time mechanism; the hot compiled path invokes a prepared typed artifact.
 
-Show the arithmetic benchmark table briefly, including the measurement boundary and limitations.
+Show the performance model and measurement boundary briefly. Prepared invocation, convenience evaluation, and compilation/setup cost must remain separate. Show numeric results only when a fresh reproducible run records the exact commit, environment, raw artifacts, and comparison contract.
 
 ## 16:00-21:30 — When one DSL became two languages
 

--- a/docs/talks/rebase-2026/README.md
+++ b/docs/talks/rebase-2026/README.md
@@ -1,0 +1,94 @@
+# REBASE 2026 talk proposal
+
+## Build the Language, Then Make the Abstractions Disappear
+
+**Engineering an Extensible .NET DSL Runtime**
+
+UniversalToolchain/Wist2 is an independent open-source .NET compiler/runtime project for restricted formulas and small domain-specific languages. This REBASE proposal presents an applied architecture and a reproducible implementation case study rather than a production-deployment claim.
+
+The central question is:
+
+> Can language features remain independently composable while a dialect is being built, then become concrete before execution without allowing the interpreter and compiler to define different languages?
+
+## Two-minute reviewer path
+
+1. Read the exact [submitted title, abstract, and speaker bio](submission.md).
+2. Review the architecture and evidence map below.
+3. Inspect the [30-minute talk outline](talk-outline.md).
+4. Run the shared reproducible demonstration from the repository root:
+
+```bash ci-run=false
+./docs/talks/langdev-2026/run-demo.sh
+```
+
+5. Follow the shared [module-to-CIL lowering walkthrough](../langdev-2026/lowering-walkthrough.md).
+6. Read the [semantic-parity regression case study](../langdev-2026/parity-regression.md).
+7. Review the [performance measurement boundary](../langdev-2026/benchmark-evidence.md).
+
+The `langdev-2026` directory is retained as the original event-specific evidence packet. REBASE reuses its reproducible technical material while providing a separate abstract, reviewer path, and 30-minute structure.
+
+## Contribution
+
+The talk presents four connected engineering decisions:
+
+1. **Construction-time extensibility.** Language features own syntax and semantic contributions and are selected into a restricted dialect.
+2. **Explicit lowering boundaries.** Bytecode separates frontend composition from Abstract IR, which exposes operations to optimizers and execution backends.
+3. **Capability-gated specialization.** Supported operations become concrete interpreter operations or typed CIL emitted through `DynamicMethod`; unsupported specialization leaves the portable representation intact.
+4. **One semantics across runtimes.** The interpreter acts as a semantic reference path, while cross-backend tests protect external bindings, lexical locals, shadowing, nested scopes, and compiled artifacts.
+
+## Architecture
+
+```mermaid
+graph LR
+    A[Feature modules] --> B[Dialect definition]
+    B --> C[Deterministic runtime plan]
+    C --> D[Lexer / Parser / AST]
+    D --> E[Bytecode]
+    E --> F[Abstract IR]
+    F --> G[Capability-gated specialization]
+    G --> H[AIR interpreter]
+    G --> I[CIL / DynamicMethod]
+    I --> J[.NET JIT machine code]
+    H -. semantic parity .-> I
+```
+
+The precise hot-path claim is bounded: for supported compiled paths, feature-module selection and plugin dispatch are construction-time mechanisms. The prepared artifact executes lowered typed operations; this is not a claim that every helper is inlined or that every Wist program matches handwritten C# performance.
+
+## Demonstration and evidence
+
+Code evidence snapshot: [`b965466e1880a2d3a9172972e05d2cbd740c891a`](https://github.com/Misha1302/Wist2/tree/b965466e1880a2d3a9172972e05d2cbd740c891a).
+
+| Talk claim | Public evidence |
+|---|---|
+| A restricted dialect is assembled from selected language/runtime capabilities | [`PricingRestrictedDialectExecutionTests.cs`](https://github.com/Misha1302/Wist2/blob/b965466e1880a2d3a9172972e05d2cbd740c891a/UniversalToolchain/UniversalToolchain.Dialects.Tests/PricingRestrictedDialectExecutionTests.cs) |
+| The same selected language executes through interpreter and CIL paths | [`WistDialectExecutionParityTests.cs`](https://github.com/Misha1302/Wist2/blob/b965466e1880a2d3a9172972e05d2cbd740c891a/UniversalToolchain/UniversalToolchain.Dialects.Tests/Wist/WistDialectExecutionParityTests.cs) |
+| External bindings and local storage remain semantically distinct | [`InterpreterBindingsParityTests.cs`](https://github.com/Misha1302/Wist2/blob/b965466e1880a2d3a9172972e05d2cbd740c891a/UniversalToolchain/Tests/Backends/InterpreterBindingsParityTests.cs) |
+| Compiled artifacts preserve interpreter/compiler semantics | [`RuntimeCompiledArtifactParityTests.cs`](https://github.com/Misha1302/Wist2/blob/b965466e1880a2d3a9172972e05d2cbd740c891a/UniversalToolchain/Tests/Backends/RuntimeCompiledArtifactParityTests.cs) |
+| The public pricing scenario compares hardcoded C#, general Wist, and a restricted dialect | [`PricingDiscountScenario.cs`](https://github.com/Misha1302/Wist2/blob/b965466e1880a2d3a9172972e05d2cbd740c891a/UniversalToolchain/Example/Scenarios/PricingDiscountScenario.cs) |
+| Performance claims separate prepared invocation, convenience evaluation, and compilation cost | [benchmark contract](https://github.com/Misha1302/Wist2/blob/b965466e1880a2d3a9172972e05d2cbd740c891a/UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/README.md) |
+
+The demonstration covers:
+
+- deterministic dialect/runtime-plan inspection;
+- a pricing formula executed through the general and restricted language paths;
+- rejection of a feature that the restricted dialect did not select;
+- interpreter/compiler parity for external bindings, local variables, shadowing, nested scopes, and compiled artifacts;
+- the distinction between language composition, semantic lowering, optimization, and backend execution.
+
+## Applied relevance
+
+The architecture and failure mode apply beyond Wist. Expression evaluators, rules engines, query compilers, template runtimes, and tiered language implementations face the same boundary: a more concrete execution path must be allowed to change representation without redefining observable semantics.
+
+The talk leaves the audience with reusable rules for locating semantic ownership, querying backend capabilities instead of concrete backend names, separating local and external storage identities, and validating parity across dialect and optimizer configurations.
+
+## Current boundary
+
+UniversalToolchain is the reusable framework; Wist is its reference language and proving ground. The current alpha demonstrates modular language composition, deterministic runtime selection, Bytecode-to-AIR lowering, interpreter/CIL execution, capability-gated specialization, and semantic-parity testing.
+
+The proposal does **not** claim:
+
+- production deployment or a stable 1.0 API;
+- hardened in-process sandboxing for hostile code;
+- fully stabilized generic third-party DSL authoring;
+- universal performance parity with handwritten C#;
+- benchmark conclusions outside the recorded scenario and environment.

--- a/docs/talks/rebase-2026/submission.md
+++ b/docs/talks/rebase-2026/submission.md
@@ -1,0 +1,27 @@
+# REBASE 2026 submission
+
+## Title
+
+**Build the Language, Then Make the Abstractions Disappear: Engineering an Extensible .NET DSL Runtime**
+
+## Abstract
+
+Extensible language architectures are often modular while they are being built but remain abstract while they execute. UniversalToolchain/Wist2 explores a different boundary: compose a language from independent feature modules, then progressively lower the selected semantics into a deterministic runtime plan and concrete interpreter or typed CIL operations.
+
+In this talk, I will build a restricted pricing DSL from independently selected language modules and trace one program through dialect composition, Bytecode, Abstract IR, and two execution paths: an AIR interpreter and a `DynamicMethod`-based CIL backend. The demonstration covers external bindings, local variables, arithmetic, control flow, backend capabilities, and the rejection of language features that were not included in the selected dialect.
+
+The central engineering question is how to preserve extensibility during language construction without keeping language-construction machinery in prepared execution paths. I will show how capability-gated lowering allows supported operations to become concrete runtime or CIL operations while keeping frontend semantics independent from a particular backend.
+
+Specialization also creates a dangerous failure mode: different backends can quietly turn one DSL into two languages. A real regression involving external bindings and local-variable shadowing will serve as a case study. I will explain how explicit semantic identities, storage contracts, deterministic composition, and cross-backend regression tests prevent this divergence.
+
+The audience will leave with a practical architecture for building DSL runtimes that remain open to extension during construction, become concrete before execution, and preserve one language semantics across supported backends.
+
+UniversalToolchain/Wist2 is an independent open-source alpha project. The talk presents a reproducible architecture, implementation experience, design trade-offs, and current limitations rather than claiming production deployment.
+
+## Short bio
+
+Mikhail Razakov is the creator and primary developer of UniversalToolchain/Wist2, an independent open-source .NET framework for building and executing embeddable domain-specific languages. His work focuses on modular language composition, intermediate representations, interpreters, typed CIL generation, runtime specialization, compiler verification, and semantic consistency across execution backends. In summer 2026, he is a compiler engineering intern at MCST and an incoming Software Engineering student at HSE University. He also teaches programming and writes about compilers, virtual machines, and .NET runtime internals.
+
+## Form material URL
+
+`https://github.com/Misha1302/Wist2/tree/master/docs/talks/rebase-2026`

--- a/docs/talks/rebase-2026/submission.md
+++ b/docs/talks/rebase-2026/submission.md
@@ -8,7 +8,7 @@
 
 Extensible language architectures are often modular while they are being built but remain abstract while they execute. UniversalToolchain/Wist2 explores a different boundary: compose a language from independent feature modules, then progressively lower the selected semantics into a deterministic runtime plan and concrete interpreter or typed CIL operations.
 
-In this talk, I will build a restricted pricing DSL from independently selected language modules and trace one program through dialect composition, Bytecode, Abstract IR, and two execution paths: an AIR interpreter and a `DynamicMethod`-based CIL backend. The demonstration covers external bindings, local variables, arithmetic, control flow, backend capabilities, and the rejection of language features that were not included in the selected dialect.
+In this talk, I will build a restricted pricing DSL from independently selected language modules and trace one program through dialect composition, Bytecode, Abstract IR, and two execution paths: an AIR interpreter and a `DynamicMethod`-based CIL backend. The demonstration covers external bindings, lexical local variables, arithmetic, backend capabilities, and the rejection of language features that were not included in the selected dialect.
 
 The central engineering question is how to preserve extensibility during language construction without keeping language-construction machinery in prepared execution paths. I will show how capability-gated lowering allows supported operations to become concrete runtime or CIL operations while keeping frontend semantics independent from a particular backend.
 

--- a/docs/talks/rebase-2026/talk-outline.md
+++ b/docs/talks/rebase-2026/talk-outline.md
@@ -1,0 +1,122 @@
+# Thirty-minute REBASE talk outline
+
+## 0:00-3:00 — The disappearing abstraction
+
+Open with the practical question:
+
+> Can a language remain extensible while it is being assembled, but execute as a prepared concrete artifact without letting each backend redefine its semantics?
+
+Show the short pipeline:
+
+```text
+feature modules -> dialect -> Bytecode -> AIR -> typed operations -> CIL -> JIT code
+```
+
+State both constraints immediately:
+
+- feature selection must remain modular and deterministic;
+- the interpreter and compiler must still execute one language.
+
+## 3:00-7:00 — Extensible programming, concretely
+
+Explain only the architecture required for the rest of the talk:
+
+- independent language feature modules;
+- dialect composition as explicit feature selection;
+- deterministic runtime-plan construction;
+- Bytecode as the frontend composition boundary;
+- AIR as the optimizer/backend execution boundary;
+- backend capability queries instead of concrete backend-name checks.
+
+Avoid class diagrams and long interface inventories.
+
+## 7:00-13:00 — Restricted pricing DSL demonstration
+
+1. Show `price * 0.9 + fee` as the smallest useful formula.
+2. Run the hardcoded C# path.
+3. Run the general Wist dialect.
+4. Run the restricted pricing dialect.
+5. Show equal results through the prepared paths.
+6. Show the restricted dialect rejecting statement-style binding syntax that was not selected.
+7. Inspect the deterministic runtime plan and selected interpreter/CIL capabilities.
+
+The point is not pricing itself. The scenario makes language-surface selection and execution-path differences visible without requiring domain-specific background.
+
+## 13:00-19:00 — Where the abstractions go
+
+Trace one representative operation through the pipeline:
+
+```text
+module-owned syntax and semantics
+-> Bytecode contribution
+-> AIR operation
+-> capability-gated typed lowering
+-> DynamicMethod CIL
+-> .NET JIT
+```
+
+Clarify the exact claim:
+
+- language modules and dialect selection are construction-time mechanisms;
+- supported compiled operations become typed operations in a prepared artifact;
+- the hot invocation path does not perform per-operation module dispatch;
+- this does not promise universal JIT inlining or handwritten-C# performance.
+
+Present the performance **model and measurement boundary**, not an unqualified benchmark table. Prepared invocation, convenience evaluation, and compilation/setup cost must be measured separately. Show numeric results only when a fresh run preserves the exact commit, environment, raw BenchmarkDotNet artifacts, and comparison contract.
+
+## 19:00-25:00 — When specialization threatened semantics
+
+Present the preserved external-binding/local-variable regression:
+
+```text
+let i = 0
+i = i + 1
+i = i + 1
+i = i + 1
+price + fee * i
+```
+
+Explain:
+
+- how interpreter and CIL storage assumptions could diverge;
+- why patching one generated instruction would hide the ownership error;
+- why external bindings and lexical locals need distinct semantic identities;
+- how late backend-specific storage mapping preserves the language contract;
+- how parity tests cover declaration order, unused bindings, nested scopes, repeated access, and shadowing.
+
+Use the current fixed regression tests as evidence. Do not break the current runtime live on stage.
+
+## 25:00-28:00 — Reusable engineering rules
+
+Leave the audience with five rules:
+
+1. Compose language features before backend activation.
+2. Put semantic identities in backend-independent representations.
+3. Let optimizers query capabilities instead of concrete backend names.
+4. Treat the interpreter as a semantic reference implementation, not merely a slow fallback.
+5. Test parity across dialect configurations, storage shapes, and optimizer states.
+
+Briefly connect the rules to expression engines, rule runtimes, query compilers, template engines, and tiered language implementations.
+
+## 28:00-30:00 — Limits and closing
+
+State the current boundary explicitly:
+
+- open-source alpha, not a production deployment report;
+- restricted dialect composition is not hardened sandboxing;
+- generic third-party DSL authoring remains less mature than the Wist-first path;
+- performance evidence is scenario- and environment-bounded.
+
+Close with:
+
+> Extensible during construction. Specialized during execution. One semantics across supported runtimes.
+
+## Demonstration fallback
+
+Prepare three levels:
+
+- **Primary:** run the shared demo script after restoring and building before the session.
+- **Fallback:** use a terminal recording of the same command and results.
+- **Last resort:** use screenshots, the committed expected output, and direct links to the focused regression tests.
+
+Never depend on conference Wi-Fi. Restore and build before the session; use `--no-restore --no-build` for live commands after the environment is prepared.


### PR DESCRIPTION
## Summary

- add a separate REBASE 2026 reviewer landing page, exact submission text, and 30-minute outline;
- preserve `langdev-2026` as the original event-specific evidence packet and reuse its technical walkthroughs;
- remove the stale hard-coded focused-test count from the shared evidence page;
- align the LangDev outline with the current benchmark evidence boundary;
- make the shared demo completion message event-neutral.

## Positioning

The REBASE proposal leads with construction-time language modularity and capability-gated Bytecode/AIR-to-interpreter/CIL specialization. The binding/shadowing semantic-parity regression remains a supporting case study rather than the whole talk.

## Validation requested

- documentation link and claim review;
- Markdown/documentation CI;
- shared demo/build/test workflow where available.

## Evidence boundary

This PR changes documentation and one shell-script status line only. It does not change compiler/runtime behavior or make new production/performance claims.