### PR TITLE
Build: use evaluated outputs and harden cross-platform validation

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Keep repository text deterministic across Linux, macOS, and Windows.
+# This is especially important for C# raw string literals that embed DSL source:
+# checkout line-ending conversion must not change their runtime contents.
+* text=auto eol=lf

--- a/.github/workflows/dotnet-ci.yml
+++ b/.github/workflows/dotnet-ci.yml
@@ -63,3 +63,22 @@ jobs:
       - name: Markdown bash smoke checks
         shell: bash
         run: python3 .github/scripts/run-markdown-bash-blocks.py
+
+  windows-build-test:
+    if: github.event_name != 'workflow_dispatch'
+    permissions:
+      contents: read
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: UniversalToolchain/global.json
+
+      - name: Run canonical PowerShell build and test entrypoint
+        shell: pwsh
+        run: ./build.ps1 -SkipDocs -SkipPack

--- a/Tools/check-build-topology.py
+++ b/Tools/check-build-topology.py
@@ -30,6 +30,10 @@ def parse_project(path: Path) -> ET.Element:
         raise BuildTopologyError(f"invalid project XML {path}: {exc}") from exc
 
 
+def direct_children(root: ET.Element, name: str) -> list[ET.Element]:
+    return [element for element in root if local_name(element.tag) == name]
+
+
 def child_text(root: ET.Element, name: str) -> str | None:
     for element in root.iter():
         if local_name(element.tag) != name:
@@ -38,6 +42,25 @@ def child_text(root: ET.Element, name: str) -> str | None:
         if text:
             return text
     return None
+
+
+def top_level_property_names(root: ET.Element) -> set[str]:
+    names: set[str] = set()
+    for group in direct_children(root, "PropertyGroup"):
+        names.update(local_name(element.tag) for element in group)
+    return names
+
+
+def normalized_expression(value: str) -> str:
+    return re.sub(r"\s+", "", value).lower()
+
+
+def named_targets(root: ET.Element) -> dict[str, ET.Element]:
+    return {
+        element.attrib.get("Name", ""): element
+        for element in root.iter()
+        if local_name(element.tag) == "Target"
+    }
 
 
 def require_build_order_references_not_copy_local(root: Path) -> None:
@@ -61,26 +84,89 @@ def require_build_order_references_not_copy_local(root: Path) -> None:
         )
 
 
-def require_language_pack_isolated_emitter_build(root: Path) -> None:
-    project = (
+def require_provider_target(
+    project_root: ET.Element,
+    *,
+    target_name: str,
+    expected_return: str,
+    description: str,
+) -> None:
+    target = named_targets(project_root).get(target_name)
+    if target is None:
+        raise BuildTopologyError(f"{description} lacks {target_name}")
+    if "Build" not in target.attrib.get("DependsOnTargets", "").split(";"):
+        raise BuildTopologyError(f"{description} provider target must depend on Build")
+    if target.attrib.get("Returns") != expected_return:
+        raise BuildTopologyError(
+            f"{description} provider target must return the evaluated {expected_return}"
+        )
+
+
+def require_language_pack_provider_contract(root: Path) -> None:
+    language_pack = (
         root
         / "UniversalToolchain"
         / "UniversalToolchain.Wist.LanguagePack"
         / "UniversalToolchain.Wist.LanguagePack.csproj"
     )
-    if not project.is_file():
-        raise BuildTopologyError(f"language-pack project does not exist: {project}")
-    project_root = parse_project(project)
+    emitter = (
+        root
+        / "UniversalToolchain"
+        / "UniversalToolchain.FeatureManifestEmitter"
+        / "UniversalToolchain.FeatureManifestEmitter.csproj"
+    )
+    wist = (
+        root
+        / "UniversalToolchain"
+        / "UniversalToolchain.Wist"
+        / "UniversalToolchain.Wist.csproj"
+    )
+    for path in (language_pack, emitter, wist):
+        if not path.is_file():
+            raise BuildTopologyError(f"required project does not exist: {path}")
 
-    emitter_property = child_text(project_root, "FeatureManifestEmitterProjectPath")
-    if emitter_property != "$(MSBuildThisFileDirectory)..\\UniversalToolchain.FeatureManifestEmitter\\UniversalToolchain.FeatureManifestEmitter.csproj":
-        raise BuildTopologyError("language pack has an unexpected FeatureManifestEmitterProjectPath")
+    language_pack_root = parse_project(language_pack)
+    emitter_root = parse_project(emitter)
+    wist_root = parse_project(wist)
 
+    expected_paths = {
+        "FeatureManifestEmitterProjectPath": (
+            "$(MSBuildThisFileDirectory)..\\UniversalToolchain.FeatureManifestEmitter\\"
+            "UniversalToolchain.FeatureManifestEmitter.csproj"
+        ),
+        "WistProjectPath": (
+            "$(MSBuildThisFileDirectory)..\\UniversalToolchain.Wist\\"
+            "UniversalToolchain.Wist.csproj"
+        ),
+    }
+    for property_name, expected in expected_paths.items():
+        if child_text(language_pack_root, property_name) != expected:
+            raise BuildTopologyError(f"language pack has an unexpected {property_name}")
+
+    prohibited_top_level_guesses = {
+        "FeatureManifestEmitterTargetFramework",
+        "FeatureManifestEmitterPlatformSegment",
+        "FeatureManifestEmitterProjectBinDll",
+        "FeatureManifestEmitterConfiguredOutputDll",
+        "FeatureManifestEmitterTargetDirDll",
+        "WistRuntimeOutputDirectory",
+    }
+    present_guesses = sorted(top_level_property_names(language_pack_root) & prohibited_top_level_guesses)
+    if present_guesses:
+        raise BuildTopologyError(
+            "language pack must consume provider-returned paths instead of guessing output layout: "
+            + ", ".join(present_guesses)
+        )
+
+    references = [
+        element
+        for element in language_pack_root.iter()
+        if local_name(element.tag) == "ProjectReference"
+    ]
     emitter_references = [
         element
-        for element in project_root.iter()
-        if local_name(element.tag) == "ProjectReference"
-        and element.attrib.get("Include") == "$(FeatureManifestEmitterProjectPath)"
+        for element in references
+        if element.attrib.get("Include") == "$(FeatureManifestEmitterProjectPath)"
     ]
     if len(emitter_references) != 1:
         raise BuildTopologyError("language pack must declare exactly one emitter ProjectReference")
@@ -89,40 +175,135 @@ def require_language_pack_isolated_emitter_build(root: Path) -> None:
        emitter_reference.attrib.get("Private", "").lower() != "false":
         raise BuildTopologyError("emitter ProjectReference must be build-only and not Copy Local")
 
-    targets = {
-        element.attrib.get("Name", ""): element
-        for element in project_root.iter()
-        if local_name(element.tag) == "Target"
-    }
-    target = targets.get("BuildFeatureManifestEmitterForIsolatedBuild")
-    if target is None:
-        raise BuildTopologyError("language pack lacks BuildFeatureManifestEmitterForIsolatedBuild")
-    if "EmitToolchainFeatureManifest" not in target.attrib.get("BeforeTargets", "").split(";"):
-        raise BuildTopologyError("isolated emitter build must run before EmitToolchainFeatureManifest")
-    condition = target.attrib.get("Condition", "")
-    if "$(BuildProjectReferences)" not in condition or "false" not in condition.lower():
-        raise BuildTopologyError("isolated emitter build must be gated by BuildProjectReferences=false")
+    wist_references = [
+        element for element in references if element.attrib.get("Include") == "$(WistProjectPath)"
+    ]
+    if len(wist_references) != 1:
+        raise BuildTopologyError("language pack must declare exactly one canonical Wist ProjectReference")
 
-    msbuild_tasks = [element for element in target if local_name(element.tag) == "MSBuild"]
-    if len(msbuild_tasks) != 1:
-        raise BuildTopologyError("isolated emitter target must contain exactly one MSBuild task")
-    msbuild = msbuild_tasks[0]
-    if msbuild.attrib.get("Projects") != "$(FeatureManifestEmitterProjectPath)":
-        raise BuildTopologyError("isolated emitter target builds the wrong project")
-    if "Build" not in msbuild.attrib.get("Targets", "").split(";"):
-        raise BuildTopologyError("isolated emitter target must invoke Build")
-    if "Configuration=$(Configuration)" not in msbuild.attrib.get("Properties", ""):
-        raise BuildTopologyError("isolated emitter build must preserve Configuration")
+    require_provider_target(
+        emitter_root,
+        target_name="GetBuiltFeatureManifestEmitterTargetPath",
+        expected_return="$(TargetPath)",
+        description="feature manifest emitter",
+    )
+    require_provider_target(
+        wist_root,
+        target_name="GetBuiltWistOutputDirectory",
+        expected_return="$(TargetDir)",
+        description="Wist runtime",
+    )
+
+    targets = named_targets(language_pack_root)
+    resolver = targets.get("ResolveLanguagePackBuildProviders")
+    if resolver is None:
+        raise BuildTopologyError("language pack lacks ResolveLanguagePackBuildProviders")
+    required_before_targets = {
+        "ResolveProjectReferences",
+        "EmitToolchainFeatureManifest",
+        "ExposeWistRuntimeClosureToProjectReferences",
+        "CollectWistRuntimeManifests",
+    }
+    actual_before_targets = set(resolver.attrib.get("BeforeTargets", "").split(";"))
+    if not required_before_targets.issubset(actual_before_targets):
+        raise BuildTopologyError("language pack provider resolution is missing required BeforeTargets")
+    expected_condition = normalized_expression("'$(DesignTimeBuild)' != 'true'")
+    if normalized_expression(resolver.attrib.get("Condition", "")) != expected_condition:
+        raise BuildTopologyError("language pack provider resolution must be disabled only for DesignTimeBuild=true")
+
+    msbuild_tasks = direct_children(resolver, "MSBuild")
+    if len(msbuild_tasks) != 2:
+        raise BuildTopologyError("language pack provider resolver must contain exactly two direct MSBuild tasks")
+    tasks_by_project = {task.attrib.get("Projects", ""): task for task in msbuild_tasks}
+    expected_tasks = {
+        "$(FeatureManifestEmitterProjectPath)": (
+            "GetBuiltFeatureManifestEmitterTargetPath",
+            "_FeatureManifestEmitterTargetPath",
+        ),
+        "$(WistProjectPath)": (
+            "GetBuiltWistOutputDirectory",
+            "_WistOutputDirectory",
+        ),
+    }
+    if set(tasks_by_project) != set(expected_tasks):
+        raise BuildTopologyError("language pack provider resolver invokes an unexpected project set")
+    for project, (target_name, output_item) in expected_tasks.items():
+        task = tasks_by_project[project]
+        if task.attrib.get("Targets") != target_name:
+            raise BuildTopologyError(f"provider resolver for {project} invokes the wrong target")
+        if normalized_expression(task.attrib.get("Properties", "")) != "buildprojectreferences=true":
+            raise BuildTopologyError(
+                f"provider resolver for {project} must force only BuildProjectReferences=true"
+            )
+        outputs = direct_children(task, "Output")
+        if len(outputs) != 1 or outputs[0].attrib.get("TaskParameter") != "TargetOutputs" or \
+           outputs[0].attrib.get("ItemName") != output_item:
+            raise BuildTopologyError(f"provider resolver for {project} must capture TargetOutputs")
+
+    resolved_values = {
+        local_name(element.tag): (element.text or "").strip()
+        for group in direct_children(resolver, "PropertyGroup")
+        for element in group
+    }
+    if resolved_values.get("FeatureManifestEmitterResolvedDll") != "@(_FeatureManifestEmitterTargetPath)":
+        raise BuildTopologyError("emitter executable path must derive from captured TargetOutputs")
+    if resolved_values.get("WistRuntimeOutputDirectory") != "@(_WistOutputDirectory)":
+        raise BuildTopologyError("Wist runtime directory must derive from captured TargetOutputs")
+
+    expected_error_conditions = {
+        normalized_expression(
+            "'$(FeatureManifestEmitterResolvedDll)' == '' or "
+            "!Exists('$(FeatureManifestEmitterResolvedDll)')"
+        ),
+        normalized_expression(
+            "'$(WistRuntimeOutputDirectory)' == '' or "
+            "!Exists('$(WistRuntimeOutputDirectory)')"
+        ),
+    }
+    actual_error_conditions = {
+        normalized_expression(error.attrib.get("Condition", ""))
+        for error in direct_children(resolver, "Error")
+    }
+    if actual_error_conditions != expected_error_conditions:
+        raise BuildTopologyError("provider resolver must fail on empty or absent returned paths")
 
     emit_target = targets.get("EmitToolchainFeatureManifest")
     if emit_target is None:
         raise BuildTopologyError("language pack lacks EmitToolchainFeatureManifest")
-    errors = [element for element in emit_target if local_name(element.tag) == "Error"]
-    execs = [element for element in emit_target if local_name(element.tag) == "Exec"]
-    if not errors or "FeatureManifestEmitterResolvedDll" not in errors[0].attrib.get("Condition", ""):
-        raise BuildTopologyError("feature manifest emission must fail clearly when the emitter is absent")
+    execs = direct_children(emit_target, "Exec")
     if len(execs) != 1 or "$(FeatureManifestEmitterResolvedDll)" not in execs[0].attrib.get("Command", ""):
-        raise BuildTopologyError("feature manifest emission must execute the resolved emitter path")
+        raise BuildTopologyError("feature manifest emission must execute the provider-returned TargetPath")
+
+    expose_target = targets.get("ExposeWistRuntimeClosureToProjectReferences")
+    if expose_target is None:
+        raise BuildTopologyError("language pack lacks ExposeWistRuntimeClosureToProjectReferences")
+    content_items = [
+        element
+        for element in expose_target.iter()
+        if local_name(element.tag) == "ContentWithTargetPath"
+    ]
+    expected_closure = (
+        "$(WistRuntimeOutputDirectory)*.dll;"
+        "$(WistRuntimeOutputDirectory)*.dialect.runtime.json"
+    )
+    if len(content_items) != 1 or content_items[0].attrib.get("Include") != expected_closure:
+        raise BuildTopologyError("runtime closure must come from the provider-returned Wist output directory")
+
+    collect_target = targets.get("CollectWistRuntimeManifests")
+    if collect_target is None:
+        raise BuildTopologyError("language pack lacks CollectWistRuntimeManifests")
+    manifest_items = [
+        element
+        for element in collect_target.iter()
+        if local_name(element.tag) == "WistRuntimeManifest"
+    ]
+    if len(manifest_items) != 1 or manifest_items[0].attrib.get("Include") != \
+       "$(WistRuntimeOutputDirectory)*.dialect.runtime.json":
+        raise BuildTopologyError("runtime manifests must come from the provider-returned Wist output directory")
+
+    raw_language_pack = language_pack.read_text(encoding="utf-8-sig")
+    if "UniversalToolchain.Wist\\$(OutputPath)" in raw_language_pack:
+        raise BuildTopologyError("language pack still concatenates the Wist project path with $(OutputPath)")
 
 
 def uncommented_text(path: Path) -> str:
@@ -143,9 +324,21 @@ def require_canonical_gate_order(root: Path) -> None:
         raise BuildTopologyError(f"runtime topology regression does not exist: {runtime_test}")
 
     bash = uncommented_text(root / "build.sh")
-    bash_static = require_one(bash, r"^\s*python3\s+Tools/check-build-topology\.py\b", "build.sh topology checker invocation")
-    bash_mutants = require_one(bash, r"^\s*python3\s+Tools/test-build-topology-mutants\.py\b", "build.sh topology mutant invocation")
-    bash_runtime = require_one(bash, r"^\s*python3\s+Tools/test-build-topology-runtime\.py\b", "build.sh runtime topology invocation")
+    bash_static = require_one(
+        bash,
+        r"^\s*python3\s+Tools/check-build-topology\.py\b",
+        "build.sh topology checker invocation",
+    )
+    bash_mutants = require_one(
+        bash,
+        r"^\s*python3\s+Tools/test-build-topology-mutants\.py\b",
+        "build.sh topology mutant invocation",
+    )
+    bash_runtime = require_one(
+        bash,
+        r"^\s*python3\s+Tools/test-build-topology-runtime\.py\b",
+        "build.sh runtime topology invocation",
+    )
     bash_restore = bash.index('"$dotnet_command" restore')
     bash_build = bash.index('"$dotnet_command" build "$solution"')
     bash_tests = bash.index("python3 Tools/run-test-contract.py")
@@ -155,9 +348,21 @@ def require_canonical_gate_order(root: Path) -> None:
         raise BuildTopologyError("build.sh runtime topology regression must run after solution build and before tests")
 
     powershell = uncommented_text(root / "build.ps1")
-    ps_static = require_one(powershell, r'Invoke-CheckedNative\s+"python"\s+@\("Tools/check-build-topology\.py"', "build.ps1 topology checker invocation")
-    ps_mutants = require_one(powershell, r'Invoke-CheckedNative\s+"python"\s+@\("Tools/test-build-topology-mutants\.py"', "build.ps1 topology mutant invocation")
-    ps_runtime = require_one(powershell, r'Invoke-CheckedNative\s+"python"\s+@\(\s*"Tools/test-build-topology-runtime\.py"', "build.ps1 runtime topology invocation")
+    ps_static = require_one(
+        powershell,
+        r'Invoke-CheckedNative\s+"python"\s+@\("Tools/check-build-topology\.py"',
+        "build.ps1 topology checker invocation",
+    )
+    ps_mutants = require_one(
+        powershell,
+        r'Invoke-CheckedNative\s+"python"\s+@\("Tools/test-build-topology-mutants\.py"',
+        "build.ps1 topology mutant invocation",
+    )
+    ps_runtime = require_one(
+        powershell,
+        r'Invoke-CheckedNative\s+"python"\s+@\(\s*"Tools/test-build-topology-runtime\.py"',
+        "build.ps1 runtime topology invocation",
+    )
     ps_restore = powershell.index("Invoke-CheckedNative $dotnet (New-RestoreArguments $solution)")
     ps_build = powershell.index('"build", $solution')
     ps_tests = powershell.index('"Tools/run-test-contract.py"')
@@ -166,14 +371,51 @@ def require_canonical_gate_order(root: Path) -> None:
     if not ps_build < ps_runtime < ps_tests:
         raise BuildTopologyError("build.ps1 runtime topology regression must run after solution build and before tests")
 
-    required_release_gates = (
-        "Tools/package_metadata.py",
-        "Tools/test-package-metadata-mutants.py",
+    bash_pack = bash.index('if [[ "$skip_pack" == false ]]')
+    ps_pack = powershell.index("if (-not $SkipPack)")
+    release_invocations = (
+        (
+            "build.sh package metadata checker",
+            bash,
+            r"^\s*python3\s+Tools/package_metadata\.py\b",
+            bash_pack,
+        ),
+        (
+            "build.sh package metadata mutants",
+            bash,
+            r"^\s*python3\s+Tools/test-package-metadata-mutants\.py\b",
+            bash_pack,
+        ),
+        (
+            "build.ps1 package metadata checker",
+            powershell,
+            r'Invoke-CheckedNative\s+"python"\s+@\(\s*"Tools/package_metadata\.py"',
+            ps_pack,
+        ),
+        (
+            "build.ps1 package metadata mutants",
+            powershell,
+            r'Invoke-CheckedNative\s+"python"\s+@\("Tools/test-package-metadata-mutants\.py"',
+            ps_pack,
+        ),
     )
-    for relative, text in (("build.sh", bash), ("build.ps1", powershell)):
-        missing = [gate for gate in required_release_gates if gate not in text]
-        if missing:
-            raise BuildTopologyError(f"{relative} omits mandatory package metadata gates: {missing}")
+    for description, text, pattern, pack_start in release_invocations:
+        if require_one(text, pattern, description) < pack_start:
+            raise BuildTopologyError(f"{description} must remain inside the packaging gate")
+
+
+def require_windows_powershell_gate(root: Path) -> None:
+    workflow = root / ".github" / "workflows" / "dotnet-ci.yml"
+    if not workflow.is_file():
+        raise BuildTopologyError(f".NET CI workflow does not exist: {workflow}")
+    text = workflow.read_text(encoding="utf-8-sig")
+    pattern = (
+        r"(?ms)^  windows-build-test:\s*$"
+        r".*?^    runs-on:\s*windows-latest\s*$"
+        r".*?^        shell:\s*pwsh\s*$"
+        r".*?^        run:\s*\./build\.ps1 -SkipDocs -SkipPack\s*$"
+    )
+    require_one(text, pattern, "Windows canonical PowerShell CI job")
 
 
 def main() -> int:
@@ -186,8 +428,9 @@ def main() -> int:
     root = args.root.resolve()
     try:
         require_build_order_references_not_copy_local(root)
-        require_language_pack_isolated_emitter_build(root)
+        require_language_pack_provider_contract(root)
         require_canonical_gate_order(root)
+        require_windows_powershell_gate(root)
     except (BuildTopologyError, OSError, ValueError) as exc:
         print(f"BUILD_TOPOLOGY=FAIL: {exc}", file=sys.stderr)
         return 1

--- a/Tools/check-build-topology.py
+++ b/Tools/check-build-topology.py
@@ -199,7 +199,6 @@ def require_language_pack_provider_contract(root: Path) -> None:
     if resolver is None:
         raise BuildTopologyError("language pack lacks ResolveLanguagePackBuildProviders")
     required_before_targets = {
-        "ResolveProjectReferences",
         "EmitToolchainFeatureManifest",
         "ExposeWistRuntimeClosureToProjectReferences",
         "CollectWistRuntimeManifests",
@@ -207,6 +206,11 @@ def require_language_pack_provider_contract(root: Path) -> None:
     actual_before_targets = set(resolver.attrib.get("BeforeTargets", "").split(";"))
     if not required_before_targets.issubset(actual_before_targets):
         raise BuildTopologyError("language pack provider resolution is missing required BeforeTargets")
+    if "ResolveProjectReferences" in actual_before_targets:
+        raise BuildTopologyError("language pack provider resolution must not race ResolveProjectReferences")
+    after_targets = set(resolver.attrib.get("AfterTargets", "").split(";"))
+    if "ResolveProjectReferences" not in after_targets:
+        raise BuildTopologyError("language pack provider resolution must run after ResolveProjectReferences")
     expected_condition = normalized_expression("'$(DesignTimeBuild)' != 'true'")
     if normalized_expression(resolver.attrib.get("Condition", "")) != expected_condition:
         raise BuildTopologyError("language pack provider resolution must be disabled only for DesignTimeBuild=true")

--- a/Tools/check-build-topology.py
+++ b/Tools/check-build-topology.py
@@ -277,17 +277,25 @@ def require_language_pack_provider_contract(root: Path) -> None:
     expose_target = targets.get("ExposeWistRuntimeClosureToProjectReferences")
     if expose_target is None:
         raise BuildTopologyError("language pack lacks ExposeWistRuntimeClosureToProjectReferences")
-    content_items = [
+    runtime_files = [
         element
         for element in expose_target.iter()
-        if local_name(element.tag) == "ContentWithTargetPath"
+        if local_name(element.tag) == "WistRuntimeFileForCopy"
     ]
     expected_closure = (
         "$(WistRuntimeOutputDirectory)*.dll;"
         "$(WistRuntimeOutputDirectory)*.dialect.runtime.json"
     )
-    if len(content_items) != 1 or content_items[0].attrib.get("Include") != expected_closure:
+    if len(runtime_files) != 1 or runtime_files[0].attrib.get("Include") != expected_closure:
         raise BuildTopologyError("runtime closure must come from the provider-returned Wist output directory")
+    assign_tasks = direct_children(expose_target, "AssignTargetPath")
+    if len(assign_tasks) != 1 or assign_tasks[0].attrib.get("Files") != "@(WistRuntimeFileForCopy)" or \
+       assign_tasks[0].attrib.get("RootFolder") != "$(WistRuntimeOutputDirectory)":
+        raise BuildTopologyError("runtime closure must preserve file-relative target paths")
+    assigned_outputs = direct_children(assign_tasks[0], "Output")
+    if len(assigned_outputs) != 1 or assigned_outputs[0].attrib.get("TaskParameter") != "AssignedFiles" or \
+       assigned_outputs[0].attrib.get("ItemName") != "ContentWithTargetPath":
+        raise BuildTopologyError("runtime closure must publish AssignTargetPath outputs")
 
     collect_target = targets.get("CollectWistRuntimeManifests")
     if collect_target is None:

--- a/Tools/test-build-topology-mutants.py
+++ b/Tools/test-build-topology-mutants.py
@@ -7,6 +7,7 @@ import subprocess
 import sys
 import tempfile
 import xml.etree.ElementTree as ET
+from collections.abc import Callable
 from pathlib import Path
 
 
@@ -22,10 +23,19 @@ LANGUAGE_PACK_PROJECT = Path(
     "UniversalToolchain/UniversalToolchain.Wist.LanguagePack/"
     "UniversalToolchain.Wist.LanguagePack.csproj"
 )
+EMITTER_PROJECT = Path(
+    "UniversalToolchain/UniversalToolchain.FeatureManifestEmitter/"
+    "UniversalToolchain.FeatureManifestEmitter.csproj"
+)
+WIST_PROJECT = Path(
+    "UniversalToolchain/UniversalToolchain.Wist/UniversalToolchain.Wist.csproj"
+)
+DOTNET_WORKFLOW = Path(".github/workflows/dotnet-ci.yml")
 SUPPORT_FILES = (
     Path("build.sh"),
     Path("build.ps1"),
     Path("Tools/test-build-topology-runtime.py"),
+    DOTNET_WORKFLOW,
 )
 
 
@@ -65,6 +75,18 @@ def replace_once(path: Path, old: str, new: str) -> None:
     path.write_text(text.replace(old, new, 1), encoding="utf-8")
 
 
+def find_target(tree: ET.ElementTree, target_name: str) -> ET.Element:
+    matches = [
+        element
+        for element in tree.getroot().iter()
+        if element.tag.rsplit("}", 1)[-1] == "Target"
+        and element.attrib.get("Name") == target_name
+    ]
+    if len(matches) != 1:
+        raise AssertionError(f"expected exactly one target {target_name!r}")
+    return matches[0]
+
+
 def mutate_project_reference(path: Path, include_fragment: str) -> None:
     tree = ET.parse(path)
     matches = [
@@ -81,36 +103,62 @@ def mutate_project_reference(path: Path, include_fragment: str) -> None:
 
 def rename_target(path: Path, old_name: str, new_name: str) -> None:
     tree = ET.parse(path)
-    matches = [
-        element
-        for element in tree.getroot().iter()
-        if element.tag.rsplit("}", 1)[-1] == "Target"
-        and element.attrib.get("Name") == old_name
-    ]
-    if len(matches) != 1:
-        raise AssertionError(f"expected target {old_name!r} in {path}")
-    matches[0].set("Name", new_name)
+    find_target(tree, old_name).set("Name", new_name)
     tree.write(path, encoding="unicode")
 
 
-def redirect_msbuild_project(path: Path, target_name: str, project: str) -> None:
+def set_target_attribute(path: Path, target_name: str, attribute: str, value: str) -> None:
     tree = ET.parse(path)
-    targets = [
-        element
-        for element in tree.getroot().iter()
-        if element.tag.rsplit("}", 1)[-1] == "Target"
-        and element.attrib.get("Name") == target_name
-    ]
-    if len(targets) != 1:
-        raise AssertionError(f"expected target {target_name!r} in {path}")
+    find_target(tree, target_name).set(attribute, value)
+    tree.write(path, encoding="unicode")
+
+
+def find_msbuild_task(path: Path, target_name: str, project: str) -> tuple[ET.ElementTree, ET.Element]:
+    tree = ET.parse(path)
+    target = find_target(tree, target_name)
     tasks = [
         element
-        for element in targets[0]
+        for element in target
         if element.tag.rsplit("}", 1)[-1] == "MSBuild"
+        and element.attrib.get("Projects") == project
     ]
     if len(tasks) != 1:
-        raise AssertionError(f"expected one MSBuild task in {target_name!r}")
-    tasks[0].set("Projects", project)
+        raise AssertionError(f"expected one MSBuild task for {project!r} in {target_name!r}")
+    return tree, tasks[0]
+
+
+def set_msbuild_attribute(
+    path: Path,
+    target_name: str,
+    project: str,
+    attribute: str,
+    value: str,
+) -> None:
+    tree, task = find_msbuild_task(path, target_name, project)
+    task.set(attribute, value)
+    tree.write(path, encoding="unicode")
+
+
+def remove_msbuild_output(path: Path, target_name: str, project: str) -> None:
+    tree, task = find_msbuild_task(path, target_name, project)
+    outputs = [element for element in task if element.tag.rsplit("}", 1)[-1] == "Output"]
+    if len(outputs) != 1:
+        raise AssertionError(f"expected one MSBuild Output for {project!r} in {target_name!r}")
+    task.remove(outputs[0])
+    tree.write(path, encoding="unicode")
+
+
+def add_top_level_property(path: Path, name: str, value: str) -> None:
+    tree = ET.parse(path)
+    property_groups = [
+        element
+        for element in tree.getroot()
+        if element.tag.rsplit("}", 1)[-1] == "PropertyGroup"
+    ]
+    if not property_groups:
+        raise AssertionError("project has no top-level PropertyGroup")
+    element = ET.SubElement(property_groups[0], name)
+    element.text = value
     tree.write(path, encoding="unicode")
 
 
@@ -133,67 +181,158 @@ def main() -> int:
         print(f"BUILD_TOPOLOGY_MUTANTS=FAIL: checker does not exist: {checker}", file=sys.stderr)
         return 1
 
-    try:
-        temporary, path = fixture(root, checker)
-        with temporary:
-            mutate_project_reference(
+    Mutation = tuple[str, Callable[[Path], None], str]
+    mutations: tuple[Mutation, ...] = (
+        (
+            "dialect-build-order-copy-local",
+            lambda path: mutate_project_reference(
                 path / DIALECT_TEST_PROJECT,
                 "RuntimeSharedAssemblyFreshProcessHost.csproj",
-            )
-            run_checker(checker, path, "repository build-order ProjectReference")
-
-        temporary, path = fixture(root, checker)
-        with temporary:
-            mutate_project_reference(
+            ),
+            "repository build-order ProjectReference",
+        ),
+        (
+            "fixture-build-order-copy-local",
+            lambda path: mutate_project_reference(
                 path / FRESH_PROCESS_HOST_PROJECT,
                 "CanonicalRuntimeFixture.csproj",
-            )
-            run_checker(checker, path, "repository build-order ProjectReference")
-
-        temporary, path = fixture(root, checker)
-        with temporary:
-            rename_target(
+            ),
+            "repository build-order ProjectReference",
+        ),
+        (
+            "provider-resolver-renamed",
+            lambda path: rename_target(
                 path / LANGUAGE_PACK_PROJECT,
-                "BuildFeatureManifestEmitterForIsolatedBuild",
-                "DisabledFeatureManifestEmitterForIsolatedBuild",
-            )
-            run_checker(checker, path, "lacks BuildFeatureManifestEmitterForIsolatedBuild")
-
-        temporary, path = fixture(root, checker)
-        with temporary:
-            redirect_msbuild_project(
+                "ResolveLanguagePackBuildProviders",
+                "DisabledResolveLanguagePackBuildProviders",
+            ),
+            "lacks ResolveLanguagePackBuildProviders",
+        ),
+        (
+            "emitter-project-redirected",
+            lambda path: set_msbuild_attribute(
                 path / LANGUAGE_PACK_PROJECT,
-                "BuildFeatureManifestEmitterForIsolatedBuild",
+                "ResolveLanguagePackBuildProviders",
+                "$(FeatureManifestEmitterProjectPath)",
+                "Projects",
                 "wrong-emitter.csproj",
-            )
-            run_checker(checker, path, "builds the wrong project")
-
-        temporary, path = fixture(root, checker)
-        with temporary:
-            replace_once(
+            ),
+            "unexpected project set",
+        ),
+        (
+            "wist-provider-target-redirected",
+            lambda path: set_msbuild_attribute(
+                path / LANGUAGE_PACK_PROJECT,
+                "ResolveLanguagePackBuildProviders",
+                "$(WistProjectPath)",
+                "Targets",
+                "Build",
+            ),
+            "invokes the wrong target",
+        ),
+        (
+            "emitter-output-not-captured",
+            lambda path: remove_msbuild_output(
+                path / LANGUAGE_PACK_PROJECT,
+                "ResolveLanguagePackBuildProviders",
+                "$(FeatureManifestEmitterProjectPath)",
+            ),
+            "capture TargetOutputs",
+        ),
+        (
+            "resolver-forwards-evaluated-output-path",
+            lambda path: set_msbuild_attribute(
+                path / LANGUAGE_PACK_PROJECT,
+                "ResolveLanguagePackBuildProviders",
+                "$(FeatureManifestEmitterProjectPath)",
+                "Properties",
+                "BuildProjectReferences=true;OutputPath=$(OutputPath)",
+            ),
+            "force only BuildProjectReferences=true",
+        ),
+        (
+            "emitter-returns-guessed-path",
+            lambda path: set_target_attribute(
+                path / EMITTER_PROJECT,
+                "GetBuiltFeatureManifestEmitterTargetPath",
+                "Returns",
+                "$(TargetDir)guessed.dll",
+            ),
+            "return the evaluated $(TargetPath)",
+        ),
+        (
+            "wist-returns-guessed-directory",
+            lambda path: set_target_attribute(
+                path / WIST_PROJECT,
+                "GetBuiltWistOutputDirectory",
+                "Returns",
+                "$(MSBuildProjectDirectory)\\bin\\Release\\net10.0\\",
+            ),
+            "return the evaluated $(TargetDir)",
+        ),
+        (
+            "language-pack-reintroduces-emitter-layout-guess",
+            lambda path: add_top_level_property(
+                path / LANGUAGE_PACK_PROJECT,
+                "FeatureManifestEmitterProjectBinDll",
+                "$(MSBuildThisFileDirectory)..\\Emitter\\bin\\Release\\net10.0\\Emitter.dll",
+            ),
+            "instead of guessing output layout",
+        ),
+        (
+            "language-pack-reintroduces-wist-layout-guess",
+            lambda path: add_top_level_property(
+                path / LANGUAGE_PACK_PROJECT,
+                "WistRuntimeOutputDirectory",
+                "$(MSBuildThisFileDirectory)..\\UniversalToolchain.Wist\\$(OutputPath)",
+            ),
+            "instead of guessing output layout",
+        ),
+        (
+            "powershell-package-gate-disabled",
+            lambda path: replace_once(
                 path / "build.ps1",
-                "Tools/package_metadata.py",
-                "Tools/package_metadata.disabled.py",
-            )
-            run_checker(checker, path, "build.ps1 omits mandatory package metadata gates")
-
-        temporary, path = fixture(root, checker)
-        with temporary:
-            replace_once(
+                '"Tools/package_metadata.py"',
+                '"Tools/package_metadata.disabled.py"',
+            ),
+            "build.ps1 package metadata checker",
+        ),
+        (
+            "bash-package-mutants-disabled",
+            lambda path: replace_once(
                 path / "build.sh",
                 "Tools/test-package-metadata-mutants.py",
                 "Tools/test-package-metadata-mutants.disabled.py",
-            )
-            run_checker(checker, path, "build.sh omits mandatory package metadata gates")
-
-        temporary, path = fixture(root, checker)
-        with temporary:
-            replace_once(
+            ),
+            "build.sh package metadata mutants",
+        ),
+        (
+            "bash-runtime-topology-disabled",
+            lambda path: replace_once(
                 path / "build.sh",
                 "Tools/test-build-topology-runtime.py",
                 "Tools/test-build-topology-runtime.disabled.py",
-            )
-            run_checker(checker, path, "build.sh runtime topology invocation")
+            ),
+            "build.sh runtime topology invocation",
+        ),
+        (
+            "windows-powershell-job-disabled",
+            lambda path: replace_once(
+                path / DOTNET_WORKFLOW,
+                "run: ./build.ps1 -SkipDocs -SkipPack",
+                "run: Write-Host 'PowerShell build disabled'",
+            ),
+            "Windows canonical PowerShell CI job",
+        ),
+    )
+
+    try:
+        for name, mutate, expected in mutations:
+            temporary, path = fixture(root, checker)
+            with temporary:
+                mutate(path)
+                run_checker(checker, path, expected)
+                print(f"SURVIVOR=0 mutant={name}")
     except (AssertionError, OSError) as exc:
         print(f"BUILD_TOPOLOGY_MUTANTS=FAIL: {exc}", file=sys.stderr)
         return 1

--- a/Tools/test-build-topology-mutants.py
+++ b/Tools/test-build-topology-mutants.py
@@ -289,6 +289,15 @@ def main() -> int:
             "instead of guessing output layout",
         ),
         (
+            "runtime-target-path-root-redirected",
+            lambda path: replace_once(
+                path / LANGUAGE_PACK_PROJECT,
+                'RootFolder="$(WistRuntimeOutputDirectory)"',
+                'RootFolder="$(TargetDir)"',
+            ),
+            "preserve file-relative target paths",
+        ),
+        (
             "powershell-package-gate-disabled",
             lambda path: replace_once(
                 path / "build.ps1",

--- a/Tools/test-build-topology-runtime.py
+++ b/Tools/test-build-topology-runtime.py
@@ -222,6 +222,7 @@ def language_pack_cases(temporary_root: Path) -> tuple[LayoutCase, ...]:
                 f"-p:ArtifactsPath={artifacts_path}",
             ),
             external_output_root=artifacts_path,
+            requires_restore=True,
             build_project_references=True,
         ),
         # The canonical layout remains the dedicated IDE-style regression where

--- a/Tools/test-build-topology-runtime.py
+++ b/Tools/test-build-topology-runtime.py
@@ -2,9 +2,13 @@
 from __future__ import annotations
 
 import argparse
+import os
+import platform
 import shutil
 import subprocess
 import sys
+import tempfile
+from dataclasses import dataclass
 from pathlib import Path
 
 
@@ -22,22 +26,81 @@ FRESH_PROCESS_PROJECTS = (
 )
 LANGUAGE_PACK = Path("UniversalToolchain/UniversalToolchain.Wist.LanguagePack/UniversalToolchain.Wist.LanguagePack.csproj")
 FEATURE_EMITTER = Path("UniversalToolchain/UniversalToolchain.FeatureManifestEmitter")
+WIST = Path("UniversalToolchain/UniversalToolchain.Wist")
 CORE_TESTS = Path("UniversalToolchain/Tests/Tests.csproj")
 WISTC = Path("UniversalToolchain/Wistc")
 
 
-def remove_configuration_outputs(project_directory: Path, configuration: str) -> None:
-    for output_root_name in ("bin", "obj"):
-        output_root = project_directory / output_root_name
-        if not output_root.is_dir():
-            continue
-        candidates = sorted(
-            (path for path in output_root.rglob(configuration) if path.is_dir()),
-            key=lambda path: len(path.parts),
-            reverse=True,
-        )
-        for candidate in candidates:
-            shutil.rmtree(candidate)
+@dataclass(frozen=True)
+class LayoutCase:
+    name: str
+    properties: tuple[str, ...] = ()
+    external_output_root: Path | None = None
+    requires_restore: bool = False
+    build_project_references: bool = False
+
+
+def remove_project_outputs(project_directory: Path, configuration: str) -> None:
+    shutil.rmtree(project_directory / "bin", ignore_errors=True)
+    obj = project_directory / "obj"
+    if not obj.is_dir():
+        return
+    candidates = sorted(
+        (path for path in obj.rglob(configuration) if path.is_dir()),
+        key=lambda path: len(path.parts),
+        reverse=True,
+    )
+    for candidate in candidates:
+        shutil.rmtree(candidate)
+
+
+def build_server_arguments() -> list[str]:
+    disabled = (
+        os.environ.get("DOTNET_CLI_DO_NOT_USE_MSBUILD_SERVER") == "1"
+        or os.environ.get("MSBUILDDISABLENODEREUSE") == "1"
+    )
+    return ["--disable-build-servers", "-p:UseSharedCompilation=false"] if disabled else []
+
+
+def run_dotnet(
+    command: list[str],
+    *,
+    root: Path,
+    description: str,
+    timeout: int = 420,
+) -> str:
+    completed = subprocess.run(
+        command,
+        cwd=root,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+        timeout=timeout,
+    )
+    if completed.returncode != 0:
+        raise RuntimeTopologyError(f"{description} failed:\n{completed.stdout}")
+    return completed.stdout
+
+
+def run_restore(
+    dotnet: str,
+    root: Path,
+    project: Path,
+    properties: tuple[str, ...],
+) -> None:
+    run_dotnet(
+        [
+            dotnet,
+            "restore",
+            str(root / project),
+            *build_server_arguments(),
+            *properties,
+            "-p:NuGetAudit=false",
+        ],
+        root=root,
+        description=f"restore for {project} with properties {properties}",
+    )
 
 
 def run_build(
@@ -47,56 +110,189 @@ def run_build(
     configuration: str,
     *,
     build_project_references: bool,
-) -> None:
-    command = [
-        dotnet,
-        "build",
-        str(root / project),
-        "-c",
-        configuration,
-        "--no-restore",
-        "-m:1",
-        f"-p:BuildProjectReferences={'true' if build_project_references else 'false'}",
-        "-p:NuGetAudit=false",
-    ]
-    completed = subprocess.run(
-        command,
-        cwd=root,
-        text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        check=False,
-        timeout=240,
-    )
-    if completed.returncode != 0:
-        raise RuntimeTopologyError(
-            f"isolated build failed for {project} (BuildProjectReferences={build_project_references}):\n"
-            f"{completed.stdout}"
-        )
-
-
-def matching_outputs(project_directory: Path, configuration: str, file_name: str) -> list[Path]:
-    output_root = project_directory / "bin"
-    if not output_root.is_dir():
-        return []
-    return sorted(
-        path
-        for path in output_root.rglob(file_name)
-        if configuration.lower() in (part.lower() for part in path.parts)
+    properties: tuple[str, ...] = (),
+) -> str:
+    return run_dotnet(
+        [
+            dotnet,
+            "build",
+            str(root / project),
+            "-c",
+            configuration,
+            "--no-restore",
+            "-m:1",
+            f"-p:BuildProjectReferences={'true' if build_project_references else 'false'}",
+            *build_server_arguments(),
+            *properties,
+            "-p:NuGetAudit=false",
+        ],
+        root=root,
+        description=(
+            f"isolated build for {project} "
+            f"(BuildProjectReferences={build_project_references}, properties={properties})"
+        ),
     )
 
 
-def require_output(project_directory: Path, configuration: str, file_name: str) -> None:
-    matches = matching_outputs(project_directory, configuration, file_name)
+def matching_outputs(
+    search_roots: tuple[Path, ...],
+    pattern: str,
+    *,
+    configuration: str | None = None,
+) -> list[Path]:
+    matches: set[Path] = set()
+    for search_root in search_roots:
+        if not search_root.is_dir():
+            continue
+        for path in search_root.rglob(pattern):
+            if not path.is_file():
+                continue
+            if configuration is not None and configuration.lower() not in {
+                part.lower() for part in path.parts
+            }:
+                continue
+            matches.add(path.resolve())
+    return sorted(matches)
+
+
+def require_output(
+    search_roots: tuple[Path, ...],
+    pattern: str,
+    case_name: str,
+    *,
+    configuration: str | None = None,
+) -> Path:
+    matches = matching_outputs(search_roots, pattern, configuration=configuration)
     if not matches:
         raise RuntimeTopologyError(
-            f"expected {file_name} under {project_directory}/bin for {configuration}"
+            f"expected {pattern} for {case_name} under: "
+            + ", ".join(str(path) for path in search_roots)
         )
+    return matches[0]
+
+
+def runtime_identifier() -> str:
+    system = platform.system().lower()
+    machine = platform.machine().lower()
+    architecture = "arm64" if machine in {"arm64", "aarch64"} else "x64"
+    if system == "windows":
+        return f"win-{architecture}"
+    if system == "darwin":
+        return f"osx-{architecture}"
+    return f"linux-{architecture}"
+
+
+def language_pack_cases(temporary_root: Path) -> tuple[LayoutCase, ...]:
+    output_path = temporary_root / "output-path"
+    base_output_path = temporary_root / "base-output-path"
+    artifacts_path = temporary_root / "artifacts-output"
+    return (
+        LayoutCase("platform", ("-p:Platform=x64",)),
+        LayoutCase(
+            "output-path",
+            (f"-p:OutputPath={output_path}{os.sep}",),
+            external_output_root=output_path,
+        ),
+        LayoutCase(
+            "base-output-path",
+            (f"-p:BaseOutputPath={base_output_path}{os.sep}",),
+            external_output_root=base_output_path,
+        ),
+        LayoutCase(
+            "runtime-identifier",
+            (f"-p:RuntimeIdentifier={runtime_identifier()}",),
+            requires_restore=True,
+            build_project_references=True,
+        ),
+        LayoutCase(
+            "no-target-framework-segment",
+            ("-p:AppendTargetFrameworkToOutputPath=false",),
+        ),
+        LayoutCase(
+            "artifacts-output",
+            (
+                "-p:UseArtifactsOutput=true",
+                f"-p:ArtifactsPath={artifacts_path}",
+            ),
+            external_output_root=artifacts_path,
+        ),
+        # Restore and rebuild the canonical layout last so later test-contract and
+        # packaging phases observe the same default assets and outputs as normal CI.
+        LayoutCase("default", requires_restore=True),
+    )
+
+
+def verify_language_pack_layouts(
+    dotnet: str,
+    root: Path,
+    configuration: str,
+) -> None:
+    language_pack_directory = (root / LANGUAGE_PACK).parent
+    emitter_directory = root / FEATURE_EMITTER
+    wist_directory = root / WIST
+
+    with tempfile.TemporaryDirectory(prefix="wist-provider-layout-") as temporary:
+        temporary_root = Path(temporary).resolve()
+        for case in language_pack_cases(temporary_root):
+            for project_directory in (
+                language_pack_directory,
+                emitter_directory,
+                wist_directory,
+            ):
+                remove_project_outputs(project_directory, configuration)
+            if case.external_output_root is not None:
+                shutil.rmtree(case.external_output_root, ignore_errors=True)
+            if case.requires_restore:
+                run_restore(dotnet, root, LANGUAGE_PACK, case.properties)
+
+            run_build(
+                dotnet,
+                root,
+                LANGUAGE_PACK,
+                configuration,
+                build_project_references=case.build_project_references,
+                properties=case.properties,
+            )
+
+            if case.external_output_root is None:
+                language_pack_roots = (language_pack_directory,)
+                emitter_roots = (emitter_directory,)
+                wist_roots = (wist_directory,)
+            else:
+                language_pack_roots = (case.external_output_root,)
+                emitter_roots = (case.external_output_root,)
+                wist_roots = (case.external_output_root,)
+
+            feature_manifest = require_output(
+                language_pack_roots,
+                "UniversalToolchain.Wist.LanguagePack.toolchain.feature.json",
+                case.name,
+            )
+            emitter = require_output(
+                emitter_roots,
+                "UniversalToolchain.FeatureManifestEmitter.dll",
+                case.name,
+            )
+            wist = require_output(
+                wist_roots,
+                "UniversalToolchain.Wist.dll",
+                case.name,
+            )
+            runtime_manifest = require_output(
+                (feature_manifest.parent,),
+                "*.dialect.runtime.json",
+                f"{case.name} language-pack runtime closure",
+            )
+            for artifact in (feature_manifest, emitter, wist, runtime_manifest):
+                if artifact.stat().st_size == 0:
+                    raise RuntimeTopologyError(
+                        f"layout case {case.name} produced an empty artifact: {artifact}"
+                    )
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(
-        description="Reproduce IDE-style BuildProjectReferences=false builds against real projects."
+        description="Reproduce IDE-style and non-default output-layout builds against real projects."
     )
     parser.add_argument("--root", type=Path, default=Path.cwd())
     parser.add_argument("--dotnet", default="dotnet")
@@ -107,41 +303,44 @@ def main() -> int:
     configuration = args.configuration
     try:
         dialect_directory = (root / DIALECT_TESTS).parent
-        remove_configuration_outputs(dialect_directory, configuration)
+        remove_project_outputs(dialect_directory, configuration)
         for relative in FRESH_PROCESS_PROJECTS:
-            remove_configuration_outputs(root / relative, configuration)
+            remove_project_outputs(root / relative, configuration)
         run_build(args.dotnet, root, DIALECT_TESTS, configuration, build_project_references=False)
         require_output(
-            root / FRESH_PROCESS_PROJECTS[-1],
-            configuration,
+            (root / FRESH_PROCESS_PROJECTS[-1],),
             "UniversalToolchain.Dialects.FreshProcessHost.dll",
+            "dialect fresh-process host",
+            configuration=configuration,
         )
 
-        language_pack_directory = (root / LANGUAGE_PACK).parent
-        remove_configuration_outputs(language_pack_directory, configuration)
-        remove_configuration_outputs(root / FEATURE_EMITTER, configuration)
-        run_build(args.dotnet, root, LANGUAGE_PACK, configuration, build_project_references=False)
-        require_output(
-            language_pack_directory,
-            configuration,
-            "UniversalToolchain.Wist.LanguagePack.toolchain.feature.json",
-        )
-        require_output(
-            root / FEATURE_EMITTER,
-            configuration,
-            "UniversalToolchain.FeatureManifestEmitter.dll",
-        )
+        verify_language_pack_layouts(args.dotnet, root, configuration)
 
         tests_directory = (root / CORE_TESTS).parent
-        remove_configuration_outputs(tests_directory, configuration)
-        remove_configuration_outputs(root / WISTC, configuration)
+        remove_project_outputs(tests_directory, configuration)
+        remove_project_outputs(root / WISTC, configuration)
         run_build(args.dotnet, root, CORE_TESTS, configuration, build_project_references=False)
-        require_output(tests_directory, configuration, "Tests.dll")
-        if matching_outputs(root / WISTC, configuration, "Wistc.dll"):
+        require_output(
+            (tests_directory,),
+            "Tests.dll",
+            "core tests",
+            configuration=configuration,
+        )
+        if matching_outputs(
+            (root / WISTC,),
+            "Wistc.dll",
+            configuration=configuration,
+        ):
             raise RuntimeTopologyError(
                 "BuildProjectReferences=false unexpectedly rebuilt the build-only Wistc reference"
             )
-        run_build(args.dotnet, root, WISTC / "Wistc.csproj", configuration, build_project_references=True)
+        run_build(
+            args.dotnet,
+            root,
+            WISTC / "Wistc.csproj",
+            configuration,
+            build_project_references=True,
+        )
     except (OSError, subprocess.SubprocessError, RuntimeTopologyError) as exc:
         print(f"BUILD_TOPOLOGY_RUNTIME=FAIL: {exc}", file=sys.stderr)
         return 1

--- a/Tools/test-build-topology-runtime.py
+++ b/Tools/test-build-topology-runtime.py
@@ -187,7 +187,11 @@ def language_pack_cases(temporary_root: Path) -> tuple[LayoutCase, ...]:
     base_output_path = temporary_root / "base-output-path"
     artifacts_path = temporary_root / "artifacts-output"
     return (
-        LayoutCase("platform", ("-p:Platform=x64",)),
+        LayoutCase(
+            "platform",
+            ("-p:Platform=x64",),
+            build_project_references=True,
+        ),
         LayoutCase(
             "output-path",
             (f"-p:OutputPath={output_path}{os.sep}",),
@@ -215,6 +219,7 @@ def language_pack_cases(temporary_root: Path) -> tuple[LayoutCase, ...]:
                 f"-p:ArtifactsPath={artifacts_path}",
             ),
             external_output_root=artifacts_path,
+            build_project_references=True,
         ),
         # Restore and rebuild the canonical layout last so later test-contract and
         # packaging phases observe the same default assets and outputs as normal CI.

--- a/Tools/test-build-topology-runtime.py
+++ b/Tools/test-build-topology-runtime.py
@@ -196,11 +196,13 @@ def language_pack_cases(temporary_root: Path) -> tuple[LayoutCase, ...]:
             "output-path",
             (f"-p:OutputPath={output_path}{os.sep}",),
             external_output_root=output_path,
+            build_project_references=True,
         ),
         LayoutCase(
             "base-output-path",
             (f"-p:BaseOutputPath={base_output_path}{os.sep}",),
             external_output_root=base_output_path,
+            build_project_references=True,
         ),
         LayoutCase(
             "runtime-identifier",
@@ -211,6 +213,7 @@ def language_pack_cases(temporary_root: Path) -> tuple[LayoutCase, ...]:
         LayoutCase(
             "no-target-framework-segment",
             ("-p:AppendTargetFrameworkToOutputPath=false",),
+            build_project_references=True,
         ),
         LayoutCase(
             "artifacts-output",
@@ -221,8 +224,8 @@ def language_pack_cases(temporary_root: Path) -> tuple[LayoutCase, ...]:
             external_output_root=artifacts_path,
             build_project_references=True,
         ),
-        # Restore and rebuild the canonical layout last so later test-contract and
-        # packaging phases observe the same default assets and outputs as normal CI.
+        # The canonical layout remains the dedicated IDE-style regression where
+        # project references were built by the preceding solution build.
         LayoutCase("default", requires_restore=True),
     )
 

--- a/UniversalToolchain/BasicCore/LexerWrapper/LexemeValue.cs
+++ b/UniversalToolchain/BasicCore/LexerWrapper/LexemeValue.cs
@@ -24,9 +24,29 @@ public class LexemeValue
 
     private static (int, int) CalcLineAndCharNums(string code, int startIndex)
     {
-        var codePart = string.Join("", code.Take(startIndex));
-        var lineNumber = codePart.Count(c => c == '\n') + 1;
-        var charNumber = codePart.Split("\n")[^1].Length;
+        var lineNumber = 1;
+        var charNumber = 0;
+
+        for (var index = 0; index < startIndex; index++)
+        {
+            switch (code[index])
+            {
+                case '\r':
+                    if (index + 1 < startIndex && code[index + 1] == '\n')
+                        index++;
+                    lineNumber++;
+                    charNumber = 0;
+                    break;
+                case '\n':
+                    lineNumber++;
+                    charNumber = 0;
+                    break;
+                default:
+                    charNumber++;
+                    break;
+            }
+        }
+
         return (lineNumber, charNumber);
     }
 

--- a/UniversalToolchain/BasicLexer/Core/BasicLexerImpl.cs
+++ b/UniversalToolchain/BasicLexer/Core/BasicLexerImpl.cs
@@ -1,7 +1,12 @@
+using System.Collections.Concurrent;
+
 namespace BasicLexer.Core;
 
 public class BasicLexerImpl(LexerConfiguration configuration) : ILexer
 {
+    private static readonly TimeSpan MatchTimeout = TimeSpan.FromMilliseconds(1000);
+    private readonly ConcurrentDictionary<string, Regex> _compiledPatterns = new(StringComparer.Ordinal);
+
     public BasicLexerImpl() : this(new LexerConfiguration([]))
     {
     }
@@ -21,13 +26,16 @@ public class BasicLexerImpl(LexerConfiguration configuration) : ILexer
 
         var allMatches = new List<LexemeValue>(); // Initialize a list to store all matches found by regex patterns.
 
-        // Iterate over each pattern defined in the configuration.
+        // Regex instances are safe for concurrent matching. Cache them by pattern
+        // text so parallel compilations do not repeatedly pay RegexOptions.Compiled
+        // startup cost while preserving the per-match timeout boundary.
         foreach (var pattern in patterns)
-            // Find all occurrences of the current pattern in the input code using regular expressions.
-
         {
+            var regex = _compiledPatterns.GetOrAdd(
+                pattern.Pattern,
+                static patternText => new Regex(patternText, RegexOptions.Compiled, MatchTimeout));
             allMatches.AddRange(
-                Regex.Matches(code, pattern.Pattern, RegexOptions.Compiled, TimeSpan.FromMilliseconds(1000))
+                regex.Matches(code)
                     .Select(match =>
                         // Create a LexemeValue object for each match.
                         new LexemeValue(match.Value, pattern, match.Index, code))

--- a/UniversalToolchain/BasicLexer/Core/BasicLexerImpl.cs
+++ b/UniversalToolchain/BasicLexer/Core/BasicLexerImpl.cs
@@ -11,6 +11,12 @@ public class BasicLexerImpl(LexerConfiguration configuration) : ILexer
     // Method that performs lexical analysis on the input code and returns a list of tokens.
     public List<LexemeValue> Lexemize(string code)
     {
+        // Lexer patterns and source locations use LF as the canonical line break.
+        // Normalize Windows CRLF and legacy CR inputs before matching so the
+        // same source text has identical lexical behavior on every platform.
+        if (code.Contains('\r'))
+            code = code.Replace("\r\n", "\n", StringComparison.Ordinal).Replace('\r', '\n');
+
         var patterns = Configuration.Patterns.ToList();
 
         var allMatches = new List<LexemeValue>(); // Initialize a list to store all matches found by regex patterns.

--- a/UniversalToolchain/BasicLexer/Core/BasicLexerImpl.cs
+++ b/UniversalToolchain/BasicLexer/Core/BasicLexerImpl.cs
@@ -1,11 +1,11 @@
-using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
 
 namespace BasicLexer.Core;
 
 public class BasicLexerImpl(LexerConfiguration configuration) : ILexer
 {
     private static readonly TimeSpan MatchTimeout = TimeSpan.FromMilliseconds(1000);
-    private readonly ConcurrentDictionary<string, Regex> _compiledPatterns = new(StringComparer.Ordinal);
+    private readonly ConditionalWeakTable<LexemePattern, Regex> _compiledPatterns = new();
 
     public BasicLexerImpl() : this(new LexerConfiguration([]))
     {
@@ -16,24 +16,18 @@ public class BasicLexerImpl(LexerConfiguration configuration) : ILexer
     // Method that performs lexical analysis on the input code and returns a list of tokens.
     public List<LexemeValue> Lexemize(string code)
     {
-        // Lexer patterns and source locations use LF as the canonical line break.
-        // Normalize Windows CRLF and legacy CR inputs before matching so the
-        // same source text has identical lexical behavior on every platform.
-        if (code.Contains('\r'))
-            code = code.Replace("\r\n", "\n", StringComparison.Ordinal).Replace('\r', '\n');
-
         var patterns = Configuration.Patterns.ToList();
 
         var allMatches = new List<LexemeValue>(); // Initialize a list to store all matches found by regex patterns.
 
-        // Regex instances are safe for concurrent matching. Cache them by pattern
-        // text so parallel compilations do not repeatedly pay RegexOptions.Compiled
-        // startup cost while preserving the per-match timeout boundary.
+        // Regex instances are safe for concurrent matching. Cache them by the
+        // LexemePattern object without retaining patterns removed by configuration
+        // replacement, while preserving the original source text and offsets.
         foreach (var pattern in patterns)
         {
-            var regex = _compiledPatterns.GetOrAdd(
-                pattern.Pattern,
-                static patternText => new Regex(patternText, RegexOptions.Compiled, MatchTimeout));
+            var regex = _compiledPatterns.GetValue(
+                pattern,
+                static item => new Regex(item.Pattern, RegexOptions.Compiled, MatchTimeout));
             allMatches.AddRange(
                 regex.Matches(code)
                     .Select(match =>

--- a/UniversalToolchain/UniversalToolchain.Dialects.Frontend/DialectDslLexemeRegistry.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Frontend/DialectDslLexemeRegistry.cs
@@ -20,11 +20,9 @@ public static class DialectDslLexemeRegistry
 
         registrations.AddRange(registry.DirectiveFeatures.Select(x => new LexemeRegistration(CreateKeywordPattern(x.Keyword), x.LexemeTag)));
         registrations.Add(new LexemeRegistration(@",", DialectLexemeTags.CommaToken));
-        registrations.Add(new LexemeRegistration(@"
-?
-", DialectLexemeTags.NewLine));
+        registrations.Add(new LexemeRegistration(@"\r\n|\n|\r", DialectLexemeTags.NewLine));
         registrations.Add(new LexemeRegistration(@"[A-Za-z_][A-Za-z0-9_\.-]*", DialectLexemeTags.Identifier));
-        registrations.Add(new LexemeRegistration(@"[ 	]+", "Whitespace", true));
+        registrations.Add(new LexemeRegistration(@"[ \t]+", "Whitespace", true));
         return registrations;
     }
 

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/DialectDslKeywordEscapingTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/DialectDslKeywordEscapingTests.cs
@@ -1,4 +1,7 @@
 using System.Text;
+using BasicCore.LexerWrapper;
+using BasicLexer.Core;
+using BasicTypesExtensions;
 using UniversalToolchain.Dialects.Frontend;
 using UniversalToolchain.Dialects.Frontend.Composition;
 
@@ -26,6 +29,23 @@ public class DialectDslKeywordEscapingTests
         var matchingCrKeyword = matchingCrLexemes.Single(x =>
             x.Text == keyword && x.LexemePattern!.LexemeType.GetName() == $"DialectDirectiveKeyword.{keyword}");
 
+        var customLexer = new BasicLexerImpl(new LexerConfiguration([]));
+        customLexer.Configuration.AddPattern(new LexemePattern(
+            @"[A-Za-z]+",
+            ExtensibleEnum<LexemeTag>.CreateOrGet("Tests.Identifier")));
+        customLexer.Configuration.AddPattern(new LexemePattern(
+            @"\r\n",
+            ExtensibleEnum<LexemeTag>.CreateOrGet("Tests.CrLf")));
+        const string customCrLfSource = "a\r\nb";
+        var customCrLfLexemes = customLexer.Lexemize(customCrLfSource);
+
+        const string invalidAfterTwoCrLf = "dialect Demo\r\nuse Arithmetic\r\n@";
+        var invalidLexeme = new LexemeValue(
+            "@",
+            null,
+            invalidAfterTwoCrLf.IndexOf('@'),
+            invalidAfterTwoCrLf);
+
         Assert.Multiple(() =>
         {
             Assert.That(matchingCrLfKeyword.StartIndex, Is.EqualTo(matchingCrLfSource.IndexOf(keyword, StringComparison.Ordinal)));
@@ -36,6 +56,13 @@ public class DialectDslKeywordEscapingTests
             Assert.That(matchingCrKeyword.LineNumber, Is.EqualTo(2));
             Assert.That(matchingCrKeyword.CharNumber, Is.Zero);
             Assert.That(matchingCrSource.Substring(matchingCrKeyword.StartIndex, matchingCrKeyword.Text.Length), Is.EqualTo(keyword));
+            Assert.That(customCrLfLexemes.Select(x => x.Text), Is.EqualTo(new[] { "a", "\r\n", "b" }));
+            Assert.That(customCrLfLexemes[1].StartIndex, Is.EqualTo(1));
+            Assert.That(customCrLfLexemes[2].StartIndex, Is.EqualTo(customCrLfSource.IndexOf('b')));
+            Assert.That(customCrLfLexemes[2].LineNumber, Is.EqualTo(2));
+            Assert.That(customCrLfLexemes[2].CharNumber, Is.Zero);
+            Assert.That(invalidLexeme.LineNumber, Is.EqualTo(3));
+            Assert.That(invalidLexeme.CharNumber, Is.Zero);
             Assert.That(nonMatchingLexemes.Any(x => x.LexemePattern!.LexemeType.GetName() == $"DialectDirectiveKeyword.{keyword}"), Is.False);
         });
     }

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/DialectDslKeywordEscapingTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/DialectDslKeywordEscapingTests.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using UniversalToolchain.Dialects.Frontend;
 using UniversalToolchain.Dialects.Frontend.Composition;
 
@@ -13,13 +14,28 @@ public class DialectDslKeywordEscapingTests
     public void KeywordLexemeRegistration_ShouldEscapeRegexMetacharacters(string keyword, string matchingDirectiveLine, string similarNonMatchLine)
     {
         var registry = new DialectDslRegistry([new RegexKeywordDirectiveFeature(keyword, 100)], []);
+        var matchingCrLfSource = $"dialect Demo\r\n{matchingDirectiveLine}\r\n";
+        var matchingCrSource = $"dialect Demo\r{matchingDirectiveLine}\r";
+        var nonMatchingSource = $"dialect Demo\r\n{similarNonMatchLine}\r\n";
 
-        var matchingLexemes = DialectDslTestSupport.Lex(registry, $"dialect Demo\n{matchingDirectiveLine}\n");
-        var nonMatchingLexemes = DialectDslTestSupport.Lex(registry, $"dialect Demo\n{similarNonMatchLine}\n");
+        var matchingCrLfLexemes = DialectDslTestSupport.Lex(registry, matchingCrLfSource);
+        var matchingCrLexemes = DialectDslTestSupport.Lex(registry, matchingCrSource);
+        var nonMatchingLexemes = DialectDslTestSupport.Lex(registry, nonMatchingSource);
+        var matchingCrLfKeyword = matchingCrLfLexemes.Single(x =>
+            x.Text == keyword && x.LexemePattern!.LexemeType.GetName() == $"DialectDirectiveKeyword.{keyword}");
+        var matchingCrKeyword = matchingCrLexemes.Single(x =>
+            x.Text == keyword && x.LexemePattern!.LexemeType.GetName() == $"DialectDirectiveKeyword.{keyword}");
 
         Assert.Multiple(() =>
         {
-            Assert.That(matchingLexemes.Any(x => x.Text == keyword && x.LexemePattern!.LexemeType.GetName() == $"DialectDirectiveKeyword.{keyword}"), Is.True);
+            Assert.That(matchingCrLfKeyword.StartIndex, Is.EqualTo(matchingCrLfSource.IndexOf(keyword, StringComparison.Ordinal)));
+            Assert.That(matchingCrLfKeyword.LineNumber, Is.EqualTo(2));
+            Assert.That(matchingCrLfKeyword.CharNumber, Is.Zero);
+            Assert.That(matchingCrLfSource.Substring(matchingCrLfKeyword.StartIndex, matchingCrLfKeyword.Text.Length), Is.EqualTo(keyword));
+            Assert.That(matchingCrKeyword.StartIndex, Is.EqualTo(matchingCrSource.IndexOf(keyword, StringComparison.Ordinal)));
+            Assert.That(matchingCrKeyword.LineNumber, Is.EqualTo(2));
+            Assert.That(matchingCrKeyword.CharNumber, Is.Zero);
+            Assert.That(matchingCrSource.Substring(matchingCrKeyword.StartIndex, matchingCrKeyword.Text.Length), Is.EqualTo(keyword));
             Assert.That(nonMatchingLexemes.Any(x => x.LexemePattern!.LexemeType.GetName() == $"DialectDirectiveKeyword.{keyword}"), Is.False);
         });
     }
@@ -31,11 +47,17 @@ public class DialectDslKeywordEscapingTests
     [TestCase("meta|pipe", 205)]
     public void EscapedRegexKeywords_ShouldParseAndLower_AsLiteralDirectiveKeywords(string keyword, int sequence)
     {
-        var compiler = CreateCompiler(keyword, sequence);
+        foreach (var lineEnding in new[] { "\n", "\r\n", "\r" })
+        {
+            using var compiler = CreateCompiler(keyword, sequence);
+            var slice = compiler.Compile($"dialect Demo{lineEnding}{keyword} token{lineEnding}");
+            var lineEndingBytes = Convert.ToHexString(Encoding.UTF8.GetBytes(lineEnding));
 
-        var slice = compiler.Compile($"dialect Demo\n{keyword} token\n");
-
-        Assert.That(slice.CapabilityDirectives.Select(x => x.Name), Is.EqualTo(new[] { $"{keyword}:token" }));
+            Assert.That(
+                slice.CapabilityDirectives.Select(x => x.Name),
+                Is.EqualTo(new[] { $"{keyword}:token" }),
+                $"line ending UTF-8 bytes: {lineEndingBytes}");
+        }
     }
 
     [Test]

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/RuntimeComponentTypeLoaderTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/RuntimeComponentTypeLoaderTests.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using System.Runtime.Loader;
 using BasicCore.Contracts;
 using UniversalToolchain.Dialects.Abstractions;
@@ -81,28 +82,14 @@ public class RuntimeComponentTypeLoaderTests
         Directory.CreateDirectory(temporaryDirectory);
         var hostilePath = Path.Combine(temporaryDirectory, "ArithmeticModule.dll");
         File.Copy(configuredPath, hostilePath);
-        var hostileContext = new AssemblyLoadContext("hostile-runtime-preload", isCollectible: true);
 
         try
         {
-            var hostileAssembly = hostileContext.LoadFromAssemblyPath(hostilePath);
-            var locator = new CountingLocator("ArithmeticModule", true, configuredPath);
-            using var strategy = CreateStrategy(locator);
-            var loader = CreateLoader(strategy);
-
-            var type = loader.LoadType(Entry("ArithmeticModule", "frontend.arithmetic"));
-
-            Assert.Multiple(() =>
-            {
-                Assert.That(type.Assembly, Is.Not.SameAs(hostileAssembly));
-                Assert.That(Path.GetFullPath(type.Assembly.Location), Is.EqualTo(Path.GetFullPath(configuredPath)));
-                Assert.That(locator.Calls, Is.EqualTo(1));
-            });
+            AssertConfiguredPathWinsOverHostilePreload(hostilePath, configuredPath);
         }
         finally
         {
-            hostileContext.Unload();
-            Directory.Delete(temporaryDirectory, recursive: true);
+            DeleteDirectoryAfterCollectibleUnload(temporaryDirectory);
         }
     }
 
@@ -127,6 +114,57 @@ public class RuntimeComponentTypeLoaderTests
     {
         var loader = CreateLoader(CreateStrategy(new DefaultRuntimeAssemblyLocator(new RuntimeArtifactLocatorOptions())));
         Assert.Throws<InvalidOperationException>(() => loader.LoadType(Entry("ArithmeticModule", "frontend.missing")));
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void AssertConfiguredPathWinsOverHostilePreload(string hostilePath, string configuredPath)
+    {
+        var hostileContext = new AssemblyLoadContext("hostile-runtime-preload", isCollectible: true);
+        try
+        {
+            var hostileAssembly = hostileContext.LoadFromAssemblyPath(hostilePath);
+            var locator = new CountingLocator("ArithmeticModule", true, configuredPath);
+            using var strategy = CreateStrategy(locator);
+            var loader = CreateLoader(strategy);
+
+            var type = loader.LoadType(Entry("ArithmeticModule", "frontend.arithmetic"));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(type.Assembly, Is.Not.SameAs(hostileAssembly));
+                Assert.That(Path.GetFullPath(type.Assembly.Location), Is.EqualTo(Path.GetFullPath(configuredPath)));
+                Assert.That(locator.Calls, Is.EqualTo(1));
+            });
+        }
+        finally
+        {
+            hostileContext.Unload();
+        }
+    }
+
+    private static void DeleteDirectoryAfterCollectibleUnload(string directory)
+    {
+        for (var attempt = 0; attempt < 80; attempt++)
+        {
+            try
+            {
+                Directory.Delete(directory, recursive: true);
+                return;
+            }
+            catch (UnauthorizedAccessException) when (attempt < 79)
+            {
+            }
+            catch (IOException) when (attempt < 79)
+            {
+            }
+
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+            Thread.Sleep(10);
+        }
+
+        Directory.Delete(directory, recursive: true);
     }
 
     private static RuntimeComponentManifestEntry Entry(string assemblySimpleName, string componentId)

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/RuntimeLoading/RuntimeSharedAssemblyFreshProcessTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/RuntimeLoading/RuntimeSharedAssemblyFreshProcessTests.cs
@@ -32,7 +32,7 @@ public sealed class RuntimeSharedAssemblyFreshProcessTests
         var hostile = ResolveFixtureAssembly("HostileRuntimeFixture", "RuntimeHostileFixture.dll", configuration, platform);
         var receipt = RunFreshProcess("hostile", canonical, hostile);
 
-        Assert.That(receipt, Is.EqualTo("HOSTILE_PRELOAD=PASS" + Environment.NewLine));
+        Assert.That(receipt, Is.EqualTo("HOSTILE_PRELOAD=PASS\n"));
     }
 
     [Test]
@@ -47,7 +47,7 @@ public sealed class RuntimeSharedAssemblyFreshProcessTests
             platform);
         var receipt = RunFreshProcess("unregistered-default-fallback", runtime);
 
-        Assert.That(receipt, Is.EqualTo("UNREGISTERED_DEFAULT_FALLBACK=PASS" + Environment.NewLine));
+        Assert.That(receipt, Is.EqualTo("UNREGISTERED_DEFAULT_FALLBACK=PASS\n"));
     }
 
     private static string RunFreshProcess(params string[] arguments)

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/RuntimeLoading/RuntimeSharedAssemblyResolverTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/RuntimeLoading/RuntimeSharedAssemblyResolverTests.cs
@@ -10,8 +10,6 @@ namespace UniversalToolchain.Dialects.Tests.RuntimeLoading;
 public sealed class RuntimeSharedAssemblyResolverTests
 {
     private static readonly Assembly HostAssembly = typeof(IRuntimeSharedAssemblyResolver).Assembly;
-    private static readonly object CleanupLock = new();
-    private static readonly List<string> DeferredCleanupDirectories = [];
 
     [Test]
     public void Resolve_CompatibleSharedAssembly_ReturnsHostAssembly()
@@ -103,19 +101,7 @@ public sealed class RuntimeSharedAssemblyResolverTests
     public void Descriptor_CustomLoadContextAssembly_IsRejected()
     {
         using var fixture = ConfiguredCopy.Create(HostAssembly);
-        var context = new AssemblyLoadContext("RuntimeSharedAssemblyResolverTests.Custom", isCollectible: true);
-        try
-        {
-            var customAssembly = context.LoadFromAssemblyPath(fixture.Path);
-
-            var ex = Assert.Throws<InvalidOperationException>(() => RuntimeSharedAssemblyDescriptor.Create(customAssembly));
-
-            Assert.That(ex!.Message, Does.Contain("AssemblyLoadContext.Default"));
-        }
-        finally
-        {
-            context.Unload();
-        }
+        AssertCustomContextAssemblyIsRejected(fixture.Path);
     }
 
     [Test]
@@ -154,18 +140,7 @@ public sealed class RuntimeSharedAssemblyResolverTests
     public void Loader_UnregisteredRoot_RemainsInCollectibleIsolatedContext()
     {
         using var fixture = ConfiguredCopy.Create(HostAssembly);
-        using var strategy = new DefaultRuntimeAssemblyLoadStrategy(
-            new SingleAssemblyLocator(HostAssembly.GetName().Name!, fixture.Path),
-            new DefaultRuntimeSharedAssemblyResolver([]));
-
-        var loaded = strategy.LoadAssembly(HostAssembly.GetName().Name!);
-
-        Assert.Multiple(() =>
-        {
-            Assert.That(loaded, Is.Not.SameAs(HostAssembly));
-            Assert.That(AssemblyLoadContext.GetLoadContext(loaded)?.Name, Is.EqualTo("UniversalToolchain.Runtime.Isolated"));
-            Assert.That(AssemblyLoadContext.GetLoadContext(loaded)?.IsCollectible, Is.True);
-        });
+        AssertUnregisteredRootRemainsCollectible(fixture.Path);
     }
 
     [Test]
@@ -186,19 +161,10 @@ public sealed class RuntimeSharedAssemblyResolverTests
     }
 
     [Test]
-    public async Task Loader_ParallelRootLoad_PublishesSingleAssemblyInstance()
+    public void Loader_ParallelRootLoad_PublishesSingleAssemblyInstance()
     {
         using var fixture = ConfiguredCopy.Create(HostAssembly);
-        using var strategy = new DefaultRuntimeAssemblyLoadStrategy(
-            new SingleAssemblyLocator(HostAssembly.GetName().Name!, fixture.Path),
-            new DefaultRuntimeSharedAssemblyResolver([]));
-
-        var tasks = Enumerable.Range(0, 32)
-            .Select(_ => Task.Run(() => strategy.LoadAssembly(HostAssembly.GetName().Name!)))
-            .ToArray();
-        var assemblies = await Task.WhenAll(tasks);
-
-        Assert.That(assemblies.All(assembly => ReferenceEquals(assembly, assemblies[0])), Is.True);
+        AssertParallelRootLoadPublishesSingleInstance(fixture.Path);
     }
 
     [Test]
@@ -230,54 +196,58 @@ public sealed class RuntimeSharedAssemblyResolverTests
         Assert.That(context.IsAlive, Is.False);
     }
 
-    [OneTimeTearDown]
-    public void CleanupDeferredConfiguredCopies()
-    {
-        for (var attempt = 0; attempt < 80; attempt++)
-        {
-            GC.Collect();
-            GC.WaitForPendingFinalizers();
-            GC.Collect();
-
-            string[] pending;
-            lock (CleanupLock)
-                pending = DeferredCleanupDirectories.ToArray();
-
-            foreach (var directory in pending)
-            {
-                try
-                {
-                    Directory.Delete(directory, recursive: true);
-                    lock (CleanupLock)
-                        DeferredCleanupDirectories.Remove(directory);
-                }
-                catch (UnauthorizedAccessException)
-                {
-                }
-                catch (IOException)
-                {
-                }
-            }
-
-            lock (CleanupLock)
-            {
-                if (DeferredCleanupDirectories.Count == 0)
-                    return;
-            }
-
-            Thread.Sleep(10);
-        }
-
-        string remaining;
-        lock (CleanupLock)
-            remaining = string.Join(", ", DeferredCleanupDirectories);
-        Assert.Fail($"Collectible runtime fixture directories remained locked: {remaining}");
-    }
-
     private static DefaultRuntimeSharedAssemblyResolver Resolver(params Assembly[] assemblies) =>
         new(assemblies.Select(RuntimeSharedAssemblyDescriptor.Create));
 
     private static AssemblyName CloneIdentity(AssemblyName source) => new(source.FullName!);
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void AssertCustomContextAssemblyIsRejected(string path)
+    {
+        var context = new AssemblyLoadContext("RuntimeSharedAssemblyResolverTests.Custom", isCollectible: true);
+        try
+        {
+            var customAssembly = context.LoadFromAssemblyPath(path);
+            var ex = Assert.Throws<InvalidOperationException>(() =>
+                RuntimeSharedAssemblyDescriptor.Create(customAssembly));
+            Assert.That(ex!.Message, Does.Contain("AssemblyLoadContext.Default"));
+        }
+        finally
+        {
+            context.Unload();
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void AssertUnregisteredRootRemainsCollectible(string path)
+    {
+        using var strategy = new DefaultRuntimeAssemblyLoadStrategy(
+            new SingleAssemblyLocator(HostAssembly.GetName().Name!, path),
+            new DefaultRuntimeSharedAssemblyResolver([]));
+
+        var loaded = strategy.LoadAssembly(HostAssembly.GetName().Name!);
+        Assert.Multiple(() =>
+        {
+            Assert.That(loaded, Is.Not.SameAs(HostAssembly));
+            Assert.That(AssemblyLoadContext.GetLoadContext(loaded)?.Name, Is.EqualTo("UniversalToolchain.Runtime.Isolated"));
+            Assert.That(AssemblyLoadContext.GetLoadContext(loaded)?.IsCollectible, Is.True);
+        });
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void AssertParallelRootLoadPublishesSingleInstance(string path)
+    {
+        using var strategy = new DefaultRuntimeAssemblyLoadStrategy(
+            new SingleAssemblyLocator(HostAssembly.GetName().Name!, path),
+            new DefaultRuntimeSharedAssemblyResolver([]));
+
+        var tasks = Enumerable.Range(0, 32)
+            .Select(_ => Task.Run(() => strategy.LoadAssembly(HostAssembly.GetName().Name!)))
+            .ToArray();
+        var assemblies = Task.WhenAll(tasks).GetAwaiter().GetResult();
+
+        Assert.That(assemblies.All(assembly => ReferenceEquals(assembly, assemblies[0])), Is.True);
+    }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     private static WeakReference LoadAndDispose(string path)
@@ -293,28 +263,29 @@ public sealed class RuntimeSharedAssemblyResolverTests
         return weak;
     }
 
-    private static void DeleteOrDefer(string directory)
+    private static void DeleteDirectoryAfterCollectibleUnload(string directory)
     {
-        try
+        for (var attempt = 0; attempt < 80; attempt++)
         {
-            Directory.Delete(directory, recursive: true);
-        }
-        catch (UnauthorizedAccessException)
-        {
-            lock (CleanupLock)
+            try
             {
-                if (!DeferredCleanupDirectories.Contains(directory, StringComparer.Ordinal))
-                    DeferredCleanupDirectories.Add(directory);
+                Directory.Delete(directory, recursive: true);
+                return;
             }
-        }
-        catch (IOException)
-        {
-            lock (CleanupLock)
+            catch (UnauthorizedAccessException) when (attempt < 79)
             {
-                if (!DeferredCleanupDirectories.Contains(directory, StringComparer.Ordinal))
-                    DeferredCleanupDirectories.Add(directory);
             }
+            catch (IOException) when (attempt < 79)
+            {
+            }
+
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+            Thread.Sleep(10);
         }
+
+        Directory.Delete(directory, recursive: true);
     }
 
     private sealed class SingleAssemblyLocator(string simpleName, string path) : IRuntimeAssemblyLocator
@@ -353,6 +324,6 @@ public sealed class RuntimeSharedAssemblyResolverTests
             return new ConfiguredCopy(directory, path);
         }
 
-        public void Dispose() => DeleteOrDefer(_directory);
+        public void Dispose() => DeleteDirectoryAfterCollectibleUnload(_directory);
     }
 }

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/RuntimeLoading/RuntimeSharedAssemblyResolverTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/RuntimeLoading/RuntimeSharedAssemblyResolverTests.cs
@@ -10,6 +10,8 @@ namespace UniversalToolchain.Dialects.Tests.RuntimeLoading;
 public sealed class RuntimeSharedAssemblyResolverTests
 {
     private static readonly Assembly HostAssembly = typeof(IRuntimeSharedAssemblyResolver).Assembly;
+    private static readonly object CleanupLock = new();
+    private static readonly List<string> DeferredCleanupDirectories = [];
 
     [Test]
     public void Resolve_CompatibleSharedAssembly_ReturnsHostAssembly()
@@ -228,6 +230,50 @@ public sealed class RuntimeSharedAssemblyResolverTests
         Assert.That(context.IsAlive, Is.False);
     }
 
+    [OneTimeTearDown]
+    public void CleanupDeferredConfiguredCopies()
+    {
+        for (var attempt = 0; attempt < 80; attempt++)
+        {
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+
+            string[] pending;
+            lock (CleanupLock)
+                pending = DeferredCleanupDirectories.ToArray();
+
+            foreach (var directory in pending)
+            {
+                try
+                {
+                    Directory.Delete(directory, recursive: true);
+                    lock (CleanupLock)
+                        DeferredCleanupDirectories.Remove(directory);
+                }
+                catch (UnauthorizedAccessException)
+                {
+                }
+                catch (IOException)
+                {
+                }
+            }
+
+            lock (CleanupLock)
+            {
+                if (DeferredCleanupDirectories.Count == 0)
+                    return;
+            }
+
+            Thread.Sleep(10);
+        }
+
+        string remaining;
+        lock (CleanupLock)
+            remaining = string.Join(", ", DeferredCleanupDirectories);
+        Assert.Fail($"Collectible runtime fixture directories remained locked: {remaining}");
+    }
+
     private static DefaultRuntimeSharedAssemblyResolver Resolver(params Assembly[] assemblies) =>
         new(assemblies.Select(RuntimeSharedAssemblyDescriptor.Create));
 
@@ -245,6 +291,30 @@ public sealed class RuntimeSharedAssemblyResolverTests
         var weak = new WeakReference(context, trackResurrection: false);
         strategy.Dispose();
         return weak;
+    }
+
+    private static void DeleteOrDefer(string directory)
+    {
+        try
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+        catch (UnauthorizedAccessException)
+        {
+            lock (CleanupLock)
+            {
+                if (!DeferredCleanupDirectories.Contains(directory, StringComparer.Ordinal))
+                    DeferredCleanupDirectories.Add(directory);
+            }
+        }
+        catch (IOException)
+        {
+            lock (CleanupLock)
+            {
+                if (!DeferredCleanupDirectories.Contains(directory, StringComparer.Ordinal))
+                    DeferredCleanupDirectories.Add(directory);
+            }
+        }
     }
 
     private sealed class SingleAssemblyLocator(string simpleName, string path) : IRuntimeAssemblyLocator
@@ -283,6 +353,6 @@ public sealed class RuntimeSharedAssemblyResolverTests
             return new ConfiguredCopy(directory, path);
         }
 
-        public void Dispose() => Directory.Delete(_directory, recursive: true);
+        public void Dispose() => DeleteOrDefer(_directory);
     }
 }

--- a/UniversalToolchain/UniversalToolchain.FeatureManifestEmitter/Program.cs
+++ b/UniversalToolchain/UniversalToolchain.FeatureManifestEmitter/Program.cs
@@ -9,13 +9,22 @@ if (args.Length != 2)
 }
 
 var assemblyPath = Path.GetFullPath(args[0]);
+var assemblyDirectory = Path.GetDirectoryName(assemblyPath)
+                        ?? throw new InvalidOperationException($"Assembly path has no directory: '{assemblyPath}'.");
 var outputPath = Path.GetFullPath(args[1]);
 var resolver = new AssemblyDependencyResolver(assemblyPath);
 var context = new AssemblyLoadContext("toolchain-feature-emitter", isCollectible: true);
 context.Resolving += (_, name) =>
 {
-    var path = resolver.ResolveAssemblyToPath(name);
-    return path == null ? null : context.LoadFromAssemblyPath(path);
+    var resolvedPath = resolver.ResolveAssemblyToPath(name);
+    if (resolvedPath != null)
+        return context.LoadFromAssemblyPath(resolvedPath);
+
+    // Library projects do not always emit a component .deps.json. In custom
+    // OutputPath/artifacts layouts their runtime closure is still copied beside
+    // the inspected assembly, so use that directory as the deterministic fallback.
+    var localPath = Path.Combine(assemblyDirectory, $"{name.Name}.dll");
+    return File.Exists(localPath) ? context.LoadFromAssemblyPath(localPath) : null;
 };
 
 try

--- a/UniversalToolchain/UniversalToolchain.FeatureManifestEmitter/UniversalToolchain.FeatureManifestEmitter.csproj
+++ b/UniversalToolchain/UniversalToolchain.FeatureManifestEmitter/UniversalToolchain.FeatureManifestEmitter.csproj
@@ -10,4 +10,7 @@
   <ItemGroup>
     <ProjectReference Include="..\UniversalToolchain.FeatureSdk\UniversalToolchain.FeatureSdk.csproj" />
   </ItemGroup>
+  <Target Name="GetBuiltFeatureManifestEmitterTargetPath"
+          DependsOnTargets="Build"
+          Returns="$(TargetPath)" />
 </Project>

--- a/UniversalToolchain/UniversalToolchain.Wist.LanguagePack/UniversalToolchain.Wist.LanguagePack.csproj
+++ b/UniversalToolchain/UniversalToolchain.Wist.LanguagePack/UniversalToolchain.Wist.LanguagePack.csproj
@@ -30,7 +30,8 @@
     <ProjectReference Include="$(WistProjectPath)" />
   </ItemGroup>
   <Target Name="ResolveLanguagePackBuildProviders"
-          BeforeTargets="ResolveProjectReferences;EmitToolchainFeatureManifest;ExposeWistRuntimeClosureToProjectReferences;CollectWistRuntimeManifests"
+          AfterTargets="ResolveProjectReferences"
+          BeforeTargets="EmitToolchainFeatureManifest;ExposeWistRuntimeClosureToProjectReferences;CollectWistRuntimeManifests"
           Condition="'$(DesignTimeBuild)' != 'true'">
     <MSBuild Projects="$(FeatureManifestEmitterProjectPath)"
              Targets="GetBuiltFeatureManifestEmitterTargetPath"

--- a/UniversalToolchain/UniversalToolchain.Wist.LanguagePack/UniversalToolchain.Wist.LanguagePack.csproj
+++ b/UniversalToolchain/UniversalToolchain.Wist.LanguagePack/UniversalToolchain.Wist.LanguagePack.csproj
@@ -12,11 +12,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);IncludeToolchainFeatureManifest</TargetsForTfmSpecificContentInPackage>
     <FeatureManifestEmitterProjectPath>$(MSBuildThisFileDirectory)..\UniversalToolchain.FeatureManifestEmitter\UniversalToolchain.FeatureManifestEmitter.csproj</FeatureManifestEmitterProjectPath>
-    <FeatureManifestEmitterTargetFramework>net10.0</FeatureManifestEmitterTargetFramework>
-    <FeatureManifestEmitterPlatformSegment Condition="'$(Platform)' != '' and '$(Platform)' != 'AnyCPU'">$(Platform)/</FeatureManifestEmitterPlatformSegment>
-    <FeatureManifestEmitterProjectBinDll>$(MSBuildThisFileDirectory)..\UniversalToolchain.FeatureManifestEmitter\bin\$(FeatureManifestEmitterPlatformSegment)$(Configuration)\$(FeatureManifestEmitterTargetFramework)\UniversalToolchain.FeatureManifestEmitter.dll</FeatureManifestEmitterProjectBinDll>
-    <FeatureManifestEmitterConfiguredOutputDll>$(MSBuildThisFileDirectory)..\UniversalToolchain.FeatureManifestEmitter\$(OutputPath)UniversalToolchain.FeatureManifestEmitter.dll</FeatureManifestEmitterConfiguredOutputDll>
-    <FeatureManifestEmitterTargetDirDll>$(TargetDir)UniversalToolchain.FeatureManifestEmitter.dll</FeatureManifestEmitterTargetDirDll>
+    <WistProjectPath>$(MSBuildThisFileDirectory)..\UniversalToolchain.Wist\UniversalToolchain.Wist.csproj</WistProjectPath>
   </PropertyGroup>
   <ItemGroup>
     <None Include="README.md" Pack="true" PackagePath="/" />
@@ -31,44 +27,49 @@
                       ReferenceOutputAssembly="false"
                       Private="false"
                       PrivateAssets="all" />
-    <ProjectReference Include="..\UniversalToolchain.Wist\UniversalToolchain.Wist.csproj" />
+    <ProjectReference Include="$(WistProjectPath)" />
   </ItemGroup>
-  <Target Name="BuildFeatureManifestEmitterForIsolatedBuild"
-          BeforeTargets="EmitToolchainFeatureManifest"
-          Condition="'$(DesignTimeBuild)' != 'true' and '$(BuildProjectReferences)' == 'false'">
+  <Target Name="ResolveLanguagePackBuildProviders"
+          BeforeTargets="ResolveProjectReferences;EmitToolchainFeatureManifest;ExposeWistRuntimeClosureToProjectReferences;CollectWistRuntimeManifests"
+          Condition="'$(DesignTimeBuild)' != 'true'">
     <MSBuild Projects="$(FeatureManifestEmitterProjectPath)"
-             Targets="Build"
-             Properties="Configuration=$(Configuration)"
-             BuildInParallel="false" />
+             Targets="GetBuiltFeatureManifestEmitterTargetPath"
+             Properties="BuildProjectReferences=true"
+             BuildInParallel="false">
+      <Output TaskParameter="TargetOutputs" ItemName="_FeatureManifestEmitterTargetPath" />
+    </MSBuild>
+    <MSBuild Projects="$(WistProjectPath)"
+             Targets="GetBuiltWistOutputDirectory"
+             Properties="BuildProjectReferences=true"
+             BuildInParallel="false">
+      <Output TaskParameter="TargetOutputs" ItemName="_WistOutputDirectory" />
+    </MSBuild>
+    <PropertyGroup>
+      <FeatureManifestEmitterResolvedDll>@(_FeatureManifestEmitterTargetPath)</FeatureManifestEmitterResolvedDll>
+      <WistRuntimeOutputDirectory>@(_WistOutputDirectory)</WistRuntimeOutputDirectory>
+    </PropertyGroup>
+    <Error Condition="'$(FeatureManifestEmitterResolvedDll)' == '' or !Exists('$(FeatureManifestEmitterResolvedDll)')"
+           Text="Feature manifest emitter target path was not returned or does not exist: '$(FeatureManifestEmitterResolvedDll)'." />
+    <Error Condition="'$(WistRuntimeOutputDirectory)' == '' or !Exists('$(WistRuntimeOutputDirectory)')"
+           Text="Wist output directory was not returned or does not exist: '$(WistRuntimeOutputDirectory)'." />
   </Target>
   <Target Name="EmitToolchainFeatureManifest" AfterTargets="Build" Condition="'$(DesignTimeBuild)' != 'true'">
     <PropertyGroup>
       <ToolchainFeatureManifestPath>$(TargetDir)$(AssemblyName).toolchain.feature.json</ToolchainFeatureManifestPath>
-      <FeatureManifestEmitterResolvedDll></FeatureManifestEmitterResolvedDll>
-      <FeatureManifestEmitterResolvedDll Condition="Exists('$(FeatureManifestEmitterTargetDirDll)')">$(FeatureManifestEmitterTargetDirDll)</FeatureManifestEmitterResolvedDll>
-      <FeatureManifestEmitterResolvedDll Condition="'$(FeatureManifestEmitterResolvedDll)' == '' and Exists('$(FeatureManifestEmitterConfiguredOutputDll)')">$(FeatureManifestEmitterConfiguredOutputDll)</FeatureManifestEmitterResolvedDll>
-      <FeatureManifestEmitterResolvedDll Condition="'$(FeatureManifestEmitterResolvedDll)' == '' and Exists('$(FeatureManifestEmitterProjectBinDll)')">$(FeatureManifestEmitterProjectBinDll)</FeatureManifestEmitterResolvedDll>
     </PropertyGroup>
-    <Error Condition="'$(FeatureManifestEmitterResolvedDll)' == ''"
-           Text="Feature manifest emitter was not found. Checked '$(FeatureManifestEmitterTargetDirDll)', '$(FeatureManifestEmitterConfiguredOutputDll)', and '$(FeatureManifestEmitterProjectBinDll)'." />
     <Exec Command="&quot;$(DOTNET_HOST_PATH)&quot; &quot;$(FeatureManifestEmitterResolvedDll)&quot; &quot;$(TargetPath)&quot; &quot;$(ToolchainFeatureManifestPath)&quot;" />
   </Target>
   <Target Name="ExposeWistRuntimeClosureToProjectReferences" BeforeTargets="_GetCopyToOutputDirectoryItemsFromThisProject">
-    <PropertyGroup>
-      <WistRuntimeOutputDirectory>$(MSBuildThisFileDirectory)..\UniversalToolchain.Wist\$(OutputPath)</WistRuntimeOutputDirectory>
-    </PropertyGroup>
     <ItemGroup>
-      <WistRuntimeFileForCopy Include="$(WistRuntimeOutputDirectory)*.dll;$(WistRuntimeOutputDirectory)*.dialect.runtime.json">
+      <ContentWithTargetPath Include="$(WistRuntimeOutputDirectory)*.dll;$(WistRuntimeOutputDirectory)*.dialect.runtime.json">
+        <TargetPath>%(Filename)%(Extension)</TargetPath>
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      </WistRuntimeFileForCopy>
+      </ContentWithTargetPath>
     </ItemGroup>
-    <AssignTargetPath Files="@(WistRuntimeFileForCopy)" RootFolder="$(WistRuntimeOutputDirectory)">
-      <Output TaskParameter="AssignedFiles" ItemName="ContentWithTargetPath" />
-    </AssignTargetPath>
   </Target>
   <Target Name="CollectWistRuntimeManifests" AfterTargets="Build">
     <ItemGroup>
-      <WistRuntimeManifest Include="$(MSBuildThisFileDirectory)..\UniversalToolchain.Wist\$(OutputPath)*.dialect.runtime.json" />
+      <WistRuntimeManifest Include="$(WistRuntimeOutputDirectory)*.dialect.runtime.json" />
     </ItemGroup>
     <Error Condition="'@(WistRuntimeManifest)' == ''" Text="The Wist runtime manifest closure was not produced before the language pack build." />
     <Copy SourceFiles="@(WistRuntimeManifest)" DestinationFolder="$(TargetDir)" SkipUnchangedFiles="true" />

--- a/UniversalToolchain/UniversalToolchain.Wist.LanguagePack/UniversalToolchain.Wist.LanguagePack.csproj
+++ b/UniversalToolchain/UniversalToolchain.Wist.LanguagePack/UniversalToolchain.Wist.LanguagePack.csproj
@@ -61,11 +61,13 @@
   </Target>
   <Target Name="ExposeWistRuntimeClosureToProjectReferences" BeforeTargets="_GetCopyToOutputDirectoryItemsFromThisProject">
     <ItemGroup>
-      <ContentWithTargetPath Include="$(WistRuntimeOutputDirectory)*.dll;$(WistRuntimeOutputDirectory)*.dialect.runtime.json">
-        <TargetPath>%(Filename)%(Extension)</TargetPath>
+      <WistRuntimeFileForCopy Include="$(WistRuntimeOutputDirectory)*.dll;$(WistRuntimeOutputDirectory)*.dialect.runtime.json">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      </ContentWithTargetPath>
+      </WistRuntimeFileForCopy>
     </ItemGroup>
+    <AssignTargetPath Files="@(WistRuntimeFileForCopy)" RootFolder="$(WistRuntimeOutputDirectory)">
+      <Output TaskParameter="AssignedFiles" ItemName="ContentWithTargetPath" />
+    </AssignTargetPath>
   </Target>
   <Target Name="CollectWistRuntimeManifests" AfterTargets="Build">
     <ItemGroup>

--- a/UniversalToolchain/UniversalToolchain.Wist/UniversalToolchain.Wist.csproj
+++ b/UniversalToolchain/UniversalToolchain.Wist/UniversalToolchain.Wist.csproj
@@ -93,4 +93,8 @@
         </ItemGroup>
     </Target>
 
+    <Target Name="GetBuiltWistOutputDirectory"
+            DependsOnTargets="Build"
+            Returns="$(TargetDir)" />
+
 </Project>


### PR DESCRIPTION
## Problem

The previous topology hardening still derived the feature-manifest emitter and Wist runtime output locations from guessed directory layouts. Standard Release builds passed, but absolute `OutputPath`, `BaseOutputPath`, RID output, disabled TFM segments, and artifacts output could not reliably locate those provider artifacts. The canonical PowerShell entrypoint was only inspected statically and never executed on Windows CI.

Windows execution also exposed three cross-platform defects that Linux-only validation could not detect: checkout-dependent raw-string regex contents, source offsets being changed by lexer-side newline normalization, and temporary assembly files remaining locked until collectible `AssemblyLoadContext` instances were fully unloaded.

## Changed files

### Build topology and CI

- `.github/workflows/dotnet-ci.yml`
- `Tools/check-build-topology.py`
- `Tools/test-build-topology-mutants.py`
- `Tools/test-build-topology-runtime.py`
- `UniversalToolchain/UniversalToolchain.FeatureManifestEmitter/UniversalToolchain.FeatureManifestEmitter.csproj`
- `UniversalToolchain/UniversalToolchain.Wist.LanguagePack/UniversalToolchain.Wist.LanguagePack.csproj`
- `UniversalToolchain/UniversalToolchain.Wist/UniversalToolchain.Wist.csproj`

### Cross-platform source and runtime behavior

- `.gitattributes`
- `UniversalToolchain/BasicCore/LexerWrapper/LexemeValue.cs`
- `UniversalToolchain/BasicLexer/Core/BasicLexerImpl.cs`
- `UniversalToolchain/UniversalToolchain.Dialects.Frontend/DialectDslLexemeRegistry.cs`
- `UniversalToolchain/UniversalToolchain.FeatureManifestEmitter/Program.cs`

### Regression tests and Windows cleanup

- `UniversalToolchain/UniversalToolchain.Dialects.Tests/DialectDslKeywordEscapingTests.cs`
- `UniversalToolchain/UniversalToolchain.Dialects.Tests/RuntimeComponentTypeLoaderTests.cs`
- `UniversalToolchain/UniversalToolchain.Dialects.Tests/RuntimeLoading/RuntimeSharedAssemblyFreshProcessTests.cs`
- `UniversalToolchain/UniversalToolchain.Dialects.Tests/RuntimeLoading/RuntimeSharedAssemblyResolverTests.cs`

## Changes

- expose the emitter's evaluated `$(TargetPath)` through a provider target;
- expose the Wist project's evaluated `$(TargetDir)` through a provider target;
- make LanguagePack consume provider-returned values through MSBuild `TargetOutputs` instead of concatenating guessed output paths;
- preserve relative runtime-closure target paths through `AssignTargetPath`;
- expand runtime topology validation across Platform, absolute `OutputPath`, absolute `BaseOutputPath`, RID, disabled TFM segments, artifacts output, and the default IDE-style `BuildProjectReferences=false` layout;
- preserve the canonical build-server-disabled mode inside nested regression builds;
- strengthen the static checker and reject 16 negative topology/CI mutants;
- execute `build.ps1 -SkipDocs -SkipPack` on `windows-latest`;
- keep repository text deterministic with LF checkout while making the Dialect DSL newline regex explicitly support LF, CRLF, and CR independent of source-file line endings;
- preserve the original lexer input, token text, and `StartIndex` values instead of normalizing the source string;
- calculate line/column coordinates correctly for LF, CRLF, and CR;
- cache compiled regexes through weak `LexemePattern` keys so replaced configurations do not accumulate retained regex entries;
- extend existing parameterized regressions to cover custom `\r\n` patterns, original source spans, coordinates after multiple CRLF pairs, and LF/CRLF/CR parsing without changing the canonical 1,597-test count;
- resolve emitter dependencies from the component resolver first and then from the inspected assembly directory for library outputs without a component `.deps.json`;
- ensure collectible load contexts leave helper scope before Windows fixture directories are deleted;
- normalize fresh-process receipt comparison without weakening the emitted runtime contract.

## Verification

PR head: `e892b87692b2ad63c12eef61dc1d000a3429b7c7`.

Local .NET SDK 10.0.301 proofs:

- explicit LF/CRLF/CR regex matching: PASS;
- original source-offset and line/column preservation: PASS;
- weak regex-cache collection: PASS;
- CRLF boundary coordinates: PASS;
- canonical test count unchanged at 1,597.

Final PR workflow results for this exact head:

- Docs Check — success (`31096910844`);
- Published Wist package smoke — success (`31096910729`);
- Wist Rollout Sample Smoke — success (`31096910733`);
- Benchmark Smoke — success (`31096910854`);
- Package Compatibility Review — success (`31096911083`);
- UniversalToolchain validation — success (`31096910827`);
- .NET CI — success (`31096910945`).

Canonical evidence:

- Linux: `BUILD_TOPOLOGY=PASS`, 16/16 topology mutants rejected, `BUILD_TOPOLOGY_RUNTIME=PASS`, 0 warnings, 0 errors, 1,597/1,597 tests;
- Windows/PowerShell: `BUILD_TOPOLOGY=PASS`, 16/16 topology mutants rejected, `BUILD_TOPOLOGY_RUNTIME=PASS`, 0 warnings, 0 errors, Core 534/534, Modules 292/292, Dialects 638/638, total 1,597/1,597;
- package compatibility, documentation, benchmark, rollout, and published-package smoke gates all passed.

This PR does not publish packages or perform a release.