### PR TITLE
docs: tighten REBASE proposal prose without dropping evidence

### DIFF
--- a/docs/talks/rebase-2026/README.md
+++ b/docs/talks/rebase-2026/README.md
@@ -4,7 +4,7 @@ Status: proposal.
 
 ## Build the Language, Then Make the Abstractions Disappear
 
-**Engineering an Extensible .NET DSL Runtime**
+**From Feature Modules to Typed CIL**
 
 UniversalToolchain/Wist2 builds restricted .NET DSLs from independently selected feature modules. Module selection defines the language during construction; supported operations are then lowered through Bytecode and Abstract IR into either an AIR interpreter or typed CIL emitted with `DynamicMethod`.
 

--- a/docs/talks/rebase-2026/README.md
+++ b/docs/talks/rebase-2026/README.md
@@ -66,7 +66,7 @@ Code evidence snapshot: [`b965466e1880a2d3a9172972e05d2cbd740c891a`](https://git
 | The pricing scenario compares hardcoded C#, general Wist, and a restricted dialect | [`PricingDiscountScenario.cs`](https://github.com/Misha1302/Wist2/blob/b965466e1880a2d3a9172972e05d2cbd740c891a/UniversalToolchain/Example/Scenarios/PricingDiscountScenario.cs) |
 | Performance measurements separate prepared invocation, convenience evaluation, and compilation cost | [benchmark contract](https://github.com/Misha1302/Wist2/blob/b965466e1880a2d3a9172972e05d2cbd740c891a/UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/README.md) |
 
-The demo inspects the selected runtime plan and runs the same pricing formula through general and restricted language paths. It also rejects a feature excluded from the restricted dialect and executes the focused interpreter/CIL parity suites.
+The demo inspects the selected runtime plan and runs the same pricing formula through general and restricted language paths. It also rejects a feature excluded from the restricted dialect and executes the focused interpreter/CIL parity suites. Together, these steps keep language composition, semantic lowering, optimization, and backend execution visibly separate.
 
 ## Why the failure matters
 

--- a/docs/talks/rebase-2026/README.md
+++ b/docs/talks/rebase-2026/README.md
@@ -1,40 +1,40 @@
 # REBASE 2026 talk proposal
 
+Authority: proposal.
+
 ## Build the Language, Then Make the Abstractions Disappear
 
 **Engineering an Extensible .NET DSL Runtime**
 
-UniversalToolchain/Wist2 is an independent open-source .NET compiler/runtime project for restricted formulas and small domain-specific languages. This REBASE proposal presents an applied architecture and a reproducible implementation case study rather than a production-deployment claim.
+UniversalToolchain/Wist2 builds restricted .NET DSLs from independently selected feature modules. The modules choose the language during construction; supported operations are then lowered through Bytecode and Abstract IR into either an AIR interpreter or typed CIL emitted with `DynamicMethod`.
 
-The central question is:
+The difficult part is keeping those execution paths as one language. A real regression involving external bindings, lexical locals, and shadowing exposed where backend storage choices had leaked into semantics. The talk uses that failure to explain the boundary between language construction, lowering, backend specialization, and semantic verification.
 
-> Can language features remain independently composable while a dialect is being built, then become concrete before execution without allowing the interpreter and compiler to define different languages?
+## Reviewer path
 
-## Two-minute reviewer path
-
-1. Read the exact [submitted title, abstract, and speaker bio](submission.md).
-2. Review the architecture and evidence map below.
-3. Inspect the [30-minute talk outline](talk-outline.md).
-4. Run the shared reproducible demonstration from the repository root:
+1. Read the exact [title, abstract, and speaker bio](submission.md).
+2. Review the architecture and evidence below, then inspect the [30-minute outline](talk-outline.md).
+3. From the repository root, run the shared demonstration:
 
 ```bash ci-run=false
 ./docs/talks/langdev-2026/run-demo.sh
 ```
 
-5. Follow the shared [module-to-CIL lowering walkthrough](../langdev-2026/lowering-walkthrough.md).
-6. Read the [semantic-parity regression case study](../langdev-2026/parity-regression.md).
-7. Review the [performance measurement boundary](../langdev-2026/benchmark-evidence.md).
+Supporting material:
 
-The `langdev-2026` directory is retained as the original event-specific evidence packet. REBASE reuses its reproducible technical material while providing a separate abstract, reviewer path, and 30-minute structure.
+- [module-to-CIL lowering walkthrough](../langdev-2026/lowering-walkthrough.md);
+- [semantic-parity regression case study](../langdev-2026/parity-regression.md);
+- [performance measurement boundary](../langdev-2026/benchmark-evidence.md);
+- [speaker preparation notes](speaker-notes.md).
 
-## Contribution
+The original `langdev-2026` directory remains the shared technical evidence packet. This directory contains the REBASE-specific submission and 30-minute structure.
 
-The talk presents four connected engineering decisions:
+## What the talk shows
 
-1. **Construction-time extensibility.** Language features own syntax and semantic contributions and are selected into a restricted dialect.
-2. **Explicit lowering boundaries.** Bytecode separates frontend composition from Abstract IR, which exposes operations to optimizers and execution backends.
-3. **Capability-gated specialization.** Supported operations become concrete interpreter operations or typed CIL emitted through `DynamicMethod`; unsupported specialization leaves the portable representation intact.
-4. **One semantics across runtimes.** The interpreter acts as a semantic reference path, while cross-backend tests protect external bindings, lexical locals, shadowing, nested scopes, and compiled artifacts.
+- Feature modules own syntax and semantic contributions, and a dialect selects the allowed language surface.
+- Bytecode is the frontend composition boundary; AIR is the optimizer and backend boundary.
+- Backend capabilities, not backend names, decide whether a portable operation can be specialized into a concrete interpreter or CIL operation.
+- The interpreter is the reference execution path, while cross-backend tests protect external bindings, lexical locals, shadowing, nested scopes, and compiled artifacts.
 
 ## Architecture
 
@@ -52,43 +52,27 @@ graph LR
     H -. semantic parity .-> I
 ```
 
-The precise hot-path claim is bounded: for supported compiled paths, feature-module selection and plugin dispatch are construction-time mechanisms. The prepared artifact executes lowered typed operations; this is not a claim that every helper is inlined or that every Wist program matches handwritten C# performance.
+For supported compiled paths, module selection and plugin dispatch happen during construction. The prepared artifact executes lowered typed operations. This claim does not imply universal JIT inlining or handwritten-C# performance.
 
 ## Demonstration and evidence
 
 Code evidence snapshot: [`b965466e1880a2d3a9172972e05d2cbd740c891a`](https://github.com/Misha1302/Wist2/tree/b965466e1880a2d3a9172972e05d2cbd740c891a).
 
-| Talk claim | Public evidence |
+| Claim | Public evidence |
 |---|---|
 | A restricted dialect is assembled from selected language/runtime capabilities | [`PricingRestrictedDialectExecutionTests.cs`](https://github.com/Misha1302/Wist2/blob/b965466e1880a2d3a9172972e05d2cbd740c891a/UniversalToolchain/UniversalToolchain.Dialects.Tests/PricingRestrictedDialectExecutionTests.cs) |
 | The same selected language executes through interpreter and CIL paths | [`WistDialectExecutionParityTests.cs`](https://github.com/Misha1302/Wist2/blob/b965466e1880a2d3a9172972e05d2cbd740c891a/UniversalToolchain/UniversalToolchain.Dialects.Tests/Wist/WistDialectExecutionParityTests.cs) |
 | External bindings and local storage remain semantically distinct | [`InterpreterBindingsParityTests.cs`](https://github.com/Misha1302/Wist2/blob/b965466e1880a2d3a9172972e05d2cbd740c891a/UniversalToolchain/Tests/Backends/InterpreterBindingsParityTests.cs) |
 | Compiled artifacts preserve interpreter/compiler semantics | [`RuntimeCompiledArtifactParityTests.cs`](https://github.com/Misha1302/Wist2/blob/b965466e1880a2d3a9172972e05d2cbd740c891a/UniversalToolchain/Tests/Backends/RuntimeCompiledArtifactParityTests.cs) |
-| The public pricing scenario compares hardcoded C#, general Wist, and a restricted dialect | [`PricingDiscountScenario.cs`](https://github.com/Misha1302/Wist2/blob/b965466e1880a2d3a9172972e05d2cbd740c891a/UniversalToolchain/Example/Scenarios/PricingDiscountScenario.cs) |
-| Performance claims separate prepared invocation, convenience evaluation, and compilation cost | [benchmark contract](https://github.com/Misha1302/Wist2/blob/b965466e1880a2d3a9172972e05d2cbd740c891a/UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/README.md) |
+| The pricing scenario compares hardcoded C#, general Wist, and a restricted dialect | [`PricingDiscountScenario.cs`](https://github.com/Misha1302/Wist2/blob/b965466e1880a2d3a9172972e05d2cbd740c891a/UniversalToolchain/Example/Scenarios/PricingDiscountScenario.cs) |
+| Performance measurements separate prepared invocation, convenience evaluation, and compilation cost | [benchmark contract](https://github.com/Misha1302/Wist2/blob/b965466e1880a2d3a9172972e05d2cbd740c891a/UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/README.md) |
 
-The demonstration covers:
+The demo inspects the selected runtime plan, runs the same pricing formula through general and restricted language paths, rejects a feature excluded from the restricted dialect, and executes the focused interpreter/CIL parity suites.
 
-- deterministic dialect/runtime-plan inspection;
-- a pricing formula executed through the general and restricted language paths;
-- rejection of a feature that the restricted dialect did not select;
-- interpreter/compiler parity for external bindings, local variables, shadowing, nested scopes, and compiled artifacts;
-- the distinction between language composition, semantic lowering, optimization, and backend execution.
+## Why the failure matters
 
-## Applied relevance
+Any runtime with interpreted and compiled paths can change representation without intending to change meaning. The binding regression shows one concrete way this happens: external values and lexical locals acquire different physical layouts, and backend allocation accidentally becomes observable language behavior. The fix is to define semantic identities before backend storage allocation and test parity across scope, storage, dialect, and optimizer variations.
 
-The architecture and failure mode apply beyond Wist. Expression evaluators, rules engines, query compilers, template runtimes, and tiered language implementations face the same boundary: a more concrete execution path must be allowed to change representation without redefining observable semantics.
+## Current limits
 
-The talk leaves the audience with reusable rules for locating semantic ownership, querying backend capabilities instead of concrete backend names, separating local and external storage identities, and validating parity across dialect and optimizer configurations.
-
-## Current boundary
-
-UniversalToolchain is the reusable framework; Wist is its reference language and proving ground. The current alpha demonstrates modular language composition, deterministic runtime selection, Bytecode-to-AIR lowering, interpreter/CIL execution, capability-gated specialization, and semantic-parity testing.
-
-The proposal does **not** claim:
-
-- production deployment or a stable 1.0 API;
-- hardened in-process sandboxing for hostile code;
-- fully stabilized generic third-party DSL authoring;
-- universal performance parity with handwritten C#;
-- benchmark conclusions outside the recorded scenario and environment.
+UniversalToolchain/Wist2 is an open-source alpha, not a production deployment report or a hardened in-process sandbox. The Wist-first path is more mature than generic third-party DSL authoring, the API is not yet a stable 1.0 contract, and performance conclusions are limited to explicitly recorded scenarios and environments.

--- a/docs/talks/rebase-2026/README.md
+++ b/docs/talks/rebase-2026/README.md
@@ -1,6 +1,6 @@
 # REBASE 2026 talk proposal
 
-Authority: proposal.
+Status: proposal.
 
 ## Build the Language, Then Make the Abstractions Disappear
 
@@ -20,12 +20,11 @@ The difficult part is keeping those execution paths as one language. A real regr
 ./docs/talks/langdev-2026/run-demo.sh
 ```
 
-Supporting material:
+Supporting technical material:
 
 - [module-to-CIL lowering walkthrough](../langdev-2026/lowering-walkthrough.md);
 - [semantic-parity regression case study](../langdev-2026/parity-regression.md);
-- [performance measurement boundary](../langdev-2026/benchmark-evidence.md);
-- [speaker preparation notes](speaker-notes.md).
+- [performance measurement boundary](../langdev-2026/benchmark-evidence.md).
 
 The original `langdev-2026` directory remains the shared technical evidence packet. This directory contains the REBASE-specific submission and 30-minute structure.
 
@@ -76,3 +75,5 @@ Any runtime with interpreted and compiled paths can change representation withou
 ## Current limits
 
 UniversalToolchain is the reusable framework; Wist is its reference language and proving ground. The project is an open-source alpha, not a production deployment report or a hardened in-process sandbox. The Wist-first path is more mature than generic third-party DSL authoring, the API is not yet a stable 1.0 contract, and performance conclusions are limited to explicitly recorded scenarios and environments.
+
+Delivery and fallback details are kept separately in [speaker preparation notes](speaker-notes.md).

--- a/docs/talks/rebase-2026/README.md
+++ b/docs/talks/rebase-2026/README.md
@@ -6,9 +6,9 @@ Authority: proposal.
 
 **Engineering an Extensible .NET DSL Runtime**
 
-UniversalToolchain/Wist2 builds restricted .NET DSLs from independently selected feature modules. The modules choose the language during construction; supported operations are then lowered through Bytecode and Abstract IR into either an AIR interpreter or typed CIL emitted with `DynamicMethod`.
+UniversalToolchain/Wist2 builds restricted .NET DSLs from independently selected feature modules. Module selection defines the language during construction; supported operations are then lowered through Bytecode and Abstract IR into either an AIR interpreter or typed CIL emitted with `DynamicMethod`.
 
-The difficult part is keeping those execution paths as one language. A real regression involving external bindings, lexical locals, and shadowing exposed where backend storage choices had leaked into semantics. The talk uses that failure to explain the boundary between language construction, lowering, backend specialization, and semantic verification.
+The difficult part is keeping those execution paths as one language. A real regression involving external bindings, lexical locals, and shadowing exposed how backend storage choices had leaked into semantics. That failure makes the boundary between language construction, lowering, backend specialization, and semantic verification concrete.
 
 ## Reviewer path
 

--- a/docs/talks/rebase-2026/README.md
+++ b/docs/talks/rebase-2026/README.md
@@ -66,7 +66,7 @@ Code evidence snapshot: [`b965466e1880a2d3a9172972e05d2cbd740c891a`](https://git
 | The pricing scenario compares hardcoded C#, general Wist, and a restricted dialect | [`PricingDiscountScenario.cs`](https://github.com/Misha1302/Wist2/blob/b965466e1880a2d3a9172972e05d2cbd740c891a/UniversalToolchain/Example/Scenarios/PricingDiscountScenario.cs) |
 | Performance measurements separate prepared invocation, convenience evaluation, and compilation cost | [benchmark contract](https://github.com/Misha1302/Wist2/blob/b965466e1880a2d3a9172972e05d2cbd740c891a/UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/README.md) |
 
-The demo inspects the selected runtime plan, runs the same pricing formula through general and restricted language paths, rejects a feature excluded from the restricted dialect, and executes the focused interpreter/CIL parity suites.
+The demo inspects the selected runtime plan and runs the same pricing formula through general and restricted language paths. It also rejects a feature excluded from the restricted dialect and executes the focused interpreter/CIL parity suites.
 
 ## Why the failure matters
 
@@ -74,6 +74,6 @@ Any runtime with interpreted and compiled paths can change representation withou
 
 ## Current limits
 
-UniversalToolchain is the reusable framework; Wist is its reference language and proving ground. The project is an open-source alpha, not a production deployment report or a hardened in-process sandbox. The Wist-first path is more mature than generic third-party DSL authoring, the API is not yet a stable 1.0 contract, and performance conclusions are limited to explicitly recorded scenarios and environments.
+UniversalToolchain is the reusable framework; Wist is its reference language and proving ground. The project is an open-source alpha, not a production deployment report or a hardened in-process sandbox. The Wist-first path is more mature than generic third-party DSL authoring. The API is not yet a stable 1.0 contract, and performance conclusions are limited to explicitly recorded scenarios and environments.
 
 Delivery and fallback details are kept separately in [speaker preparation notes](speaker-notes.md).

--- a/docs/talks/rebase-2026/README.md
+++ b/docs/talks/rebase-2026/README.md
@@ -75,4 +75,4 @@ Any runtime with interpreted and compiled paths can change representation withou
 
 ## Current limits
 
-UniversalToolchain/Wist2 is an open-source alpha, not a production deployment report or a hardened in-process sandbox. The Wist-first path is more mature than generic third-party DSL authoring, the API is not yet a stable 1.0 contract, and performance conclusions are limited to explicitly recorded scenarios and environments.
+UniversalToolchain is the reusable framework; Wist is its reference language and proving ground. The project is an open-source alpha, not a production deployment report or a hardened in-process sandbox. The Wist-first path is more mature than generic third-party DSL authoring, the API is not yet a stable 1.0 contract, and performance conclusions are limited to explicitly recorded scenarios and environments.

--- a/docs/talks/rebase-2026/speaker-notes.md
+++ b/docs/talks/rebase-2026/speaker-notes.md
@@ -1,0 +1,53 @@
+# REBASE 2026 speaker preparation notes
+
+Authority: proposal.
+
+These notes support delivery of the talk. They are not part of the submission abstract.
+
+## Scope discipline
+
+- Explain only the architecture needed for the running example.
+- Do not use class diagrams or long interface inventories.
+- Keep semantic parity as evidence for the architecture, not as a replacement for the main topic.
+- Do not claim production deployment, hardened sandboxing, stable 1.0 compatibility, or general parity with handwritten C#.
+
+## Demonstration sequence
+
+1. Show the pricing formula and the three execution paths.
+2. Show equal results.
+3. Show rejection of the excluded statement-style feature.
+4. Inspect the selected runtime plan.
+5. Trace one operation from module contribution to typed CIL.
+6. Show the fixed binding/local regression tests.
+
+Do not intentionally break the current runtime during the talk. Use the preserved reproducer and the current passing regression tests.
+
+## Performance evidence
+
+Present the measurement model before any number:
+
+- prepared invocation excludes parsing, dialect composition, and compilation;
+- convenience evaluation includes public API overhead and is not a hot-path comparison;
+- compilation benchmarks measure engine creation and formula preparation, not runtime throughput.
+
+Show numeric results only after a fresh run records the exact commit, working-tree state, SDK/runtime, CPU, OS, comparison contract, and raw BenchmarkDotNet artifacts.
+
+## Demo fallback
+
+Prepare three levels:
+
+- **Primary:** the live shared demo script with restore and build completed before the session;
+- **Fallback:** a terminal recording of the same command and output;
+- **Last resort:** screenshots, the committed expected output, and direct links to the focused regression tests.
+
+Do not depend on conference Wi-Fi. Prepare the environment in advance and use `--no-restore --no-build` for live commands after the build is complete.
+
+## Closing checks
+
+Before presenting:
+
+- confirm the repository commit used by the slides and demo;
+- run the shared demo script;
+- confirm all links in the reviewer page still resolve;
+- check that the abstract, slides, and spoken claims use the same project boundaries;
+- keep the closing sentence only once: “Extensible during construction. Specialized during execution. One semantics across supported runtimes.”

--- a/docs/talks/rebase-2026/speaker-notes.md
+++ b/docs/talks/rebase-2026/speaker-notes.md
@@ -1,6 +1,6 @@
 # REBASE 2026 speaker preparation notes
 
-Authority: proposal.
+Status: proposal.
 
 These notes support delivery of the talk. They are not part of the submission abstract.
 

--- a/docs/talks/rebase-2026/submission.md
+++ b/docs/talks/rebase-2026/submission.md
@@ -4,7 +4,7 @@ Status: proposal.
 
 ## Title
 
-**Build the Language, Then Make the Abstractions Disappear: Engineering an Extensible .NET DSL Runtime**
+**Build the Language, Then Make the Abstractions Disappear: From Feature Modules to Typed CIL**
 
 ## Abstract
 

--- a/docs/talks/rebase-2026/submission.md
+++ b/docs/talks/rebase-2026/submission.md
@@ -16,7 +16,7 @@ Specialization is gated by declared backend capabilities. Frontend modules do no
 
 The first implementation got this boundary wrong. External bindings and lexical locals were mapped through incompatible storage assumptions, so the interpreter and CIL backend could disagree on the same program. The fix was not a backend patch: bindings and locals received distinct semantic identities, storage mapping moved behind backend contracts, composition remained deterministic, and shared regression tests covered shadowing, nested scopes, unused inputs, and repeated reads and writes.
 
-UniversalToolchain/Wist2 is an independent open-source alpha project. This is an implementation case study with public code, reproducible tests, explicit trade-offs, and known limits; it is not a production-deployment or hardened-sandbox claim.
+The code and tests are public and the demonstration is reproducible. UniversalToolchain/Wist2 is still an alpha project, so the talk states the current trade-offs and limits instead of presenting a production deployment or hardened sandbox.
 
 ## Short bio
 

--- a/docs/talks/rebase-2026/submission.md
+++ b/docs/talks/rebase-2026/submission.md
@@ -14,7 +14,7 @@ The talk builds a small pricing DSL and follows it through dialect selection, de
 
 Specialization is gated by declared backend capabilities. Frontend modules do not branch on a backend implementation. If a capability is missing, the portable representation remains unchanged.
 
-The first implementation got this boundary wrong. External bindings and lexical locals were mapped through incompatible storage assumptions, so the interpreter and CIL backend could disagree on the same program. The fix was not a backend patch: bindings and locals received distinct semantic identities, storage mapping moved behind backend contracts, composition remained deterministic, and shared regression tests covered shadowing, nested scopes, unused inputs, and repeated reads and writes.
+The first implementation got this boundary wrong. External bindings and lexical locals were mapped through incompatible storage assumptions, so the interpreter and CIL backend could disagree on the same program. A backend patch would have hidden the ownership error. Instead, bindings and locals received distinct semantic identities, storage mapping moved behind backend contracts, composition remained deterministic, and shared regression tests covered shadowing, nested scopes, unused inputs, and repeated reads and writes.
 
 The code and tests are public and the demonstration is reproducible. UniversalToolchain/Wist2 is still an alpha project, so the talk states the current trade-offs and limits instead of presenting a production deployment or hardened sandbox.
 

--- a/docs/talks/rebase-2026/submission.md
+++ b/docs/talks/rebase-2026/submission.md
@@ -8,13 +8,13 @@ Authority: proposal.
 
 ## Abstract
 
-UniversalToolchain/Wist2 lets a .NET host assemble a restricted DSL from independent feature modules, then lower the selected semantics to an AIR interpreter or typed CIL. The modules need to remain visible while the language is being built, but they should not require per-operation dispatch once a compiled artifact is prepared.
+UniversalToolchain/Wist2 lets a .NET host assemble a restricted DSL from independent feature modules, then lower the selected semantics to an AIR interpreter or typed CIL. Language composition belongs in the build phase; a prepared compiled delegate should not dispatch through the module system for every operation.
 
-The talk follows a small pricing DSL through the whole path: dialect selection, deterministic runtime planning, Bytecode, Abstract IR, capability-gated lowering, and execution through an AIR interpreter and a `DynamicMethod`-based CIL backend. The demo uses external bindings, lexical locals, and arithmetic, and shows the restricted dialect rejecting syntax for a feature it did not select.
+The talk builds a small pricing DSL and follows it through dialect selection, deterministic runtime planning, Bytecode, Abstract IR, capability-gated lowering, and execution through an AIR interpreter and a `DynamicMethod`-based CIL backend. The demo uses external bindings, lexical locals, and arithmetic, and shows the restricted dialect rejecting syntax for a feature it did not select.
 
-Capability checks decide which portable operations can become concrete runtime or CIL operations. Frontend modules do not branch on a backend implementation, and unsupported specialization leaves the portable representation intact.
+Specialization is gated by declared backend capabilities. Frontend modules never branch on a backend implementation. If a capability is missing, the portable representation remains unchanged.
 
-That separation was tested by a real failure. External bindings and local variables were mapped through incompatible storage assumptions, so the interpreter and CIL backend could disagree on the same program. The fix was not a backend patch: bindings and locals received distinct semantic identities, storage mapping moved behind backend contracts, composition remained deterministic, and shared regression tests covered shadowing, nested scopes, unused inputs, and repeated reads and writes.
+The first implementation got this boundary wrong. External bindings and lexical locals were mapped through incompatible storage assumptions, so the interpreter and CIL backend could disagree on the same program. The fix was not a backend patch: bindings and locals received distinct semantic identities, storage mapping moved behind backend contracts, composition remained deterministic, and shared regression tests covered shadowing, nested scopes, unused inputs, and repeated reads and writes.
 
 UniversalToolchain/Wist2 is an independent open-source alpha project. This is an implementation case study with public code, reproducible tests, explicit trade-offs, and known limits; it is not a production-deployment or hardened-sandbox claim.
 

--- a/docs/talks/rebase-2026/submission.md
+++ b/docs/talks/rebase-2026/submission.md
@@ -1,26 +1,26 @@
 # REBASE 2026 submission
 
+Authority: proposal.
+
 ## Title
 
 **Build the Language, Then Make the Abstractions Disappear: Engineering an Extensible .NET DSL Runtime**
 
 ## Abstract
 
-Extensible language architectures are often modular while they are being built but remain abstract while they execute. UniversalToolchain/Wist2 explores a different boundary: compose a language from independent feature modules, then progressively lower the selected semantics into a deterministic runtime plan and concrete interpreter or typed CIL operations.
+UniversalToolchain/Wist2 lets a .NET host assemble a restricted DSL from independent feature modules, then lower the selected semantics to an AIR interpreter or typed CIL. The modules need to remain visible while the language is being built, but they should not require per-operation dispatch once a compiled artifact is prepared.
 
-In this talk, I will build a restricted pricing DSL from independently selected language modules and trace one program through dialect composition, Bytecode, Abstract IR, and two execution paths: an AIR interpreter and a `DynamicMethod`-based CIL backend. The demonstration covers external bindings, lexical local variables, arithmetic, backend capabilities, and the rejection of language features that were not included in the selected dialect.
+The talk follows a small pricing DSL through the whole path: dialect selection, deterministic runtime planning, Bytecode, Abstract IR, capability-gated lowering, and execution through an AIR interpreter and a `DynamicMethod`-based CIL backend. The demo uses external bindings, lexical locals, and arithmetic, and shows the restricted dialect rejecting syntax for a feature it did not select.
 
-The central engineering question is how to preserve extensibility during language construction without keeping language-construction machinery in prepared execution paths. I will show how capability-gated lowering allows supported operations to become concrete runtime or CIL operations while keeping frontend semantics independent from a particular backend.
+Capability checks decide which portable operations can become concrete runtime or CIL operations. Frontend modules do not branch on a backend implementation, and unsupported specialization leaves the portable representation intact.
 
-Specialization also creates a dangerous failure mode: different backends can quietly turn one DSL into two languages. A real regression involving external bindings and local-variable shadowing will serve as a case study. I will explain how explicit semantic identities, storage contracts, deterministic composition, and cross-backend regression tests prevent this divergence.
+That separation was tested by a real failure. External bindings and local variables were mapped through incompatible storage assumptions, so the interpreter and CIL backend could disagree on the same program. The fix was not a backend patch: bindings and locals received distinct semantic identities, storage mapping moved behind backend contracts, composition remained deterministic, and shared regression tests covered shadowing, nested scopes, unused inputs, and repeated reads and writes.
 
-The audience will leave with a practical architecture for building DSL runtimes that remain open to extension during construction, become concrete before execution, and preserve one language semantics across supported backends.
-
-UniversalToolchain/Wist2 is an independent open-source alpha project. The talk presents a reproducible architecture, implementation experience, design trade-offs, and current limitations rather than claiming production deployment.
+UniversalToolchain/Wist2 is an independent open-source alpha project. This is an implementation case study with public code, reproducible tests, explicit trade-offs, and known limits; it is not a production-deployment or hardened-sandbox claim.
 
 ## Short bio
 
-Mikhail Razakov is the creator and primary developer of UniversalToolchain/Wist2, an independent open-source .NET framework for building and executing embeddable domain-specific languages. His work focuses on modular language composition, intermediate representations, interpreters, typed CIL generation, runtime specialization, compiler verification, and semantic consistency across execution backends. In summer 2026, he is a compiler engineering intern at MCST and an incoming Software Engineering student at HSE University. He also teaches programming and writes about compilers, virtual machines, and .NET runtime internals.
+Mikhail Razakov is the creator and primary developer of UniversalToolchain/Wist2, an independent open-source .NET framework for embeddable domain-specific languages. He works on modular language composition, intermediate representations, interpreters, typed CIL generation, runtime specialization, compiler verification, and semantic consistency between execution backends. In summer 2026, he is a compiler engineering intern at MCST and an incoming Software Engineering student at HSE University. He also teaches programming and writes about compilers, virtual machines, and .NET runtime internals.
 
 ## Form material URL
 

--- a/docs/talks/rebase-2026/submission.md
+++ b/docs/talks/rebase-2026/submission.md
@@ -1,6 +1,6 @@
 # REBASE 2026 submission
 
-Authority: proposal.
+Status: proposal.
 
 ## Title
 
@@ -12,7 +12,7 @@ UniversalToolchain/Wist2 lets a .NET host assemble a restricted DSL from indepen
 
 The talk builds a small pricing DSL and follows it through dialect selection, deterministic runtime planning, Bytecode, Abstract IR, capability-gated lowering, and execution through an AIR interpreter and a `DynamicMethod`-based CIL backend. The demo uses external bindings, lexical locals, and arithmetic, and shows the restricted dialect rejecting syntax for a feature it did not select.
 
-Specialization is gated by declared backend capabilities. Frontend modules never branch on a backend implementation. If a capability is missing, the portable representation remains unchanged.
+Specialization is gated by declared backend capabilities. Frontend modules do not branch on a backend implementation. If a capability is missing, the portable representation remains unchanged.
 
 The first implementation got this boundary wrong. External bindings and lexical locals were mapped through incompatible storage assumptions, so the interpreter and CIL backend could disagree on the same program. The fix was not a backend patch: bindings and locals received distinct semantic identities, storage mapping moved behind backend contracts, composition remained deterministic, and shared regression tests covered shadowing, nested scopes, unused inputs, and repeated reads and writes.
 
@@ -20,7 +20,7 @@ UniversalToolchain/Wist2 is an independent open-source alpha project. This is an
 
 ## Short bio
 
-Mikhail Razakov is the creator and primary developer of UniversalToolchain/Wist2, an independent open-source .NET framework for embeddable domain-specific languages. He works on modular language composition, intermediate representations, interpreters, typed CIL generation, runtime specialization, compiler verification, and semantic consistency between execution backends. In summer 2026, he is a compiler engineering intern at MCST and an incoming Software Engineering student at HSE University. He also teaches programming and writes about compilers, virtual machines, and .NET runtime internals.
+Mikhail Razakov created UniversalToolchain/Wist2, an independent open-source .NET framework for embeddable domain-specific languages. He works across its module system, intermediate representations, interpreter, typed CIL backend, and cross-backend verification, with a focus on runtime specialization and compiler correctness. In summer 2026, he is a compiler engineering intern at MCST and an incoming Software Engineering student at HSE University. He also teaches programming and writes about compilers, virtual machines, and .NET runtime internals.
 
 ## Form material URL
 

--- a/docs/talks/rebase-2026/talk-outline.md
+++ b/docs/talks/rebase-2026/talk-outline.md
@@ -1,6 +1,6 @@
 # Thirty-minute REBASE talk outline
 
-Authority: proposal.
+Status: proposal.
 
 ## 0:00-3:00 — The problem
 

--- a/docs/talks/rebase-2026/talk-outline.md
+++ b/docs/talks/rebase-2026/talk-outline.md
@@ -1,50 +1,49 @@
 # Thirty-minute REBASE talk outline
 
-## 0:00-3:00 — The disappearing abstraction
+Authority: proposal.
 
-Open with the practical question:
+## 0:00-3:00 — The problem
 
-> Can a language remain extensible while it is being assembled, but execute as a prepared concrete artifact without letting each backend redefine its semantics?
-
-Show the short pipeline:
+Open with the pipeline:
 
 ```text
 feature modules -> dialect -> Bytecode -> AIR -> typed operations -> CIL -> JIT code
 ```
 
-State both constraints immediately:
+Then state the two requirements:
 
-- feature selection must remain modular and deterministic;
-- the interpreter and compiler must still execute one language.
+- the language surface must be selected modularly and deterministically;
+- interpreter and compiled execution must preserve the same observable semantics.
 
-## 3:00-7:00 — Extensible programming, concretely
+The question is not whether modules can be added. It is whether their dispatch can disappear from a prepared execution path without moving language semantics into a backend.
 
-Explain only the architecture required for the rest of the talk:
+## 3:00-7:00 — How the language is assembled
 
-- independent language feature modules;
-- dialect composition as explicit feature selection;
-- deterministic runtime-plan construction;
-- Bytecode as the frontend composition boundary;
-- AIR as the optimizer/backend execution boundary;
-- backend capability queries instead of concrete backend-name checks.
+Introduce only the boundaries needed for the rest of the talk:
 
-Avoid class diagrams and long interface inventories.
+- feature modules own syntax and semantic contributions;
+- a dialect selects modules, optimizers, capabilities, and backends;
+- the selected configuration becomes a deterministic runtime plan;
+- Bytecode is the frontend composition boundary;
+- AIR is the optimizer and backend boundary;
+- optimizers query capabilities rather than concrete backend names.
 
-## 7:00-13:00 — Restricted pricing DSL demonstration
+## 7:00-13:00 — Restricted pricing DSL
 
-1. Show `price * 0.9 + fee` as the smallest useful formula.
-2. Run the hardcoded C# path.
-3. Run the general Wist dialect.
-4. Run the restricted pricing dialect.
-5. Show equal results through the prepared paths.
-6. Show the restricted dialect rejecting statement-style binding syntax that was not selected.
-7. Inspect the deterministic runtime plan and selected interpreter/CIL capabilities.
+Use `price * 0.9 + fee` as the running example.
 
-The point is not pricing itself. The scenario makes language-surface selection and execution-path differences visible without requiring domain-specific background.
+1. Run the hardcoded C# implementation.
+2. Run the general Wist dialect.
+3. Run the restricted pricing dialect.
+4. Compare the results.
+5. Show the restricted dialect rejecting statement-style binding syntax that it did not select.
+6. Inspect the deterministic runtime plan and the selected interpreter/CIL capabilities.
 
-## 13:00-19:00 — Where the abstractions go
+The scenario keeps the domain simple while making feature selection and execution-path differences visible.
 
-Trace one representative operation through the pipeline:
+## 13:00-19:00 — From a module to typed CIL
+
+Trace one representative operation:
 
 ```text
 module-owned syntax and semantics
@@ -55,18 +54,19 @@ module-owned syntax and semantics
 -> .NET JIT
 ```
 
-Clarify the exact claim:
+Make the claim precise:
 
-- language modules and dialect selection are construction-time mechanisms;
+- modules and dialect selection are construction-time mechanisms;
 - supported compiled operations become typed operations in a prepared artifact;
 - the hot invocation path does not perform per-operation module dispatch;
-- this does not promise universal JIT inlining or handwritten-C# performance.
+- unsupported specialization keeps the portable representation;
+- none of this guarantees universal JIT inlining or handwritten-C# performance.
 
-Present the performance **model and measurement boundary**, not an unqualified benchmark table. Prepared invocation, convenience evaluation, and compilation/setup cost must be measured separately. Show numeric results only when a fresh run preserves the exact commit, environment, raw BenchmarkDotNet artifacts, and comparison contract.
+Briefly show the performance model. Prepared invocation, convenience evaluation, and compilation/setup cost are separate measurements and must not be compared as one benchmark.
 
-## 19:00-25:00 — When specialization threatened semantics
+## 19:00-25:00 — The regression that exposed the boundary
 
-Present the preserved external-binding/local-variable regression:
+Use the preserved scenario:
 
 ```text
 let i = 0
@@ -76,47 +76,33 @@ i = i + 1
 price + fee * i
 ```
 
-Explain:
+Explain the failure in order:
 
-- how interpreter and CIL storage assumptions could diverge;
-- why patching one generated instruction would hide the ownership error;
-- why external bindings and lexical locals need distinct semantic identities;
-- how late backend-specific storage mapping preserves the language contract;
-- how parity tests cover declaration order, unused bindings, nested scopes, repeated access, and shadowing.
+1. External bindings and lexical locals acquired incompatible storage assumptions.
+2. Interpreter and CIL execution could therefore disagree on the same program.
+3. Patching one generated instruction would have hidden the ownership error.
+4. Bindings and locals were given distinct semantic identities before backend storage allocation.
+5. Backend contracts now own physical mapping, while parity tests cover declaration order, unused bindings, repeated access, nested scopes, and shadowing.
 
-Use the current fixed regression tests as evidence. Do not break the current runtime live on stage.
+Show the current fixed regression tests as evidence.
 
-## 25:00-28:00 — Reusable engineering rules
+## 25:00-28:00 — Three conclusions
 
-Leave the audience with five rules:
+1. **Define the language before activating a backend.** Compose features first, and keep semantic identities in backend-independent representations.
+2. **Specialize by capability, not by implementation name.** Optimizers may change representation only when the selected backend proves support.
+3. **Use the interpreter as a semantic reference.** Test parity across dialect configurations, storage layouts, scope shapes, and optimizer states rather than treating the interpreter as only a slow fallback.
 
-1. Compose language features before backend activation.
-2. Put semantic identities in backend-independent representations.
-3. Let optimizers query capabilities instead of concrete backend names.
-4. Treat the interpreter as a semantic reference implementation, not merely a slow fallback.
-5. Test parity across dialect configurations, storage shapes, and optimizer states.
-
-Briefly connect the rules to expression engines, rule runtimes, query compilers, template engines, and tiered language implementations.
+These rules apply to expression evaluators, rule runtimes, query compilers, template engines, and other systems that maintain interpreted and compiled paths.
 
 ## 28:00-30:00 — Limits and closing
 
-State the current boundary explicitly:
+State the current limits directly:
 
-- open-source alpha, not a production deployment report;
+- the project is an open-source alpha, not a production deployment report;
 - restricted dialect composition is not hardened sandboxing;
-- generic third-party DSL authoring remains less mature than the Wist-first path;
-- performance evidence is scenario- and environment-bounded.
+- generic third-party DSL authoring is less mature than the Wist-first path;
+- performance evidence is tied to recorded scenarios and environments.
 
 Close with:
 
 > Extensible during construction. Specialized during execution. One semantics across supported runtimes.
-
-## Demonstration fallback
-
-Prepare three levels:
-
-- **Primary:** run the shared demo script after restoring and building before the session.
-- **Fallback:** use a terminal recording of the same command and results.
-- **Last resort:** use screenshots, the committed expected output, and direct links to the focused regression tests.
-
-Never depend on conference Wi-Fi. Restore and build before the session; use `--no-restore --no-build` for live commands after the environment is prepared.

--- a/docs/talks/rebase-2026/talk-outline.md
+++ b/docs/talks/rebase-2026/talk-outline.md
@@ -92,7 +92,7 @@ Show the current fixed regression tests as evidence.
 2. **Specialize by capability, not by implementation name.** Optimizers may change representation only when the selected backend proves support.
 3. **Use the interpreter as a semantic reference.** Test parity across dialect configurations, storage layouts, scope shapes, and optimizer states rather than treating the interpreter as only a slow fallback.
 
-These rules apply to expression evaluators, rule runtimes, query compilers, template engines, and other systems that maintain interpreted and compiled paths.
+The same boundary appears in expression evaluators, rule runtimes, query compilers, and template engines whenever interpreted and compiled paths share one language contract.
 
 ## 28:00-30:00 — Limits and closing
 


### PR DESCRIPTION
## Summary

- rewrite the REBASE submission and reviewer page in direct engineering language;
- remove repeated conference-template phrases and duplicated claims;
- keep the architecture diagram, evidence table, demo scope, claim boundaries, and project limits;
- move delivery logistics and fallback details into a dedicated `speaker-notes.md` instead of deleting them;
- keep the 30-minute outline focused on public talk content while preserving every technical decision and validation point.

## Review focus

- no useful claim or evidence link should be lost;
- the abstract should sound like an engineer describing a concrete system and failure, not generic generated conference copy;
- claim boundaries must remain consistent with the current alpha project and benchmark contract.

## Validation

- documentation CI;
- repository validation and .NET CI;
- final diff review for information preservation and repeated/templated phrasing.