### PR TITLE
Fix current Wist architecture and performance documentation

### DIFF
--- a/Tools/test-documentation-release-state-mutants.py
+++ b/Tools/test-documentation-release-state-mutants.py
@@ -64,6 +64,15 @@ def main() -> int:
     require_killed(root, 'source-version-drift', stale_source_version)
     require_killed(
         root,
+        'current-architecture-source-version-drift',
+        lambda mutant: replace(
+            mutant / 'docs/CURRENT_ARCHITECTURE_STATUS.md',
+            f'`{source_version}`',
+            '`0.0.0-mutant`',
+        ),
+    )
+    require_killed(
+        root,
         'published-install-drift',
         lambda mutant: replace(
             mutant / 'docs/start/first-program.md',

--- a/docs/CURRENT_ARCHITECTURE_STATUS.md
+++ b/docs/CURRENT_ARCHITECTURE_STATUS.md
@@ -9,7 +9,9 @@ This page is the current architecture authority for the repository. Historical c
 
 ## Current public/product surface
 
-`UniversalToolchain.Wist` source candidate `0.1.0-alpha.6` provides:
+<!-- wist-source-candidate:begin -->
+`UniversalToolchain.Wist` source candidate `0.1.0-alpha.7` is **not published on NuGet.org** and provides:
+<!-- wist-source-candidate:end -->
 
 - `WistEngine`;
 - restricted arithmetic and broader native presets;
@@ -31,8 +33,10 @@ The repository implements:
 - `UniversalToolchain.Runtime` for exact plan verification, route materialization, executor selection, policy validation and lifecycle;
 - `UniversalToolchain.Testing` for reusable contract/parity support;
 - `UniversalToolchain.Templates` with `ut-language`;
-- `UniversalToolchain.Wist.LanguagePack` `0.3.0-alpha.5` as the typed Wist package boundary;
+- `UniversalToolchain.Wist.LanguagePack` as the typed Wist package boundary;
 - `samples/Acme.PricingLanguage` as a non-Wist sample.
+
+Package versions are release identities rather than architecture contracts. The active Wist source identity is checked through `eng/documentation-release-state.json`; the full candidate package matrix belongs to release evidence rather than this architecture authority.
 
 ## Implemented generic contracts
 

--- a/docs/reference/performance-model.md
+++ b/docs/reference/performance-model.md
@@ -1,25 +1,57 @@
 ---
 title: Performance Model
-description: Separate Wist compilation, convenience execution and prepared hot invocation; avoid generic claims.
+description: Separate Wist setup, formula compilation, convenience execution and prepared hot invocation; avoid generic claims.
 audience: all-technical-users
 status: current-reference
-lastVerifiedAgainst: wist-release-state-2026-08-06
+lastVerifiedAgainst: wist-architecture-production-hardening-2026-08-13
 ---
 
 # Performance model
 
 ## Wist paths
 
-Cold path:
+Wist has three materially different cost boundaries. Do not collapse them into one "execution" path.
+
+### 1. Engine setup and semantic planning
+
+`WistEngine.Create(...)` resolves the selected preset or dialect once and materializes one exact runtime from the resulting immutable plan:
 
 ```text
-source -> parse/bind -> dialect/runtime selection -> compile or execute
+DialectSource / preset
+  -> LanguageDefinition
+  -> LanguageCompiler
+  -> immutable LanguagePlan
+  -> LanguageBuildRuntime
 ```
 
-Prepared hot path:
+`LanguageCompiler` is the semantic planner. `Evaluate`, `Validate`, `Compile<TDelegate>` and `TryCompile<TDelegate>` reuse the plan/runtime created here; they do not perform dialect selection or create a second backend plan for each formula.
+
+Measure this boundary when engine construction itself matters to startup or request latency.
+
+### 2. Formula processing
+
+Formula work begins after the engine already owns its plan/runtime. The exact stages depend on the selected route, but the Wist pipeline is conceptually:
 
 ```text
-compiled typed delegate -> invocation
+source
+  -> lexer / parser
+  -> AST
+  -> Bytecode
+  -> AIR
+  -> optional optimizer / SSA route
+  -> selected backend artifact or execution
+```
+
+`Evaluate<T>` is the convenience path for one-off execution. It includes source processing and the selected runtime route on every call.
+
+`Compile<TDelegate>` processes the formula and materializes a typed durable program/delegate for repeated invocation. Compilation is therefore a cold operation relative to the prepared delegate hot path.
+
+### 3. Prepared hot invocation
+
+```text
+compiled typed delegate
+  -> invocation
+  -> result
 ```
 
 Use `Evaluate<T>` for one-off evaluation, tests and administration paths. Use `Compile<TDelegate>` when the same approved formula is invoked repeatedly.
@@ -34,7 +66,7 @@ var program = engine.Compile<Func<double, double, double>>(
 double result = program.CompiledDelegate(100.0, 5.0);
 ```
 
-Do not compare `Evaluate` against a prepared delegate and call the result “execution overhead”; those paths include different work.
+Do not compare `Evaluate` against a prepared delegate and call the difference "execution overhead": those paths include different work. Likewise, do not attribute `WistEngine.Create` planning/runtime-creation cost to per-formula execution; it is a distinct setup boundary.
 
 ## Generic language runtime
 

--- a/eng/documentation-release-state.json
+++ b/eng/documentation-release-state.json
@@ -15,7 +15,8 @@
   ],
   "sourceCandidateDocuments": [
     "readme.md",
-    "docs/start/installation.md"
+    "docs/start/installation.md",
+    "docs/CURRENT_ARCHITECTURE_STATUS.md"
   ],
   "sourceBuildDocuments": [
     "readme.md",


### PR DESCRIPTION
## Summary

Fix the two P1 documentation findings from the current Wist/UniversalToolchain review.

- align `docs/CURRENT_ARCHITECTURE_STATUS.md` with the current `UniversalToolchain.Wist` `0.1.0-alpha.7` source candidate;
- stop duplicating the `Wist.LanguagePack` package version in the architecture authority, because package versions are release identities rather than architecture contracts;
- bind the architecture authority to `eng/documentation-release-state.json` through the existing source-candidate marker contract;
- add a focused mutation test proving stale architecture source identity is rejected;
- correct `docs/reference/performance-model.md` so semantic planning/runtime materialization happen once in `WistEngine.Create`, separately from per-formula processing and prepared delegate invocation.

## Why

The previous architecture authority contained stale package versions while declaring itself current. The previous performance diagram also visually implied per-formula dialect/runtime selection, contradicting the canonical `LanguageDefinition -> LanguageCompiler -> LanguagePlan -> LanguageRuntime` ownership model.

## Validation target

`Docs Check` must pass, including documentation release-state positive control, release-state mutants, link checks, first-contact compilation and VitePress build.