### PR TITLE
chore: run observable branch cleanup

### DIFF
--- a/.github/workflows/wist-branch-cleanup-once.yml
+++ b/.github/workflows/wist-branch-cleanup-once.yml
@@ -1,4 +1,3 @@
-# Installed first; this follow-up commit triggers the one-time cleanup.
 name: One-time Wist Branch Cleanup
 
 on:
@@ -18,80 +17,37 @@ jobs:
   cleanup:
     runs-on: ubuntu-latest
     env:
-      ADMIN_TOKEN: ${{ github.token }}
+      GH_TOKEN: ${{ github.token }}
       OWNER: Misha1302
       REPO: Wist2
       WORKFLOW_PATH: .github/workflows/wist-branch-cleanup-once.yml
     steps:
-      - name: Validate administrative token
+      - name: Plan and execute conservative cleanup
         shell: bash
         run: |
           set -euo pipefail
-          if [[ -z "${ADMIN_TOKEN:-}" ]]; then
-            echo 'GitHub Actions token is missing or empty.' >&2
-            exit 1
-          fi
 
-          status="$(curl -sS -o /tmp/repository.json -w '%{http_code}' \
-            -H "Authorization: Bearer ${ADMIN_TOKEN}" \
-            -H 'Accept: application/vnd.github+json' \
-            -H 'X-GitHub-Api-Version: 2022-11-28' \
-            "https://api.github.com/repos/${OWNER}/${REPO}")"
-
-          if [[ "$status" != "200" ]]; then
-            echo "GitHub Actions token cannot access the repository (HTTP ${status})." >&2
-            exit 1
-          fi
-
-          jq -e --arg expected "${OWNER}/${REPO}" '.full_name == $expected' /tmp/repository.json >/dev/null
-
-      - name: Audit current branches
-        shell: bash
-        run: |
-          set -euo pipefail
-          echo '=== current branches ==='
-          page=1
-          while :; do
-            batch="$(curl -fsS \
-              -H "Authorization: Bearer ${ADMIN_TOKEN}" \
-              -H 'Accept: application/vnd.github+json' \
-              -H 'X-GitHub-Api-Version: 2022-11-28' \
-              "https://api.github.com/repos/${OWNER}/${REPO}/branches?per_page=100&page=${page}")"
-            jq -r '.[].name' <<<"$batch"
-            if (( $(jq 'length' <<<"$batch") < 100 )); then
-              break
-            fi
-            page=$((page + 1))
-          done
-          echo '=== open pull-request heads ==='
-          curl -fsS \
-            -H "Authorization: Bearer ${ADMIN_TOKEN}" \
-            -H 'Accept: application/vnd.github+json' \
-            -H 'X-GitHub-Api-Version: 2022-11-28' \
-            "https://api.github.com/repos/${OWNER}/${REPO}/pulls?state=open&per_page=100" \
-            | jq -r '.[] | "#\(.number)\t\(.head.ref)"'
-
-      - name: Delete inactive branches safely
-        if: ${{ github.event_name == 'push' }}
-        shell: bash
-        run: |
-          set -euo pipefail
+          targets=(
+            'chore/one-time-branch-cleanup'
+            'chore/run-observable-branch-cleanup'
+            'chore/run-wist-admin-pr'
+            'chore/trigger-wist-admin-finalization'
+            'docs/rebase-2026-proposal'
+            'docs/rebase-2026-tighten-copy'
+            'docs/replace-readme-gif-with-png'
+            'growth/launch-surface-20260716'
+          )
 
           api() {
-            local method="$1"
-            local path="$2"
-            local data="${3-}"
-            local args=(
-              -fsS --retry 3 --retry-all-errors
-              -X "$method"
-              -H "Authorization: Bearer ${ADMIN_TOKEN}"
+            local method="$1" path="$2" data="${3-}"
+            local args=(-sS -X "$method"
+              -H "Authorization: Bearer ${GH_TOKEN}"
               -H 'Accept: application/vnd.github+json'
-              -H 'X-GitHub-Api-Version: 2022-11-28'
-            )
+              -H 'X-GitHub-Api-Version: 2022-11-28')
             if [[ -n "$data" ]]; then
               args+=(-H 'Content-Type: application/json' --data "$data")
             fi
-            curl "${args[@]}" "https://api.github.com${path}"
+            curl "${args[@]}" -w '\n%{http_code}' "https://api.github.com${path}"
           }
 
           encode_ref() {
@@ -102,162 +58,126 @@ jobs:
           PY
           }
 
-          collect_pages() {
-            local path_prefix="$1"
-            local page=1
-            local result='[]'
-            while :; do
-              local separator='?'
-              if [[ "$path_prefix" == *'?'* ]]; then
-                separator='&'
-              fi
-              local batch
-              batch="$(api GET "${path_prefix}${separator}per_page=100&page=${page}")"
-              result="$(jq -nc --argjson left "$result" --argjson right "$batch" '$left + $right')"
-              if (( $(jq 'length' <<<"$batch") < 100 )); then
-                break
-              fi
-              page=$((page + 1))
-            done
-            printf '%s' "$result"
+          request() {
+            local method="$1" path="$2" data="${3-}"
+            local response status body
+            response="$(api "$method" "$path" "$data")"
+            status="${response##*$'\n'}"
+            body="${response%$'\n'*}"
+            printf '%s\n' "$status" > /tmp/http-status
+            printf '%s' "$body"
           }
 
-          repo_state="$(api GET "/repos/${OWNER}/${REPO}")"
-          default_branch="$(jq -er '.default_branch' <<<"$repo_state")"
-          branches="$(collect_pages "/repos/${OWNER}/${REPO}/branches")"
-          pulls="$(collect_pages "/repos/${OWNER}/${REPO}/pulls?state=all")"
-          full_repo="${OWNER}/${REPO}"
+          open_pulls="$(request GET "/repos/${OWNER}/${REPO}/pulls?state=open&per_page=100")"
+          [[ "$(cat /tmp/http-status)" == 200 ]]
+          closed_pulls="$(request GET "/repos/${OWNER}/${REPO}/pulls?state=closed&per_page=100")"
+          [[ "$(cat /tmp/http-status)" == 200 ]]
 
+          : > /tmp/planned.tsv
           : > /tmp/deleted.tsv
           : > /tmp/preserved.tsv
+          : > /tmp/absent.tsv
           : > /tmp/failed.tsv
 
-          mapfile -t branch_names < <(jq -r '.[].name' <<<"$branches" | sort)
-
-          for branch in "${branch_names[@]}"; do
-            if [[ "$branch" == "$default_branch" ]]; then
-              printf '%s\t%s\n' "$branch" 'default branch' >> /tmp/preserved.tsv
+          for branch in "${targets[@]}"; do
+            encoded="$(encode_ref "$branch")"
+            ref_body="$(request GET "/repos/${OWNER}/${REPO}/git/ref/heads/${encoded}")"
+            status="$(cat /tmp/http-status)"
+            if [[ "$status" == 404 ]]; then
+              printf '%s\n' "$branch" >> /tmp/absent.tsv
+              continue
+            fi
+            if [[ "$status" != 200 ]]; then
+              printf '%s\tref lookup HTTP %s\n' "$branch" "$status" >> /tmp/failed.tsv
               continue
             fi
 
-            open_pr_count="$(jq --arg branch "$branch" --arg repo "$full_repo" \
-              '[.[] | select(.state == "open" and .head.ref == $branch and .head.repo.full_name == $repo)] | length' \
-              <<<"$pulls")"
-
-            if (( open_pr_count > 0 )); then
-              printf '%s\t%s\n' "$branch" 'head of an open pull request' >> /tmp/preserved.tsv
+            open_count="$(jq --arg branch "$branch" --arg repo "${OWNER}/${REPO}" \
+              '[.[] | select(.head.ref == $branch and .head.repo.full_name == $repo)] | length' \
+              <<<"$open_pulls")"
+            if (( open_count > 0 )); then
+              printf '%s\topen pull request\n' "$branch" >> /tmp/preserved.tsv
               continue
             fi
 
-            closed_pr_count="$(jq --arg branch "$branch" --arg repo "$full_repo" \
-              '[.[] | select(.state == "closed" and .head.ref == $branch and .head.repo.full_name == $repo)] | length' \
-              <<<"$pulls")"
+            closed_count="$(jq --arg branch "$branch" --arg repo "${OWNER}/${REPO}" \
+              '[.[] | select(.head.ref == $branch and .head.repo.full_name == $repo)] | length' \
+              <<<"$closed_pulls")"
+            compare="$(request GET "/repos/${OWNER}/${REPO}/compare/master...${encoded}")"
+            status="$(cat /tmp/http-status)"
+            if [[ "$status" != 200 ]]; then
+              printf '%s\tcompare HTTP %s\n' "$branch" "$status" >> /tmp/failed.tsv
+              continue
+            fi
+            ahead="$(jq -er '.ahead_by' <<<"$compare")"
 
-            reason=''
-            if (( closed_pr_count > 0 )); then
+            if (( ahead > 0 && closed_count == 0 )); then
+              printf '%s\t%s unique commit(s), no closed PR\n' "$branch" "$ahead" >> /tmp/preserved.tsv
+              continue
+            fi
+
+            reason='fully contained in master'
+            if (( closed_count > 0 )); then
               reason='closed pull-request branch'
-            else
-              encoded_default="$(encode_ref "$default_branch")"
-              encoded_branch="$(encode_ref "$branch")"
-              compare="$(api GET "/repos/${OWNER}/${REPO}/compare/${encoded_default}...${encoded_branch}")"
-              ahead_by="$(jq -er '.ahead_by' <<<"$compare")"
-              if (( ahead_by == 0 )); then
-                reason='fully contained in default branch'
-              else
-                printf '%s\t%s\n' "$branch" "unique commits and no closed PR (${ahead_by} commit(s) ahead)" >> /tmp/preserved.tsv
-                continue
-              fi
             fi
+            printf '%s\t%s\n' "$branch" "$reason" >> /tmp/planned.tsv
 
-            encoded_branch="$(encode_ref "$branch")"
-            if api DELETE "/repos/${OWNER}/${REPO}/git/refs/heads/${encoded_branch}" >/tmp/delete-response.json 2>/tmp/delete-error.txt; then
-              printf '%s\t%s\n' "$branch" "$reason" >> /tmp/deleted.tsv
-            else
-              error_text="$(tr '\n' ' ' </tmp/delete-error.txt | sed 's/[[:space:]]\+/ /g')"
-              printf '%s\t%s\n' "$branch" "${reason}; deletion failed: ${error_text}" >> /tmp/failed.tsv
+            if [[ "${GITHUB_EVENT_NAME}" == push ]]; then
+              request DELETE "/repos/${OWNER}/${REPO}/git/refs/heads/${encoded}" >/dev/null
+              status="$(cat /tmp/http-status)"
+              if [[ "$status" == 204 ]]; then
+                printf '%s\t%s\n' "$branch" "$reason" >> /tmp/deleted.tsv
+              else
+                printf '%s\tdelete HTTP %s\n' "$branch" "$status" >> /tmp/failed.tsv
+              fi
             fi
           done
 
-          deleted_count="$(wc -l </tmp/deleted.tsv | tr -d ' ')"
-          preserved_count="$(wc -l </tmp/preserved.tsv | tr -d ' ')"
-          failed_count="$(wc -l </tmp/failed.tsv | tr -d ' ')"
+          echo '=== cleanup plan ==='
+          cat /tmp/planned.tsv
+          echo '=== deleted ==='
+          cat /tmp/deleted.tsv
+          echo '=== preserved ==='
+          cat /tmp/preserved.tsv
+          echo '=== already absent ==='
+          cat /tmp/absent.tsv
+          echo '=== failures ==='
+          cat /tmp/failed.tsv
 
           {
             echo '## One-time branch cleanup'
             echo
-            echo "- Deleted: ${deleted_count}"
-            echo "- Preserved: ${preserved_count}"
-            echo "- Failed: ${failed_count}"
+            echo "Event: \`${GITHUB_EVENT_NAME}\`"
             echo
-            echo '### Deleted'
-            if [[ -s /tmp/deleted.tsv ]]; then
-              awk -F '\t' '{printf "- `%s` — %s\n", $1, $2}' /tmp/deleted.tsv
-            else
-              echo '- None'
-            fi
-            echo
-            echo '### Preserved'
-            if [[ -s /tmp/preserved.tsv ]]; then
-              awk -F '\t' '{printf "- `%s` — %s\n", $1, $2}' /tmp/preserved.tsv
-            else
-              echo '- None'
-            fi
-            if [[ -s /tmp/failed.tsv ]]; then
-              echo
-              echo '### Failed'
-              awk -F '\t' '{printf "- `%s` — %s\n", $1, $2}' /tmp/failed.tsv
-            fi
+            echo "- Planned: $(wc -l < /tmp/planned.tsv)"
+            echo "- Deleted: $(wc -l < /tmp/deleted.tsv)"
+            echo "- Preserved: $(wc -l < /tmp/preserved.tsv)"
+            echo "- Already absent: $(wc -l < /tmp/absent.tsv)"
+            echo "- Failed: $(wc -l < /tmp/failed.tsv)"
           } >> "$GITHUB_STEP_SUMMARY"
 
-          echo '=== deleted branches ==='
-          cat /tmp/deleted.tsv
-          echo '=== preserved branches ==='
-          cat /tmp/preserved.tsv
-          echo '=== failed deletions ==='
-          cat /tmp/failed.tsv
+          [[ ! -s /tmp/failed.tsv ]]
 
-          if (( failed_count > 0 )); then
-            echo "${failed_count} branch deletion(s) failed." >&2
-            exit 1
-          fi
-
-      - name: Remove one-time cleanup workflow
+      - name: Remove one-time workflow
         if: ${{ always() && github.event_name == 'push' }}
         shell: bash
         run: |
           set -euo pipefail
-
-          if [[ -z "${ADMIN_TOKEN:-}" ]]; then
-            echo 'GitHub Actions token is missing; cannot remove one-time workflow.' >&2
-            exit 1
-          fi
-
-          api() {
-            local method="$1"
-            local path="$2"
-            local data="${3-}"
-            local args=(
-              -fsS --retry 3 --retry-all-errors
-              -X "$method"
-              -H "Authorization: Bearer ${ADMIN_TOKEN}"
-              -H 'Accept: application/vnd.github+json'
-              -H 'X-GitHub-Api-Version: 2022-11-28'
-            )
-            if [[ -n "$data" ]]; then
-              args+=(-H 'Content-Type: application/json' --data "$data")
-            fi
-            curl "${args[@]}" "https://api.github.com${path}"
-          }
-
-          if ! workflow_state="$(api GET "/repos/${OWNER}/${REPO}/contents/${WORKFLOW_PATH}?ref=master" 2>/dev/null)"; then
-            exit 0
-          fi
-
-          workflow_sha="$(jq -er '.sha' <<<"$workflow_state")"
-          delete_payload="$(jq -nc \
+          response="$(curl -sS \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H 'Accept: application/vnd.github+json' \
+            -H 'X-GitHub-Api-Version: 2022-11-28' \
+            "https://api.github.com/repos/${OWNER}/${REPO}/contents/${WORKFLOW_PATH}?ref=master")"
+          sha="$(jq -er '.sha' <<<"$response")"
+          payload="$(jq -nc \
             --arg message 'chore: remove completed one-time branch cleanup workflow' \
-            --arg sha "$workflow_sha" \
+            --arg sha "$sha" \
             --arg branch master \
             '{message: $message, sha: $sha, branch: $branch}')"
-
-          api DELETE "/repos/${OWNER}/${REPO}/contents/${WORKFLOW_PATH}" "$delete_payload" >/dev/null
+          curl -fsS -X DELETE \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H 'Accept: application/vnd.github+json' \
+            -H 'X-GitHub-Api-Version: 2022-11-28' \
+            -H 'Content-Type: application/json' \
+            --data "$payload" \
+            "https://api.github.com/repos/${OWNER}/${REPO}/contents/${WORKFLOW_PATH}" >/dev/null

--- a/.github/workflows/wist-branch-cleanup-once.yml
+++ b/.github/workflows/wist-branch-cleanup-once.yml
@@ -12,13 +12,13 @@ on:
       - '.github/workflows/wist-branch-cleanup-once.yml'
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   cleanup:
     runs-on: ubuntu-latest
     env:
-      ADMIN_TOKEN: ${{ secrets.WIST_ADMIN_TOKEN }}
+      ADMIN_TOKEN: ${{ github.token }}
       OWNER: Misha1302
       REPO: Wist2
       WORKFLOW_PATH: .github/workflows/wist-branch-cleanup-once.yml
@@ -28,22 +28,22 @@ jobs:
         run: |
           set -euo pipefail
           if [[ -z "${ADMIN_TOKEN:-}" ]]; then
-            echo 'Repository secret WIST_ADMIN_TOKEN is missing or empty.' >&2
+            echo 'GitHub Actions token is missing or empty.' >&2
             exit 1
           fi
 
-          status="$(curl -sS -o /tmp/user.json -w '%{http_code}' \
+          status="$(curl -sS -o /tmp/repository.json -w '%{http_code}' \
             -H "Authorization: Bearer ${ADMIN_TOKEN}" \
             -H 'Accept: application/vnd.github+json' \
             -H 'X-GitHub-Api-Version: 2022-11-28' \
-            https://api.github.com/user)"
+            "https://api.github.com/repos/${OWNER}/${REPO}")"
 
           if [[ "$status" != "200" ]]; then
-            echo "WIST_ADMIN_TOKEN was rejected by GitHub (HTTP ${status})." >&2
+            echo "GitHub Actions token cannot access the repository (HTTP ${status})." >&2
             exit 1
           fi
 
-          jq -e '.login == "Misha1302"' /tmp/user.json >/dev/null
+          jq -e --arg expected "${OWNER}/${REPO}" '.full_name == $expected' /tmp/repository.json >/dev/null
 
       - name: Delete inactive branches safely
         shell: bash
@@ -201,7 +201,8 @@ jobs:
           set -euo pipefail
 
           if [[ -z "${ADMIN_TOKEN:-}" ]]; then
-            exit 0
+            echo 'GitHub Actions token is missing; cannot remove one-time workflow.' >&2
+            exit 1
           fi
 
           api() {

--- a/.github/workflows/wist-branch-cleanup-once.yml
+++ b/.github/workflows/wist-branch-cleanup-once.yml
@@ -2,6 +2,10 @@
 name: One-time Wist Branch Cleanup
 
 on:
+  pull_request:
+    branches: [ master ]
+    paths:
+      - '.github/workflows/wist-branch-cleanup-once.yml'
   push:
     branches: [ master ]
     paths:
@@ -178,13 +182,20 @@ jobs:
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 
+          echo '=== deleted branches ==='
+          cat /tmp/deleted.tsv
+          echo '=== preserved branches ==='
+          cat /tmp/preserved.tsv
+          echo '=== failed deletions ==='
+          cat /tmp/failed.tsv
+
           if (( failed_count > 0 )); then
             echo "${failed_count} branch deletion(s) failed." >&2
             exit 1
           fi
 
       - name: Remove one-time cleanup workflow
-        if: always()
+        if: ${{ always() && github.event_name == 'push' }}
         shell: bash
         run: |
           set -euo pipefail

--- a/.github/workflows/wist-branch-cleanup-once.yml
+++ b/.github/workflows/wist-branch-cleanup-once.yml
@@ -45,7 +45,34 @@ jobs:
 
           jq -e --arg expected "${OWNER}/${REPO}" '.full_name == $expected' /tmp/repository.json >/dev/null
 
+      - name: Audit current branches
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo '=== current branches ==='
+          page=1
+          while :; do
+            batch="$(curl -fsS \
+              -H "Authorization: Bearer ${ADMIN_TOKEN}" \
+              -H 'Accept: application/vnd.github+json' \
+              -H 'X-GitHub-Api-Version: 2022-11-28' \
+              "https://api.github.com/repos/${OWNER}/${REPO}/branches?per_page=100&page=${page}")"
+            jq -r '.[].name' <<<"$batch"
+            if (( $(jq 'length' <<<"$batch") < 100 )); then
+              break
+            fi
+            page=$((page + 1))
+          done
+          echo '=== open pull-request heads ==='
+          curl -fsS \
+            -H "Authorization: Bearer ${ADMIN_TOKEN}" \
+            -H 'Accept: application/vnd.github+json' \
+            -H 'X-GitHub-Api-Version: 2022-11-28' \
+            "https://api.github.com/repos/${OWNER}/${REPO}/pulls?state=open&per_page=100" \
+            | jq -r '.[] | "#\(.number)\t\(.head.ref)"'
+
       - name: Delete inactive branches safely
+        if: ${{ github.event_name == 'push' }}
         shell: bash
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary

- run the installed one-time cleanup as an observable same-repository PR check;
- print exact deleted, preserved, and failed branch lists into the job log;
- keep self-removal restricted to the final `push` event;
- preserve all heads of open pull requests, including this PR and PR #291.

## Why this follow-up exists

The workflow was initially installed and then separately triggered on `master`, but push-triggered runs are not exposed by the current repository connector. This same-repository PR run makes the destructive operation and its exact result auditable before final self-removal.

## Safety

- `master` is never deleted;
- open-PR branches are never deleted;
- branches with unique commits and no closed PR are preserved;
- deletions and failures are reported explicitly;
- the workflow file is not removed during the PR run.