### PR TITLE
Docs: repair Wist release-state and first-contact paths

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -3,13 +3,19 @@ name: Docs Check
 on:
   pull_request:
     paths:
+      - 'readme.md'
       - 'docs/**'
       - 'internal-docs/**'
+      - 'UniversalToolchain/UniversalToolchain.Wist/README.md'
+      - 'UniversalToolchain/UniversalToolchain.Wist/UniversalToolchain.Wist.csproj'
+      - 'eng/documentation-release-state.json'
       - 'Tools/check_documentation_*.py'
+      - 'Tools/test-documentation-*.py'
       - 'package.json'
       - 'package-lock.json'
       - '.github/workflows/docs-check.yml'
       - '.github/workflows/deploy-docs.yml'
+      - '.github/workflows/published-package-smoke.yml'
   push:
     branches:
       - master
@@ -34,8 +40,11 @@ jobs:
       - name: Install dependencies
         run: npm ci --no-audit --no-fund
 
-      - name: Validate documentation structure and links
+      - name: Validate documentation structure, release state and links
         run: npm run docs:status && npm run docs:links
+
+      - name: Reject documentation release-state mutants
+        run: python3 Tools/test-documentation-release-state-mutants.py --root .
 
       - name: Build documentation
         run: npm run docs:build

--- a/.github/workflows/published-package-smoke.yml
+++ b/.github/workflows/published-package-smoke.yml
@@ -9,17 +9,19 @@ on:
       - master
   pull_request:
     paths:
+      - readme.md
       - .github/workflows/published-package-smoke.yml
+      - Tools/check_documentation_release_state.py
       - Tools/smoke-published-wist-package.sh
+      - eng/documentation-release-state.json
       - UniversalToolchain/UniversalToolchain.Wist/UniversalToolchain.Wist.csproj
       - UniversalToolchain/UniversalToolchain.Wist/README.md
       - docs/start/installation.md
+      - docs/start/first-program.md
+      - docs/start/use-case-recipes.md
 
 permissions:
   contents: read
-
-env:
-  PUBLISHED_WIST_VERSION: 0.1.0-alpha.1
 
 jobs:
   smoke:
@@ -35,5 +37,12 @@ jobs:
         with:
           global-json-file: UniversalToolchain/global.json
 
+      - name: Resolve published package version
+        id: release-state
+        shell: bash
+        run: |
+          version="$(python3 Tools/check_documentation_release_state.py --print-published-version)"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
       - name: Install and execute the published package
-        run: ./Tools/smoke-published-wist-package.sh "$PUBLISHED_WIST_VERSION"
+        run: ./Tools/smoke-published-wist-package.sh "${{ steps.release-state.outputs.version }}"

--- a/Tools/check_documentation_release_state.py
+++ b/Tools/check_documentation_release_state.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+DEFAULT_STATE = Path("eng/documentation-release-state.json")
+PUBLISHED_MARKER_BEGIN = "<!-- wist-published-install:begin -->"
+PUBLISHED_MARKER_END = "<!-- wist-published-install:end -->"
+SOURCE_MARKER_BEGIN = "<!-- wist-source-candidate:begin -->"
+SOURCE_MARKER_END = "<!-- wist-source-candidate:end -->"
+
+
+class ReleaseStateError(ValueError):
+    pass
+
+
+def local_name(tag: str) -> str:
+    return tag.rsplit("}", 1)[-1]
+
+
+def child_text(root: ET.Element, name: str) -> str | None:
+    for element in root.iter():
+        if local_name(element.tag) == name:
+            value = (element.text or "").strip()
+            if value:
+                return value
+    return None
+
+
+def require_string(data: dict[str, object], key: str) -> str:
+    value = data.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise ReleaseStateError(f"release state field {key!r} must be a non-empty string")
+    return value.strip()
+
+
+def require_string_list(data: dict[str, object], key: str) -> list[str]:
+    value = data.get(key)
+    if not isinstance(value, list) or not value or not all(isinstance(item, str) and item.strip() for item in value):
+        raise ReleaseStateError(f"release state field {key!r} must be a non-empty string list")
+    return [item.strip() for item in value]
+
+
+def load_state(path: Path) -> dict[str, object]:
+    if not path.is_file():
+        raise ReleaseStateError(f"release state file does not exist: {path}")
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ReleaseStateError(f"invalid release state JSON: {exc}") from exc
+    if not isinstance(data, dict):
+        raise ReleaseStateError("release state root must be an object")
+    if data.get("schemaVersion") != 1:
+        raise ReleaseStateError(f"unsupported release state schemaVersion: {data.get('schemaVersion')!r}")
+    return data
+
+
+def read_project_identity(project: Path) -> tuple[str, str, str]:
+    if not project.is_file():
+        raise ReleaseStateError(f"package project does not exist: {project}")
+    try:
+        root = ET.parse(project).getroot()
+    except ET.ParseError as exc:
+        raise ReleaseStateError(f"invalid project XML {project}: {exc}") from exc
+    package_id = child_text(root, "PackageId") or project.stem
+    version = child_text(root, "PackageVersion") or child_text(root, "Version")
+    target_framework = child_text(root, "TargetFramework")
+    if not version or not target_framework:
+        raise ReleaseStateError(f"project identity is incomplete: {project}")
+    return package_id, version, target_framework
+
+
+def marked_block(text: str, begin: str, end: str, document: Path) -> str:
+    if text.count(begin) != 1 or text.count(end) != 1:
+        raise ReleaseStateError(
+            f"{document}: expected exactly one marker pair {begin!r} / {end!r}"
+        )
+    return text.split(begin, 1)[1].split(end, 1)[0]
+
+
+def compact_command_text(text: str) -> str:
+    return re.sub(r"\\\s*\n\s*", " ", text)
+
+
+def validate_install_block(
+    document: Path,
+    block: str,
+    package_id: str,
+    version: str,
+    *,
+    require_nuget_source: bool,
+) -> None:
+    compact = compact_command_text(block)
+    command = re.compile(
+        rf"dotnet\s+add\s+package\s+{re.escape(package_id)}\b(?:(?!dotnet\s+add\s+package).)*?"
+        rf"--version\s+{re.escape(version)}\b",
+        re.DOTALL,
+    )
+    if not command.search(compact):
+        raise ReleaseStateError(
+            f"{document}: install block does not contain {package_id} {version}"
+        )
+    has_nuget_source = "https://api.nuget.org/v3/index.json" in compact
+    if require_nuget_source and not has_nuget_source:
+        raise ReleaseStateError(f"{document}: published install must pin the NuGet.org v3 feed")
+    if not require_nuget_source and "--source" not in compact:
+        raise ReleaseStateError(f"{document}: source-candidate install must name its local feed")
+
+
+def validate_build_commands(document: Path, text: str) -> None:
+    for match in re.finditer(r"(?m)^\s*(\./build\.sh[^\n]*)$", text):
+        command = match.group(1)
+        if "--skip-pack" in command:
+            continue
+        if "--baseline-source-archive" in command and "--previous-package-bundle" in command:
+            continue
+        raise ReleaseStateError(
+            f"{document}: build command would enter the baseline-bearing package gate without its inputs: {command}"
+        )
+
+
+def validate_root_readme_links(root: Path) -> None:
+    readme = root / "readme.md"
+    if not readme.is_file():
+        raise ReleaseStateError("readme.md does not exist")
+    text = readme.read_text(encoding="utf-8")
+    for raw in re.findall(r"!?\[[^\]]*\]\(([^)]+)\)", text):
+        target = raw.strip()
+        if target.startswith("<") and target.endswith(">"):
+            target = target[1:-1]
+        target = re.split(r"\s+['\"]", target, maxsplit=1)[0]
+        target = target.split("#", 1)[0]
+        if not target or target.startswith(("http://", "https://", "mailto:", "tel:", "data:")):
+            continue
+        candidate = (root / target).resolve()
+        try:
+            candidate.relative_to(root)
+        except ValueError as exc:
+            raise ReleaseStateError(f"readme.md: local link escapes repository: {raw}") from exc
+        if candidate.is_dir():
+            candidate = candidate / "index.md"
+        elif not candidate.exists() and candidate.suffix == "":
+            markdown = Path(str(candidate) + ".md")
+            candidate = markdown if markdown.exists() else candidate / "index.md"
+        if not candidate.exists():
+            raise ReleaseStateError(f"readme.md: missing local link target: {raw}")
+
+
+def validate(root: Path, state_path: Path) -> dict[str, str]:
+    state = load_state(state_path)
+    package_id = require_string(state, "packageId")
+    source_version = require_string(state, "sourceVersion")
+    published_version = require_string(state, "publishedVersion")
+    target_framework = require_string(state, "targetFramework")
+    project_path = require_string(state, "project")
+    stability_path = require_string(state, "stabilityDocument")
+    published_documents = require_string_list(state, "publishedInstallDocuments")
+    source_documents = require_string_list(state, "sourceCandidateDocuments")
+    build_documents = require_string_list(state, "sourceBuildDocuments")
+    stability_link_documents = require_string_list(state, "stabilityLinkDocuments")
+    workflow_path = require_string(state, "publishedSmokeWorkflow")
+
+    project = root / project_path
+    actual_id, actual_source_version, actual_target_framework = read_project_identity(project)
+    if actual_id != package_id:
+        raise ReleaseStateError(
+            f"release state packageId {package_id} does not match project PackageId {actual_id}"
+        )
+    if actual_source_version != source_version:
+        raise ReleaseStateError(
+            f"release state sourceVersion {source_version} does not match project version {actual_source_version}"
+        )
+    if actual_target_framework != target_framework:
+        raise ReleaseStateError(
+            f"release state targetFramework {target_framework} does not match project target {actual_target_framework}"
+        )
+
+    stability = root / stability_path
+    if not stability.is_file():
+        raise ReleaseStateError(f"active stability document does not exist: {stability_path}")
+    stability_text = stability.read_text(encoding="utf-8")
+    if source_version not in stability_text:
+        raise ReleaseStateError(
+            f"{stability_path}: active stability document does not identify source version {source_version}"
+        )
+
+    for relative in published_documents:
+        document = root / relative
+        if not document.is_file():
+            raise ReleaseStateError(f"published-install document does not exist: {relative}")
+        text = document.read_text(encoding="utf-8")
+        block = marked_block(text, PUBLISHED_MARKER_BEGIN, PUBLISHED_MARKER_END, document)
+        validate_install_block(
+            document,
+            block,
+            package_id,
+            published_version,
+            require_nuget_source=True,
+        )
+        if source_version != published_version and source_version in block:
+            raise ReleaseStateError(
+                f"{relative}: published install block contains unpublished source version {source_version}"
+            )
+
+    for relative in source_documents:
+        document = root / relative
+        if not document.is_file():
+            raise ReleaseStateError(f"source-candidate document does not exist: {relative}")
+        text = document.read_text(encoding="utf-8")
+        block = marked_block(text, SOURCE_MARKER_BEGIN, SOURCE_MARKER_END, document)
+        if source_version not in block:
+            raise ReleaseStateError(
+                f"{relative}: source-candidate block does not identify source version {source_version}"
+            )
+        lowered = block.lower()
+        if published_version != source_version and not any(
+            phrase in lowered for phrase in ("not published", "unpublished", "not on nuget.org")
+        ):
+            raise ReleaseStateError(
+                f"{relative}: unpublished source candidate must be labeled as not published"
+            )
+
+    for relative in build_documents:
+        document = root / relative
+        if not document.is_file():
+            raise ReleaseStateError(f"source-build document does not exist: {relative}")
+        validate_build_commands(document, document.read_text(encoding="utf-8"))
+
+    stability_link = "/" + stability_path.removeprefix("docs/").removesuffix(".md")
+    for relative in stability_link_documents:
+        document = root / relative
+        if not document.is_file():
+            raise ReleaseStateError(f"stability-link document does not exist: {relative}")
+        text = document.read_text(encoding="utf-8")
+        if stability_link not in text and stability_path not in text:
+            raise ReleaseStateError(
+                f"{relative}: active stability link {stability_link} is missing"
+            )
+
+    validate_root_readme_links(root)
+
+    workflow = root / workflow_path
+    if not workflow.is_file():
+        raise ReleaseStateError(f"published-package smoke workflow does not exist: {workflow_path}")
+    workflow_text = workflow.read_text(encoding="utf-8")
+    if "PUBLISHED_WIST_VERSION:" in workflow_text:
+        raise ReleaseStateError(
+            f"{workflow_path}: published version must come from {state_path.relative_to(root)}, not a workflow literal"
+        )
+    if "--print-published-version" not in workflow_text:
+        raise ReleaseStateError(
+            f"{workflow_path}: workflow does not resolve the published version through the release-state checker"
+        )
+
+    return {
+        "packageId": package_id,
+        "sourceVersion": source_version,
+        "publishedVersion": published_version,
+        "targetFramework": target_framework,
+        "stabilityDocument": stability_path,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Validate Wist documentation release state and first-contact commands.")
+    parser.add_argument("--root", type=Path, default=Path(__file__).resolve().parents[1])
+    parser.add_argument("--state", type=Path, default=DEFAULT_STATE)
+    parser.add_argument("--print-published-version", action="store_true")
+    parser.add_argument("--print-source-version", action="store_true")
+    args = parser.parse_args(argv)
+
+    root = args.root.resolve()
+    state_path = args.state.resolve() if args.state.is_absolute() else (root / args.state).resolve()
+    try:
+        result = validate(root, state_path)
+    except (OSError, ReleaseStateError) as exc:
+        print(f"documentation-release-state: ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    if args.print_published_version:
+        print(result["publishedVersion"])
+    elif args.print_source_version:
+        print(result["sourceVersion"])
+    else:
+        print(
+            "documentation-release-state: PASS "
+            f"published={result['publishedVersion']} source={result['sourceVersion']} "
+            f"target={result['targetFramework']}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Tools/test-documentation-release-state-mutants.py
+++ b/Tools/test-documentation-release-state-mutants.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+EXCLUDED = shutil.ignore_patterns('.git', 'artifacts', 'bin', 'obj', 'node_modules', 'packages', '.cache')
+
+
+def run(checker: Path, root: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ['python3', str(checker), '--root', str(root)],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+    )
+
+
+def require_killed(source_root: Path, name: str, mutate) -> None:
+    with tempfile.TemporaryDirectory(prefix=f'documentation-release-{name}-') as tmp_name:
+        mutant_root = Path(tmp_name) / 'repo'
+        shutil.copytree(source_root, mutant_root, ignore=EXCLUDED)
+        mutate(mutant_root)
+        completed = run(mutant_root / 'Tools/check_documentation_release_state.py', mutant_root)
+        if completed.returncode == 0:
+            raise RuntimeError(f'{name} mutant survived:\n{completed.stdout}')
+        print(f'SURVIVOR=0 mutant={name}')
+
+
+def replace(path: Path, old: str, new: str) -> None:
+    text = path.read_text(encoding='utf-8')
+    if old not in text:
+        raise RuntimeError(f'mutation precondition missing in {path}: {old}')
+    path.write_text(text.replace(old, new, 1), encoding='utf-8')
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--root', type=Path, default=Path(__file__).resolve().parents[1])
+    args = parser.parse_args()
+    root = args.root.resolve()
+    checker = root / 'Tools/check_documentation_release_state.py'
+    state = json.loads((root / 'eng/documentation-release-state.json').read_text(encoding='utf-8'))
+    source_version = state['sourceVersion']
+    published_version = state['publishedVersion']
+    stability_document = state['stabilityDocument']
+
+    positive = run(checker, root)
+    if positive.returncode != 0:
+        raise RuntimeError('positive documentation release-state check failed:\n' + positive.stdout)
+    print('positive-control=1 documentation-release-state')
+
+    def stale_source_version(mutant: Path) -> None:
+        state_path = mutant / 'eng/documentation-release-state.json'
+        state = json.loads(state_path.read_text(encoding='utf-8'))
+        state['sourceVersion'] = source_version + '.mutant'
+        state_path.write_text(json.dumps(state, indent=2) + '\n', encoding='utf-8')
+
+    require_killed(root, 'source-version-drift', stale_source_version)
+    require_killed(
+        root,
+        'published-install-drift',
+        lambda mutant: replace(
+            mutant / 'docs/start/first-program.md',
+            f'--version {published_version}',
+            '--version 0.0.0-mutant',
+        ),
+    )
+    require_killed(
+        root,
+        'missing-stability-target',
+        lambda mutant: (mutant / stability_document).unlink(),
+    )
+    require_killed(
+        root,
+        'unsafe-source-build-command',
+        lambda mutant: replace(
+            mutant / 'docs/start/installation.md',
+            './build.sh --skip-docs --skip-pack',
+            './build.sh --skip-docs',
+        ),
+    )
+    require_killed(
+        root,
+        'workflow-version-literal',
+        lambda mutant: (mutant / '.github/workflows/published-package-smoke.yml').write_text(
+            (mutant / '.github/workflows/published-package-smoke.yml').read_text(encoding='utf-8')
+            + '\nenv:\n  PUBLISHED_WIST_VERSION: 0.1.0-alpha.1\n',
+            encoding='utf-8',
+        ),
+    )
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/UniversalToolchain/UniversalToolchain.Wist/README.md
+++ b/UniversalToolchain/UniversalToolchain.Wist/README.md
@@ -5,7 +5,9 @@
 
 **Tiny controlled rules for .NET applications.**
 
-`UniversalToolchain.Wist` is the first-contact facade for restricted formula execution without exposing the lower-level compiler pipeline, dialect host, manifests, `DynamicMethod`, AIR or session APIs.
+`UniversalToolchain.Wist` is the first-contact package for UniversalToolchain. It gives .NET applications a small facade for restricted formula execution without exposing the lower-level compiler pipeline, dialect host, manifests, `DynamicMethod`, AIR, or session APIs.
+
+Use it when configuration starts turning into logic:
 
 ```text
 admin / config / LLM suggestion
@@ -16,16 +18,20 @@ admin / config / LLM suggestion
         -> your application decides the side effect
 ```
 
-## Artifact identity
+## Install
 
-<!-- wist-source-candidate:begin -->
-This README is embedded in the source candidate `UniversalToolchain.Wist` `0.1.0-alpha.6`. That candidate is **not published on NuGet.org**. Consume it only from the reviewed feed that contains this exact package artifact. For the version currently available from NuGet.org, use the [public installation guide](https://misha1302.github.io/Wist2/start/installation).
-<!-- wist-source-candidate:end -->
+This source tree builds the verified `UniversalToolchain.Wist` `0.1.0-alpha.6` release artifact. This statement does not imply that the package has already been published to NuGet.org.
+
+```bash ci-run=false
+dotnet add package UniversalToolchain.Wist --version 0.1.0-alpha.6 --source ./artifacts/packages
+```
+
+For a clean-room install and execution check, follow the [package installation guide](https://misha1302.github.io/Wist2/start/installation).
 
 Requirements:
 
 - target framework: `net10.0`;
-- .NET SDK `10.0.103` or a compatible SDK accepted by the repository `global.json`.
+- .NET SDK `10.0.103` or a compatible prerelease SDK accepted by the repository `global.json`.
 
 ## 30-second example
 
@@ -70,11 +76,11 @@ if (!validation.IsValid)
 }
 ```
 
-The restricted arithmetic preset intentionally rejects statement-style bindings such as `let`. `Compile` also validates and throws on failure; use `Validate` or `TryCompile` when invalid author input is expected.
+The current restricted arithmetic preset starts narrow. Statement-style bindings such as `let` are rejected by that restricted surface.
 
 ## Hot path vs convenience path
 
-Use `Evaluate<T>` for one-off trial runs, admin tools, tests and non-hot paths:
+Use `Evaluate<T>` for one-off trial runs, admin tools, tests, and non-hot paths:
 
 ```csharp
 double score = rules.Evaluate<double>(
@@ -100,6 +106,8 @@ for (var i = 0; i < usages.Length; i++)
 }
 ```
 
+Rule of thumb:
+
 ```text
 Use Evaluate for one-off execution.
 Use Compile<TDelegate> for hot paths.
@@ -109,7 +117,7 @@ Invocation is the performance-oriented path.
 
 ## Experimental SSA route
 
-SSA is opt-in and remains an experimental compiler feature:
+SSA is opt-in and remains an experimental compiler feature. Enable it through the facade; a physical dialect file is not required:
 
 ```csharp
 using UniversalToolchain.Wist;
@@ -138,11 +146,13 @@ Console.WriteLine(string.Join(", ", report.ExecutedPasses));
 Policy semantics:
 
 - `Disabled`: do not attempt the SSA route;
-- `Prefer`: attempt SSA and return to original AIR only for known unsupported-route diagnostics;
+- `Prefer`: attempt SSA and return to the original AIR only for known unsupported-route diagnostics;
 - `Require`: fail compilation when the supported SSA route cannot complete;
 - `Debug`: behave like `Require` and retain detailed stage trace entries.
 
-Unexpected optimizer defects never become a silent `Prefer` fallback. The SSA route is not a sandbox, an SSA-native backend or a performance guarantee; it is a verifier-gated `AIR -> SSA -> AIR` boundary for a supported subset.
+`TryCompile` and `Validate` preserve the optimization report even when `Require` or `Debug` fails. Unexpected optimizer defects never become a silent `Prefer` fallback.
+
+The current SSA route is not a sandbox, not an SSA-native backend, and not a performance guarantee. It is a verifier-gated `AIR -> SSA -> AIR` optimization boundary for the currently supported subset.
 
 ## Presets
 
@@ -155,27 +165,32 @@ using var trustedInterop = WistEngine.Create(new WistEngineOptions
     DialectSource = WistDialectSource.FromShippedPreset("full-default-native"),
     AllowedAssemblies = [typeof(Math).Assembly]
 });
+
 ```
 
-`CreateRestrictedArithmetic` is the recommended first-contact preset. `CreateFullNative` selects the broad language profile but does not implicitly expose CLR assemblies.
+`CreateRestrictedArithmetic` is the recommended first-contact preset for restricted formulas.
+
+`CreateFullNative` selects the broad language profile, but it does not implicitly expose CLR assemblies. Add only reviewed assemblies through `AllowedAssemblies`. The facade deliberately does not expose ambiguous “safe”, “trusted”, or “business rules” aliases.
 
 ## Security and trust
 
-Restricted presets limit the selected language/runtime surface. They are not hardened sandboxes for arbitrary untrusted code. Compiled execution is a performance feature, not a sandbox boundary. Isolate hostile execution at the process/environment level.
+Restricted presets limit the selected language/runtime surface. They are not hardened sandboxes for arbitrary untrusted code. Compiled execution is a performance feature, not a sandbox boundary. Treat untrusted script execution as high risk and isolate it at the process/environment level when needed.
 
 ## Current alpha scope
 
-The facade exposes:
+This facade currently exposes:
 
 - convenience `Evaluate<T>`;
 - non-throwing `Validate`;
-- typed `Compile<TDelegate>` and `TryCompile<TDelegate>`;
-- backend-neutral compiled program metadata;
-- host-owned source-length and parameter-count preflight limits;
-- structured diagnostics and opt-in SSA reports.
+- typed fast `Compile<TDelegate>` and `TryCompile<TDelegate>`;
+- backend-neutral compiled program metadata.
 
-The larger direction is controlled application DSLs for .NET. The current claim is restricted numeric/formula execution, validation and typed compiled invocation for supported shapes.
+The larger direction is controlled application DSLs for .NET. The current alpha claim is restricted numeric/formula execution, validation, and typed compiled invocation for supported shapes.
 
-CLR interop and type directives resolve only against the shipped `BasicStdLib` assembly plus the immutable host allowlist in `WistEngineOptions.AllowedAssemblies`; dialect implementation assemblies, the AppDomain and output directory are not discovery sources.
+## Resource limits and diagnostics
 
-Only the facade reference assembly under `ref/net10.0/UniversalToolchain.Wist.dll` is the supported compile-time API boundary. Runtime-closure assemblies under `lib/net10.0` are implementation dependencies, not compatibility promises.
+`WistEngineOptions.ResourceLimits` enforces host-owned preflight limits for source length and parameter count. `Validate` and `TryCompile` return structured `WistDiagnostic` values with stable codes, severity, stage, span when available, message, and hints. These limits do not provide execution timeouts, memory quotas, or process isolation.
+
+CLR interop and type directives resolve only against the shipped `BasicStdLib` assembly plus the immutable host allowlist in `WistEngineOptions.AllowedAssemblies`; dialect implementation assemblies, the AppDomain, and the output directory are not discovery sources.
+
+Only the facade reference assembly under `ref/net10.0/UniversalToolchain.Wist.dll` is the supported compile-time API boundary. Its reviewed exported surface is recorded in `PublicAPI.Shipped.txt` in the source repository. The 64 assemblies under `lib/net10.0` form the runtime closure; all except the facade are implementation dependencies and are not compatibility promises.

--- a/UniversalToolchain/UniversalToolchain.Wist/README.md
+++ b/UniversalToolchain/UniversalToolchain.Wist/README.md
@@ -5,9 +5,7 @@
 
 **Tiny controlled rules for .NET applications.**
 
-`UniversalToolchain.Wist` is the first-contact package for UniversalToolchain. It gives .NET applications a small facade for restricted formula execution without exposing the lower-level compiler pipeline, dialect host, manifests, `DynamicMethod`, AIR, or session APIs.
-
-Use it when configuration starts turning into logic:
+`UniversalToolchain.Wist` is the first-contact facade for restricted formula execution without exposing the lower-level compiler pipeline, dialect host, manifests, `DynamicMethod`, AIR or session APIs.
 
 ```text
 admin / config / LLM suggestion
@@ -18,20 +16,16 @@ admin / config / LLM suggestion
         -> your application decides the side effect
 ```
 
-## Install
+## Artifact identity
 
-This source tree builds the verified `UniversalToolchain.Wist` `0.1.0-alpha.6` release artifact. This statement does not imply that the package has already been published to NuGet.org.
-
-```bash ci-run=false
-dotnet add package UniversalToolchain.Wist --version 0.1.0-alpha.6 --source ./artifacts/packages
-```
-
-For a clean-room install and execution check, follow the [package installation guide](https://misha1302.github.io/Wist2/start/installation).
+<!-- wist-source-candidate:begin -->
+This README is embedded in the source candidate `UniversalToolchain.Wist` `0.1.0-alpha.6`. That candidate is **not published on NuGet.org**. Consume it only from the reviewed feed that contains this exact package artifact. For the version currently available from NuGet.org, use the [public installation guide](https://misha1302.github.io/Wist2/start/installation).
+<!-- wist-source-candidate:end -->
 
 Requirements:
 
 - target framework: `net10.0`;
-- .NET SDK `10.0.103` or a compatible prerelease SDK accepted by the repository `global.json`.
+- .NET SDK `10.0.103` or a compatible SDK accepted by the repository `global.json`.
 
 ## 30-second example
 
@@ -76,11 +70,11 @@ if (!validation.IsValid)
 }
 ```
 
-The current restricted arithmetic preset starts narrow. Statement-style bindings such as `let` are rejected by that restricted surface.
+The restricted arithmetic preset intentionally rejects statement-style bindings such as `let`. `Compile` also validates and throws on failure; use `Validate` or `TryCompile` when invalid author input is expected.
 
 ## Hot path vs convenience path
 
-Use `Evaluate<T>` for one-off trial runs, admin tools, tests, and non-hot paths:
+Use `Evaluate<T>` for one-off trial runs, admin tools, tests and non-hot paths:
 
 ```csharp
 double score = rules.Evaluate<double>(
@@ -106,8 +100,6 @@ for (var i = 0; i < usages.Length; i++)
 }
 ```
 
-Rule of thumb:
-
 ```text
 Use Evaluate for one-off execution.
 Use Compile<TDelegate> for hot paths.
@@ -117,7 +109,7 @@ Invocation is the performance-oriented path.
 
 ## Experimental SSA route
 
-SSA is opt-in and remains an experimental compiler feature. Enable it through the facade; a physical dialect file is not required:
+SSA is opt-in and remains an experimental compiler feature:
 
 ```csharp
 using UniversalToolchain.Wist;
@@ -146,13 +138,11 @@ Console.WriteLine(string.Join(", ", report.ExecutedPasses));
 Policy semantics:
 
 - `Disabled`: do not attempt the SSA route;
-- `Prefer`: attempt SSA and return to the original AIR only for known unsupported-route diagnostics;
+- `Prefer`: attempt SSA and return to original AIR only for known unsupported-route diagnostics;
 - `Require`: fail compilation when the supported SSA route cannot complete;
 - `Debug`: behave like `Require` and retain detailed stage trace entries.
 
-`TryCompile` and `Validate` preserve the optimization report even when `Require` or `Debug` fails. Unexpected optimizer defects never become a silent `Prefer` fallback.
-
-The current SSA route is not a sandbox, not an SSA-native backend, and not a performance guarantee. It is a verifier-gated `AIR -> SSA -> AIR` optimization boundary for the currently supported subset.
+Unexpected optimizer defects never become a silent `Prefer` fallback. The SSA route is not a sandbox, an SSA-native backend or a performance guarantee; it is a verifier-gated `AIR -> SSA -> AIR` boundary for a supported subset.
 
 ## Presets
 
@@ -165,32 +155,27 @@ using var trustedInterop = WistEngine.Create(new WistEngineOptions
     DialectSource = WistDialectSource.FromShippedPreset("full-default-native"),
     AllowedAssemblies = [typeof(Math).Assembly]
 });
-
 ```
 
-`CreateRestrictedArithmetic` is the recommended first-contact preset for restricted formulas.
-
-`CreateFullNative` selects the broad language profile, but it does not implicitly expose CLR assemblies. Add only reviewed assemblies through `AllowedAssemblies`. The facade deliberately does not expose ambiguous “safe”, “trusted”, or “business rules” aliases.
+`CreateRestrictedArithmetic` is the recommended first-contact preset. `CreateFullNative` selects the broad language profile but does not implicitly expose CLR assemblies.
 
 ## Security and trust
 
-Restricted presets limit the selected language/runtime surface. They are not hardened sandboxes for arbitrary untrusted code. Compiled execution is a performance feature, not a sandbox boundary. Treat untrusted script execution as high risk and isolate it at the process/environment level when needed.
+Restricted presets limit the selected language/runtime surface. They are not hardened sandboxes for arbitrary untrusted code. Compiled execution is a performance feature, not a sandbox boundary. Isolate hostile execution at the process/environment level.
 
 ## Current alpha scope
 
-This facade currently exposes:
+The facade exposes:
 
 - convenience `Evaluate<T>`;
 - non-throwing `Validate`;
-- typed fast `Compile<TDelegate>` and `TryCompile<TDelegate>`;
-- backend-neutral compiled program metadata.
+- typed `Compile<TDelegate>` and `TryCompile<TDelegate>`;
+- backend-neutral compiled program metadata;
+- host-owned source-length and parameter-count preflight limits;
+- structured diagnostics and opt-in SSA reports.
 
-The larger direction is controlled application DSLs for .NET. The current alpha claim is restricted numeric/formula execution, validation, and typed compiled invocation for supported shapes.
+The larger direction is controlled application DSLs for .NET. The current claim is restricted numeric/formula execution, validation and typed compiled invocation for supported shapes.
 
-## Resource limits and diagnostics
+CLR interop and type directives resolve only against the shipped `BasicStdLib` assembly plus the immutable host allowlist in `WistEngineOptions.AllowedAssemblies`; dialect implementation assemblies, the AppDomain and output directory are not discovery sources.
 
-`WistEngineOptions.ResourceLimits` enforces host-owned preflight limits for source length and parameter count. `Validate` and `TryCompile` return structured `WistDiagnostic` values with stable codes, severity, stage, span when available, message, and hints. These limits do not provide execution timeouts, memory quotas, or process isolation.
-
-CLR interop and type directives resolve only against the shipped `BasicStdLib` assembly plus the immutable host allowlist in `WistEngineOptions.AllowedAssemblies`; dialect implementation assemblies, the AppDomain, and the output directory are not discovery sources.
-
-Only the facade reference assembly under `ref/net10.0/UniversalToolchain.Wist.dll` is the supported compile-time API boundary. Its reviewed exported surface is recorded in `PublicAPI.Shipped.txt` in the source repository. The 64 assemblies under `lib/net10.0` form the runtime closure; all except the facade are implementation dependencies and are not compatibility promises.
+Only the facade reference assembly under `ref/net10.0/UniversalToolchain.Wist.dll` is the supported compile-time API boundary. Runtime-closure assemblies under `lib/net10.0` are implementation dependencies, not compatibility promises.

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -229,9 +229,9 @@ const evidenceSidebar = [
         items: [
             { text: 'Evidence Home', link: '/evidence/' },
             { text: 'Maintainer and Release Guide', link: '/evidence/maintainer-guide' },
-            { text: 'Current Verification', link: '/evidence/current-verification' },
+            { text: 'Verification Snapshot', link: '/evidence/current-verification' },
             { text: 'Language Authoring Alpha', link: '/evidence/language-authoring-alpha' },
-            { text: 'Wist Alpha Stability', link: '/evidence/wist-stability-v0.1.0-alpha.4' },
+            { text: 'Wist 0.1.0-alpha.6 Candidate Stability', link: '/evidence/wist-stability-v0.1.0-alpha.6' },
             { text: 'External Authoring Hardening', link: '/releases/external-language-authoring-hardening-2026-07-21' },
             { text: 'Composition Hardening', link: '/releases/external-language-composition-hardening-2026-07-22' },
             { text: 'Contribution Planning', link: '/releases/external-language-contribution-planning-2026-07-21' },

--- a/docs/evidence/current-verification.md
+++ b/docs/evidence/current-verification.md
@@ -1,12 +1,15 @@
 ---
-title: Current Verification
-description: Current build, test, workflow and bounded research-evidence record.
+title: Verification Snapshot
+description: Pinned build, test, workflow and bounded research-evidence record for a named repository baseline.
 audience: maintainer-or-evaluator
-status: current
-lastVerifiedAgainst: f13ad131-plus-runtime-boundary-candidate
+status: pinned-snapshot
+lastVerifiedAgainst: 99d9c81aadf3b335524b5bd1e77533612cc2ed93
+snapshotCommit: 99d9c81aadf3b335524b5bd1e77533612cc2ed93
 ---
 
-# Current verification
+# Verification snapshot
+
+This page is a pinned evidence record, not a live claim about whichever commit is currently at `master`. The code-bearing baseline is commit `99d9c81aadf3b335524b5bd1e77533612cc2ed93`. Later documentation-only changes must pass their own CI, but they do not silently rewrite the runtime evidence below.
 
 ## Ordinary integration gate
 
@@ -16,7 +19,7 @@ The canonical non-release GitHub Actions gate runs:
 ./build.sh --skip-docs --skip-pack
 ```
 
-It restores and builds both `UniversalToolchain/Wist.sln` and the configuration-complete `UniversalToolchain/PlanFuzz.sln`, builds the runnable samples, executes the shared test manifest and runs architecture/documentation-status guards. Parallel project-graph traversal and shared compilation are the defaults; serial and no-build-server modes remain explicit diagnostic options.
+It restores and builds both `UniversalToolchain/Wist.sln` and `UniversalToolchain/PlanFuzz.sln`, builds runnable samples, executes the shared test manifest and runs architecture/documentation-status guards. Parallel project-graph traversal and shared compilation are the defaults; serial/no-build-server modes remain explicit diagnostics.
 
 | Project | Passed | Failed | Skipped |
 |---|---:|---:|---:|
@@ -28,13 +31,24 @@ It restores and builds both `UniversalToolchain/Wist.sln` and the configuration-
 | `UniversalToolchain.PlanFuzz.IntegrationTests` | 10 | 0 | 0 |
 | **Total** | **1,597** | **0** | **0** |
 
-This deterministic runtime-boundary change adds 18 resolver, loader, fresh-process, integrity, isolation, concurrency, unload and forbidden-default-fallback regressions beyond the merged 1,579-test baseline. The exact manifest belongs to `eng/test-counts.json`; the 1,597 count is locally confirmed from fresh TRX results and remains pending provider-backed CI confirmation.
+The exact manifest belongs to `eng/test-counts.json`. `.NET CI` run `31049607823` completed the canonical entrypoint for the pinned commit. Because the entrypoint enforces the manifest, a stale or partial test total cannot satisfy that gate.
 
 ## Workflow set
 
-Every `master` revision must start and complete `.NET CI`, `UniversalToolchain validation`, `Docs Check`, documentation deployment, published-package smoke, rollout sample smoke, benchmark smoke and the contract experiment. `CI aggregate` waits for the complete set and publishes the `ci/aggregate` commit status. Master-push triggers are unconditional, preventing a false aggregate timeout caused by a required path-filtered workflow never starting.
+Aggregate run `31049607752` completed successfully for commit `99d9c81aadf3b335524b5bd1e77533612cc2ed93`. The required push runs were:
 
-Review-remediation master commit `2b0a4d1f0e255432daf0d5ddd485269b6490b67e` completed aggregate run `30585251873` successfully. The exact successful push runs were: Docs Check `30585251865`, published-package smoke `30585251928`, documentation deployment `30585251875`, Contract Experiment `30585251945`, rollout smoke `30585251930`, Benchmark Smoke `30585251904`, UniversalToolchain validation `30585251890`, and `.NET CI` `30585251901`.
+| Workflow | Run | Result |
+|---|---:|---|
+| Docs Check | `31049609290` | success |
+| Published Wist package smoke | `31049608876` | success |
+| Documentation deployment | `31049608971` | success |
+| Contract Experiment | `31049608582` | success |
+| Wist Rollout Sample Smoke | `31049608089` | success |
+| Benchmark Smoke | `31049608154` | success |
+| UniversalToolchain validation | `31049608038` | success |
+| .NET CI | `31049607823` | success |
+
+`ci/aggregate` waits for the complete required workflow set and fails when a required workflow is missing, active beyond the deadline or completes with a non-acceptable conclusion.
 
 ## Production-boundary contract study
 
@@ -54,22 +68,22 @@ Master Contract Experiment run `30585251945` executed on commit `2b0a4d1f0e25543
 
 On this frozen author-designed corpus, B0 versus B2 differs on 20/32 operators and exact McNemar is `p = 1.9073486328125e-06`; B1 versus B2 has four discordant operators and `p = 0.125`. These values describe the fixed corpus and do not establish population-level superiority.
 
-The master artifact's isolated B2 verifier-kernel microbenchmark is 46.0% median across five process replicates, range 44.7%-57.1%. Earlier functionally identical runs produced materially different values. This timing is environment-sensitive and is not whole-compilation overhead or a controlled pooled performance estimate.
+The isolated B2 verifier-kernel microbenchmark was 46.0% median across five process replicates, range 44.7%-57.1%. This timing is environment-sensitive and is not whole-compilation overhead or a controlled pooled performance estimate.
 
 ## Post-freeze review holdouts
 
-The master artifact also contains a four-case post-freeze review-derived holdout set: missing Bytecode producer identity, missing source-node identity, repeated pipeline occurrence and extension-provided verifier routing. Its protocol and expected matrix were frozen before result inspection.
+The artifact contains a four-case post-freeze review-derived holdout set: missing Bytecode producer identity, missing source-node identity, repeated pipeline occurrence and extension-provided verifier routing. Its protocol and expected matrix were frozen before result inspection.
 
 | Set | B0 | B1 | B2 |
 |---|---:|---:|---:|
 | Review-derived holdouts | 0/4 | 4/4 | 4/4 |
 | Valid-control false positives | 0/20 | 0/20 | 0/20 |
 
-These holdouts remain separate from the original primary and challenge denominators. They are bounded evidence against overfitting to the earlier corpus, but they are not independently authored, statistically representative or sufficient for a general unseen-fault claim.
+These holdouts remain separate from the original denominators. They are bounded evidence against overfitting to the earlier corpus, not an independently authored or statistically representative population sample.
 
 ## Documentation gates
 
-The integrated revision also runs:
+The pinned revision ran:
 
 ```bash ci-run=false
 npm ci --no-audit --no-fund
@@ -79,11 +93,11 @@ npm run docs:build
 python3 .github/scripts/run-markdown-bash-blocks.py
 ```
 
-Master Docs Check run `30585251865` and the Markdown command smoke in `.NET CI` run `30585251901` completed successfully.
+The documentation-only remediation following this snapshot adds a release-state contract so root/package README, first-contact install pages, published-package smoke and the active stability document cannot drift independently.
 
 ## Package/release boundary
 
-The deterministic runtime-boundary package matrix contains seven SDK/template packages at `0.3.0-alpha.4`, `UniversalToolchain.Wist.LanguagePack` at `0.3.0-alpha.5`, and `UniversalToolchain.Wist` at `0.1.0-alpha.6`. The published-package smoke remains intentionally pinned to actually published facade `0.1.0-alpha.1`.
+The deterministic runtime-boundary package matrix contains seven SDK/template packages at `0.3.0-alpha.4`, `UniversalToolchain.Wist.LanguagePack` at `0.3.0-alpha.5`, and the `UniversalToolchain.Wist` source candidate at `0.1.0-alpha.6`.
 
 <!-- package-matrix:begin -->
 | Package ID | Version |
@@ -99,9 +113,9 @@ The deterministic runtime-boundary package matrix contains seven SDK/template pa
 | `UniversalToolchain.Wist` | `0.1.0-alpha.6` |
 <!-- package-matrix:end -->
 
-The local baseline-aware package gate was replayed against the exact `f13ad1310856e5618e1c3042c447ca543e0f3125` source archive and its deterministic reviewed package bundle. It passed version/content provenance for 9/9 package identities, embedded metadata and active-document synchronization, exact Wist API delta classification, package-surface checks, clean Wist/template/cross-package consumers and detached release-integrity mutation checks.
+The published-package smoke is a different boundary: it installs `0.1.0-alpha.1` from NuGet.org in a clean temporary project. `0.1.0-alpha.6` was not published by the candidate verification work.
 
-This evidence applies to the local candidate tree and generated package bundle. GitHub Actions and aggregate status remain independent provider-backed confirmation; the packages were not published to NuGet.org.
+The local baseline-aware package gate was replayed against the exact `f13ad1310856e5618e1c3042c447ca543e0f3125` source archive and its deterministic reviewed package bundle. It passed version/content provenance for 9/9 package identities, embedded metadata and active-document synchronization, exact Wist API delta classification, package-surface checks, clean Wist/template/cross-package consumers and detached release-integrity mutation checks.
 
 ## PlanFuzz evidence boundary
 
@@ -111,4 +125,4 @@ The preserved Wist pilot included the regression corpus. Its violating-case coun
 
 Schedule reduction, lifecycle/concurrency campaigns, equal-budget baselines, a third adapter and publication novelty remain unverified future work.
 
-The root `VERIFICATION.md` is the detailed authority for commands, package boundaries, claim limits and artifact requirements.
+The root `VERIFICATION.md` remains the detailed authority for commands, package boundaries, claim limits and artifact requirements.

--- a/docs/evidence/index.md
+++ b/docs/evidence/index.md
@@ -3,20 +3,23 @@ title: Evidence and Release Status
 description: Verified artifact identity, tests, documentation checks and public stability boundaries.
 audience: maintainer-evaluator
 status: current-evidence-index
-lastVerifiedAgainst: publication-readiness-contract-study
+lastVerifiedAgainst: wist-release-state-2026-08-06
 ---
 
 # Evidence and release status
 
-- [Current verification](/evidence/current-verification)
+- [Pinned verification snapshot](/evidence/current-verification)
 - [Generic language-authoring alpha status](/evidence/language-authoring-alpha)
-- [Wist 0.1.0-alpha.4 stability](/evidence/wist-stability-v0.1.0-alpha.4)
+- [Wist 0.1.0-alpha.6 source-candidate stability](/evidence/wist-stability-v0.1.0-alpha.6)
+- [Historical Wist 0.1.0-alpha.4 stability record](/evidence/wist-stability-v0.1.0-alpha.4)
 - [Historical Wist 0.1.0-alpha.3 stability record](/evidence/wist-stability-v0.1.0-alpha.3)
 - [Benchmark methodology](/reference/benchmark-methodology)
 - [Performance model](/reference/performance-model)
 - [Release notes](/releases/external-language-authoring-hardening-2026-07-21)
 
-Evidence records are tied to named artifacts. A test count does not by itself prove package restore, runtime policy, benchmark validity, sandboxing or outsider usability.
+The package currently verified from NuGet.org and the source candidate are different identities. `eng/documentation-release-state.json` binds the published version, source version, target framework, first-contact install pages and active stability record.
+
+Evidence records are tied to named artifacts or commits. A test count does not by itself prove package publication, restore, runtime policy, benchmark validity, sandboxing or outsider usability.
 
 ## Maintainer path
 

--- a/docs/evidence/maintainer-guide.md
+++ b/docs/evidence/maintainer-guide.md
@@ -3,7 +3,7 @@ title: Maintainer and Release Guide
 description: Keep public documentation, package evidence, manifests and clean artifacts synchronized.
 audience: maintainer-release-engineer
 status: current
-lastVerifiedAgainst: language-authoring-p0-p1-hardening-2026-07-23.1
+lastVerifiedAgainst: wist-release-state-2026-08-06
 ---
 
 # Maintainer and release guide
@@ -18,10 +18,13 @@ This page is the public entry point for release maintenance. Repository-only pol
 | public trust boundary | `docs/SECURITY.md` and `docs/limitations.md` |
 | coding and architecture policy | `internal-docs/policies-and-reports/PROJECT_RULES.md` and `ARCHITECTURE_RULES.md` |
 | documentation authority | `internal-docs/policies-and-reports/DOCUMENTATION_INDEX.md` and `DOCUMENTATION_RULES.md` |
-| package matrix | `eng/package-projects.txt` |
+| published/source Wist release state | `eng/documentation-release-state.json` plus `UniversalToolchain.Wist.csproj` |
+| package matrix | `eng/package-projects.txt` and package project metadata |
 | exact test matrix | `eng/test-counts.json` |
-| verified results | `VERIFICATION.md` and `docs/evidence/` |
+| pinned verified results | `VERIFICATION.md` and `docs/evidence/` |
 | source-tree integrity | Git commit/tree identity |
+
+`eng/documentation-release-state.json` distinguishes the package verified from NuGet.org from the newer source candidate. It binds the target framework, first-contact install pages, package README, published-package smoke workflow and active Wist stability record.
 
 ## Documentation change gate
 
@@ -38,29 +41,69 @@ The checks cover:
 - public/internal split;
 - role-specific navigation targets;
 - Markdown links and anchors;
+- root README local links and release commands;
 - repository paths in current public/maintainer documents;
 - orphan public pages;
 - required current pages and front matter;
+- published/source version synchronization;
+- active stability-record existence;
+- contributor build commands that must not accidentally enter the release package gate;
 - VitePress compilation.
 
-A green build does not validate every C# example. When a public snippet changes an API contract, build a clean consumer or add a focused executable test.
+The canonical build also runs both documentation-status mutant suites. They must reject source-version drift, published-install drift, missing stability evidence, unsafe source build commands and a workflow-local published-version literal.
+
+A green documentation build does not validate every C# example. When a public snippet changes an API contract, build a clean consumer or add a focused executable test.
+
+## Contributor build versus release packaging
+
+Normal source validation must disable packaging unless the reviewed release inputs are available:
+
+```bash ci-run=false
+./build.sh --skip-docs --skip-pack
+```
+
+Release packaging is intentionally fail-closed. It requires both the reviewed previous source archive and previous package bundle:
+
+```bash ci-run=false
+./build.sh \
+  --baseline-source-archive /path/to/previous-source.zip \
+  --previous-package-bundle /path/to/previous-packages.tar.gz
+```
+
+Do not document `./build.sh`, `./build.sh --skip-docs` or `./build.ps1 -SkipDocs` as ordinary contributor commands. Without `--skip-pack`/`-SkipPack`, those commands enter the baseline-bearing release gate by design.
 
 ## Release evidence gate
 
-Before updating current verification claims:
+Before updating verification claims:
 
 1. record the exact source artifact or commit;
 2. run the canonical build without weakening warnings or tests;
 3. record each test-project total, failures and skips;
-4. pack every project in `eng/package-projects.txt`;
+4. pack every project in `eng/package-projects.txt` using reviewed baseline inputs;
 5. verify package IDs, versions and dependency closure;
 6. build the clean Wist consumer;
 7. build the clean cross-package Language SDK consumer;
-8. install and run the `ut-language` template from the produced package;
-9. run documentation checks;
-10. verify the detached package integrity metadata produced by the canonical build from a clean unpack.
+8. install and run the `ut-language` template from produced packages;
+9. run documentation and release-state checks;
+10. verify detached package integrity from a clean unpack;
+11. publish only the intended artifacts;
+12. run the clean-room NuGet.org smoke for the exact published version.
 
-Update `VERIFICATION.md` and [Current Verification](/evidence/current-verification) together. A historical test count must not be labeled current after the tree changes.
+A verification page must identify its exact commit/artifact and status as a pinned snapshot. A historical test count must not be presented as live HEAD state.
+
+## Promoting a Wist candidate to published
+
+The source project version and published version are allowed to differ. To promote a candidate:
+
+1. publish the exact reviewed package artifact;
+2. confirm the NuGet.org package identity;
+3. update `publishedVersion` in `eng/documentation-release-state.json`;
+4. run `.github/workflows/published-package-smoke.yml` against that value;
+5. update wording only where the candidate/published distinction changed;
+6. keep historical stability pages immutable;
+7. run release-state mutants before merging.
+
+Do not copy version literals into workflow `env`, README snippets or navigation independently. The release-state checker must remain the single synchronization gate.
 
 ## Public/internal movement
 
@@ -77,7 +120,7 @@ Reviews, proposals and talks must not appear in the public source tree merely be
 
 ## Package version synchronization
 
-The generic SDK/template family advances to `0.3.0-alpha.4` because strict package-content provenance rejected reuse of `0.3.0-alpha.3`; the deterministic runtime-boundary candidate advances `UniversalToolchain.Wist.LanguagePack` to `0.3.0-alpha.5` and the Wist facade to `0.1.0-alpha.6`. The canonical matrix below is checked against every package project and built `.nupkg`; do not duplicate active versions outside this block without extending the metadata checker.
+The generic SDK/template family is `0.3.0-alpha.4`; `UniversalToolchain.Wist.LanguagePack` is `0.3.0-alpha.5`; the Wist facade source candidate is `0.1.0-alpha.6`.
 
 <!-- package-matrix:begin -->
 | Package ID | Version |
@@ -104,4 +147,4 @@ For generic package migrations, follow [Package Versioning and Migrations](/lang
 - detached package-integrity manifest regenerated after all intended changes;
 - manifest checked from a clean extraction;
 - archive SHA-256 published beside the archive;
-- final diff confirms that unrelated production code was not changed by documentation-only work.
+- final diff confirms unrelated production code was not changed by documentation-only work.

--- a/docs/evidence/maintainer-guide.md
+++ b/docs/evidence/maintainer-guide.md
@@ -50,7 +50,7 @@ The checks cover:
 - contributor build commands that must not accidentally enter the release package gate;
 - VitePress compilation.
 
-The canonical build also runs both documentation-status mutant suites. They must reject source-version drift, published-install drift, missing stability evidence, unsafe source build commands and a workflow-local published-version literal.
+The canonical build runs the established documentation-status mutants, while `Docs Check` also runs the release-state mutant suite. Together they reject source-version drift, published-install drift, missing stability evidence, unsafe source build commands and a workflow-local published-version literal.
 
 A green documentation build does not validate every C# example. When a public snippet changes an API contract, build a clean consumer or add a focused executable test.
 

--- a/docs/evidence/wist-stability-v0.1.0-alpha.6.md
+++ b/docs/evidence/wist-stability-v0.1.0-alpha.6.md
@@ -1,0 +1,57 @@
+---
+title: Wist 0.1.0-alpha.6 Candidate Stability
+description: Public source-candidate contract after deterministic runtime-boundary hardening.
+audience: wist-application-developer
+status: source-candidate
+lastVerifiedAgainst: runtime-boundary-candidate-2026-08-03
+---
+
+# Wist 0.1.0-alpha.6 candidate stability
+
+`UniversalToolchain.Wist` `0.1.0-alpha.6` is the current source/release candidate for controlled evaluation and prototypes. It is **not published on NuGet.org** and is not a stable 1.0 compatibility contract. The package currently exercised from NuGet.org remains `0.1.0-alpha.1`.
+
+## Reviewed first-contact surface
+
+- `WistEngine`;
+- restricted arithmetic and broad native presets;
+- `Validate`, `Evaluate`, `Compile<TDelegate>` and `TryCompile<TDelegate>`;
+- stable CLR numeric arguments/results across isolated runtime contexts;
+- structured diagnostics, typed metadata and optimization reports;
+- exact public API baseline and classified deltas.
+
+## Runtime-boundary changes in alpha.6
+
+- process-history-dependent default-context sharing was removed;
+- the host registers shared contract assemblies through an immutable snapshot;
+- full assembly identity and fail-closed SHA-256 validation bind configured shared copies;
+- implementation assemblies remain in collectible isolated load contexts unless explicitly registered;
+- hidden application-assembly/default-context fallback is forbidden;
+- preload-order, hostile same-name, concurrency, disposal and unload regressions cover the boundary;
+- public results normalize implementation-owned numeric values to stable CLR categories;
+- package metadata and active documentation are checked against project and package identities.
+
+## Verification boundary
+
+The candidate package matrix contains `UniversalToolchain.Wist` `0.1.0-alpha.6` and `UniversalToolchain.Wist.LanguagePack` `0.3.0-alpha.5`. The exact repository test contract is 1,597 passed, 0 failed and 0 skipped for the pinned verification baseline. Package publication remains a separate operation and was not performed by the candidate verification work.
+
+See the pinned [verification snapshot](/evidence/current-verification) for commit/run identities and the [Maintainer and Release Guide](/evidence/maintainer-guide) for the baseline-bearing package gate.
+
+## Not promised
+
+- publication of `0.1.0-alpha.6` on NuGet.org;
+- OS/process sandboxing;
+- compatibility with every future alpha;
+- binary compatibility with pre-hardening runtime assemblies;
+- universal near-C# performance;
+- complete SSA coverage or an SSA-native backend;
+- stable generic language-authoring APIs through the Wist facade.
+
+## Promotion rule
+
+Do not describe this candidate as the published package until:
+
+1. the exact package artifact passes the release gates;
+2. the package is actually published;
+3. the clean-room NuGet.org smoke succeeds for `0.1.0-alpha.6`;
+4. `eng/documentation-release-state.json` promotes `publishedVersion`;
+5. public installation commands and evidence links pass the release-state mutants.

--- a/docs/start/first-program.md
+++ b/docs/start/first-program.md
@@ -1,24 +1,29 @@
 ---
 title: First Program
-description: Run the smallest useful Wist program from a .NET host or through the CLI.
+description: Run the smallest useful Wist program from a published package or repository checkout.
+audience: wist-application-developer
+status: current
+lastVerifiedAgainst: wist-release-state-2026-08-06
 ---
 
 # First Program
 
-This page shows the shortest practical checks for Wist:
+This page shows two independently supported checks:
 
-- package-first usage from a .NET console application;
-- CLI execution from a repository checkout.
+- package-first usage with the version currently published on NuGet.org;
+- CLI/source execution from a repository checkout.
 
 ## Package-first .NET example
 
-Install the published package first:
+<!-- wist-published-install:begin -->
+Install the package version exercised by the clean-room NuGet.org smoke:
 
 ```bash ci-run=false
-dotnet add package UniversalToolchain.Wist --version 0.1.0-alpha.5 --source ./artifacts/packages
+dotnet add package UniversalToolchain.Wist \
+  --version 0.1.0-alpha.1 \
+  --source https://api.nuget.org/v3/index.json
 ```
-
-For a clean-room NuGet.org check, set `PUBLISHED_WIST_VERSION` to the version shown on the package page and run `./Tools/smoke-published-wist-package.sh "$PUBLISHED_WIST_VERSION"` from a repository checkout.
+<!-- wist-published-install:end -->
 
 Then run a simple formula through the public facade:
 
@@ -36,11 +41,13 @@ double result = formula.CompiledDelegate(100.0, 5.0);
 Console.WriteLine(result); // 95
 ```
 
-This is the normal alpha.1 first-contact path for application developers. `Compile<TDelegate>` compiles once and returns a typed program whose delegate can be invoked repeatedly.
+`Compile<TDelegate>` validates and compiles once. For expected invalid author input, use `Validate` or `TryCompile` and keep the last-known-good program active.
+
+The repository source may define a newer candidate than the published package. That does not make the candidate installable from NuGet.org.
 
 ## Trusted C# interop example
 
-Enable CLR interop only for trusted source code controlled by the host application, and expose each host assembly explicitly.
+Enable CLR interop only for trusted source controlled by the host application, and expose each host assembly explicitly:
 
 ```csharp
 using UniversalToolchain.Wist;
@@ -60,11 +67,11 @@ double result = calcHypotenuse.CompiledDelegate(7.0, 24.0);
 Console.WriteLine(result); // 25
 ```
 
-This example uses C# interop and therefore belongs to the trusted profile, not to the restricted arithmetic profile.
+This belongs to the trusted profile, not the restricted arithmetic profile.
 
 ## Repository CLI check
 
-Read this section when you have cloned the repository and want to validate the CLI/runtime path.
+Read this section when you have cloned the repository and want to validate the current source/runtime path.
 
 ### 1. Run the CIL mode quick start
 
@@ -80,8 +87,6 @@ Expected output:
 12
 ```
 
-`cil` is the user-facing backend alias that selects the CIL backend when the active dialect exposes the CIL backend.
-
 ### 2. Run the same expression through the interpreter
 
 ```bash
@@ -94,7 +99,7 @@ Expected output:
 12
 ```
 
-The interpreter path is useful when validating semantic parity. If a selected dialect does not expose `interpreter`, Wistc will reject that backend alias.
+The interpreter path is useful for semantic parity checks. A dialect that does not expose `interpreter` must reject that backend alias.
 
 ### 3. Run the pricing demo
 
@@ -102,35 +107,36 @@ The interpreter path is useful when validating semantic parity. If a selected di
 dotnet run --project UniversalToolchain/Example/Example.csproj
 ```
 
-The pricing demo runs a pricing formula through hardcoded C# logic, the shipped `full-default-native` Wist preset and the shipped `pricing-restricted` dialect. It also demonstrates compiler, interpreter and fast native invocation paths.
+The demo compares hardcoded C# logic, the shipped `full-default-native` Wist preset and the shipped `pricing-restricted` dialect across compiler, interpreter and prepared invocation paths.
 
 ## What happened internally
 
-For the simple expression, the runtime path is:
+For the simple expression:
 
 ```text
 source -> parser -> AST -> bytecode/AIR -> selected backend -> result
 ```
 
-For compiled formulas, the important distinction is:
+For compiled formulas:
 
 ```text
 cold path: source -> parse -> compile
 hot path: typed function -> Invoke(arg0, arg1, ...)
 ```
 
-The same source should produce the same observable result in compiler and interpreter modes when both modes are available. This parity is one of the main correctness expectations for Wist backends.
+The same supported source should produce the same observable result in CIL and interpreter modes when both are available.
 
 ## Common mistakes
 
-- Installing the package into a project that does not target `net10.0`.
-- Exposing CLR assemblies to untrusted user input.
-- Expecting `System.Math.Sqrt(...)` interop to work without adding `typeof(Math).Assembly` to `AllowedAssemblies`.
-- Running repository CLI commands from a subdirectory, causing project paths to fail.
-- Using `--backend cil` with a dialect that exposes only `interpreter`.
-- Assuming all dialects expose all Wist syntax. Syntax exists only when the owning module is selected.
-- Treating restricted dialects as security sandboxes. They restrict composition, but they are not hardened process sandboxes.
+- installing a source-candidate version that is not published on NuGet.org;
+- adding a local `./artifacts/packages` feed that has not been produced by the release package gate;
+- installing into a project that does not target `net10.0`;
+- exposing CLR assemblies to untrusted input;
+- expecting `System.Math.Sqrt(...)` interop without adding `typeof(Math).Assembly` to `AllowedAssemblies`;
+- running repository CLI commands from a subdirectory;
+- assuming every dialect exposes every Wist syntax feature;
+- treating restricted dialects as hardened process sandboxes.
 
 ## Next
 
-Continue with the [Use-case Recipes](/start/use-case-recipes) for three copy-ready application scenarios. Read the [CLI Reference](/start/cli-reference) for the command surface, or continue with the [Mental Model](/start/mental-model) and the [Wist Syntax Tour](/wist/syntax-tour).
+Continue with [Use-case Recipes](/start/use-case-recipes), [CLI Reference](/start/cli-reference), [Mental Model](/start/mental-model) or the [Wist Syntax Tour](/wist/syntax-tour).

--- a/docs/start/index.md
+++ b/docs/start/index.md
@@ -3,7 +3,7 @@ title: Start Here
 description: Choose the Wist, external language-authoring or framework-internals route.
 audience: wist-application-developer
 status: current
-lastVerifiedAgainst: language-authoring-p0-p1-hardening-2026-07-23.1
+lastVerifiedAgainst: wist-release-state-2026-08-06
 ---
 
 # Start here
@@ -34,7 +34,9 @@ The generic SDK does not force every language through Wist AST, Bytecode or AIR.
 
 ## Current maturity
 
-- Wist `0.1.0-alpha.5` is a controlled-evaluation/prototype package, not a stable 1.0 contract.
+- The package currently verified from NuGet.org is `UniversalToolchain.Wist` `0.1.0-alpha.1`.
+- The repository source candidate is `0.1.0-alpha.6`; it is not published on NuGet.org.
+- Both are alpha surfaces for controlled evaluation and prototypes, not stable 1.0 contracts.
 - Generic language authoring is a low-level alpha with typed routing, deterministic planning and runtime lifecycle contracts.
 - Restricted composition is not a hardened sandbox.
 - Public evidence and current gaps are tracked under [Evidence and Release Status](/evidence/).

--- a/docs/start/installation.md
+++ b/docs/start/installation.md
@@ -1,58 +1,64 @@
 ---
 title: Installation
-description: Show how to install UniversalToolchain.Wist from NuGet.org or prepare the repository locally.
+description: Install the published Wist package or prepare the current repository source safely.
+audience: wist-application-developer
+status: current
+lastVerifiedAgainst: wist-release-state-2026-08-06
 ---
 
 # Installation
 
-This page shows two installation paths:
+There are three different operations that must not be confused:
 
-- install the published `UniversalToolchain.Wist` package from NuGet.org;
-- clone and build the repository for framework development, tests and documentation work.
+1. install the package currently published on NuGet.org;
+2. build and run the current repository source;
+3. produce a reviewed release-candidate package bundle as a maintainer.
 
-## Package-first installation
+## Install the published package
 
-`UniversalToolchain.Wist` is the intended first-contact package for .NET developers. This source tree builds and verifies version `0.1.0-alpha.5`; that is a local release-artifact statement, not a claim that the same version is already published on NuGet.org. The package exposes the `WistEngine` facade and hides the lower-level dialect/runtime pipeline for normal formula usage.
-
-The current alpha package is:
-
-```text
-PackageId: UniversalToolchain.Wist
-Version: 0.1.0-alpha.5
-Target framework: net10.0
-```
-
-From a clean .NET project:
+<!-- wist-published-install:begin -->
+The clean-room package smoke currently verifies `UniversalToolchain.Wist` `0.1.0-alpha.1` from the NuGet.org v3 feed:
 
 ```bash ci-run=false
-dotnet add package UniversalToolchain.Wist --version 0.1.0-alpha.5 --source ./artifacts/packages
+dotnet add package UniversalToolchain.Wist \
+  --version 0.1.0-alpha.1 \
+  --source https://api.nuget.org/v3/index.json
 ```
+<!-- wist-published-install:end -->
 
-The NuGet.org package page is <https://www.nuget.org/packages/UniversalToolchain.Wist>. Use its displayed version for published-package checks.
-
-### Clean-room published-package check
-
-The repository includes a smoke script that creates a temporary `net10.0` console project, uses an isolated NuGet package cache, restores only from NuGet.org, compiles a formula, evaluates it and verifies a rejected statement-style rule:
-
-```bash ci-run=false
-./Tools/smoke-published-wist-package.sh "$PUBLISHED_WIST_VERSION"
-```
-
-Expected final line:
-
-```text
-Published UniversalToolchain.Wist <explicit-version> smoke passed.
-```
-
-Use a `net10.0` project while this alpha targets .NET 10:
+Use a `net10.0` project while the published alpha targets .NET 10:
 
 ```xml
 <TargetFramework>net10.0</TargetFramework>
 ```
 
+The package page is <https://www.nuget.org/packages/UniversalToolchain.Wist>.
+
+### Clean-room published-package check
+
+The repository smoke script creates a temporary `net10.0` project, isolates NuGet caches, restores only from NuGet.org, compiles and evaluates formulas and verifies a rejected statement-style rule:
+
+```bash ci-run=false
+./Tools/smoke-published-wist-package.sh 0.1.0-alpha.1
+```
+
+Expected final line:
+
+```text
+Published UniversalToolchain.Wist 0.1.0-alpha.1 smoke passed.
+```
+
+## Current source candidate
+
+<!-- wist-source-candidate:begin -->
+The current source project defines `UniversalToolchain.Wist` `0.1.0-alpha.6`. This candidate is **not published on NuGet.org**. The repository does not present `./artifacts/packages` as a public feed: that directory exists only after the baseline-bearing maintainer packaging gate succeeds.
+<!-- wist-source-candidate:end -->
+
+To evaluate the current implementation, clone the repository and build/run it as source. Do not change the published install command to `0.1.0-alpha.6` unless you were given a reviewed feed containing that exact package.
+
 ## Minimal package smoke test
 
-After installing the package, create a small console program:
+After installing the published package, create a small console program:
 
 ```csharp
 using UniversalToolchain.Wist;
@@ -68,11 +74,11 @@ double result = formula.CompiledDelegate(100.0, 5.0);
 Console.WriteLine(result); // 95
 ```
 
-This is the recommended first-contact shape for alpha.1: use `Compile<TDelegate>`, compile once, keep the returned typed program and call `CompiledDelegate` from the hot path.
+`Compile<TDelegate>` validates and compiles once. Keep the returned typed program and call `CompiledDelegate` from the hot path. Use `Validate` or `TryCompile` for expected authoring failures that should not throw.
 
 ## Trusted interop example
 
-Use the full native alpha only when the Wist source is trusted by the host application. CLR interop is available only for assemblies explicitly selected by the host.
+Use the full native profile only when the Wist source is trusted by the host application. CLR interop is available only for assemblies explicitly selected by the host:
 
 ```csharp
 using UniversalToolchain.Wist;
@@ -92,20 +98,20 @@ double result = calcHypotenuse.CompiledDelegate(7.0, 24.0);
 Console.WriteLine(result); // 25
 ```
 
-Do not expose CLR assemblies to arbitrary user-authored code. For untrusted or semi-trusted formula input, start with `CreateRestrictedArithmetic` and use external process/resource isolation when needed.
+Do not expose CLR assemblies to arbitrary user-authored code. Restricted composition is not a hardened sandbox.
 
 ## Repository development prerequisites
 
-Use the repository path when you want to modify UniversalToolchain, run the full test suite, edit docs or validate packaging.
+Use the repository path when you want to modify UniversalToolchain, run the full test contract, edit docs or validate the current source candidate.
 
 Prerequisites:
 
-- Git.
-- .NET SDK `10.0.103` or a compatible SDK accepted by `UniversalToolchain/global.json`.
-- Node.js and npm for VitePress documentation.
-- A checked-out working branch for the change you are validating.
+- Git;
+- .NET SDK `10.0.103` or a compatible SDK accepted by `UniversalToolchain/global.json`;
+- Node.js and npm for VitePress documentation;
+- a checked-out working branch for the change you are validating.
 
-The current validation baseline is .NET 10 and target framework `net10.0`. Older target frameworks are not the current compatibility target.
+The current validation target is `net10.0`.
 
 ## Repository development steps
 
@@ -118,21 +124,19 @@ git status
 git branch --show-current
 ```
 
-Use the branch required by your task. For normal validation, use the branch you plan to push or open a pull request from.
-
-### 2. Restore and build the .NET solution
+### 2. Restore, build and test the .NET source
 
 ```bash ci-run=false
-./build.sh --skip-docs
+./build.sh --skip-docs --skip-pack
 ```
 
-This is the canonical repository build path. It builds the two solutions sequentially while parallelizing each solution's project graph, runs the declared test contract, packs the facade, and checks the package surface. The default job count is the number of logical processors; use `--jobs N` on Bash or `-Jobs N` on PowerShell to cap it. Use `--serial --no-build-servers` or `-Serial -NoBuildServers` only for isolated diagnostics.
+This is the canonical contributor path when release packaging inputs are not present. It builds both solutions and runnable samples, executes the exact test-count contract and runs architecture/documentation-status guards.
 
-Do not use a bare repository-root `dotnet build` as release evidence; it does not execute the repository's complete build, test, package, and verification contract.
+Do not use `./build.sh --skip-docs` by itself: without `--skip-pack`, the command intentionally enters the release package gate and requires reviewed previous-source and previous-package artifacts.
 
-### 3. Run tests when changing behavior
+### 3. Run focused tests when changing behavior
 
-For documentation-only changes, tests may not be necessary. For code, module, dialect or runtime changes, run the relevant test projects:
+After the canonical build, focused diagnostics can reuse the build outputs:
 
 ```bash ci-run=false
 dotnet test UniversalToolchain/Tests/Tests.csproj -c Release --no-build
@@ -140,12 +144,10 @@ dotnet test UniversalToolchain/UniversalToolchain.Modules.Tests/UniversalToolcha
 dotnet test UniversalToolchain/UniversalToolchain.Dialects.Tests/UniversalToolchain.Dialects.Tests.csproj -c Release --no-build
 ```
 
-The Markdown command runner intentionally skips this block because it is a local validation checklist, not a small documentation smoke command. The main `.NET CI` workflow already runs the full solution test step with `dotnet test UniversalToolchain/Wist.sln -c Release --no-build` before Markdown command validation.
-
 ### 4. Install documentation dependencies
 
 ```bash ci-run=false
-npm ci
+npm ci --no-audit --no-fund
 ```
 
 ### 5. Run the documentation site locally
@@ -154,41 +156,50 @@ npm ci
 npm run docs:dev
 ```
 
-This starts the VitePress development server for the `docs/` directory. The command keeps running until stopped manually with `Ctrl+C`, so it is intentionally skipped by Markdown command validation in CI.
+This command keeps running until stopped with `Ctrl+C`, so it is not a CI smoke command.
 
-### 6. Build the documentation site
+### 6. Validate the documentation
 
 ```bash ci-run=false
-npm run docs:build
+npm run docs:check
 ```
 
-This must pass before merging documentation changes.
+The documentation gate validates structure, navigation, links, release-state synchronization and VitePress compilation.
+
+## Maintainer candidate packaging
+
+Producing `artifacts/packages` is a release operation, not a normal installation prerequisite. The canonical package gate requires both:
+
+- `--baseline-source-archive` pointing to the reviewed previous source archive;
+- `--previous-package-bundle` pointing to the reviewed previous package bundle.
+
+It then verifies package provenance, API compatibility, package identities, clean consumers and detached integrity metadata. Follow the [Maintainer and Release Guide](/evidence/maintainer-guide).
 
 ## Expected result
 
-After completing the package path:
+After the published-package path:
 
-- the host project references `UniversalToolchain.Wist`;
+- the host project references `UniversalToolchain.Wist` `0.1.0-alpha.1` from NuGet.org;
 - `using UniversalToolchain.Wist;` resolves;
 - `WistEngine.CreateRestrictedArithmetic()` can compile and invoke a typed formula.
 
-After completing the repository path:
+After the repository path:
 
-- the .NET solution builds;
-- the Wist CLI can run examples;
-- the VitePress documentation site can be served locally;
-- `npm run docs:build` produces a static documentation build without broken internal links.
+- both solutions and samples build;
+- the exact test contract passes;
+- source demos and CLI commands can run;
+- documentation checks can be executed without pretending that a release package was produced.
 
 ## Common mistakes
 
-- Installing the package into a project that does not target `net10.0`.
-- Exposing CLR assemblies to untrusted user input.
-- Expecting C# interop to be available in restricted formula presets.
-- Running repository commands from inside `docs/` instead of the repository root.
-- Validating a different branch from the one you plan to push or open a pull request from.
-- Installing an older .NET SDK that cannot build `net10.0` projects.
-- Forgetting `npm ci` before `npm run docs:dev` or `npm run docs:build`.
-- Treating docs build success as runtime validation. Documentation build does not replace .NET tests.
+- replacing the published version with the newer source version even though that candidate is not on NuGet.org;
+- using `--source ./artifacts/packages` from a clean external checkout where no reviewed package bundle exists;
+- running `./build.sh` or `./build.sh --skip-docs` without the required release-package baseline inputs;
+- installing into a project that does not target `net10.0`;
+- exposing CLR assemblies to untrusted user input;
+- treating restricted dialects as security sandboxes;
+- running repository commands from inside `docs/` instead of the repository root;
+- treating docs build success as runtime validation.
 
 ## Next
 

--- a/docs/start/use-case-recipes.md
+++ b/docs/start/use-case-recipes.md
@@ -1,21 +1,30 @@
 ---
 title: Use-case Recipes
 description: Copy-ready Wist examples for pricing, rollout scoring and LMS scoring.
+audience: wist-application-developer
+status: current
+lastVerifiedAgainst: wist-release-state-2026-08-06
 ---
 
 # Use-case Recipes
 
-These examples use the current public `UniversalToolchain.Wist` facade and the restricted arithmetic preset. They deliberately keep side effects in the .NET host:
+These examples use the public `UniversalToolchain.Wist` facade and the restricted arithmetic preset. They deliberately keep side effects in the .NET host:
 
 ```text
 rule text -> validate or compile -> numeric result -> host application decides the action
 ```
 
-Install the review-remediation package candidate from a reviewed local feed:
+<!-- wist-published-install:begin -->
+Install the package currently exercised by the clean-room NuGet.org smoke:
 
 ```bash ci-run=false
-dotnet add package UniversalToolchain.Wist --version 0.1.0-alpha.5 --source ./artifacts/packages
+dotnet add package UniversalToolchain.Wist \
+  --version 0.1.0-alpha.1 \
+  --source https://api.nuget.org/v3/index.json
 ```
+<!-- wist-published-install:end -->
+
+The repository may contain a newer unpublished source candidate. Recipes do not silently switch package feeds or versions.
 
 ## Pricing and commission
 
@@ -55,7 +64,7 @@ double score = rolloutScore.CompiledDelegate(100.0, 90.0, 1.0);
 bool enableNewDashboard = score >= 80.0;
 ```
 
-The threshold and the feature switch remain ordinary reviewed .NET code.
+The threshold and feature switch remain ordinary reviewed .NET code.
 
 ## LMS or autograding score
 
@@ -108,13 +117,13 @@ Before using a configurable rule in an application:
 2. Validate the text before storing or activating it.
 3. Compile once after approval; do not compile inside the hot loop.
 4. Keep side effects, authorization and persistence in ordinary .NET code.
-5. Store the last known-good rule so an invalid update does not replace working behavior.
+5. Store the last-known-good rule so an invalid update does not replace working behavior.
 6. Treat restricted syntax as a language-surface limit, not as process isolation or a hardened sandbox.
 
 ## When not to use this alpha
 
-Do not use the current restricted arithmetic preset when you need arbitrary C# execution, process isolation, execution timeouts, memory quotas or a stable full business-rule language. Those are outside the current alpha claim.
+Do not use the restricted arithmetic preset when you need arbitrary C# execution, process isolation, execution timeouts, memory quotas or a stable full business-rule language.
 
 ## Next
 
-Read the latest completed [Wist alpha.4 stability record](/evidence/wist-stability-v0.1.0-alpha.4), the [current verification record](/evidence/current-verification), the [Performance Model](/reference/performance-model) and [Security](/SECURITY) before integrating a newer package candidate into a consequential workflow.
+Read the [Wist `0.1.0-alpha.6` source-candidate stability record](/evidence/wist-stability-v0.1.0-alpha.6), the pinned [verification snapshot](/evidence/current-verification), the [Performance Model](/reference/performance-model) and [Security](/SECURITY) before moving beyond the currently published package.

--- a/eng/documentation-release-state.json
+++ b/eng/documentation-release-state.json
@@ -15,8 +15,7 @@
   ],
   "sourceCandidateDocuments": [
     "readme.md",
-    "docs/start/installation.md",
-    "UniversalToolchain/UniversalToolchain.Wist/README.md"
+    "docs/start/installation.md"
   ],
   "sourceBuildDocuments": [
     "readme.md",

--- a/eng/documentation-release-state.json
+++ b/eng/documentation-release-state.json
@@ -1,0 +1,30 @@
+{
+  "schemaVersion": 1,
+  "packageId": "UniversalToolchain.Wist",
+  "project": "UniversalToolchain/UniversalToolchain.Wist/UniversalToolchain.Wist.csproj",
+  "sourceVersion": "0.1.0-alpha.6",
+  "publishedVersion": "0.1.0-alpha.1",
+  "targetFramework": "net10.0",
+  "stabilityDocument": "docs/evidence/wist-stability-v0.1.0-alpha.6.md",
+  "publishedSmokeWorkflow": ".github/workflows/published-package-smoke.yml",
+  "publishedInstallDocuments": [
+    "readme.md",
+    "docs/start/installation.md",
+    "docs/start/first-program.md",
+    "docs/start/use-case-recipes.md"
+  ],
+  "sourceCandidateDocuments": [
+    "readme.md",
+    "docs/start/installation.md",
+    "UniversalToolchain/UniversalToolchain.Wist/README.md"
+  ],
+  "sourceBuildDocuments": [
+    "readme.md",
+    "docs/start/installation.md"
+  ],
+  "stabilityLinkDocuments": [
+    "readme.md",
+    "docs/evidence/index.md",
+    "docs/.vitepress/config.mts"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
     "docs:dev": "vitepress dev docs --host 0.0.0.0",
     "docs:build": "vitepress build docs",
     "docs:preview": "vitepress preview docs --host 0.0.0.0",
-    "docs:status": "python3 Tools/check_documentation_status.py",
+    "docs:release-state": "python3 Tools/check_documentation_release_state.py",
+    "docs:status": "python3 Tools/check_documentation_status.py && npm run docs:release-state",
     "docs:links": "python3 Tools/check_documentation_links.py",
     "docs:check": "npm run docs:status && npm run docs:links && npm run docs:build"
   },

--- a/readme.md
+++ b/readme.md
@@ -9,17 +9,37 @@
 
 **Validate restricted formulas, then compile approved rules into typed .NET delegates.**
 
-`UniversalToolchain.Wist` is the first-contact package for .NET applications that need configurable numeric logic without exposing a broad scripting language. Your application owns inputs, authorization, persistence, resource isolation, and side effects.
+`UniversalToolchain.Wist` is the first-contact package for .NET applications that need configurable numeric logic without exposing a broad scripting language. Your application owns inputs, authorization, persistence, resource isolation and side effects.
 
-UniversalToolchain is the modular compiler/runtime framework underneath Wist. Start with the package and practical formula API; explore dialect composition, AIR, backends, and experimental SSA only when you need the framework internals.
+UniversalToolchain is the modular compiler/runtime framework underneath Wist. Start with the package and practical formula API; explore dialect composition, AIR, backends and experimental SSA only when you need framework internals.
 
-## Try Wist in 60 seconds
+## Choose the correct installation path
 
-Install the public alpha:
+The repository distinguishes the package currently available on NuGet.org from the newer source candidate in this tree.
+
+### Published package
+
+<!-- wist-published-install:begin -->
+The clean-room published-package smoke currently verifies `UniversalToolchain.Wist` `0.1.0-alpha.1` directly from NuGet.org:
 
 ```bash ci-run=false
-dotnet add package UniversalToolchain.Wist --version 0.1.0-alpha.5 --source ./artifacts/packages
+dotnet add package UniversalToolchain.Wist \
+  --version 0.1.0-alpha.1 \
+  --source https://api.nuget.org/v3/index.json
 ```
+<!-- wist-published-install:end -->
+
+Use this path when you want an installable package without cloning the repository.
+
+### Current source candidate
+
+<!-- wist-source-candidate:begin -->
+This source tree defines `UniversalToolchain.Wist` `0.1.0-alpha.6`. That candidate is **not published on NuGet.org**. Do not replace the published command above with `0.1.0-alpha.6` unless you have a reviewed package feed containing that exact artifact.
+<!-- wist-source-candidate:end -->
+
+To evaluate the current repository implementation, clone the repository and use the source build/sample path below. Release packaging is a separate baseline-bearing maintainer gate.
+
+## Try Wist in 60 seconds
 
 Compile a reviewed rollout formula once and invoke the typed delegate repeatedly:
 
@@ -47,6 +67,8 @@ var rolloutScore = rules.Compile<Func<double, double, double, double>>(
 double score = rolloutScore.CompiledDelegate(100.0, 90.0, 1.0);
 bool enableNewDashboard = score >= 80.0;
 ```
+
+`Compile` also validates and throws when compilation fails. Use `Validate` or `TryCompile` when invalid user/admin input is an expected outcome and you need structured diagnostics without replacing the active rule.
 
 The formula returns data. The host application decides what the result means and performs the action.
 
@@ -85,7 +107,7 @@ Console.WriteLine(rejected.IsValid); // false
 Console.WriteLine(rejected.Message); // structured validation failure
 ```
 
-This is language-surface restriction, not a hardened sandbox. Arbitrary hostile input still requires process/environment isolation, resource limits, and an explicit threat model.
+This is language-surface restriction, not a hardened sandbox. Arbitrary hostile input still requires process/environment isolation, resource limits and an explicit threat model.
 
 ## What Wist gives a .NET host
 
@@ -107,7 +129,7 @@ Use Wist when:
 - JSON or configuration is starting to become logic;
 - an expression evaluator is too small for the product direction;
 - C# scripting exposes more language surface than the application wants to own;
-- user, admin, configuration, or LLM-suggested formulas must be validated before execution;
+- user, admin, configuration or LLM-suggested formulas must be validated before execution;
 - the same approved formula should become a typed delegate for repeated invocation;
 - interpreter/compiler semantic parity matters for the language contract.
 
@@ -122,19 +144,21 @@ Do not use the current alpha when:
 
 | Capability | Status |
 |---|---|
-| `WistEngine` facade | available in `UniversalToolchain.Wist` |
+| Published NuGet package | `UniversalToolchain.Wist` `0.1.0-alpha.1`, clean-room smoke verified |
+| Current source candidate | `UniversalToolchain.Wist` `0.1.0-alpha.6`, not published on NuGet.org |
+| `WistEngine` facade | available |
 | Restricted arithmetic preset | `CreateRestrictedArithmetic()` |
 | Broad native preview preset | `CreateFullNative()` with explicit host assembly allowlist |
 | Typed compiled hot path | `Compile<TDelegate>()` |
-| Interpreter path | diagnostics, fallback, and semantic parity work |
+| Interpreter path | diagnostics, fallback and semantic parity work |
 | Dialect composition | shipped `.wistdialect` profiles and lower-level APIs |
-| Experimental SSA route | opt-in, observable, verifier-gated |
+| Experimental SSA route | opt-in, observable and verifier-gated |
 | Full business-rule platform | direction, not a current claim |
 | Hardened sandboxing | not claimed |
 
 ## Performance model
 
-Use `Evaluate<T>` for onboarding, admin trial runs, tests, and non-hot paths. Use `Compile<TDelegate>` when the same formula is invoked repeatedly:
+Use `Evaluate<T>` for onboarding, admin trial runs, tests and non-hot paths. Use `Compile<TDelegate>` when the same formula is invoked repeatedly:
 
 ```csharp
 var formula = rules.Compile<Func<double, double, double>>(
@@ -152,7 +176,9 @@ See [the performance model](docs/reference/performance-model.md) for benchmark b
 
 ## External language authoring alpha
 
-External .NET projects can define non-Wist languages through `UniversalToolchain.LanguageAuthoring`. A single typed registration creates both descriptor metadata and immutable runtime components; independently shipped packages are assembled against the exact manifest hashes captured by the plan. The planner supports configurable entry artifacts, package-level extensions, deterministic same-artifact pass ordering, planning-only definitions, exact backend executor selection and fail-closed runtime policy. The Wist adapter rejects routes it cannot faithfully execute instead of ignoring them. Start with the [External Language Authoring quickstart](docs/language-authoring/quickstart.md), then use the [deep SDK architecture reference](docs/architecture/external-language-authoring-sdk.md). The independent `samples/Acme.PricingLanguage` and `dotnet new ut-language` exercise the non-Wist path. High-level grammar, binder and operation authoring remain future work.
+External .NET projects can define non-Wist languages through `UniversalToolchain.LanguageAuthoring`. A single typed registration creates descriptor metadata and immutable runtime components; independently shipped packages are assembled against the exact manifest hashes captured by the plan. The planner supports configurable entry artifacts, package-level extensions, deterministic same-artifact pass ordering, planning-only definitions, exact backend executor selection and fail-closed runtime policy. The Wist adapter rejects routes it cannot faithfully execute instead of ignoring them.
+
+Start with the [External Language Authoring quickstart](docs/language-authoring/quickstart.md), then use the [deep SDK architecture reference](docs/architecture/external-language-authoring-sdk.md). The independent `samples/Acme.PricingLanguage` and `dotnet new ut-language` exercise the non-Wist path. High-level grammar, binder and operation authoring remain future work.
 
 ## UniversalToolchain underneath Wist
 
@@ -167,33 +193,36 @@ Source
   -> Execution
 ```
 
-The framework keeps language features composable, runtime selection dialect-driven, and shared semantics protected by interpreter/CIL parity tests. Wist is the reference language and the packaged first-contact experience.
+The framework keeps language features composable, runtime selection dialect-driven and shared semantics protected by interpreter/CIL parity tests. Wist is the reference language and packaged first-contact experience.
 
 Technical material:
 
 - [Project documentation](docs/index.md)
 - [Installation and clean-room smoke](docs/start/installation.md)
 - [Use-case recipes](docs/start/use-case-recipes.md)
-- [Wist alpha stability contract](docs/evidence/wist-stability-v0.1.0-alpha.5.md)
+- [Wist `0.1.0-alpha.6` candidate stability contract](docs/evidence/wist-stability-v0.1.0-alpha.6.md)
 - [External Language Authoring quickstart](docs/language-authoring/quickstart.md)
 - [Architecture and project map](docs/architecture/project-map.md)
+
 ## Build and verify from source
 
-Use the canonical repository entrypoint:
+Normal contributors should not enter the release packaging gate, which requires reviewed previous-source and previous-package artifacts. Use the canonical build with packaging disabled:
 
 ```bash ci-run=false
-./build.sh
+./build.sh --skip-pack
 ```
 
 Useful bounded variants:
 
 ```bash ci-run=false
-./build.sh --skip-docs
 ./build.sh --skip-docs --skip-pack
 ./build.sh --jobs 4 --skip-docs --skip-pack
+./build.sh --serial --no-build-servers --skip-docs --skip-pack
 ```
 
-The wrapper restores and builds each solution sequentially, while MSBuild traverses the project graph in parallel. It then runs the test projects, packs the public facade, checks package-surface growth, builds documentation, and runs Markdown checks. The default job count is the number of logical processors; override it with `--jobs N` or `WIST_BUILD_JOBS=N`. For isolated diagnostics, use `--serial --no-build-servers`.
+The wrapper restores and builds each solution sequentially while MSBuild traverses each project graph in parallel. It then runs the exact test contract, architecture guards and documentation checks unless explicitly skipped. The default job count is the number of logical processors; override it with `--jobs N` or `WIST_BUILD_JOBS=N`.
+
+Release packaging is intentionally separate. It requires `--baseline-source-archive` and `--previous-package-bundle`; follow the [Maintainer and Release Guide](docs/evidence/maintainer-guide.md) instead of fabricating or bypassing those inputs.
 
 ## Contributing
 
@@ -205,7 +234,7 @@ External feedback is most useful when it describes observed behavior:
 - which diagnostic or trust boundary was unclear;
 - what would stop you from using Wist in a small internal tool.
 
-Read [the contribution guide](docs/CONTRIBUTING.md). Small documentation, diagnostics, examples, and clean-room compatibility improvements are welcome.
+Read [the contribution guide](docs/CONTRIBUTING.md). Small documentation, diagnostics, examples and clean-room compatibility improvements are welcome.
 
 ## Maintainer launch material
 


### PR DESCRIPTION
## Summary

- separate the package currently verified from NuGet.org (`0.1.0-alpha.1`) from the repository source candidate (`0.1.0-alpha.6`)
- repair README, installation, first-program and recipe commands so an external user is never pointed at an absent local feed
- add a canonical machine-readable documentation release state and an `alpha.6` candidate stability record
- pin verification evidence to the exact code-bearing commit instead of presenting it as live HEAD state
- prevent ordinary contributor build commands from accidentally entering the baseline-bearing package gate
- extend Docs Check and the published-package smoke to consume the same release-state contract
- add negative mutation tests for version drift, missing stability evidence, unsafe build commands and workflow-local version literals

## Validation

- local synthetic positive fixture passed for `check_documentation_release_state.py`
- five adversarial release-state mutants were rejected
- full repository checks are required on this PR before merge

## Scope

Documentation, validation scripts and CI only. No runtime implementation files are changed.