### PR TITLE
docs: tighten REBASE claims against current implementation

### DIFF
--- a/docs/talks/langdev-2026/lowering-walkthrough.md
+++ b/docs/talks/langdev-2026/lowering-walkthrough.md
@@ -32,7 +32,7 @@ Only when the selected backend supports the required intrinsic does the optimize
 - typed constant loads;
 - typed external-binding loads.
 
-If the capability is absent, the optimizer preserves the portable representation.
+If the capability is absent, the optimizer preserves the corresponding portable AIR sequence.
 
 ## 4. Locals and external bindings become concrete storage operations
 
@@ -58,6 +58,6 @@ This is not a claim that every helper call is guaranteed to be inlined by every 
 
 ## 6. Why semantic parity is the second half of the design
 
-Specialization is useful only if the representation change preserves meaning. The interpreter remains the semantic reference path, and the CIL path is checked against it through the parity fixtures linked from the [main talk page](README.md).
+Specialization is useful only if the representation change preserves meaning. The interpreter remains the semantic reference path, and the CIL path is checked against it through parity fixtures linked from the [REBASE proposal page](../rebase-2026/README.md) and the [original LangDev page](README.md).
 
 The binding regression case demonstrates why this matters: if lexical locals and external slots are not explicitly distinguished, a more concrete backend representation can silently redefine the language.

--- a/docs/talks/rebase-2026/README.md
+++ b/docs/talks/rebase-2026/README.md
@@ -44,8 +44,8 @@ graph LR
     C --> D[Lexer / Parser / AST]
     D --> E[Bytecode]
     E --> F[Abstract IR]
+    F --> H[AIR interpreter / reference path]
     F --> G[Capability-aware optimization]
-    G --> H[AIR interpreter]
     G --> I[CIL compiler / DynamicMethod]
     K[Backend intrinsic capabilities] -. constrain rewrites .-> G
     I --> J[.NET JIT machine code]

--- a/docs/talks/rebase-2026/README.md
+++ b/docs/talks/rebase-2026/README.md
@@ -6,9 +6,9 @@ Status: proposal.
 
 **From Feature Modules to Typed CIL**
 
-UniversalToolchain/Wist2 builds restricted .NET DSLs from independently selected feature modules. Module selection defines the language during construction; supported operations are then lowered through Bytecode and Abstract IR into either an AIR interpreter or typed CIL emitted with `DynamicMethod`.
+UniversalToolchain/Wist2 builds restricted .NET DSLs from independently selected feature modules. Module selection defines the language before execution. Programs are then lowered through Bytecode and Abstract IR; AIR can be interpreted directly or compiled to typed CIL emitted with `DynamicMethod`.
 
-The difficult part is keeping those execution paths as one language. A real regression involving external bindings, lexical locals, and shadowing exposed how backend storage choices had leaked into semantics. That failure makes the boundary between language construction, lowering, backend specialization, and semantic verification concrete.
+The difficult part is keeping those paths as one language. A real regression involving external bindings, lexical locals, and shadowing exposed how backend storage choices had leaked into semantics. That failure makes the boundary between language construction, lowering, backend specialization, and semantic verification concrete.
 
 ## Reviewer path
 
@@ -26,13 +26,13 @@ Supporting technical material:
 - [semantic-parity regression case study](../langdev-2026/parity-regression.md);
 - [performance measurement boundary](../langdev-2026/benchmark-evidence.md).
 
-The original `langdev-2026` directory remains the shared technical evidence packet. This directory contains the REBASE-specific submission and 30-minute structure.
+The original `langdev-2026` directory remains the shared technical evidence packet. Its documents retain their original event history; the claim-to-code links on this page are the authoritative evidence map for the REBASE proposal.
 
 ## What the talk shows
 
 - Feature modules own syntax and semantic contributions, and a dialect selects the allowed language surface.
 - Bytecode is the frontend composition boundary; AIR is the optimizer and backend boundary.
-- Backend capabilities, not backend names, decide whether a portable operation can be specialized into a concrete interpreter or CIL operation.
+- The demonstrated native-load optimizer queries intrinsic capabilities before replacing portable AIR with typed load operations; it does not branch on concrete backend types.
 - The interpreter is the reference execution path, while cross-backend tests protect external bindings, lexical locals, shadowing, nested scopes, and compiled artifacts.
 
 ## Architecture
@@ -44,29 +44,31 @@ graph LR
     C --> D[Lexer / Parser / AST]
     D --> E[Bytecode]
     E --> F[Abstract IR]
-    F --> G[Capability-gated specialization]
+    F --> G[Capability-aware optimization]
     G --> H[AIR interpreter]
-    G --> I[CIL / DynamicMethod]
+    G --> I[CIL compiler / DynamicMethod]
+    K[Backend intrinsic capabilities] -. constrain rewrites .-> G
     I --> J[.NET JIT machine code]
     H -. semantic parity .-> I
 ```
 
-For supported compiled paths, module selection and plugin dispatch happen during construction. The prepared artifact executes lowered typed operations. This claim does not imply universal JIT inlining or handwritten-C# performance.
+For supported compiled paths, module selection and plugin dispatch happen during language and runtime preparation. The generated delegate executes emitted CIL rather than consulting the module registry for each operation. This claim does not imply universal JIT inlining or handwritten-C# performance.
 
 ## Demonstration and evidence
 
-Code evidence snapshot: [`b965466e1880a2d3a9172972e05d2cbd740c891a`](https://github.com/Misha1302/Wist2/tree/b965466e1880a2d3a9172972e05d2cbd740c891a).
+All claim-to-code links below are pinned to one code evidence snapshot: [`499529af506939c8047387e3f05598459bd7edfd`](https://github.com/Misha1302/Wist2/tree/499529af506939c8047387e3f05598459bd7edfd).
 
 | Claim | Public evidence |
 |---|---|
-| A restricted dialect is assembled from selected language/runtime capabilities | [`PricingRestrictedDialectExecutionTests.cs`](https://github.com/Misha1302/Wist2/blob/b965466e1880a2d3a9172972e05d2cbd740c891a/UniversalToolchain/UniversalToolchain.Dialects.Tests/PricingRestrictedDialectExecutionTests.cs) |
-| The same selected language executes through interpreter and CIL paths | [`WistDialectExecutionParityTests.cs`](https://github.com/Misha1302/Wist2/blob/b965466e1880a2d3a9172972e05d2cbd740c891a/UniversalToolchain/UniversalToolchain.Dialects.Tests/Wist/WistDialectExecutionParityTests.cs) |
-| External bindings and local storage remain semantically distinct | [`InterpreterBindingsParityTests.cs`](https://github.com/Misha1302/Wist2/blob/b965466e1880a2d3a9172972e05d2cbd740c891a/UniversalToolchain/Tests/Backends/InterpreterBindingsParityTests.cs) |
-| Compiled artifacts preserve interpreter/compiler semantics | [`RuntimeCompiledArtifactParityTests.cs`](https://github.com/Misha1302/Wist2/blob/b965466e1880a2d3a9172972e05d2cbd740c891a/UniversalToolchain/Tests/Backends/RuntimeCompiledArtifactParityTests.cs) |
-| The pricing scenario compares hardcoded C#, general Wist, and a restricted dialect | [`PricingDiscountScenario.cs`](https://github.com/Misha1302/Wist2/blob/b965466e1880a2d3a9172972e05d2cbd740c891a/UniversalToolchain/Example/Scenarios/PricingDiscountScenario.cs) |
-| Performance measurements separate prepared invocation, convenience evaluation, and compilation cost | [benchmark contract](https://github.com/Misha1302/Wist2/blob/b965466e1880a2d3a9172972e05d2cbd740c891a/UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/README.md) |
+| A restricted dialect is assembled from selected language/runtime capabilities | [`PricingRestrictedDialectExecutionTests.cs`](https://github.com/Misha1302/Wist2/blob/499529af506939c8047387e3f05598459bd7edfd/UniversalToolchain/UniversalToolchain.Dialects.Tests/PricingRestrictedDialectExecutionTests.cs) |
+| The same selected language executes through interpreter and CIL paths | [`WistDialectExecutionParityTests.cs`](https://github.com/Misha1302/Wist2/blob/499529af506939c8047387e3f05598459bd7edfd/UniversalToolchain/UniversalToolchain.Dialects.Tests/Wist/WistDialectExecutionParityTests.cs) |
+| External bindings and local storage remain semantically distinct | [`InterpreterBindingsParityTests.cs`](https://github.com/Misha1302/Wist2/blob/499529af506939c8047387e3f05598459bd7edfd/UniversalToolchain/Tests/Backends/InterpreterBindingsParityTests.cs) |
+| Compiled artifacts preserve interpreter/compiler semantics | [`RuntimeCompiledArtifactParityTests.cs`](https://github.com/Misha1302/Wist2/blob/499529af506939c8047387e3f05598459bd7edfd/UniversalToolchain/Tests/Backends/RuntimeCompiledArtifactParityTests.cs) |
+| The pricing scenario compares hardcoded C#, general Wist, and a restricted dialect | [`PricingDiscountScenario.cs`](https://github.com/Misha1302/Wist2/blob/499529af506939c8047387e3f05598459bd7edfd/UniversalToolchain/Example/Scenarios/PricingDiscountScenario.cs) |
+| Native-load rewrites are gated by intrinsic capabilities and preserve unmatched AIR | [`NativeCilOptimizerModule.cs`](https://github.com/Misha1302/Wist2/blob/499529af506939c8047387e3f05598459bd7edfd/UniversalToolchain/NativeMathModule/NativeCILOptimizerModule.cs) |
+| Performance measurements separate prepared invocation, convenience evaluation, and compilation cost | [benchmark contract](https://github.com/Misha1302/Wist2/blob/499529af506939c8047387e3f05598459bd7edfd/UniversalToolchain/Benchmarks/UniversalToolchain.Benchmarks/README.md) |
 
-The demo inspects the selected runtime plan and runs the same pricing formula through general and restricted language paths. It also rejects a feature excluded from the restricted dialect and executes the focused interpreter/CIL parity suites. Together, these steps keep language composition, semantic lowering, optimization, and backend execution visibly separate.
+The pricing demo inspects the selected runtime plan, compares hardcoded C# with general and restricted Wist dialects, and rejects a feature excluded from the restricted dialect. The focused regression suites separately exercise lexical locals, shadowing, nested scopes, external bindings, and interpreter/CIL parity. Together, these steps keep language composition, semantic lowering, optimization, and backend execution visibly separate.
 
 ## Why the failure matters
 

--- a/docs/talks/rebase-2026/speaker-notes.md
+++ b/docs/talks/rebase-2026/speaker-notes.md
@@ -9,16 +9,18 @@ These notes support delivery of the talk. They are not part of the submission ab
 - Explain only the architecture needed for the running example.
 - Do not use class diagrams or long interface inventories.
 - Keep semantic parity as evidence for the architecture, not as a replacement for the main topic.
+- Scope capability claims to the optimizer behavior and intrinsic contracts actually shown.
 - Do not claim production deployment, hardened sandboxing, stable 1.0 compatibility, or general parity with handwritten C#.
 
 ## Demonstration sequence
 
-1. Show the pricing formula and the three execution paths.
-2. Show equal results.
-3. Show rejection of the excluded statement-style feature.
-4. Inspect the selected runtime plan.
-5. Trace one operation from module contribution to typed CIL.
-6. Show the fixed binding/local regression tests.
+1. Show the pricing formula.
+2. Compare hardcoded C#, the general Wist dialect, and the restricted Wist dialect.
+3. Expand the Wist results to show compiler/interpreter parity and the prepared fast-invoker path used by the general dialect.
+4. Show rejection of the excluded statement-style feature.
+5. Inspect the selected runtime plan and backend capabilities.
+6. Trace one native-load operation from module contribution through AIR and intrinsic-capability checks to typed CIL.
+7. Move to the separate binding/local regression and show the current passing parity tests.
 
 Do not intentionally break the current runtime during the talk. Use the preserved reproducer and the current passing regression tests.
 

--- a/docs/talks/rebase-2026/submission.md
+++ b/docs/talks/rebase-2026/submission.md
@@ -4,17 +4,17 @@ Status: proposal.
 
 ## Title
 
-**Build the Language, Then Make the Abstractions Disappear: From Feature Modules to Typed CIL**
+Build the Language, Then Make the Abstractions Disappear: From Feature Modules to Typed CIL
 
 ## Abstract
 
-UniversalToolchain/Wist2 lets a .NET host assemble a restricted DSL from independent feature modules, then lower the selected semantics to an AIR interpreter or typed CIL. Language composition belongs in the build phase; a prepared compiled delegate should not dispatch through the module system for every operation.
+UniversalToolchain/Wist2 lets a .NET host assemble a restricted DSL from independent feature modules. Programs are lowered through Bytecode and Abstract IR; the resulting AIR can be interpreted directly or compiled to typed CIL. Modules define the language before execution, but once a compiled artifact is prepared, its operations should not dispatch through the module system.
 
-The talk builds a small pricing DSL and follows it through dialect selection, deterministic runtime planning, Bytecode, Abstract IR, capability-gated lowering, and execution through an AIR interpreter and a `DynamicMethod`-based CIL backend. The demo uses external bindings, lexical locals, and arithmetic, and shows the restricted dialect rejecting syntax for a feature it did not select.
+The talk builds a small pricing DSL and follows it through dialect selection, deterministic runtime planning, Bytecode, AIR, and a DynamicMethod-based CIL backend. The pricing example uses external bindings and arithmetic. A separate regression case adds lexical locals and shadowing, while the restricted dialect demonstrates rejection of syntax for a feature it did not select.
 
-Specialization is gated by declared backend capabilities. Frontend modules do not branch on a backend implementation. If a capability is missing, the portable representation remains unchanged.
+The demonstrated native-load specialization is gated by declared intrinsic capabilities. Frontend visitors do not branch on a concrete backend type; when a required intrinsic is unavailable, the optimizer keeps the corresponding portable AIR sequence.
 
-The first implementation got this boundary wrong. External bindings and lexical locals were mapped through incompatible storage assumptions, so the interpreter and CIL backend could disagree on the same program. A backend patch would have hidden the ownership error. Instead, bindings and locals received distinct semantic identities, storage mapping moved behind backend contracts, composition remained deterministic, and shared regression tests covered shadowing, nested scopes, unused inputs, and repeated reads and writes.
+An earlier implementation got the storage boundary wrong. External bindings and lexical locals were mapped through incompatible assumptions, so the interpreter and CIL backend could disagree on the same program. A backend patch would have hidden the ownership error. Instead, bindings and locals received distinct semantic identities, physical storage mapping moved behind backend contracts, and shared regression tests covered shadowing, nested scopes, unused inputs, and repeated reads and writes.
 
 The code and tests are public and the demonstration is reproducible. UniversalToolchain/Wist2 is still an alpha project, so the talk states the current trade-offs and limits instead of presenting a production deployment or hardened sandbox.
 
@@ -24,4 +24,4 @@ Mikhail Razakov created UniversalToolchain/Wist2, an independent open-source .NE
 
 ## Form material URL
 
-`https://github.com/Misha1302/Wist2/tree/master/docs/talks/rebase-2026`
+https://github.com/Misha1302/Wist2/tree/master/docs/talks/rebase-2026

--- a/docs/talks/rebase-2026/talk-outline.md
+++ b/docs/talks/rebase-2026/talk-outline.md
@@ -7,7 +7,7 @@ Status: proposal.
 Open with the pipeline:
 
 ```text
-feature modules -> dialect -> Bytecode -> AIR -> typed operations -> CIL -> JIT code
+feature modules -> dialect -> Bytecode -> AIR -> optimization -> backend -> execution
 ```
 
 Then state the two requirements:
@@ -15,7 +15,7 @@ Then state the two requirements:
 - the language surface must be selected modularly and deterministically;
 - interpreter and compiled execution must preserve the same observable semantics.
 
-The question is not whether modules can be added. It is whether their dispatch can disappear from a prepared execution path without moving language semantics into a backend.
+The question is not whether modules can be added. It is whether their dispatch can disappear from a prepared compiled path without moving language semantics into a backend.
 
 ## 3:00-7:00 — How the language is assembled
 
@@ -33,33 +33,35 @@ Introduce only the boundaries needed for the rest of the talk:
 Use `price * 0.9 + fee` as the running example.
 
 1. Run the hardcoded C# implementation.
-2. Run the general Wist dialect.
-3. Run the restricted pricing dialect.
+2. Run the general Wist dialect through compiler, interpreter, and prepared fast-invoker paths.
+3. Run the restricted pricing dialect through compiler and interpreter paths.
 4. Compare the results.
 5. Show the restricted dialect rejecting statement-style binding syntax that it did not select.
-6. Inspect the deterministic runtime plan and the selected interpreter/CIL capabilities.
+6. Inspect the deterministic runtime plan and selected backend capabilities.
 
 The scenario keeps the domain simple while making feature selection and execution-path differences visible.
 
 ## 13:00-19:00 — From a module to typed CIL
 
-Trace one representative operation:
+Trace one representative native-load operation:
 
 ```text
 module-owned syntax and semantics
 -> Bytecode contribution
--> AIR operation
--> capability-gated typed lowering
+-> AIR sequence
+-> intrinsic-capability check
+-> typed load intrinsic
 -> DynamicMethod CIL
 -> .NET JIT
 ```
 
 Make the claim precise:
 
-- modules and dialect selection are construction-time mechanisms;
-- supported compiled operations become typed operations in a prepared artifact;
-- the hot invocation path does not perform per-operation module dispatch;
-- unsupported specialization keeps the portable representation;
+- modules and dialect selection are construction-time and preparation-time mechanisms;
+- the demonstrated native-load optimizer rewrites only when the required intrinsic capability is declared;
+- when the capability is absent, it keeps the corresponding portable AIR sequence;
+- supported compiled operations become emitted CIL in a prepared delegate;
+- the hot invocation path does not perform per-operation module-registry dispatch;
 - none of this guarantees universal JIT inlining or handwritten-C# performance.
 
 Briefly show the performance model. Prepared invocation, convenience evaluation, and compilation/setup cost are separate measurements and must not be compared as one benchmark.


### PR DESCRIPTION
## Summary

- replace the ambiguous `build phase` wording with language/runtime preparation before execution;
- scope capability claims to the demonstrated native-load optimizer and intrinsic contracts;
- separate the pricing example from the lexical-local/shadowing regression case;
- change `first implementation` to the evidence-supported `earlier implementation`;
- make the submission text directly copyable into the form;
- clarify the real demo paths and fast-invoker coverage;
- pin the REBASE claim-to-code map to one code snapshot and add optimizer evidence;
- make the shared lowering walkthrough point to both event-specific proposal pages.

## Evidence reviewed

- canonical runtime pipeline and backend contracts;
- `NativeCilOptimizerModule` capability checks and AIR-preservation behavior;
- pricing scenario and restricted-dialect tests;
- interpreter/CIL parity and binding/local regression fixtures;
- benchmark claim boundary.

## Validation requested

- documentation checks;
- repository validation and .NET CI;
- final diff review for claim precision, information preservation, and link consistency.