### PR TITLE
Docs: bind ten-finding remediation to master evidence

### DIFF
--- a/VERIFICATION.md
+++ b/VERIFICATION.md
@@ -2,7 +2,7 @@
 
 ## Environment and authority
 
-- Record refreshed: 2026-07-30.
+- Record refreshed: 2026-07-31.
 - Target CI environment: GitHub Actions Ubuntu 24.04, Linux x64.
 - SDK policy: `UniversalToolchain/global.json` with .NET 10 feature-band roll-forward.
 - Ordinary integration command: `./build.sh --skip-docs --skip-pack`.
@@ -58,7 +58,7 @@ Parallel graph traversal and shared compilation are the default. `--jobs`, `--se
 | `UniversalToolchain.PlanFuzz.IntegrationTests` | 10 | 0 | 0 |
 | **Total** | **1,551** | **0** | **0** |
 
-The seven focused review-remediation regressions cover incomplete Bytecode emission identity, repeated pipeline occurrences, extension verifier routing, primary-first construction failure preservation and stale flowed operation leases. `.NET CI` run `30580457345` on branch head `77edfb05047c933665912015af6d242a3a9f7fed` completed successfully and recorded `TEST-CONTRACT COMPLETE passed=1551 entries=14`.
+The seven focused review-remediation regressions cover incomplete Bytecode emission identity, repeated pipeline occurrences, extension verifier routing, primary-first construction failure preservation and stale flowed operation leases. Master `.NET CI` run `30585251901` on commit `2b0a4d1f0e255432daf0d5ddd485269b6490b67e` completed successfully and recorded `TEST-CONTRACT COMPLETE passed=1551 entries=14`. Its canonical-build artifact has ID `8776313506` and digest `sha256:1a7875efad0bc1fc230f61bd9b4d578e7d626c0230905ecbb193846c742f9e30`.
 
 ## Production-boundary contract experiment
 
@@ -74,9 +74,9 @@ The dedicated `Contract Experiment` workflow restores and builds the non-packabl
 
 The pre-remediation publication baseline is tied to master commit `92028b76b108822c5cdd41432721ac63c4e49b48`, workflow run `30542053093` and artifact ID `8759126014`, digest `sha256:e87ea19405cce64df8d76ea83fc3b02c5db5c7b83f435ee940d7ee2bb850209f`.
 
-### Review-remediation reproduction
+### Review-remediation master reproduction
 
-Contract workflow run `30580457769` executed for branch head `77edfb05047c933665912015af6d242a3a9f7fed` through PR merge ref `ea2b99b6edf1ea171f2c6932531d2870f5a2ec0d`. Artifact `contract-experiment-ea2b99b6edf1ea171f2c6932531d2870f5a2ec0d` has artifact ID `8774419595` and digest `sha256:57f90f0b4b359d7cf98e3549091c2fd7f1387b3fe90b0766faf2b6b40b1cba4f`. Both internal checksum trees verify after extraction and both captured git-status files are empty.
+Master Contract Experiment run `30585251945` executed on commit `2b0a4d1f0e255432daf0d5ddd485269b6490b67e`. Artifact `contract-experiment-2b0a4d1f0e255432daf0d5ddd485269b6490b67e` has ID `8776245456` and digest `sha256:ca1708b8054e63eb9fff0526f9113013a9569121890ff3b0ea19572e5c199961`. Independent extraction verified every entry in both internal checksum trees and both captured git-status files are empty.
 
 The original frozen corpus remains unchanged: 40 primary instances representing 32 operator shapes, 10 challenge operators, three deterministic repetitions per instance/mode and 100 valid controls per mode.
 
@@ -88,11 +88,11 @@ The original frozen corpus remains unchanged: 40 primary instances representing 
 
 On this frozen author-designed corpus, the paired B0-versus-B2 difference is 20/32 and exact McNemar is `p = 1.9073486328125e-06`; B1 versus B2 is four discordant operators and `p = 0.125`. These values describe this corpus and are not a population-level superiority claim.
 
-The current five process-level timing replicates report isolated B2 boundary-kernel overhead of **47.3% median**, range **44.4%–50.7%**. Earlier identical functional runs reported materially lower values. This confirms that the timing is an environment-sensitive verifier-kernel microbenchmark, not whole-compilation or application overhead and not a controlled pooled performance estimate.
+The master artifact's five process-level timing replicates report isolated B2 boundary-kernel overhead of **46.0% median**, range **44.7%-57.1%**. Earlier identical functional runs reported materially different values. This confirms that the timing is an environment-sensitive verifier-kernel microbenchmark, not whole-compilation or application overhead and not a controlled pooled performance estimate.
 
 ### Post-freeze review holdouts
 
-The same artifact contains a separately checksummed four-operator holdout executable covering missing Bytecode producer identity, missing source-node identity, repeated pipeline occurrence and extension-provided verifier routing. The protocol and expected matrix were frozen before inspecting the workflow result. Cases remain outside the original primary and challenge denominators.
+The same master artifact contains a separately checksummed four-operator holdout executable covering missing Bytecode producer identity, missing source-node identity, repeated pipeline occurrence and extension-provided verifier routing. The protocol and expected matrix were frozen before inspecting the workflow result. Cases remain outside the original primary and challenge denominators.
 
 | Set | B0 | B1 | B2 |
 |---|---:|---:|---:|
@@ -116,7 +116,7 @@ Every `master` revision is required to start and complete:
 
 `CI aggregate` waits for this complete workflow set and publishes the `ci/aggregate` commit status. Path-filtered pull-request checks remain narrow where appropriate; master-push checks are unconditional so the aggregate cannot wait for a workflow that was never eligible to start.
 
-For the immutable pre-remediation baseline commit `92028b76b108822c5cdd41432721ac63c4e49b48`, aggregate run `30542053062` completed successfully. On review-remediation branch head `77edfb05047c933665912015af6d242a3a9f7fed`, `.NET CI`, validation, docs, published-package smoke, rollout smoke, benchmark smoke, contract experiment and package-compatibility review all completed successfully. Final master authority still requires the post-merge aggregate.
+Review-remediation master commit `2b0a4d1f0e255432daf0d5ddd485269b6490b67e` completed aggregate run `30585251873` successfully. The exact successful push runs were Docs Check `30585251865`, published-package smoke `30585251928`, documentation deployment `30585251875`, Contract Experiment `30585251945`, rollout smoke `30585251930`, Benchmark Smoke `30585251904`, UniversalToolchain validation `30585251890`, and `.NET CI` `30585251901`.
 
 ## Package and release boundary
 
@@ -146,6 +146,8 @@ Package Compatibility Review run `30580457427` built deterministic previous sour
 ```
 
 The run succeeded: 1,551 tests, monotonic version provenance for all nine package identities, exact Wist API delta `removed=0, added=0`, package matrix 9/9, clean facade consumer, incompatible-checkout rejection, template smoke, cross-package consumer and release-integrity mutants. Artifact `package-compatibility-review-ea2b99b6edf1ea171f2c6932531d2870f5a2ec0d` has artifact ID `8774539955`, digest `sha256:6cfa9d197548887ef8a80e701900d936c4364aa849e70e9c2b8ed420adfd3a7b`. Its 27-entry outer checksum manifest, both baseline hashes and release-integrity root verify after extraction. The release-integrity root is `7069c53758e1735ecf41813d65782dcd76f2d22f8e00e8c193bc42ee50a1457a` and covers ten current package artifacts, including the Wist symbols package.
+
+The package run was produced on code head `77edfb05047c933665912015af6d242a3a9f7fed`. The only changes from that head to PR head `7600b591813cb0066151204c012ee161ad348d8e` were this file, `docs/evidence/current-verification.md` and the internal remediation ledger; the merge commit introduced no file changes relative to the PR head. Therefore the package-affecting source and declared package versions in master are the exact validated candidate source.
 
 The published-package smoke remains intentionally pinned to actually published `UniversalToolchain.Wist` `0.1.0-alpha.1`; the review-remediation package versions are validated candidates, not a claim that they were published to NuGet.org.
 

--- a/docs/evidence/current-verification.md
+++ b/docs/evidence/current-verification.md
@@ -3,7 +3,7 @@ title: Current Verification
 description: Current build, test, workflow and bounded research-evidence record.
 audience: maintainer-or-evaluator
 status: current
-lastVerifiedAgainst: review-remediation-head-77edfb05
+lastVerifiedAgainst: master-2b0a4d1f
 ---
 
 # Current verification
@@ -28,15 +28,13 @@ It restores and builds both `UniversalToolchain/Wist.sln` and the configuration-
 | `UniversalToolchain.PlanFuzz.IntegrationTests` | 10 | 0 | 0 |
 | **Total** | **1,551** | **0** | **0** |
 
-The seven added regressions cover incomplete Bytecode emission identity, repeated pipeline occurrences, extension verifier routing, primary-first construction failure preservation and stale flowed operation leases. `.NET CI` run `30580457345` on review-remediation head `77edfb05047c933665912015af6d242a3a9f7fed` completed successfully with `TEST-CONTRACT COMPLETE passed=1551 entries=14`.
+The seven added regressions cover incomplete Bytecode emission identity, repeated pipeline occurrences, extension verifier routing, primary-first construction failure preservation and stale flowed operation leases. Master `.NET CI` run `30585251901` on commit `2b0a4d1f0e255432daf0d5ddd485269b6490b67e` completed successfully with `TEST-CONTRACT COMPLETE passed=1551 entries=14`. Canonical-build artifact ID `8776313506` has digest `sha256:1a7875efad0bc1fc230f61bd9b4d578e7d626c0230905ecbb193846c742f9e30`.
 
 ## Workflow set
 
 Every `master` revision must start and complete `.NET CI`, `UniversalToolchain validation`, `Docs Check`, documentation deployment, published-package smoke, rollout sample smoke, benchmark smoke and the contract experiment. `CI aggregate` waits for the complete set and publishes the `ci/aggregate` commit status. Master-push triggers are unconditional, preventing a false aggregate timeout caused by a required path-filtered workflow never starting.
 
-Master commit `92028b76b108822c5cdd41432721ac63c4e49b48` is the immutable pre-remediation publication baseline. Aggregate run `30542053062` completed successfully after all eight required workflows reported success.
-
-On review-remediation branch head `77edfb05047c933665912015af6d242a3a9f7fed`, `.NET CI`, validation, Docs Check, published-package smoke, rollout smoke, benchmark smoke, Contract Experiment and Package Compatibility Review all completed successfully. Final master authority is assigned only after the post-merge aggregate.
+Review-remediation master commit `2b0a4d1f0e255432daf0d5ddd485269b6490b67e` completed aggregate run `30585251873` successfully. The exact successful push runs were: Docs Check `30585251865`, published-package smoke `30585251928`, documentation deployment `30585251875`, Contract Experiment `30585251945`, rollout smoke `30585251930`, Benchmark Smoke `30585251904`, UniversalToolchain validation `30585251890`, and `.NET CI` `30585251901`.
 
 ## Production-boundary contract study
 
@@ -46,7 +44,7 @@ The non-packable experiment compares:
 - **B1:** typed selection, ownership, Bytecode and facts/effects in addition to B0;
 - **B2:** B1 with fail-closed unresolved reverification.
 
-Contract workflow run `30580457769` executed through PR merge ref `ea2b99b6edf1ea171f2c6932531d2870f5a2ec0d` for branch head `77edfb05047c933665912015af6d242a3a9f7fed`. Artifact ID `8774419595`, digest `sha256:57f90f0b4b359d7cf98e3549091c2fd7f1387b3fe90b0766faf2b6b40b1cba4f`, contains separately verified main-study and holdout checksum trees; both captured git-status files are empty.
+Master Contract Experiment run `30585251945` executed on commit `2b0a4d1f0e255432daf0d5ddd485269b6490b67e`. Artifact `contract-experiment-2b0a4d1f0e255432daf0d5ddd485269b6490b67e` has ID `8776245456` and digest `sha256:ca1708b8054e63eb9fff0526f9113013a9569121890ff3b0ea19572e5c199961`. Independent extraction verified every entry in both the main-study and holdout checksum trees; both captured git-status files are empty.
 
 | Set | B0 | B1 | B2 |
 |---|---:|---:|---:|
@@ -56,11 +54,11 @@ Contract workflow run `30580457769` executed through PR merge ref `ea2b99b6edf1e
 
 On this frozen author-designed corpus, B0 versus B2 differs on 20/32 operators and exact McNemar is `p = 1.9073486328125e-06`; B1 versus B2 has four discordant operators and `p = 0.125`. These values describe the fixed corpus and do not establish population-level superiority.
 
-The current isolated B2 verifier-kernel microbenchmark is 47.3% median across five process replicates, range 44.4%–50.7%. Earlier functionally identical runs produced materially lower values. This timing is environment-sensitive and is not whole-compilation overhead or a controlled pooled performance estimate.
+The master artifact's isolated B2 verifier-kernel microbenchmark is 46.0% median across five process replicates, range 44.7%-57.1%. Earlier functionally identical runs produced materially different values. This timing is environment-sensitive and is not whole-compilation overhead or a controlled pooled performance estimate.
 
 ## Post-freeze review holdouts
 
-The artifact also contains a four-case post-freeze review-derived holdout set: missing Bytecode producer identity, missing source-node identity, repeated pipeline occurrence and extension-provided verifier routing. Its protocol and expected matrix were frozen before result inspection.
+The master artifact also contains a four-case post-freeze review-derived holdout set: missing Bytecode producer identity, missing source-node identity, repeated pipeline occurrence and extension-provided verifier routing. Its protocol and expected matrix were frozen before result inspection.
 
 | Set | B0 | B1 | B2 |
 |---|---:|---:|---:|
@@ -81,7 +79,7 @@ npm run docs:build
 python3 .github/scripts/run-markdown-bash-blocks.py
 ```
 
-Docs Check run `30580457714` completed successfully on the same review-remediation head.
+Master Docs Check run `30585251865` and the Markdown command smoke in `.NET CI` run `30585251901` completed successfully.
 
 ## Package/release boundary
 
@@ -91,7 +89,7 @@ Package Compatibility Review run `30580457427` deterministically reconstructed r
 
 Artifact ID `8774539955`, digest `sha256:6cfa9d197548887ef8a80e701900d936c4364aa849e70e9c2b8ed420adfd3a7b`, has a verified 27-entry outer checksum manifest. Both baseline artifact hashes verify, and release-integrity root `7069c53758e1735ecf41813d65782dcd76f2d22f8e00e8c193bc42ee50a1457a` covers ten current package artifacts, including the Wist symbols package.
 
-The candidate package versions are validated but were not published to NuGet.org by this workflow.
+The package run was produced on code head `77edfb05047c933665912015af6d242a3a9f7fed`. The only changes from that head to PR head `7600b591813cb0066151204c012ee161ad348d8e` were `VERIFICATION.md`, this page and the internal remediation ledger; the merge commit introduced no file changes relative to that PR head. Therefore the package-affecting source and declared package versions in master are the exact validated candidate source. The candidate packages were not published to NuGet.org by this workflow.
 
 ## PlanFuzz evidence boundary
 

--- a/internal-docs/reviews/review-ten-findings-remediation-2026-07-30.md
+++ b/internal-docs/reviews/review-ten-findings-remediation-2026-07-30.md
@@ -1,6 +1,6 @@
 # Review findings remediation ledger
 
-Status: all ten requested findings are complete at PR level on `fix/review-ten-findings-20260730`; post-merge master aggregate remains the final repository authority.
+Status: all ten requested findings are complete on master commit `2b0a4d1f0e255432daf0d5ddd485269b6490b67e`; aggregate run `30585251873` completed successfully.
 
 This ledger binds the requested outcomes to code, tests, evidence and publication artifacts. Candidate package versions are validated but are not claimed as published to NuGet.org.
 
@@ -12,12 +12,14 @@ This ledger binds the requested outcomes to code, tests, evidence and publicatio
 | 4 | External language packages can contribute compiler-fact verifier routes | provider aggregation, conflict handling and custom-route regression | complete |
 | 5 | Flowed child execution contexts do not retain completed operation leases | child-task disposal regression | complete |
 | 6 | Technical article states the exact Bytecode ownership boundary | remediated Markdown/PDF and rendered-page inspection | complete |
-| 7 | Article contains a compact evidence-identity table | front-matter table with archive, commits and workflow artifacts | complete |
-| 8 | A narrow conference draft isolates contract-guided reverification | focused eight-page Markdown/PDF draft with related mechanisms and threats | complete |
-| 9 | Package compatibility uses reviewed previous source/package identities | workflow `30580457427`, artifact `8774539955`, 9/9 packages, API delta 0/0, consumers/templates/integrity pass | complete |
-| 10 | Post-freeze review holdouts are separate from the original corpus | workflow `30580457769`, artifact `8774419595`, B0/B1/B2 0/4, 4/4, 4/4 and 0/20 controls | complete |
+| 7 | Article contains a compact evidence-identity table | archive, baselines, master commit, runs and artifact digests are separated | complete |
+| 8 | A narrow conference draft isolates contract-guided reverification | focused Markdown/PDF draft with related mechanisms and threats | complete |
+| 9 | Package compatibility uses reviewed previous source/package identities | run `30580457427`, artifact `8774539955`, 9/9 packages, API delta 0/0, consumers/templates/integrity pass; later changes were documentation-only | complete |
+| 10 | Post-freeze review holdouts are separate from the original corpus | master run `30585251945`, artifact `8776245456`, B0/B1/B2 0/4, 4/4, 4/4 and 0/20 controls | complete |
 
-The exact PR-level regression authority is `.NET CI` run `30580457345`: `TEST-CONTRACT COMPLETE passed=1551 entries=14`. Validation, Docs Check, published-package smoke, rollout smoke, benchmark smoke, Contract Experiment and Package Compatibility Review also completed successfully for the reviewed code head.
+Master `.NET CI` run `30585251901` recorded `TEST-CONTRACT COMPLETE passed=1551 entries=14`. Canonical-build artifact ID `8776313506` has digest `sha256:1a7875efad0bc1fc230f61bd9b4d578e7d626c0230905ecbb193846c742f9e30`.
+
+Master Contract Experiment artifact ID `8776245456` has digest `sha256:ca1708b8054e63eb9fff0526f9113013a9569121890ff3b0ea19572e5c199961`. Both the main-study and review-holdout checksum trees verify after extraction, and both captured git-status files are empty.
 
 The package surfaces use monotonic remediation versions: the seven SDK/template packages are `0.3.0-alpha.3`, `UniversalToolchain.Wist.LanguagePack` is `0.3.0-alpha.4`, and `UniversalToolchain.Wist` is `0.1.0-alpha.5`.
 


### PR DESCRIPTION
Finalize the ten-finding remediation evidence after merging #320.

This documentation-only follow-up records:
- master commit `2b0a4d1f0e255432daf0d5ddd485269b6490b67e`;
- successful aggregate run `30585251873` and all eight required push workflows;
- master `.NET CI` run `30585251901` with the exact 1,551-test contract;
- master Contract Experiment run `30585251945`, artifact `8776245456`, and verified checksum trees;
- the bounded post-freeze holdout matrix;
- why the PR package-compatibility artifact remains applicable: only three documentation files changed after the package-tested code head, and the merge commit introduced no file changes relative to the final PR head.

No production code, package surface, experiment implementation, test manifest, or runtime behavior changes.