### PR TITLE
test: repair clean-checkout architecture guardrails

### DIFF
--- a/UniversalToolchain/Tests/Architecture/StaticStateGuardrailTests.cs
+++ b/UniversalToolchain/Tests/Architecture/StaticStateGuardrailTests.cs
@@ -81,7 +81,9 @@ public sealed class StaticStateGuardrailTests
     {
         var root = FindRepositoryRoot();
         var packageRoot = Path.Combine(root, "UniversalToolchain", "packages");
-        var files = Directory.GetFiles(packageRoot, "*", SearchOption.AllDirectories);
+        var files = Directory.Exists(packageRoot)
+            ? Directory.GetFiles(packageRoot, "*", SearchOption.AllDirectories)
+            : Array.Empty<string>();
 
         var violations = files
             .Select(path => NormalizePath(Path.GetRelativePath(packageRoot, path)))

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/Architecture/SsaAndLegacyDocumentationGuardrailTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/Architecture/SsaAndLegacyDocumentationGuardrailTests.cs
@@ -21,7 +21,7 @@ public sealed class SsaAndLegacyDocumentationGuardrailTests
     [Test]
     public void CompatibilityBoundary_DocumentsOnlyExplicitUndeclaredModuleObservation()
     {
-        var debt = File.ReadAllText(FindRepositoryFile("docs", "technical-debt.md"));
+        var debt = File.ReadAllText(FindRepositoryFile("internal-docs", "policies-and-reports", "technical-debt.md"));
 
         Assert.Multiple(() =>
         {


### PR DESCRIPTION
## Problem

Two architecture guardrails failed in the current clean GitHub checkout for repository-shape reasons rather than product behavior:

1. `VendoredPackageFeed_ShouldContainOnlyCanonicalRootNugetPackages` called `Directory.GetFiles` unconditionally on the optional `UniversalToolchain/packages` directory.
2. `CompatibilityBoundary_DocumentsOnlyExplicitUndeclaredModuleObservation` still looked for `docs/technical-debt.md` after the documentation split moved the canonical file to `internal-docs/policies-and-reports/technical-debt.md`.

These failures blocked the canonical build before PlanFuzz-specific tests could be evaluated.

## Changes

- Treat a missing vendored feed as an empty file set. If the directory exists, the existing invariant remains unchanged: every file must be a root-level `.nupkg`.
- Point the documentation guardrail at the current canonical technical-debt owner.

## Verification

Focused local verification against the clean source bundle:

```text
UniversalToolchain/Tests: 482 passed, 0 failed, 0 skipped
UniversalToolchain.Dialects.Tests: 588 passed, 0 failed, 0 skipped
```

This repair remains isolated from the PlanFuzz proposal and implementation PRs so they can be evaluated against a healthy baseline.
