### PR TITLE
Build: repair topology guardrail and isolated graph validation

### DIFF
--- a/Tools/check-build-topology.py
+++ b/Tools/check-build-topology.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import argparse
+import re
 import sys
 import xml.etree.ElementTree as ET
 from pathlib import Path
@@ -22,14 +23,28 @@ def project_xml_files(root: Path) -> list[Path]:
     return sorted(toolchain.rglob("*.csproj"))
 
 
+def parse_project(path: Path) -> ET.Element:
+    try:
+        return ET.parse(path).getroot()
+    except ET.ParseError as exc:
+        raise BuildTopologyError(f"invalid project XML {path}: {exc}") from exc
+
+
+def child_text(root: ET.Element, name: str) -> str | None:
+    for element in root.iter():
+        if local_name(element.tag) != name:
+            continue
+        text = (element.text or "").strip()
+        if text:
+            return text
+    return None
+
+
 def require_build_order_references_not_copy_local(root: Path) -> None:
     failures: list[str] = []
     for project in project_xml_files(root):
-        try:
-            tree = ET.parse(project)
-        except ET.ParseError as exc:
-            raise BuildTopologyError(f"invalid project XML {project}: {exc}") from exc
-        for element in tree.getroot().iter():
+        project_root = parse_project(project)
+        for element in project_root.iter():
             if local_name(element.tag) != "ProjectReference":
                 continue
             if element.attrib.get("ReferenceOutputAssembly", "").lower() != "false":
@@ -40,9 +55,9 @@ def require_build_order_references_not_copy_local(root: Path) -> None:
             failures.append(f"{project.relative_to(root)} -> {include}")
     if failures:
         raise BuildTopologyError(
-            "ReferenceOutputAssembly=false references must also use Private=false; "
-            "otherwise IDE/BuildProjectReferences=false builds try to copy missing "
-            "apphost/deps/runtimeconfig files: " + "; ".join(failures)
+            "repository build-order ProjectReference items must set both "
+            "ReferenceOutputAssembly=false and Private=false so their outputs are not "
+            "treated as Copy Local payload: " + "; ".join(failures)
         )
 
 
@@ -55,50 +70,115 @@ def require_language_pack_isolated_emitter_build(root: Path) -> None:
     )
     if not project.is_file():
         raise BuildTopologyError(f"language-pack project does not exist: {project}")
-    tree = ET.parse(project)
+    project_root = parse_project(project)
+
+    emitter_property = child_text(project_root, "FeatureManifestEmitterProjectPath")
+    if emitter_property != "$(MSBuildThisFileDirectory)..\\UniversalToolchain.FeatureManifestEmitter\\UniversalToolchain.FeatureManifestEmitter.csproj":
+        raise BuildTopologyError("language pack has an unexpected FeatureManifestEmitterProjectPath")
+
+    emitter_references = [
+        element
+        for element in project_root.iter()
+        if local_name(element.tag) == "ProjectReference"
+        and element.attrib.get("Include") == "$(FeatureManifestEmitterProjectPath)"
+    ]
+    if len(emitter_references) != 1:
+        raise BuildTopologyError("language pack must declare exactly one emitter ProjectReference")
+    emitter_reference = emitter_references[0]
+    if emitter_reference.attrib.get("ReferenceOutputAssembly", "").lower() != "false" or \
+       emitter_reference.attrib.get("Private", "").lower() != "false":
+        raise BuildTopologyError("emitter ProjectReference must be build-only and not Copy Local")
+
     targets = {
         element.attrib.get("Name", ""): element
-        for element in tree.getroot().iter()
+        for element in project_root.iter()
         if local_name(element.tag) == "Target"
     }
     target = targets.get("BuildFeatureManifestEmitterForIsolatedBuild")
     if target is None:
-        raise BuildTopologyError(
-            "language pack lacks BuildFeatureManifestEmitterForIsolatedBuild"
-        )
-    if "EmitToolchainFeatureManifest" not in target.attrib.get("BeforeTargets", ""):
-        raise BuildTopologyError(
-            "isolated emitter build must run before EmitToolchainFeatureManifest"
-        )
+        raise BuildTopologyError("language pack lacks BuildFeatureManifestEmitterForIsolatedBuild")
+    if "EmitToolchainFeatureManifest" not in target.attrib.get("BeforeTargets", "").split(";"):
+        raise BuildTopologyError("isolated emitter build must run before EmitToolchainFeatureManifest")
     condition = target.attrib.get("Condition", "")
-    if "BuildProjectReferences" not in condition or "false" not in condition.lower():
-        raise BuildTopologyError(
-            "isolated emitter build must be gated by BuildProjectReferences=false"
-        )
-    if not any(local_name(element.tag) == "MSBuild" for element in target.iter()):
-        raise BuildTopologyError("isolated emitter target does not build the emitter project")
+    if "$(BuildProjectReferences)" not in condition or "false" not in condition.lower():
+        raise BuildTopologyError("isolated emitter build must be gated by BuildProjectReferences=false")
+
+    msbuild_tasks = [element for element in target if local_name(element.tag) == "MSBuild"]
+    if len(msbuild_tasks) != 1:
+        raise BuildTopologyError("isolated emitter target must contain exactly one MSBuild task")
+    msbuild = msbuild_tasks[0]
+    if msbuild.attrib.get("Projects") != "$(FeatureManifestEmitterProjectPath)":
+        raise BuildTopologyError("isolated emitter target builds the wrong project")
+    if "Build" not in msbuild.attrib.get("Targets", "").split(";"):
+        raise BuildTopologyError("isolated emitter target must invoke Build")
+    if "Configuration=$(Configuration)" not in msbuild.attrib.get("Properties", ""):
+        raise BuildTopologyError("isolated emitter build must preserve Configuration")
+
+    emit_target = targets.get("EmitToolchainFeatureManifest")
+    if emit_target is None:
+        raise BuildTopologyError("language pack lacks EmitToolchainFeatureManifest")
+    errors = [element for element in emit_target if local_name(element.tag) == "Error"]
+    execs = [element for element in emit_target if local_name(element.tag) == "Exec"]
+    if not errors or "FeatureManifestEmitterResolvedDll" not in errors[0].attrib.get("Condition", ""):
+        raise BuildTopologyError("feature manifest emission must fail clearly when the emitter is absent")
+    if len(execs) != 1 or "$(FeatureManifestEmitterResolvedDll)" not in execs[0].attrib.get("Command", ""):
+        raise BuildTopologyError("feature manifest emission must execute the resolved emitter path")
 
 
-def require_release_gate_parity(root: Path) -> None:
-    required = (
+def uncommented_text(path: Path) -> str:
+    lines = path.read_text(encoding="utf-8-sig").splitlines()
+    return "\n".join(line for line in lines if not line.lstrip().startswith("#"))
+
+
+def require_one(text: str, pattern: str, description: str) -> int:
+    matches = list(re.finditer(pattern, text, flags=re.MULTILINE | re.DOTALL))
+    if len(matches) != 1:
+        raise BuildTopologyError(f"expected exactly one {description}, found {len(matches)}")
+    return matches[0].start()
+
+
+def require_canonical_gate_order(root: Path) -> None:
+    runtime_test = root / "Tools" / "test-build-topology-runtime.py"
+    if not runtime_test.is_file():
+        raise BuildTopologyError(f"runtime topology regression does not exist: {runtime_test}")
+
+    bash = uncommented_text(root / "build.sh")
+    bash_static = require_one(bash, r"^\s*python3\s+Tools/check-build-topology\.py\b", "build.sh topology checker invocation")
+    bash_mutants = require_one(bash, r"^\s*python3\s+Tools/test-build-topology-mutants\.py\b", "build.sh topology mutant invocation")
+    bash_runtime = require_one(bash, r"^\s*python3\s+Tools/test-build-topology-runtime\.py\b", "build.sh runtime topology invocation")
+    bash_restore = bash.index('"$dotnet_command" restore')
+    bash_build = bash.index('"$dotnet_command" build "$solution"')
+    bash_tests = bash.index("python3 Tools/run-test-contract.py")
+    if max(bash_static, bash_mutants) > bash_restore:
+        raise BuildTopologyError("build.sh static topology gates must run before restore")
+    if not bash_build < bash_runtime < bash_tests:
+        raise BuildTopologyError("build.sh runtime topology regression must run after solution build and before tests")
+
+    powershell = uncommented_text(root / "build.ps1")
+    ps_static = require_one(powershell, r'Invoke-CheckedNative\s+"python"\s+@\("Tools/check-build-topology\.py"', "build.ps1 topology checker invocation")
+    ps_mutants = require_one(powershell, r'Invoke-CheckedNative\s+"python"\s+@\("Tools/test-build-topology-mutants\.py"', "build.ps1 topology mutant invocation")
+    ps_runtime = require_one(powershell, r'Invoke-CheckedNative\s+"python"\s+@\(\s*"Tools/test-build-topology-runtime\.py"', "build.ps1 runtime topology invocation")
+    ps_restore = powershell.index("Invoke-CheckedNative $dotnet (New-RestoreArguments $solution)")
+    ps_build = powershell.index('"build", $solution')
+    ps_tests = powershell.index('"Tools/run-test-contract.py"')
+    if max(ps_static, ps_mutants) > ps_restore:
+        raise BuildTopologyError("build.ps1 static topology gates must run before restore")
+    if not ps_build < ps_runtime < ps_tests:
+        raise BuildTopologyError("build.ps1 runtime topology regression must run after solution build and before tests")
+
+    required_release_gates = (
         "Tools/package_metadata.py",
         "Tools/test-package-metadata-mutants.py",
     )
-    for relative in ("build.sh", "build.ps1"):
-        script = root / relative
-        if not script.is_file():
-            raise BuildTopologyError(f"canonical build entry point does not exist: {script}")
-        text = script.read_text(encoding="utf-8-sig")
-        missing = [token for token in required if token not in text]
+    for relative, text in (("build.sh", bash), ("build.ps1", powershell)):
+        missing = [gate for gate in required_release_gates if gate not in text]
         if missing:
-            raise BuildTopologyError(
-                f"{relative} omits mandatory package metadata gates: {missing}"
-            )
+            raise BuildTopologyError(f"{relative} omits mandatory package metadata gates: {missing}")
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(
-        description="Validate IDE-safe project references and canonical build-gate parity."
+        description="Validate IDE-safe project references and canonical build topology gates."
     )
     parser.add_argument("--root", type=Path, default=Path.cwd())
     args = parser.parse_args()
@@ -107,8 +187,8 @@ def main() -> int:
     try:
         require_build_order_references_not_copy_local(root)
         require_language_pack_isolated_emitter_build(root)
-        require_release_gate_parity(root)
-    except BuildTopologyError as exc:
+        require_canonical_gate_order(root)
+    except (BuildTopologyError, OSError, ValueError) as exc:
         print(f"BUILD_TOPOLOGY=FAIL: {exc}", file=sys.stderr)
         return 1
 

--- a/Tools/test-build-topology-mutants.py
+++ b/Tools/test-build-topology-mutants.py
@@ -6,21 +6,26 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import xml.etree.ElementTree as ET
 from pathlib import Path
 
 
-INPUTS = (
+DIALECT_TEST_PROJECT = Path(
+    "UniversalToolchain/UniversalToolchain.Dialects.Tests/"
+    "UniversalToolchain.Dialects.Tests.csproj"
+)
+FRESH_PROCESS_HOST_PROJECT = Path(
+    "UniversalToolchain/UniversalToolchain.Dialects.Tests/FreshProcess/"
+    "RuntimeSharedAssemblyFreshProcessHost/RuntimeSharedAssemblyFreshProcessHost.csproj"
+)
+LANGUAGE_PACK_PROJECT = Path(
+    "UniversalToolchain/UniversalToolchain.Wist.LanguagePack/"
+    "UniversalToolchain.Wist.LanguagePack.csproj"
+)
+SUPPORT_FILES = (
     Path("build.sh"),
     Path("build.ps1"),
-    Path("UniversalToolchain/Tests/Tests.csproj"),
-    Path(
-        "UniversalToolchain/UniversalToolchain.Dialects.Tests/"
-        "UniversalToolchain.Dialects.Tests.csproj"
-    ),
-    Path(
-        "UniversalToolchain/UniversalToolchain.Wist.LanguagePack/"
-        "UniversalToolchain.Wist.LanguagePack.csproj"
-    ),
+    Path("Tools/test-build-topology-runtime.py"),
 )
 
 
@@ -43,10 +48,14 @@ def run_checker(checker: Path, root: Path, expected_fragment: str | None = None)
 
 
 def copy_inputs(source: Path, destination: Path) -> None:
-    for relative in INPUTS:
+    project_files = sorted((source / "UniversalToolchain").rglob("*.csproj"))
+    if not project_files:
+        raise AssertionError("no project files found for topology fixture")
+    for source_path in [*(source / relative for relative in SUPPORT_FILES), *project_files]:
+        relative = source_path.relative_to(source)
         target = destination / relative
         target.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(source / relative, target)
+        shutil.copy2(source_path, target)
 
 
 def replace_once(path: Path, old: str, new: str) -> None:
@@ -54,6 +63,55 @@ def replace_once(path: Path, old: str, new: str) -> None:
     if old not in text:
         raise AssertionError(f"mutation anchor not found in {path}: {old!r}")
     path.write_text(text.replace(old, new, 1), encoding="utf-8")
+
+
+def mutate_project_reference(path: Path, include_fragment: str) -> None:
+    tree = ET.parse(path)
+    matches = [
+        element
+        for element in tree.getroot().iter()
+        if element.tag.rsplit("}", 1)[-1] == "ProjectReference"
+        and include_fragment in element.attrib.get("Include", "")
+    ]
+    if len(matches) != 1 or matches[0].attrib.get("Private", "").lower() != "false":
+        raise AssertionError(f"expected one Private=false reference containing {include_fragment!r} in {path}")
+    del matches[0].attrib["Private"]
+    tree.write(path, encoding="unicode")
+
+
+def rename_target(path: Path, old_name: str, new_name: str) -> None:
+    tree = ET.parse(path)
+    matches = [
+        element
+        for element in tree.getroot().iter()
+        if element.tag.rsplit("}", 1)[-1] == "Target"
+        and element.attrib.get("Name") == old_name
+    ]
+    if len(matches) != 1:
+        raise AssertionError(f"expected target {old_name!r} in {path}")
+    matches[0].set("Name", new_name)
+    tree.write(path, encoding="unicode")
+
+
+def redirect_msbuild_project(path: Path, target_name: str, project: str) -> None:
+    tree = ET.parse(path)
+    targets = [
+        element
+        for element in tree.getroot().iter()
+        if element.tag.rsplit("}", 1)[-1] == "Target"
+        and element.attrib.get("Name") == target_name
+    ]
+    if len(targets) != 1:
+        raise AssertionError(f"expected target {target_name!r} in {path}")
+    tasks = [
+        element
+        for element in targets[0]
+        if element.tag.rsplit("}", 1)[-1] == "MSBuild"
+    ]
+    if len(tasks) != 1:
+        raise AssertionError(f"expected one MSBuild task in {target_name!r}")
+    tasks[0].set("Projects", project)
+    tree.write(path, encoding="unicode")
 
 
 def fixture(root: Path, checker: Path) -> tuple[tempfile.TemporaryDirectory[str], Path]:
@@ -78,17 +136,37 @@ def main() -> int:
     try:
         temporary, path = fixture(root, checker)
         with temporary:
-            replace_once(path / INPUTS[3], '\n                          Private="false"', "")
-            run_checker(checker, path, "ReferenceOutputAssembly=false references")
+            mutate_project_reference(
+                path / DIALECT_TEST_PROJECT,
+                "RuntimeSharedAssemblyFreshProcessHost.csproj",
+            )
+            run_checker(checker, path, "repository build-order ProjectReference")
 
         temporary, path = fixture(root, checker)
         with temporary:
-            replace_once(
-                path / INPUTS[4],
-                'Name="BuildFeatureManifestEmitterForIsolatedBuild"',
-                'Name="DisabledFeatureManifestEmitterForIsolatedBuild"',
+            mutate_project_reference(
+                path / FRESH_PROCESS_HOST_PROJECT,
+                "CanonicalRuntimeFixture.csproj",
+            )
+            run_checker(checker, path, "repository build-order ProjectReference")
+
+        temporary, path = fixture(root, checker)
+        with temporary:
+            rename_target(
+                path / LANGUAGE_PACK_PROJECT,
+                "BuildFeatureManifestEmitterForIsolatedBuild",
+                "DisabledFeatureManifestEmitterForIsolatedBuild",
             )
             run_checker(checker, path, "lacks BuildFeatureManifestEmitterForIsolatedBuild")
+
+        temporary, path = fixture(root, checker)
+        with temporary:
+            redirect_msbuild_project(
+                path / LANGUAGE_PACK_PROJECT,
+                "BuildFeatureManifestEmitterForIsolatedBuild",
+                "wrong-emitter.csproj",
+            )
+            run_checker(checker, path, "builds the wrong project")
 
         temporary, path = fixture(root, checker)
         with temporary:
@@ -107,6 +185,15 @@ def main() -> int:
                 "Tools/test-package-metadata-mutants.disabled.py",
             )
             run_checker(checker, path, "build.sh omits mandatory package metadata gates")
+
+        temporary, path = fixture(root, checker)
+        with temporary:
+            replace_once(
+                path / "build.sh",
+                "Tools/test-build-topology-runtime.py",
+                "Tools/test-build-topology-runtime.disabled.py",
+            )
+            run_checker(checker, path, "build.sh runtime topology invocation")
     except (AssertionError, OSError) as exc:
         print(f"BUILD_TOPOLOGY_MUTANTS=FAIL: {exc}", file=sys.stderr)
         return 1

--- a/Tools/test-build-topology-runtime.py
+++ b/Tools/test-build-topology-runtime.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+class RuntimeTopologyError(RuntimeError):
+    pass
+
+
+DIALECT_TESTS = Path("UniversalToolchain/UniversalToolchain.Dialects.Tests/UniversalToolchain.Dialects.Tests.csproj")
+FRESH_PROCESS_PROJECTS = (
+    Path("UniversalToolchain/UniversalToolchain.Dialects.Tests/FreshProcess/HostOnlyContractFixture"),
+    Path("UniversalToolchain/UniversalToolchain.Dialects.Tests/FreshProcess/HostileRuntimeFixture"),
+    Path("UniversalToolchain/UniversalToolchain.Dialects.Tests/FreshProcess/CanonicalRuntimeFixture"),
+    Path("UniversalToolchain/UniversalToolchain.Dialects.Tests/FreshProcess/UnregisteredDependencyRuntimeFixture"),
+    Path("UniversalToolchain/UniversalToolchain.Dialects.Tests/FreshProcess/RuntimeSharedAssemblyFreshProcessHost"),
+)
+LANGUAGE_PACK = Path("UniversalToolchain/UniversalToolchain.Wist.LanguagePack/UniversalToolchain.Wist.LanguagePack.csproj")
+FEATURE_EMITTER = Path("UniversalToolchain/UniversalToolchain.FeatureManifestEmitter")
+CORE_TESTS = Path("UniversalToolchain/Tests/Tests.csproj")
+WISTC = Path("UniversalToolchain/Wistc")
+
+
+def remove_configuration_outputs(project_directory: Path, configuration: str) -> None:
+    for output_root_name in ("bin", "obj"):
+        output_root = project_directory / output_root_name
+        if not output_root.is_dir():
+            continue
+        candidates = sorted(
+            (path for path in output_root.rglob(configuration) if path.is_dir()),
+            key=lambda path: len(path.parts),
+            reverse=True,
+        )
+        for candidate in candidates:
+            shutil.rmtree(candidate)
+
+
+def run_build(
+    dotnet: str,
+    root: Path,
+    project: Path,
+    configuration: str,
+    *,
+    build_project_references: bool,
+) -> None:
+    command = [
+        dotnet,
+        "build",
+        str(root / project),
+        "-c",
+        configuration,
+        "--no-restore",
+        "-m:1",
+        f"-p:BuildProjectReferences={'true' if build_project_references else 'false'}",
+        "-p:NuGetAudit=false",
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=root,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+        timeout=240,
+    )
+    if completed.returncode != 0:
+        raise RuntimeTopologyError(
+            f"isolated build failed for {project} (BuildProjectReferences={build_project_references}):\n"
+            f"{completed.stdout}"
+        )
+
+
+def matching_outputs(project_directory: Path, configuration: str, file_name: str) -> list[Path]:
+    output_root = project_directory / "bin"
+    if not output_root.is_dir():
+        return []
+    return sorted(
+        path
+        for path in output_root.rglob(file_name)
+        if configuration.lower() in (part.lower() for part in path.parts)
+    )
+
+
+def require_output(project_directory: Path, configuration: str, file_name: str) -> None:
+    matches = matching_outputs(project_directory, configuration, file_name)
+    if not matches:
+        raise RuntimeTopologyError(
+            f"expected {file_name} under {project_directory}/bin for {configuration}"
+        )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Reproduce IDE-style BuildProjectReferences=false builds against real projects."
+    )
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--dotnet", default="dotnet")
+    parser.add_argument("--configuration", default="Release")
+    args = parser.parse_args()
+
+    root = args.root.resolve()
+    configuration = args.configuration
+    try:
+        dialect_directory = (root / DIALECT_TESTS).parent
+        remove_configuration_outputs(dialect_directory, configuration)
+        for relative in FRESH_PROCESS_PROJECTS:
+            remove_configuration_outputs(root / relative, configuration)
+        run_build(args.dotnet, root, DIALECT_TESTS, configuration, build_project_references=False)
+        require_output(
+            root / FRESH_PROCESS_PROJECTS[-1],
+            configuration,
+            "UniversalToolchain.Dialects.FreshProcessHost.dll",
+        )
+
+        language_pack_directory = (root / LANGUAGE_PACK).parent
+        remove_configuration_outputs(language_pack_directory, configuration)
+        remove_configuration_outputs(root / FEATURE_EMITTER, configuration)
+        run_build(args.dotnet, root, LANGUAGE_PACK, configuration, build_project_references=False)
+        require_output(
+            language_pack_directory,
+            configuration,
+            "UniversalToolchain.Wist.LanguagePack.toolchain.feature.json",
+        )
+        require_output(
+            root / FEATURE_EMITTER,
+            configuration,
+            "UniversalToolchain.FeatureManifestEmitter.dll",
+        )
+
+        tests_directory = (root / CORE_TESTS).parent
+        remove_configuration_outputs(tests_directory, configuration)
+        remove_configuration_outputs(root / WISTC, configuration)
+        run_build(args.dotnet, root, CORE_TESTS, configuration, build_project_references=False)
+        require_output(tests_directory, configuration, "Tests.dll")
+        if matching_outputs(root / WISTC, configuration, "Wistc.dll"):
+            raise RuntimeTopologyError(
+                "BuildProjectReferences=false unexpectedly rebuilt the build-only Wistc reference"
+            )
+        run_build(args.dotnet, root, WISTC / "Wistc.csproj", configuration, build_project_references=True)
+    except (OSError, subprocess.SubprocessError, RuntimeTopologyError) as exc:
+        print(f"BUILD_TOPOLOGY_RUNTIME=FAIL: {exc}", file=sys.stderr)
+        return 1
+
+    print("BUILD_TOPOLOGY_RUNTIME=PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/FreshProcess/RuntimeSharedAssemblyFreshProcessHost/RuntimeSharedAssemblyFreshProcessHost.csproj
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/FreshProcess/RuntimeSharedAssemblyFreshProcessHost/RuntimeSharedAssemblyFreshProcessHost.csproj
@@ -18,10 +18,16 @@
     <ProjectReference Include="..\..\..\UniversalToolchain.Dialects.Integration\UniversalToolchain.Dialects.Integration.csproj" />
     <ProjectReference Include="..\..\..\UniversalToolchain.Dialects.Wist\UniversalToolchain.Dialects.Wist.csproj" />
     <ProjectReference Include="..\..\..\UniversalToolchain.Functions.Abstractions\UniversalToolchain.Functions.Abstractions.csproj" />
-    <ProjectReference Include="..\CanonicalRuntimeFixture\CanonicalRuntimeFixture.csproj" ReferenceOutputAssembly="false" />
-    <ProjectReference Include="..\HostileRuntimeFixture\HostileRuntimeFixture.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\CanonicalRuntimeFixture\CanonicalRuntimeFixture.csproj"
+                      ReferenceOutputAssembly="false"
+                      Private="false" />
+    <ProjectReference Include="..\HostileRuntimeFixture\HostileRuntimeFixture.csproj"
+                      ReferenceOutputAssembly="false"
+                      Private="false" />
     <ProjectReference Include="..\HostOnlyContractFixture\HostOnlyContractFixture.csproj" />
-    <ProjectReference Include="..\UnregisteredDependencyRuntimeFixture\UnregisteredDependencyRuntimeFixture.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\UnregisteredDependencyRuntimeFixture\UnregisteredDependencyRuntimeFixture.csproj"
+                      ReferenceOutputAssembly="false"
+                      Private="false" />
   </ItemGroup>
 
   <ItemGroup>

--- a/UniversalToolchain/UniversalToolchain.Wist.LanguagePack/UniversalToolchain.Wist.LanguagePack.csproj
+++ b/UniversalToolchain/UniversalToolchain.Wist.LanguagePack/UniversalToolchain.Wist.LanguagePack.csproj
@@ -12,6 +12,11 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);IncludeToolchainFeatureManifest</TargetsForTfmSpecificContentInPackage>
     <FeatureManifestEmitterProjectPath>$(MSBuildThisFileDirectory)..\UniversalToolchain.FeatureManifestEmitter\UniversalToolchain.FeatureManifestEmitter.csproj</FeatureManifestEmitterProjectPath>
+    <FeatureManifestEmitterTargetFramework>net10.0</FeatureManifestEmitterTargetFramework>
+    <FeatureManifestEmitterPlatformSegment Condition="'$(Platform)' != '' and '$(Platform)' != 'AnyCPU'">$(Platform)/</FeatureManifestEmitterPlatformSegment>
+    <FeatureManifestEmitterProjectBinDll>$(MSBuildThisFileDirectory)..\UniversalToolchain.FeatureManifestEmitter\bin\$(FeatureManifestEmitterPlatformSegment)$(Configuration)\$(FeatureManifestEmitterTargetFramework)\UniversalToolchain.FeatureManifestEmitter.dll</FeatureManifestEmitterProjectBinDll>
+    <FeatureManifestEmitterConfiguredOutputDll>$(MSBuildThisFileDirectory)..\UniversalToolchain.FeatureManifestEmitter\$(OutputPath)UniversalToolchain.FeatureManifestEmitter.dll</FeatureManifestEmitterConfiguredOutputDll>
+    <FeatureManifestEmitterTargetDirDll>$(TargetDir)UniversalToolchain.FeatureManifestEmitter.dll</FeatureManifestEmitterTargetDirDll>
   </PropertyGroup>
   <ItemGroup>
     <None Include="README.md" Pack="true" PackagePath="/" />
@@ -33,14 +38,20 @@
           Condition="'$(DesignTimeBuild)' != 'true' and '$(BuildProjectReferences)' == 'false'">
     <MSBuild Projects="$(FeatureManifestEmitterProjectPath)"
              Targets="Build"
-             Properties="Configuration=$(Configuration)" />
+             Properties="Configuration=$(Configuration)"
+             BuildInParallel="false" />
   </Target>
   <Target Name="EmitToolchainFeatureManifest" AfterTargets="Build" Condition="'$(DesignTimeBuild)' != 'true'">
     <PropertyGroup>
       <ToolchainFeatureManifestPath>$(TargetDir)$(AssemblyName).toolchain.feature.json</ToolchainFeatureManifestPath>
-      <FeatureEmitterPath>$(MSBuildThisFileDirectory)..\UniversalToolchain.FeatureManifestEmitter\$(OutputPath)UniversalToolchain.FeatureManifestEmitter.dll</FeatureEmitterPath>
+      <FeatureManifestEmitterResolvedDll></FeatureManifestEmitterResolvedDll>
+      <FeatureManifestEmitterResolvedDll Condition="Exists('$(FeatureManifestEmitterTargetDirDll)')">$(FeatureManifestEmitterTargetDirDll)</FeatureManifestEmitterResolvedDll>
+      <FeatureManifestEmitterResolvedDll Condition="'$(FeatureManifestEmitterResolvedDll)' == '' and Exists('$(FeatureManifestEmitterConfiguredOutputDll)')">$(FeatureManifestEmitterConfiguredOutputDll)</FeatureManifestEmitterResolvedDll>
+      <FeatureManifestEmitterResolvedDll Condition="'$(FeatureManifestEmitterResolvedDll)' == '' and Exists('$(FeatureManifestEmitterProjectBinDll)')">$(FeatureManifestEmitterProjectBinDll)</FeatureManifestEmitterResolvedDll>
     </PropertyGroup>
-    <Exec Command="&quot;$(DOTNET_HOST_PATH)&quot; &quot;$(FeatureEmitterPath)&quot; &quot;$(TargetPath)&quot; &quot;$(ToolchainFeatureManifestPath)&quot;" />
+    <Error Condition="'$(FeatureManifestEmitterResolvedDll)' == ''"
+           Text="Feature manifest emitter was not found. Checked '$(FeatureManifestEmitterTargetDirDll)', '$(FeatureManifestEmitterConfiguredOutputDll)', and '$(FeatureManifestEmitterProjectBinDll)'." />
+    <Exec Command="&quot;$(DOTNET_HOST_PATH)&quot; &quot;$(FeatureManifestEmitterResolvedDll)&quot; &quot;$(TargetPath)&quot; &quot;$(ToolchainFeatureManifestPath)&quot;" />
   </Target>
   <Target Name="ExposeWistRuntimeClosureToProjectReferences" BeforeTargets="_GetCopyToOutputDirectoryItemsFromThisProject">
     <PropertyGroup>

--- a/build.ps1
+++ b/build.ps1
@@ -97,6 +97,9 @@ function New-RestoreArguments {
     return $arguments
 }
 
+Invoke-CheckedNative "python" @("Tools/check-build-topology.py", "--root", $root)
+Invoke-CheckedNative "python" @("Tools/test-build-topology-mutants.py", "--root", $root)
+
 foreach ($solution in $solutions) {
     Invoke-CheckedNative $dotnet (New-RestoreArguments $solution)
 }
@@ -116,6 +119,13 @@ foreach ($solution in $solutions) {
         "-p:NuGetAudit=false"
     ))
 }
+
+Invoke-CheckedNative "python" @(
+    "Tools/test-build-topology-runtime.py",
+    "--root", $root,
+    "--dotnet", $dotnet,
+    "--configuration", $Configuration
+)
 
 foreach ($project in $markdownSampleProjects) {
     Invoke-CheckedNative $dotnet (@(
@@ -147,8 +157,6 @@ Invoke-CheckedNative "python" @("Tools/check-retired-surface.py", "--root", $roo
 Invoke-CheckedNative "python" @("Tools/test-retired-surface-mutants.py", "--root", $root)
 Invoke-CheckedNative "python" @("Tools/check_documentation_status.py")
 Invoke-CheckedNative "python" @("Tools/test-documentation-status-mutants.py", "--root", $root)
-Invoke-CheckedNative "python" @("Tools/check-build-topology.py", "--root", $root)
-Invoke-CheckedNative "python" @("Tools/test-build-topology-mutants.py", "--root", $root)
 
 if (-not $SkipPack) {
     if (-not $BaselineSourceArchive -or -not (Test-Path -LiteralPath $BaselineSourceArchive -PathType Leaf)) {

--- a/build.sh
+++ b/build.sh
@@ -134,6 +134,9 @@ read_manifest() {
   sed -e 's/[[:space:]]*$//' -e '/^[[:space:]]*#/d' -e '/^[[:space:]]*$/d' "$path"
 }
 
+python3 Tools/check-build-topology.py --root "$root"
+python3 Tools/test-build-topology-mutants.py --root "$root"
+
 for solution in "${solutions[@]}"; do
   "$dotnet_command" restore "$solution" \
     "${restore_mode_args[@]}" \
@@ -165,6 +168,11 @@ for solution in "${solutions[@]}"; do
     -p:NuGetAudit=false
 done
 
+python3 Tools/test-build-topology-runtime.py \
+  --root "$root" \
+  --dotnet "$dotnet_command" \
+  --configuration "$configuration"
+
 # Runnable Markdown samples are built by the canonical entrypoint so docs checks
 # can execute with --no-build --no-restore.
 for sample_project in "${markdown_sample_projects[@]}"; do
@@ -191,8 +199,6 @@ python3 Tools/check-retired-surface.py --root "$root"
 python3 Tools/test-retired-surface-mutants.py --root "$root"
 python3 Tools/check_documentation_status.py
 python3 Tools/test-documentation-status-mutants.py --root "$root"
-python3 Tools/check-build-topology.py --root "$root"
-python3 Tools/test-build-topology-mutants.py --root "$root"
 
 if [[ "$skip_pack" == false ]]; then
   if [[ -z "$baseline_source_archive" || ! -f "$baseline_source_archive" ]]; then


### PR DESCRIPTION
## Problem

The previous build-topology hardening fixed the original executable Copy Local failures but introduced a guardrail that failed on the full repository while its mutant fixture copied only a partial project set. `master` therefore built both solutions and passed 1,597 tests, then failed the new static topology gate.

## Changes

- mark the three fresh-process fixture references as build-only/non-Copy-Local;
- scan the complete `UniversalToolchain/**/*.csproj` set in topology mutants;
- strengthen the LanguagePack emitter contract and output-path resolution;
- add a real `BuildProjectReferences=false` regression for Dialects.Tests, LanguagePack, and Tests/Wistc;
- run static topology gates before restore and the runtime graph regression after solution builds but before tests;
- tighten canonical entrypoint ordering and emitter target validation.

## Local verification

- synthetic .NET SDK 10.0.301 reproduction: static checker PASS;
- seven negative topology mutants PASS;
- real isolated graph reproduction against synthetic projects PASS for all three scenarios;
- Python compilation and `bash -n` PASS;
- exact baseline blob hashes for `build.sh` and `build.ps1` matched current `master` before modification.

No package publication or release action is included.