### PR TITLE
docs(verification): sync active test census

### DIFF
--- a/RELEASE_NOTES_RU.md
+++ b/RELEASE_NOTES_RU.md
@@ -36,7 +36,7 @@
 
 ## Проверка
 
-Exact test manifest текущей ветки: **1,408 тестов**. Canonical build/test gate обязан подтвердить 0 failed и 0 skipped на exact candidate revision; provider-backed run IDs фиксируются в migration PR, а не подменяются более старым локальным результатом.
+Exact test manifest текущей ветки: **1,412 тестов**. Canonical build/test gate обязан подтвердить 0 failed и 0 skipped на exact candidate revision; provider-backed run IDs фиксируются в migration PR, а не подменяются более старым локальным результатом.
 
 Fresh-process SafeMath receipts подтверждают `DIALECT_INSPECT=PASS`, Interpreter/CIL result `255`, одинаковую CLR value category, negative dialect rejection, hostile preload rejection и отсутствие незарегистрированного default-context fallback.
 

--- a/VERIFICATION.md
+++ b/VERIFICATION.md
@@ -53,11 +53,11 @@ Parallel graph traversal and shared compilation are the default. `--jobs`, `--se
 |---|---:|---:|---:|
 | `Tests` | 540 | 0 | 0 |
 | `UniversalToolchain.Modules.Tests` | 292 | 0 | 0 |
-| `UniversalToolchain.Dialects.Tests` | 369 | 0 | 0 |
+| `UniversalToolchain.Dialects.Tests` | 373 | 0 | 0 |
 | `UniversalToolchain.LanguageSdk.Tests` | 156 | 0 | 0 |
 | `UniversalToolchain.PlanFuzz.Tests` | 41 | 0 | 0 |
 | `UniversalToolchain.PlanFuzz.IntegrationTests` | 10 | 0 | 0 |
-| **Total** | **1,408** | **0** | **0** |
+| **Total** | **1,412** | **0** | **0** |
 
 The deterministic runtime-boundary candidate adds resolver, loader, hostile-preload, fresh-process, package-metadata and boundary-regression coverage over merged baseline `f13ad1310856e5618e1c3042c447ca543e0f3125`. The exact manifest is owned by `eng/test-counts.json`; provider-backed exact-head results for the active migration stage are recorded against their commit/run identities rather than inferred from an older local TRX snapshot.
 

--- a/docs/evidence/current-verification.md
+++ b/docs/evidence/current-verification.md
@@ -27,11 +27,11 @@ The documentation guard requires this table to mirror the repository's current e
 |---|---:|---:|---:|
 | `Tests` | 540 | 0 | 0 |
 | `UniversalToolchain.Modules.Tests` | 292 | 0 | 0 |
-| `UniversalToolchain.Dialects.Tests` | 369 | 0 | 0 |
+| `UniversalToolchain.Dialects.Tests` | 373 | 0 | 0 |
 | `UniversalToolchain.LanguageSdk.Tests` | 156 | 0 | 0 |
 | `UniversalToolchain.PlanFuzz.Tests` | 41 | 0 | 0 |
 | `UniversalToolchain.PlanFuzz.IntegrationTests` | 10 | 0 | 0 |
-| **Total** | **1,408** | **0** | **0** |
+| **Total** | **1,412** | **0** | **0** |
 
 The exact manifest belongs to `eng/test-counts.json`. `.NET CI` run `31049607823` completed the canonical entrypoint for the pinned commit. Because the entrypoint enforces the manifest associated with its own revision, a stale or partial test total cannot satisfy that gate.
 


### PR DESCRIPTION
Docs-only census synchronization after provider proved Dialects 373/373 and aggregate 1,412/1,412 on the repair candidate. Historical receipts/snapshot identities are intentionally unchanged; only the active manifest mirrors are updated.