### PR TITLE
Docs: bind publication evidence to exact master artifact

### DIFF
--- a/VERIFICATION.md
+++ b/VERIFICATION.md
@@ -63,9 +63,11 @@ The dedicated `Contract Experiment` workflow restores and builds the non-packabl
 - **B1:** B0 plus typed selection, ownership, Bytecode and facts/effects checks; unresolved reverification is recorded but not fail-closed.
 - **B2:** B1 plus mandatory failure on unresolved reverification requests.
 
-### Archived result
+### Immutable master baseline
 
-The refreshed PR evidence used 40 primary fault instances representing 32 independent operator shapes in five families, 10 post-freeze challenge operators, three deterministic repetitions per instance/mode and 100 valid controls per mode across five strata.
+The publication baseline is tied to master commit `92028b76b108822c5cdd41432721ac63c4e49b48`, workflow run `30542053093` and artifact `contract-experiment-92028b76b108822c5cdd41432721ac63c4e49b48` (artifact ID `8759126014`, digest `sha256:e87ea19405cce64df8d76ea83fc3b02c5db5c7b83f435ee940d7ee2bb850209f`). Its 36-file checksum index verifies successfully after extraction.
+
+The run used 40 primary fault instances representing 32 independent operator shapes in five families, 10 post-freeze challenge operators, three deterministic repetitions per instance/mode and 100 valid controls per mode across five strata.
 
 | Set | B0 | B1 | B2 |
 |---|---:|---:|---:|
@@ -73,7 +75,7 @@ The refreshed PR evidence used 40 primary fault instances representing 32 indepe
 | Challenge operators detected | 1/10 | 10/10 | 10/10 |
 | Valid-control false positives | 0/100 | 0/100 | 0/100 |
 
-Primary exact paired McNemar results were `p = 1.9073486e-06` for B0 versus B2 and `p = 0.125` for B1 versus B2. Across five process-level timing replicates, isolated B2 boundary-kernel overhead had a median of **29.4%**, with a range of **28.9%–31.0%**.
+Primary exact paired McNemar results were `p = 1.9073486e-06` for B0 versus B2 and `p = 0.125` for B1 versus B2. Across five process-level timing replicates, isolated B2 boundary-kernel overhead had a median of **27.8%**, with a range of **25.6%–31.6%**.
 
 These are author-designed, single-framework, production-boundary results. They do not establish general compiler correctness, end-to-end source-to-execution detection, externally authored unseen-fault effectiveness or external validity across unrelated runtimes. The timing number is verifier-kernel cost, not whole-compilation or application overhead.
 
@@ -91,6 +93,8 @@ Every `master` revision is required to start and complete:
 - `Contract Experiment`.
 
 `CI aggregate` waits for this complete workflow set and publishes the `ci/aggregate` commit status. Path-filtered pull-request checks remain narrow where appropriate; master-push checks are unconditional so the aggregate cannot wait for a workflow that was never eligible to start.
+
+For the immutable publication baseline commit `92028b76b108822c5cdd41432721ac63c4e49b48`, aggregate run `30542053062` completed successfully after all eight required workflows reported success.
 
 ## Package and release boundary
 

--- a/docs/evidence/current-verification.md
+++ b/docs/evidence/current-verification.md
@@ -3,7 +3,7 @@ title: Current Verification
 description: Current build, test, workflow and bounded research-evidence record.
 audience: maintainer-or-evaluator
 status: current
-lastVerifiedAgainst: publication-readiness-contract-study
+lastVerifiedAgainst: master-92028b76-publication-baseline
 ---
 
 # Current verification
@@ -41,6 +41,8 @@ Release builds succeeded
 
 Every `master` revision must start and complete `.NET CI`, `UniversalToolchain validation`, `Docs Check`, documentation deployment, published-package smoke, rollout sample smoke, benchmark smoke and the contract experiment. `CI aggregate` waits for the complete set and publishes the `ci/aggregate` commit status. Master-push triggers are unconditional, preventing a false aggregate timeout caused by a required path-filtered workflow never starting.
 
+Master commit `92028b76b108822c5cdd41432721ac63c4e49b48` is the immutable publication baseline. Aggregate run `30542053062` completed successfully after all eight required workflows reported success.
+
 ## Production-boundary contract study
 
 The non-packable experiment compares:
@@ -49,7 +51,9 @@ The non-packable experiment compares:
 - **B1:** typed selection, ownership, Bytecode and facts/effects in addition to B0;
 - **B2:** B1 with fail-closed unresolved reverification.
 
-The refreshed archived run used 32 primary operator shapes, 10 post-freeze challenge operators, three repetitions per instance/mode and 100 valid controls per mode across five boundary families.
+The immutable baseline is workflow run `30542053093`, artifact ID `8759126014`, digest `sha256:e87ea19405cce64df8d76ea83fc3b02c5db5c7b83f435ee940d7ee2bb850209f`. Its checksum index covers 36 files and verifies after extraction.
+
+The run used 32 primary operator shapes, 10 post-freeze challenge operators, three repetitions per instance/mode and 100 valid controls per mode across five boundary families.
 
 | Set | B0 | B1 | B2 |
 |---|---:|---:|---:|
@@ -57,7 +61,7 @@ The refreshed archived run used 32 primary operator shapes, 10 post-freeze chall
 | Challenge detections | 1/10 | 10/10 | 10/10 |
 | Control false positives | 0/100 | 0/100 | 0/100 |
 
-The exact paired primary comparison gave `p = 1.9073486e-06` for B0 versus B2 and `p = 0.125` for B1 versus B2. The isolated B2 verifier-kernel overhead was 29.4% median across five process replicates, range 28.9%–31.0%.
+The exact paired primary comparison gave `p = 1.9073486e-06` for B0 versus B2 and `p = 0.125` for B1 versus B2. The isolated B2 verifier-kernel overhead was 27.8% median across five process replicates, range 25.6%–31.6%.
 
 This is an author-designed production-boundary experiment, not an externally authored unseen-fault study or an end-to-end whole-compiler benchmark. Raw JSONL, runner inputs, environment records, analysis and a per-file checksum index are archived by the workflow for the exact checked-out commit.
 


### PR DESCRIPTION
## Purpose

Correct the research-evidence record after independently inspecting the exact master artifact produced by commit `92028b76b108822c5cdd41432721ac63c4e49b48`.

## Corrections

- bind the contract-study table to workflow run `30542053093`, artifact ID `8759126014`, and digest `sha256:e87ea19405cce64df8d76ea83fc3b02c5db5c7b83f435ee940d7ee2bb850209f`;
- record that all 36 checksum entries validated after extraction;
- replace the earlier PR-run timing estimate with the exact master artifact aggregate: B2 median overhead `27.8%`, range `25.6%–31.6%` across five process replicates;
- record aggregate run `30542053062` and its eight successful required workflows;
- preserve all existing claim limitations and the separate baseline-bearing package release boundary.

No production code, package surface, test contract, or experiment implementation changes.