### PR TITLE
Docs: harden Wist first-contact contracts

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -9,8 +9,11 @@ on:
       - 'UniversalToolchain/UniversalToolchain.Wist/README.md'
       - 'UniversalToolchain/UniversalToolchain.Wist/UniversalToolchain.Wist.csproj'
       - 'eng/documentation-release-state.json'
+      - 'eng/wist-package-surface.json'
       - 'Tools/check_documentation_*.py'
       - 'Tools/test-documentation-*.py'
+      - 'Tools/check-wist-documentation-*.py'
+      - 'Tools/test-wist-documentation-*.py'
       - 'package.json'
       - 'package-lock.json'
       - '.github/workflows/docs-check.yml'
@@ -37,14 +40,25 @@ jobs:
         with:
           node-version: 22
 
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: UniversalToolchain/global.json
+
       - name: Install dependencies
         run: npm ci --no-audit --no-fund
 
       - name: Validate documentation structure, release state and links
         run: npm run docs:status && npm run docs:links
 
+      - name: Compile first-contact Wist documentation snippets
+        run: npm run docs:first-contact
+
       - name: Reject documentation release-state mutants
         run: python3 Tools/test-documentation-release-state-mutants.py --root .
+
+      - name: Reject Wist first-contact documentation mutants
+        run: python3 Tools/test-wist-documentation-first-contact-mutants.py --root .
 
       - name: Build documentation
         run: npm run docs:build

--- a/Tools/check-wist-documentation-first-contact.py
+++ b/Tools/check-wist-documentation-first-contact.py
@@ -8,6 +8,7 @@ import re
 import shutil
 import subprocess
 import tempfile
+import xml.etree.ElementTree as ET
 from pathlib import Path
 from xml.sax.saxutils import escape
 
@@ -18,13 +19,26 @@ CSHARP_FENCE = re.compile(r"```csharp[^\n]*\n(.*?)\n```", re.DOTALL)
 LOCAL_ARTIFACT_FEED = re.compile(r"(?:--source\s+)?\.?/?artifacts/packages", re.IGNORECASE)
 VALIDATION_MESSAGE_ACCESS = re.compile(r"\b(?:validation|rejected)\.Message\b")
 RUNTIME_ASSEMBLY_COUNT = re.compile(
-    r"\b(?:The\s+)?(?P<count>\d+)\s+assemblies\s+under\s+`lib/net10\.0`",
+    r"\b(?:the\s+)?\d+\s+(?:runtime\s+)?assemblies\s+under\s+`lib/net10\.0`",
     re.IGNORECASE,
 )
 
 
 class FirstContactError(ValueError):
     pass
+
+
+def local_name(tag: str) -> str:
+    return tag.rsplit("}", 1)[-1]
+
+
+def child_text(root: ET.Element, name: str) -> str | None:
+    for element in root.iter():
+        if local_name(element.tag) == name:
+            value = (element.text or "").strip()
+            if value:
+                return value
+    return None
 
 
 def require_string(data: dict[str, object], key: str) -> str:
@@ -61,7 +75,35 @@ def marked_block(text: str, begin: str, end: str, document: Path) -> str:
     return text.split(begin, 1)[1].split(end, 1)[0]
 
 
-def validate_package_readmes(root: Path, state: dict[str, object]) -> list[Path]:
+def validate_package_project(
+    root: Path,
+    state: dict[str, object],
+    package_readmes: list[str],
+) -> Path:
+    project = root / require_string(state, "project")
+    if not project.is_file():
+        raise FirstContactError(f"Wist package project does not exist: {project.relative_to(root)}")
+    try:
+        project_root = ET.parse(project).getroot()
+    except ET.ParseError as exc:
+        raise FirstContactError(f"invalid Wist package project XML: {exc}") from exc
+
+    package_readme_file = child_text(project_root, "PackageReadmeFile")
+    if not package_readme_file:
+        raise FirstContactError(f"{project.relative_to(root)}: PackageReadmeFile is missing")
+    resolved = (project.parent / package_readme_file).resolve()
+    declared = {(root / relative).resolve() for relative in package_readmes}
+    if resolved not in declared:
+        raise FirstContactError(
+            f"{project.relative_to(root)}: packed README {resolved.relative_to(root)} "
+            "is not listed in packageReadmeDocuments"
+        )
+    if not resolved.is_file():
+        raise FirstContactError(f"packed README does not exist: {resolved.relative_to(root)}")
+    return project
+
+
+def validate_package_readmes(root: Path, state: dict[str, object]) -> tuple[list[Path], Path]:
     package_id = require_string(state, "packageId")
     source_version = require_string(state, "sourceVersion")
     package_readmes = require_string_list(state, "packageReadmeDocuments")
@@ -74,12 +116,14 @@ def validate_package_readmes(root: Path, state: dict[str, object]) -> list[Path]
             + ", ".join(missing_from_source_contract)
         )
 
-    paths: list[Path] = []
+    project = validate_package_project(root, state, package_readmes)
     install = re.compile(
         rf"dotnet\s+add\s+package\s+{re.escape(package_id)}\b"
         rf"(?:(?!dotnet\s+add\s+package).)*?--version\s+{re.escape(source_version)}\b",
         re.DOTALL,
     )
+
+    paths: list[Path] = []
     for relative in package_readmes:
         document = root / relative
         if not document.is_file():
@@ -99,24 +143,29 @@ def validate_package_readmes(root: Path, state: dict[str, object]) -> list[Path]
             )
         if not install.search(text):
             raise FirstContactError(
-                f"{relative}: package-facing install command does not pin {package_id} {source_version}"
+                f"{relative}: package-facing install command does not pin "
+                f"{package_id} {source_version}"
             )
         if LOCAL_ARTIFACT_FEED.search(text):
             raise FirstContactError(
                 f"{relative}: package README must not assume a repository-local artifacts/packages feed"
             )
         paths.append(document)
-    return paths
+    return paths, project
 
 
 def validate_first_contact_text(root: Path, package_readmes: list[Path]) -> None:
     documents = [root / "readme.md", *package_readmes]
-    surface_path = root / "eng/wist-package-surface.json"
+    surface = root / "eng/wist-package-surface.json"
+    if not surface.is_file():
+        raise FirstContactError("eng/wist-package-surface.json does not exist")
     try:
-        surface = json.loads(surface_path.read_text(encoding="utf-8"))
-        expected_runtime_count = len(surface["runtimeAssemblies"])
-    except (OSError, json.JSONDecodeError, KeyError, TypeError) as exc:
-        raise FirstContactError(f"cannot read runtime package surface: {exc}") from exc
+        surface_data = json.loads(surface.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise FirstContactError(f"invalid Wist package surface JSON: {exc}") from exc
+    runtime_assemblies = surface_data.get("runtimeAssemblies")
+    if not isinstance(runtime_assemblies, list) or not runtime_assemblies:
+        raise FirstContactError("Wist package surface has no runtimeAssemblies contract")
 
     for document in documents:
         text = document.read_text(encoding="utf-8")
@@ -126,13 +175,11 @@ def validate_first_contact_text(root: Path, package_readmes: list[Path]) -> None
                 f"{document.relative_to(root)}: validation result has no aggregate Message property: "
                 f"{bad_member.group(0)}"
             )
-        for match in RUNTIME_ASSEMBLY_COUNT.finditer(text):
-            actual = int(match.group("count"))
-            if actual != expected_runtime_count:
-                raise FirstContactError(
-                    f"{document.relative_to(root)}: stale runtime assembly count {actual}; "
-                    f"expected {expected_runtime_count} from eng/wist-package-surface.json"
-                )
+        if RUNTIME_ASSEMBLY_COUNT.search(text):
+            raise FirstContactError(
+                f"{document.relative_to(root)}: do not hard-code the runtime assembly count; "
+                "eng/wist-package-surface.json owns the exact closure"
+            )
 
 
 def extract_snippets(root: Path, state: dict[str, object]) -> list[tuple[str, str]]:
@@ -140,6 +187,7 @@ def extract_snippets(root: Path, state: dict[str, object]) -> list[tuple[str, st
     if not isinstance(raw_specs, list) or not raw_specs:
         raise FirstContactError("firstContactCsharpSnippets must be a non-empty list")
 
+    seen: set[tuple[str, str]] = set()
     snippets: list[tuple[str, str]] = []
     for index, raw in enumerate(raw_specs):
         if not isinstance(raw, dict):
@@ -150,18 +198,23 @@ def extract_snippets(root: Path, state: dict[str, object]) -> list[tuple[str, st
             raise FirstContactError(f"snippet specification {index} has no document")
         if not isinstance(marker, str) or not marker.strip():
             raise FirstContactError(f"snippet specification {index} has no marker")
-        document = root / relative
+        key = (relative.strip(), marker.strip())
+        if key in seen:
+            raise FirstContactError(f"duplicate first-contact snippet specification: {key}")
+        seen.add(key)
+
+        document = root / key[0]
         if not document.is_file():
-            raise FirstContactError(f"snippet document does not exist: {relative}")
-        begin = f"<!-- {marker}:begin -->"
-        end = f"<!-- {marker}:end -->"
+            raise FirstContactError(f"snippet document does not exist: {key[0]}")
+        begin = f"<!-- {key[1]}:begin -->"
+        end = f"<!-- {key[1]}:end -->"
         block = marked_block(document.read_text(encoding="utf-8"), begin, end, document)
         matches = CSHARP_FENCE.findall(block)
         if len(matches) != 1:
             raise FirstContactError(
-                f"{relative}: marker {marker!r} must contain exactly one C# fence"
+                f"{key[0]}: marker {key[1]!r} must contain exactly one C# fence"
             )
-        snippets.append((f"{relative}:{marker}", matches[0].strip() + "\n"))
+        snippets.append((f"{key[0]}:{key[1]}", matches[0].strip() + "\n"))
     return snippets
 
 
@@ -184,13 +237,10 @@ def split_usings(code: str) -> tuple[list[str], str]:
 
 def compile_snippets(
     root: Path,
-    state: dict[str, object],
+    project: Path,
     snippets: list[tuple[str, str]],
     dotnet: str,
 ) -> None:
-    project = (root / require_string(state, "project")).resolve()
-    if not project.is_file():
-        raise FirstContactError(f"Wist project does not exist: {project}")
     executable = shutil.which(dotnet)
     if executable is None:
         raise FirstContactError(f"dotnet executable not found: {dotnet}")
@@ -202,12 +252,12 @@ def compile_snippets(
             "<Project Sdk=\"Microsoft.NET.Sdk\">\n"
             "  <PropertyGroup>\n"
             "    <TargetFramework>net10.0</TargetFramework>\n"
-            "    <ImplicitUsings>enable</ImplicitUsings>\n"
+            "    <ImplicitUsings>disable</ImplicitUsings>\n"
             "    <Nullable>enable</Nullable>\n"
             "    <LangVersion>14</LangVersion>\n"
             "  </PropertyGroup>\n"
             "  <ItemGroup>\n"
-            f"    <ProjectReference Include=\"{escape(str(project))}\" />\n"
+            f"    <ProjectReference Include=\"{escape(str(project.resolve()))}\" />\n"
             "  </ItemGroup>\n"
             "</Project>\n",
             encoding="utf-8",
@@ -236,8 +286,10 @@ def compile_snippets(
         env = os.environ.copy()
         env.update(
             {
+                "DOTNET_CLI_HOME": str(temp / "dotnet-home"),
                 "DOTNET_CLI_TELEMETRY_OPTOUT": "1",
                 "DOTNET_NOLOGO": "1",
+                "DOTNET_SKIP_FIRST_TIME_EXPERIENCE": "1",
                 "NuGetAudit": "false",
             }
         )
@@ -268,11 +320,11 @@ def compile_snippets(
 
 def validate(root: Path, state_path: Path, *, skip_compile: bool, dotnet: str) -> dict[str, int]:
     state = load_state(state_path)
-    package_readmes = validate_package_readmes(root, state)
+    package_readmes, project = validate_package_readmes(root, state)
     validate_first_contact_text(root, package_readmes)
     snippets = extract_snippets(root, state)
     if not skip_compile:
-        compile_snippets(root, state, snippets, dotnet)
+        compile_snippets(root, project, snippets, dotnet)
     return {"packageReadmes": len(package_readmes), "snippets": len(snippets)}
 
 
@@ -294,10 +346,10 @@ def main() -> int:
         print(f"wist-documentation-first-contact: ERROR: {exc}", file=os.sys.stderr)
         return 1
 
-    suffix = "static-only" if args.skip_compile else "compiled"
+    mode = "static-only" if args.skip_compile else "compiled"
     print(
         "wist-documentation-first-contact: PASS "
-        f"package-readmes={result['packageReadmes']} snippets={result['snippets']} mode={suffix}"
+        f"package-readmes={result['packageReadmes']} snippets={result['snippets']} mode={mode}"
     )
     return 0
 

--- a/Tools/check-wist-documentation-first-contact.py
+++ b/Tools/check-wist-documentation-first-contact.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from xml.sax.saxutils import escape
+
+DEFAULT_STATE = Path("eng/documentation-release-state.json")
+SOURCE_MARKER_BEGIN = "<!-- wist-source-candidate:begin -->"
+SOURCE_MARKER_END = "<!-- wist-source-candidate:end -->"
+CSHARP_FENCE = re.compile(r"```csharp[^\n]*\n(.*?)\n```", re.DOTALL)
+LOCAL_ARTIFACT_FEED = re.compile(r"(?:--source\s+)?\.?/?artifacts/packages", re.IGNORECASE)
+VALIDATION_MESSAGE_ACCESS = re.compile(r"\b(?:validation|rejected)\.Message\b")
+RUNTIME_ASSEMBLY_COUNT = re.compile(
+    r"\b(?:The\s+)?(?P<count>\d+)\s+assemblies\s+under\s+`lib/net10\.0`",
+    re.IGNORECASE,
+)
+
+
+class FirstContactError(ValueError):
+    pass
+
+
+def require_string(data: dict[str, object], key: str) -> str:
+    value = data.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise FirstContactError(f"release state field {key!r} must be a non-empty string")
+    return value.strip()
+
+
+def require_string_list(data: dict[str, object], key: str) -> list[str]:
+    value = data.get(key)
+    if not isinstance(value, list) or not value or not all(
+        isinstance(item, str) and item.strip() for item in value
+    ):
+        raise FirstContactError(f"release state field {key!r} must be a non-empty string list")
+    return [item.strip() for item in value]
+
+
+def load_state(path: Path) -> dict[str, object]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise FirstContactError(f"cannot read release state {path}: {exc}") from exc
+    if not isinstance(data, dict) or data.get("schemaVersion") != 1:
+        raise FirstContactError("unsupported documentation release-state schema")
+    return data
+
+
+def marked_block(text: str, begin: str, end: str, document: Path) -> str:
+    if text.count(begin) != 1 or text.count(end) != 1:
+        raise FirstContactError(
+            f"{document}: expected exactly one marker pair {begin!r} / {end!r}"
+        )
+    return text.split(begin, 1)[1].split(end, 1)[0]
+
+
+def validate_package_readmes(root: Path, state: dict[str, object]) -> list[Path]:
+    package_id = require_string(state, "packageId")
+    source_version = require_string(state, "sourceVersion")
+    package_readmes = require_string_list(state, "packageReadmeDocuments")
+    source_documents = set(require_string_list(state, "sourceCandidateDocuments"))
+
+    missing_from_source_contract = sorted(set(package_readmes) - source_documents)
+    if missing_from_source_contract:
+        raise FirstContactError(
+            "package README documents are not release-state source candidates: "
+            + ", ".join(missing_from_source_contract)
+        )
+
+    paths: list[Path] = []
+    install = re.compile(
+        rf"dotnet\s+add\s+package\s+{re.escape(package_id)}\b"
+        rf"(?:(?!dotnet\s+add\s+package).)*?--version\s+{re.escape(source_version)}\b",
+        re.DOTALL,
+    )
+    for relative in package_readmes:
+        document = root / relative
+        if not document.is_file():
+            raise FirstContactError(f"package README does not exist: {relative}")
+        text = document.read_text(encoding="utf-8")
+        candidate = marked_block(text, SOURCE_MARKER_BEGIN, SOURCE_MARKER_END, document)
+        if source_version not in candidate:
+            raise FirstContactError(
+                f"{relative}: source-candidate block does not identify {source_version}"
+            )
+        if not any(
+            phrase in candidate.lower()
+            for phrase in ("not published", "unpublished", "not on nuget.org")
+        ):
+            raise FirstContactError(
+                f"{relative}: source candidate is not explicitly labeled unpublished"
+            )
+        if not install.search(text):
+            raise FirstContactError(
+                f"{relative}: package-facing install command does not pin {package_id} {source_version}"
+            )
+        if LOCAL_ARTIFACT_FEED.search(text):
+            raise FirstContactError(
+                f"{relative}: package README must not assume a repository-local artifacts/packages feed"
+            )
+        paths.append(document)
+    return paths
+
+
+def validate_first_contact_text(root: Path, package_readmes: list[Path]) -> None:
+    documents = [root / "readme.md", *package_readmes]
+    surface_path = root / "eng/wist-package-surface.json"
+    try:
+        surface = json.loads(surface_path.read_text(encoding="utf-8"))
+        expected_runtime_count = len(surface["runtimeAssemblies"])
+    except (OSError, json.JSONDecodeError, KeyError, TypeError) as exc:
+        raise FirstContactError(f"cannot read runtime package surface: {exc}") from exc
+
+    for document in documents:
+        text = document.read_text(encoding="utf-8")
+        bad_member = VALIDATION_MESSAGE_ACCESS.search(text)
+        if bad_member:
+            raise FirstContactError(
+                f"{document.relative_to(root)}: validation result has no aggregate Message property: "
+                f"{bad_member.group(0)}"
+            )
+        for match in RUNTIME_ASSEMBLY_COUNT.finditer(text):
+            actual = int(match.group("count"))
+            if actual != expected_runtime_count:
+                raise FirstContactError(
+                    f"{document.relative_to(root)}: stale runtime assembly count {actual}; "
+                    f"expected {expected_runtime_count} from eng/wist-package-surface.json"
+                )
+
+
+def extract_snippets(root: Path, state: dict[str, object]) -> list[tuple[str, str]]:
+    raw_specs = state.get("firstContactCsharpSnippets")
+    if not isinstance(raw_specs, list) or not raw_specs:
+        raise FirstContactError("firstContactCsharpSnippets must be a non-empty list")
+
+    snippets: list[tuple[str, str]] = []
+    for index, raw in enumerate(raw_specs):
+        if not isinstance(raw, dict):
+            raise FirstContactError(f"snippet specification {index} must be an object")
+        relative = raw.get("document")
+        marker = raw.get("marker")
+        if not isinstance(relative, str) or not relative.strip():
+            raise FirstContactError(f"snippet specification {index} has no document")
+        if not isinstance(marker, str) or not marker.strip():
+            raise FirstContactError(f"snippet specification {index} has no marker")
+        document = root / relative
+        if not document.is_file():
+            raise FirstContactError(f"snippet document does not exist: {relative}")
+        begin = f"<!-- {marker}:begin -->"
+        end = f"<!-- {marker}:end -->"
+        block = marked_block(document.read_text(encoding="utf-8"), begin, end, document)
+        matches = CSHARP_FENCE.findall(block)
+        if len(matches) != 1:
+            raise FirstContactError(
+                f"{relative}: marker {marker!r} must contain exactly one C# fence"
+            )
+        snippets.append((f"{relative}:{marker}", matches[0].strip() + "\n"))
+    return snippets
+
+
+def split_usings(code: str) -> tuple[list[str], str]:
+    lines = code.splitlines()
+    usings: list[str] = []
+    body_start = 0
+    for index, line in enumerate(lines):
+        stripped = line.strip()
+        if not stripped:
+            body_start = index + 1
+            continue
+        if stripped.startswith("using ") and stripped.endswith(";") and "=" not in stripped:
+            usings.append(stripped)
+            body_start = index + 1
+            continue
+        break
+    return usings, "\n".join(lines[body_start:]).strip()
+
+
+def compile_snippets(
+    root: Path,
+    state: dict[str, object],
+    snippets: list[tuple[str, str]],
+    dotnet: str,
+) -> None:
+    project = (root / require_string(state, "project")).resolve()
+    if not project.is_file():
+        raise FirstContactError(f"Wist project does not exist: {project}")
+    executable = shutil.which(dotnet)
+    if executable is None:
+        raise FirstContactError(f"dotnet executable not found: {dotnet}")
+
+    with tempfile.TemporaryDirectory(prefix="wist-doc-snippets-") as temp_name:
+        temp = Path(temp_name)
+        csproj = temp / "DocumentationSnippets.csproj"
+        csproj.write_text(
+            "<Project Sdk=\"Microsoft.NET.Sdk\">\n"
+            "  <PropertyGroup>\n"
+            "    <TargetFramework>net10.0</TargetFramework>\n"
+            "    <ImplicitUsings>enable</ImplicitUsings>\n"
+            "    <Nullable>enable</Nullable>\n"
+            "    <LangVersion>14</LangVersion>\n"
+            "  </PropertyGroup>\n"
+            "  <ItemGroup>\n"
+            f"    <ProjectReference Include=\"{escape(str(project))}\" />\n"
+            "  </ItemGroup>\n"
+            "</Project>\n",
+            encoding="utf-8",
+        )
+
+        for index, (label, code) in enumerate(snippets):
+            usings, body = split_usings(code)
+            if not body:
+                raise FirstContactError(f"{label}: C# snippet has no executable body")
+            indented = "\n".join("        " + line if line else "" for line in body.splitlines())
+            source = "\n".join(usings)
+            if source:
+                source += "\n\n"
+            source += (
+                "namespace WistDocumentationSnippets;\n\n"
+                f"internal static class Snippet{index}\n"
+                "{\n"
+                "    internal static void CompileOnly()\n"
+                "    {\n"
+                f"{indented}\n"
+                "    }\n"
+                "}\n"
+            )
+            (temp / f"Snippet{index}.cs").write_text(source, encoding="utf-8")
+
+        env = os.environ.copy()
+        env.update(
+            {
+                "DOTNET_CLI_TELEMETRY_OPTOUT": "1",
+                "DOTNET_NOLOGO": "1",
+                "NuGetAudit": "false",
+            }
+        )
+        completed = subprocess.run(
+            [
+                executable,
+                "build",
+                str(csproj),
+                "-c",
+                "Release",
+                "--nologo",
+                "-v:minimal",
+                "-p:NuGetAudit=false",
+            ],
+            cwd=root,
+            env=env,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            check=False,
+        )
+        if completed.returncode != 0:
+            labels = ", ".join(label for label, _ in snippets)
+            raise FirstContactError(
+                f"first-contact C# snippets failed to compile ({labels}):\n{completed.stdout}"
+            )
+
+
+def validate(root: Path, state_path: Path, *, skip_compile: bool, dotnet: str) -> dict[str, int]:
+    state = load_state(state_path)
+    package_readmes = validate_package_readmes(root, state)
+    validate_first_contact_text(root, package_readmes)
+    snippets = extract_snippets(root, state)
+    if not skip_compile:
+        compile_snippets(root, state, snippets, dotnet)
+    return {"packageReadmes": len(package_readmes), "snippets": len(snippets)}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate Wist package README and compile first-contact documentation snippets."
+    )
+    parser.add_argument("--root", type=Path, default=Path(__file__).resolve().parents[1])
+    parser.add_argument("--state", type=Path, default=DEFAULT_STATE)
+    parser.add_argument("--skip-compile", action="store_true")
+    parser.add_argument("--dotnet", default=os.environ.get("DOTNET", "dotnet"))
+    args = parser.parse_args()
+
+    root = args.root.resolve()
+    state_path = args.state.resolve() if args.state.is_absolute() else (root / args.state).resolve()
+    try:
+        result = validate(root, state_path, skip_compile=args.skip_compile, dotnet=args.dotnet)
+    except (OSError, FirstContactError) as exc:
+        print(f"wist-documentation-first-contact: ERROR: {exc}", file=os.sys.stderr)
+        return 1
+
+    suffix = "static-only" if args.skip_compile else "compiled"
+    print(
+        "wist-documentation-first-contact: PASS "
+        f"package-readmes={result['packageReadmes']} snippets={result['snippets']} mode={suffix}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Tools/check-wist-documentation-first-contact.py
+++ b/Tools/check-wist-documentation-first-contact.py
@@ -106,6 +106,7 @@ def validate_package_project(
 def validate_package_readmes(root: Path, state: dict[str, object]) -> tuple[list[Path], Path]:
     package_id = require_string(state, "packageId")
     source_version = require_string(state, "sourceVersion")
+    published_version = require_string(state, "publishedVersion")
     package_readmes = require_string_list(state, "packageReadmeDocuments")
     source_documents = set(require_string_list(state, "sourceCandidateDocuments"))
 
@@ -134,12 +135,18 @@ def validate_package_readmes(root: Path, state: dict[str, object]) -> tuple[list
             raise FirstContactError(
                 f"{relative}: source-candidate block does not identify {source_version}"
             )
-        if not any(
-            phrase in candidate.lower()
+        candidate_lower = candidate.lower()
+        says_unpublished = any(
+            phrase in candidate_lower
             for phrase in ("not published", "unpublished", "not on nuget.org")
-        ):
+        )
+        if source_version != published_version and not says_unpublished:
             raise FirstContactError(
-                f"{relative}: source candidate is not explicitly labeled unpublished"
+                f"{relative}: unpublished source candidate is not explicitly labeled unpublished"
+            )
+        if source_version == published_version and says_unpublished:
+            raise FirstContactError(
+                f"{relative}: published version {source_version} is still labeled unpublished"
             )
         if not install.search(text):
             raise FirstContactError(

--- a/Tools/test-wist-documentation-first-contact-mutants.py
+++ b/Tools/test-wist-documentation-first-contact-mutants.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+EXCLUDED = shutil.ignore_patterns(
+    ".git", "artifacts", "bin", "obj", "node_modules", "packages", ".cache"
+)
+
+
+def run(checker: Path, root: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["python3", str(checker), "--root", str(root), "--skip-compile"],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+    )
+
+
+def require_killed(source_root: Path, name: str, mutate) -> None:
+    with tempfile.TemporaryDirectory(prefix=f"wist-doc-first-contact-{name}-") as temp_name:
+        mutant_root = Path(temp_name) / "repo"
+        shutil.copytree(source_root, mutant_root, ignore=EXCLUDED)
+        mutate(mutant_root)
+        completed = run(
+            mutant_root / "Tools/check-wist-documentation-first-contact.py",
+            mutant_root,
+        )
+        if completed.returncode == 0:
+            raise RuntimeError(f"{name} mutant survived:\n{completed.stdout}")
+        print(f"SURVIVOR=0 mutant={name}")
+
+
+def replace(path: Path, old: str, new: str) -> None:
+    text = path.read_text(encoding="utf-8")
+    if old not in text:
+        raise RuntimeError(f"mutation precondition missing in {path}: {old}")
+    path.write_text(text.replace(old, new, 1), encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path(__file__).resolve().parents[1])
+    args = parser.parse_args()
+    root = args.root.resolve()
+    checker = root / "Tools/check-wist-documentation-first-contact.py"
+    state_path = root / "eng/documentation-release-state.json"
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    source_version = state["sourceVersion"]
+    package_readme = root / state["packageReadmeDocuments"][0]
+
+    positive = run(checker, root)
+    if positive.returncode != 0:
+        raise RuntimeError("positive first-contact check failed:\n" + positive.stdout)
+    print("positive-control=1 wist-documentation-first-contact")
+
+    require_killed(
+        root,
+        "invalid-validation-result-member",
+        lambda mutant: replace(
+            mutant / "readme.md",
+            "validation.Diagnostics.Select(diagnostic => diagnostic.Message)",
+            "validation.Message",
+        ),
+    )
+    require_killed(
+        root,
+        "repository-local-package-feed",
+        lambda mutant: replace(
+            mutant / package_readme.relative_to(root),
+            f"dotnet add package UniversalToolchain.Wist --version {source_version}",
+            (
+                f"dotnet add package UniversalToolchain.Wist --version {source_version} "
+                "--source ./artifacts/packages"
+            ),
+        ),
+    )
+
+    def omit_package_readme(mutant: Path) -> None:
+        mutant_state_path = mutant / "eng/documentation-release-state.json"
+        mutant_state = json.loads(mutant_state_path.read_text(encoding="utf-8"))
+        package_path = mutant_state["packageReadmeDocuments"][0]
+        mutant_state["sourceCandidateDocuments"].remove(package_path)
+        mutant_state_path.write_text(json.dumps(mutant_state, indent=2) + "\n", encoding="utf-8")
+
+    require_killed(root, "package-readme-unregistered", omit_package_readme)
+    require_killed(
+        root,
+        "stale-runtime-assembly-count",
+        lambda mutant: replace(
+            mutant / package_readme.relative_to(root),
+            "Assemblies under `lib/net10.0` form the runtime implementation closure",
+            "The 64 assemblies under `lib/net10.0` form the runtime implementation closure",
+        ),
+    )
+    require_killed(
+        root,
+        "missing-quickstart-marker",
+        lambda mutant: replace(
+            mutant / "readme.md",
+            "<!-- wist-source-quickstart-csharp:begin -->",
+            "<!-- removed-wist-source-quickstart-csharp:begin -->",
+        ),
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Tools/test-wist-documentation-first-contact-mutants.py
+++ b/Tools/test-wist-documentation-first-contact-mutants.py
@@ -90,6 +90,14 @@ def main() -> int:
         mutant_state_path.write_text(json.dumps(mutant_state, indent=2) + "\n", encoding="utf-8")
 
     require_killed(root, "package-readme-unregistered", omit_package_readme)
+
+    def publish_without_updating_readme(mutant: Path) -> None:
+        mutant_state_path = mutant / "eng/documentation-release-state.json"
+        mutant_state = json.loads(mutant_state_path.read_text(encoding="utf-8"))
+        mutant_state["publishedVersion"] = mutant_state["sourceVersion"]
+        mutant_state_path.write_text(json.dumps(mutant_state, indent=2) + "\n", encoding="utf-8")
+
+    require_killed(root, "stale-unpublished-package-claim", publish_without_updating_readme)
     require_killed(
         root,
         "stale-runtime-assembly-count",

--- a/UniversalToolchain/UniversalToolchain.Wist/README.md
+++ b/UniversalToolchain/UniversalToolchain.Wist/README.md
@@ -20,21 +20,24 @@ admin / config / LLM suggestion
 
 ## Install
 
-This source tree builds the verified `UniversalToolchain.Wist` `0.1.0-alpha.6` release artifact. This statement does not imply that the package has already been published to NuGet.org.
+<!-- wist-source-candidate:begin -->
+This source tree defines `UniversalToolchain.Wist` `0.1.0-alpha.6`. This candidate is **not published on NuGet.org**. The package-facing command below applies only after that exact version is available on a reviewed NuGet feed; it is not a claim that NuGet.org already serves the candidate.
+<!-- wist-source-candidate:end -->
 
 ```bash ci-run=false
-dotnet add package UniversalToolchain.Wist --version 0.1.0-alpha.6 --source ./artifacts/packages
+dotnet add package UniversalToolchain.Wist --version 0.1.0-alpha.6
 ```
 
-For a clean-room install and execution check, follow the [package installation guide](https://misha1302.github.io/Wist2/start/installation).
+For the version currently published on NuGet.org, source-build evaluation and clean-room checks, follow the [package installation guide](https://misha1302.github.io/Wist2/start/installation). Do not assume a repository-local `./artifacts/packages` directory exists in an external consumer project.
 
 Requirements:
 
 - target framework: `net10.0`;
-- .NET SDK `10.0.103` or a compatible prerelease SDK accepted by the repository `global.json`.
+- .NET SDK `10.0.103` or a compatible SDK accepted by the repository `global.json`.
 
 ## 30-second example
 
+<!-- wist-package-quickstart-csharp:begin -->
 ```csharp
 using UniversalToolchain.Wist;
 
@@ -49,6 +52,7 @@ var rolloutScore = rules.Compile<Func<double, double, double, double>>(
 double score = rolloutScore.CompiledDelegate(100.0, 90.0, 1.0);
 bool enableNewDashboard = score >= 80.0;
 ```
+<!-- wist-package-quickstart-csharp:end -->
 
 The formula returns data. The host application performs the action.
 
@@ -165,7 +169,6 @@ using var trustedInterop = WistEngine.Create(new WistEngineOptions
     DialectSource = WistDialectSource.FromShippedPreset("full-default-native"),
     AllowedAssemblies = [typeof(Math).Assembly]
 });
-
 ```
 
 `CreateRestrictedArithmetic` is the recommended first-contact preset for restricted formulas.
@@ -193,4 +196,6 @@ The larger direction is controlled application DSLs for .NET. The current alpha 
 
 CLR interop and type directives resolve only against the shipped `BasicStdLib` assembly plus the immutable host allowlist in `WistEngineOptions.AllowedAssemblies`; dialect implementation assemblies, the AppDomain, and the output directory are not discovery sources.
 
-Only the facade reference assembly under `ref/net10.0/UniversalToolchain.Wist.dll` is the supported compile-time API boundary. Its reviewed exported surface is recorded in `PublicAPI.Shipped.txt` in the source repository. The 64 assemblies under `lib/net10.0` form the runtime closure; all except the facade are implementation dependencies and are not compatibility promises.
+Only the facade reference assembly under `ref/net10.0/UniversalToolchain.Wist.dll` is the supported compile-time API boundary. Its reviewed exported surface is recorded in `PublicAPI.Shipped.txt` in the source repository. Assemblies under `lib/net10.0` form the runtime implementation closure; all except the facade are implementation dependencies and are not compatibility promises.
+
+See the [Wist facade API reference](https://misha1302.github.io/Wist2/reference/wist-facade-api) for the supported entry points, result types and ownership rules.

--- a/UniversalToolchain/UniversalToolchain.Wist/README.md
+++ b/UniversalToolchain/UniversalToolchain.Wist/README.md
@@ -28,7 +28,7 @@ This source tree defines `UniversalToolchain.Wist` `0.1.0-alpha.6`. This candida
 dotnet add package UniversalToolchain.Wist --version 0.1.0-alpha.6
 ```
 
-For the version currently published on NuGet.org, source-build evaluation and clean-room checks, follow the [package installation guide](https://misha1302.github.io/Wist2/start/installation). Do not assume a repository-local `./artifacts/packages` directory exists in an external consumer project.
+For the version currently published on NuGet.org, source-build evaluation and clean-room checks, follow the [package installation guide](https://misha1302.github.io/Wist2/start/installation). Do not assume a repository-local package output directory exists in an external consumer project.
 
 Requirements:
 

--- a/UniversalToolchain/UniversalToolchain.Wist/README.md
+++ b/UniversalToolchain/UniversalToolchain.Wist/README.md
@@ -39,6 +39,7 @@ Requirements:
 
 <!-- wist-package-quickstart-csharp:begin -->
 ```csharp
+using System;
 using UniversalToolchain.Wist;
 
 using var rules = WistEngine.CreateRestrictedArithmetic();
@@ -61,6 +62,8 @@ The formula returns data. The host application performs the action.
 Use `Validate` before storing or executing user/admin/config-supplied formulas:
 
 ```csharp
+using System;
+using System.Linq;
 using UniversalToolchain.Wist;
 
 using var rules = WistEngine.CreateRestrictedArithmetic();

--- a/docs/reference/diagnostics.md
+++ b/docs/reference/diagnostics.md
@@ -1,6 +1,9 @@
 ---
 title: Diagnostics Reference
 description: Stable Wist facade codes and generic language-planning diagnostics.
+audience: all-technical-users
+status: current-reference
+lastVerifiedAgainst: wist-release-state-2026-08-06
 ---
 
 # Diagnostics reference

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -10,6 +10,7 @@ lastVerifiedAgainst: language-authoring-p0-p1-hardening-2026-07-23.1
 
 ## Public/runtime contracts
 
+- [Wist facade API](/reference/wist-facade-api)
 - [Diagnostics](/reference/diagnostics)
 - [Lifecycle, concurrency and privacy](/reference/lifecycle-concurrency-privacy)
 - [Runtime profiles](/reference/runtime-profiles)

--- a/docs/reference/performance-model.md
+++ b/docs/reference/performance-model.md
@@ -1,6 +1,9 @@
 ---
 title: Performance Model
 description: Separate Wist compilation, convenience execution and prepared hot invocation; avoid generic claims.
+audience: all-technical-users
+status: current-reference
+lastVerifiedAgainst: wist-release-state-2026-08-06
 ---
 
 # Performance model

--- a/docs/reference/wist-facade-api.md
+++ b/docs/reference/wist-facade-api.md
@@ -1,0 +1,231 @@
+---
+title: Wist Facade API
+description: Supported public entry points, result types, options and ownership rules for UniversalToolchain.Wist.
+audience: wist-application-developer
+status: current-alpha-reference
+lastVerifiedAgainst: wist-release-state-2026-08-06
+---
+
+# Wist facade API
+
+This page describes the supported compile-time facade exposed by `UniversalToolchain.Wist`. The current source candidate is `0.1.0-alpha.6`; the version currently verified from NuGet.org is listed in [Installation](/start/installation).
+
+The authoritative exported surface is `UniversalToolchain/UniversalToolchain.Wist/PublicAPI.Shipped.txt`. Runtime implementation assemblies are not public compatibility contracts.
+
+## Create an engine
+
+```csharp
+using UniversalToolchain.Wist;
+
+using var restricted = WistEngine.CreateRestrictedArithmetic();
+using var fullNative = WistEngine.CreateFullNative();
+```
+
+`CreateRestrictedArithmetic()` is the recommended first-contact preset for restricted formulas.
+
+`CreateFullNative()` selects the broader native profile, but it does not automatically expose host CLR assemblies. Use `WistEngine.Create(options)` when you need an explicit preset, backend, resource limits, host assembly allowlist or experimental optimization route.
+
+```csharp
+using var engine = WistEngine.Create(new WistEngineOptions
+{
+    DialectSource = WistDialectSource.FromShippedPreset("pricing-restricted"),
+    BackendId = "cil",
+    ResourceLimits = new WistResourceLimits
+    {
+        MaxSourceLength = 16_384,
+        MaxParameterCount = 16
+    }
+});
+```
+
+Options are snapshotted when the engine is created. Changing the original options object later does not reconfigure an existing engine.
+
+## Validate without throwing
+
+```csharp
+var validation = engine.Validate(
+    "price * discount + fee",
+    new { price = 100.0, discount = 0.9, fee = 5.0 });
+
+if (!validation.IsValid)
+{
+    foreach (var diagnostic in validation.Diagnostics)
+        Console.WriteLine($"{diagnostic.Code}: {diagnostic.Message}");
+}
+```
+
+Public overloads:
+
+```csharp
+WistValidationResult Validate(string code);
+WistValidationResult Validate(string code, object sampleArguments);
+```
+
+`WistValidationResult` exposes:
+
+- `IsValid`;
+- `Diagnostics`;
+- `Exception` for investigation of the captured failure;
+- `OptimizationReport`, including route information captured before a failure.
+
+There is no aggregate `Message` property. Consume structured diagnostics instead of parsing exception text.
+
+## Evaluate once
+
+```csharp
+double value = engine.Evaluate<double>(
+    "price * discount + fee",
+    new { price = 100.0, discount = 0.9, fee = 5.0 });
+```
+
+Public overloads:
+
+```csharp
+T Evaluate<T>(string code);
+T Evaluate<T>(string code, object arguments);
+T Evaluate<T>(string code, IReadOnlyDictionary<string, object?> arguments);
+```
+
+Use `Evaluate<T>` for one-off execution, diagnostics tools, tests and non-hot paths. It performs source processing for the call and throws when evaluation fails.
+
+## Compile once, invoke repeatedly
+
+```csharp
+var program = engine.Compile<Func<double, double, double>>(
+    "price * discount",
+    "price",
+    "discount");
+
+double value = program.CompiledDelegate(100.0, 0.9);
+```
+
+Public methods:
+
+```csharp
+WistProgram<TDelegate> Compile<TDelegate>(
+    string formula,
+    params string[] parameterNames)
+    where TDelegate : Delegate;
+
+WistCompileResult<TDelegate> TryCompile<TDelegate>(
+    string formula,
+    params string[] parameterNames)
+    where TDelegate : Delegate;
+```
+
+`Compile<TDelegate>` validates and compiles, then throws when the operation cannot complete. `TryCompile<TDelegate>` returns:
+
+- `IsSuccess`;
+- `Program` when successful;
+- `Diagnostics`;
+- `Exception` for failure investigation;
+- `OptimizationReport`.
+
+`WistProgram<TDelegate>` exposes the typed `CompiledDelegate` and `Metadata`. Metadata includes source text, backend, ordered parameter names and types, return type and optimization report.
+
+The delegate signature and the ordered `parameterNames` must describe the same parameters. Do not cache or reuse a compiled program under a different parameter order, dialect, backend or options snapshot.
+
+## Ownership and lifetime
+
+`WistEngine` is disposable. `WistProgram<TDelegate>` is not a separate disposable owner.
+
+Keep the engine alive for as long as any program compiled by that engine remains active:
+
+```csharp
+sealed class ActiveRule : IDisposable
+{
+    private readonly WistEngine _engine;
+
+    public ActiveRule(string source)
+    {
+        _engine = WistEngine.CreateRestrictedArithmetic();
+        Program = _engine.Compile<Func<double, double>>(source, "value");
+    }
+
+    public WistProgram<Func<double, double>> Program { get; }
+
+    public void Dispose() => _engine.Dispose();
+}
+```
+
+The host application owns synchronization when replacing and disposing engines. The alpha facade does not claim universal thread safety for arbitrary engine operations, custom dialect components or host interop. See [Production Integration](/start/production-integration) and [Lifecycle, Concurrency and Privacy](/reference/lifecycle-concurrency-privacy).
+
+## Engine options
+
+`WistEngineOptions` exposes:
+
+| Property | Meaning |
+|---|---|
+| `DialectSource` | Exact shipped preset, file or inline dialect source |
+| `BackendId` | Canonical backend identifier, currently `cil` or `interpreter` when supported by the selected dialect |
+| `AllowedAssemblies` | Immutable-at-creation host assembly allowlist for CLR interop and type directives |
+| `ResourceLimits` | Host-owned source-length and parameter-count preflight limits |
+| `Optimization` | Optional compiler optimization routes; SSA remains experimental |
+
+Factory helpers:
+
+```csharp
+WistEngineOptions.FromPresetId("pricing-restricted");
+WistEngineOptions.FromDialectFile("custom.wistdialect");
+WistEngineOptions.FromDialectText(sourceText, "custom.wistdialect");
+```
+
+Dialect source helpers:
+
+```csharp
+WistDialectSource.FromShippedPreset("pricing-restricted");
+WistDialectSource.FromFile("custom.wistdialect");
+WistDialectSource.FromText(sourceText, "custom.wistdialect");
+```
+
+A backend alias that the selected dialect does not expose is rejected during engine creation.
+
+## Resource limits
+
+```csharp
+var limits = new WistResourceLimits
+{
+    MaxSourceLength = 65_536,
+    MaxParameterCount = 64
+};
+```
+
+These are preflight limits only. They do not provide execution timeouts, memory quotas, cancellation or process isolation.
+
+## Diagnostics
+
+`WistDiagnostic` contains:
+
+- stable `Code`;
+- `Severity`;
+- pipeline `Stage`;
+- `SourceName` and `Span` when available;
+- human-readable `Message`;
+- structured `Hints`.
+
+Use diagnostic codes as compatibility keys. English message wording may become more precise during alpha. See [Diagnostics Reference](/reference/diagnostics).
+
+## Experimental SSA options
+
+SSA is an opt-in `AIR -> SSA -> AIR` route. It is not an SSA-native backend, a sandbox or a performance guarantee.
+
+```csharp
+using var engine = WistEngine.Create(new WistEngineOptions
+{
+    DialectSource = WistDialectSource.FromShippedPreset("pricing-restricted"),
+    Optimization = new WistOptimizationOptions
+    {
+        Ssa = new WistSsaOptions
+        {
+            Policy = WistSsaPolicy.Prefer,
+            DiagnosticLevel = WistSsaDiagnosticLevel.Detailed
+        }
+    }
+});
+```
+
+Use the returned optimization report to determine whether SSA was used, whether the route fell back to AIR, which passes executed and which route diagnostics were produced.
+
+## Trust boundary
+
+Restricted presets reduce the selected language and runtime surface. They are not hardened in-process sandboxes for arbitrary hostile code. The host owns authorization, persistence, approval, side effects, secrets, time and memory limits, process isolation and rollback.

--- a/docs/reference/wist-facade-api.md
+++ b/docs/reference/wist-facade-api.md
@@ -12,6 +12,12 @@ This page describes the supported compile-time facade exposed by `UniversalToolc
 
 The authoritative exported surface is `UniversalToolchain/UniversalToolchain.Wist/PublicAPI.Shipped.txt`. Runtime implementation assemblies are not public compatibility contracts.
 
+## Stability and package boundary
+
+The facade types documented here are the intended application-facing surface for the named alpha candidate. Alpha versions may still make reviewed breaking changes; pin the exact package version and read its stability record before upgrading.
+
+Only `ref/net10.0/UniversalToolchain.Wist.dll` is the supported compile-time contract. Assemblies carried under `lib/net10.0` are runtime implementation dependencies. Do not reference their types directly or treat their assembly count, names or layout as a stable application API.
+
 ## Create an engine
 
 ```csharp

--- a/eng/documentation-release-state.json
+++ b/eng/documentation-release-state.json
@@ -15,7 +15,8 @@
   ],
   "sourceCandidateDocuments": [
     "readme.md",
-    "docs/start/installation.md"
+    "docs/start/installation.md",
+    "UniversalToolchain/UniversalToolchain.Wist/README.md"
   ],
   "sourceBuildDocuments": [
     "readme.md",
@@ -25,5 +26,18 @@
     "readme.md",
     "docs/evidence/index.md",
     "docs/.vitepress/config.mts"
+  ],
+  "packageReadmeDocuments": [
+    "UniversalToolchain/UniversalToolchain.Wist/README.md"
+  ],
+  "firstContactCsharpSnippets": [
+    {
+      "document": "readme.md",
+      "marker": "wist-source-quickstart-csharp"
+    },
+    {
+      "document": "UniversalToolchain/UniversalToolchain.Wist/README.md",
+      "marker": "wist-package-quickstart-csharp"
+    }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -5,9 +5,10 @@
     "docs:build": "vitepress build docs",
     "docs:preview": "vitepress preview docs --host 0.0.0.0",
     "docs:release-state": "python3 Tools/check_documentation_release_state.py",
+    "docs:first-contact": "python3 Tools/check-wist-documentation-first-contact.py",
     "docs:status": "python3 Tools/check_documentation_status.py && npm run docs:release-state",
     "docs:links": "python3 Tools/check_documentation_links.py",
-    "docs:check": "npm run docs:status && npm run docs:links && npm run docs:build"
+    "docs:check": "npm run docs:status && npm run docs:links && npm run docs:first-contact && npm run docs:build"
   },
   "devDependencies": {
     "vitepress": "1.6.4"

--- a/readme.md
+++ b/readme.md
@@ -45,6 +45,8 @@ Compile a reviewed rollout formula once and invoke the typed delegate repeatedly
 
 <!-- wist-source-quickstart-csharp:begin -->
 ```csharp
+using System;
+using System.Linq;
 using UniversalToolchain.Wist;
 
 using var rules = WistEngine.CreateRestrictedArithmetic();

--- a/readme.md
+++ b/readme.md
@@ -43,6 +43,7 @@ To evaluate the current repository implementation, clone the repository and use 
 
 Compile a reviewed rollout formula once and invoke the typed delegate repeatedly:
 
+<!-- wist-source-quickstart-csharp:begin -->
 ```csharp
 using UniversalToolchain.Wist;
 
@@ -56,7 +57,10 @@ var validation = rules.Validate(
     new { usage = 100.0, reliability = 90.0, incidents = 1.0 });
 
 if (!validation.IsValid)
-    throw new InvalidOperationException(validation.Message);
+{
+    throw new InvalidOperationException(
+        string.Join("; ", validation.Diagnostics.Select(diagnostic => diagnostic.Message)));
+}
 
 var rolloutScore = rules.Compile<Func<double, double, double, double>>(
     formula,
@@ -67,6 +71,7 @@ var rolloutScore = rules.Compile<Func<double, double, double, double>>(
 double score = rolloutScore.CompiledDelegate(100.0, 90.0, 1.0);
 bool enableNewDashboard = score >= 80.0;
 ```
+<!-- wist-source-quickstart-csharp:end -->
 
 `Compile` also validates and throws when compilation fails. Use `Validate` or `TryCompile` when invalid user/admin input is an expected outcome and you need structured diagnostics without replacing the active rule.
 
@@ -104,7 +109,7 @@ var rejected = rules.Validate(
     new { usage = 100.0, reliability = 90.0, incidents = 1.0 });
 
 Console.WriteLine(rejected.IsValid); // false
-Console.WriteLine(rejected.Message); // structured validation failure
+Console.WriteLine(string.Join("; ", rejected.Diagnostics.Select(diagnostic => diagnostic.Message)));
 ```
 
 This is language-surface restriction, not a hardened sandbox. Arbitrary hostile input still requires process/environment isolation, resource limits and an explicit threat model.
@@ -199,6 +204,7 @@ Technical material:
 
 - [Project documentation](docs/index.md)
 - [Installation and clean-room smoke](docs/start/installation.md)
+- [Wist facade API reference](docs/reference/wist-facade-api.md)
 - [Use-case recipes](docs/start/use-case-recipes.md)
 - [Wist `0.1.0-alpha.6` candidate stability contract](docs/evidence/wist-stability-v0.1.0-alpha.6.md)
 - [External Language Authoring quickstart](docs/language-authoring/quickstart.md)


### PR DESCRIPTION
## Summary

- fix root README examples to consume structured validation diagnostics instead of the nonexistent `WistValidationResult.Message`
- make the packaged README feed-neutral and register it in the release-state contract
- remove the manually maintained runtime-assembly count
- add a current Wist facade API reference and release-state metadata to key reference pages
- compile marked first-contact C# snippets in Docs Check
- add mutation coverage for stale API usage, local-feed assumptions, unregistered package README, stale runtime count and missing snippet markers

## Validation

- branch is based on `9c2955f058db77598bc5c590f29446977308da71`
- GitHub Docs Check and the aggregate CI status are expected to provide final repository-backed validation

## Scope

Documentation and documentation validation only. No public API or runtime behavior changes.