### PR TITLE
chore: trigger final Wist visual publication

### DIFF
--- a/.github/workflows/wist-visual-refresh-once.yml
+++ b/.github/workflows/wist-visual-refresh-once.yml
@@ -1,5 +1,6 @@
 name: One-time Wist Visual Refresh
 
+# Triggered through a reviewed merge so GitHub Actions runs the one-time publication job.
 on:
   push:
     branches: [ master ]


### PR DESCRIPTION
Triggers the one-time visual publication workflow through a reviewed merge so it can render the final README hero and social-preview PNGs, update references, and remove itself.