### PR TITLE
Prepare Wist 0.1.0-alpha.7 release readiness

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -13,6 +13,8 @@ on:
       - 'Tools/test-documentation-*.py'
       - 'Tools/check-wist-documentation-*.py'
       - 'Tools/test-wist-documentation-*.py'
+      - 'Tools/check-wist-release-readiness-docs.py'
+      - 'Tools/test-wist-release-readiness-doc-mutants.py'
       - 'package.json'
       - 'package-lock.json'
       - '.github/workflows/docs-check.yml'
@@ -49,6 +51,9 @@ jobs:
 
       - name: Validate documentation structure, release state and links
         run: npm run docs:status && npm run docs:links
+
+      - name: Reject Wist release-readiness documentation mutants
+        run: npm run docs:readiness-mutants
 
       - name: Compile first-contact Wist documentation snippets
         run: npm run docs:first-contact

--- a/.github/workflows/package-compatibility-review.yml
+++ b/.github/workflows/package-compatibility-review.yml
@@ -2,6 +2,9 @@ name: Package Compatibility Review
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - master
   pull_request:
     branches:
       - master

--- a/.github/workflows/published-package-smoke.yml
+++ b/.github/workflows/published-package-smoke.yml
@@ -13,6 +13,7 @@ on:
       - .github/workflows/published-package-smoke.yml
       - Tools/check_documentation_release_state.py
       - Tools/smoke-published-wist-package.sh
+      - Tools/smoke-published-wist-package.ps1
       - eng/documentation-release-state.json
       - UniversalToolchain/UniversalToolchain.Wist/UniversalToolchain.Wist.csproj
       - UniversalToolchain/UniversalToolchain.Wist/README.md
@@ -46,3 +47,27 @@ jobs:
 
       - name: Install and execute the published package
         run: ./Tools/smoke-published-wist-package.sh "${{ steps.release-state.outputs.version }}"
+
+  smoke-windows:
+    runs-on: windows-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: UniversalToolchain/global.json
+
+      - name: Resolve published package version
+        id: release-state
+        shell: pwsh
+        run: |
+          $version = python Tools/check_documentation_release_state.py --print-published-version
+          "version=$version" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+
+      - name: Install and execute the published package
+        shell: pwsh
+        run: ./Tools/smoke-published-wist-package.ps1 -PackageVersion "${{ steps.release-state.outputs.version }}"

--- a/RELEASE_NOTES_RU.md
+++ b/RELEASE_NOTES_RU.md
@@ -1,8 +1,8 @@
 # UniversalToolchain.Wist 0.1.0-alpha.7 — architecture & production hardening candidate
 
-Дата candidate source: 2026-08-15.
+Дата candidate source: 2026-08-18.
 
-`0.1.0-alpha.7` — новая **неопубликованная** candidate identity поверх канонической LanguagePlan/LanguageRuntime архитектуры из migration #332. Эта работа не выполняет publish, release promotion или merge в `master`.
+`0.1.0-alpha.7` — новая **неопубликованная** candidate identity поверх канонической LanguagePlan/LanguageRuntime архитектуры из migration #332. Эта работа не выполняет publish, release promotion или создание release/tag.
 
 ## Основные изменения
 
@@ -17,7 +17,11 @@
 - physical Wist runtime closure классифицирован по фактическому package artifact; package graph не дробился без доказанной выгоды;
 - Wist feature ownership разделён по фактическим syntax / semantic-binding / lowering обязанностям, runtime materializes эти роли только из exact `LanguagePlan`, а DSL ordering распространяется на соответствующие phase-owned contributions;
 - generic Dialects/CIL/runtime implementation tests перенесены из mixed Wist-owned suites в `UniversalToolchain.LanguageSdk.Generic.Tests`, поэтому UT internal friend edges остаются только `UNIVERSAL -> UNIVERSAL`, а Wist-free proof стал содержательнее;
-- flaky percentage performance gate не добавлялся: сохранён benchmark smoke и добавлен artifact/trend collection.
+- rollout-scoring documentation теперь имеет focused public-facade regression и механическую защиту от docs/test drift;
+- для опубликованного NuGet package добавлен Windows PowerShell 7 clean-room smoke с isolated cache, stage diagnostics и `finally` cleanup;
+- getting-started docs показывают stable structured `WistDiagnostic` fields и явно отделяют validation/policy rejection от process/security sandboxing;
+- release-evidence test-count claims сверяются с единым `eng/test-counts.json` и защищены negative mutant;
+- flaky percentage performance gate не добавлялся: сохранён benchmark smoke и artifact/trend collection.
 
 ## Матрица candidate packages
 
@@ -39,15 +43,15 @@
 
 ## Проверка
 
-Exact test manifest текущей ветки: **1,305 тестов**: Core 500, Modules 292, Dialects 233, LanguageSdk.Generic 62, LanguageSdk 167, PlanFuzz 41 и 10 isolated integration cases. Перенос 58 generic implementation tests между owner-specific suites не уменьшает покрытие; 4 ранее существовавших Wist-free generic tests вместе с ними образуют 62-test canonical generic suite в Linux/Windows contract. Дополнительные regressions фиксируют реальную `Syntax -> Semantic -> Bytecode` границу, stage-local lifetime, plan-owned lowering/fail-closed activation, phase-owned module ordering, detached optimizer-contract provenance и скрытые `UNIVERSAL -> WIST_PRODUCT` friend edges. Canonical build/test gate обязан подтвердить 0 failed и 0 skipped на exact candidate revision; более старые workflow receipts не подменяют exact-head verification.
+Exact test manifest текущей ветки: **1,306 тестов**: Core 500, Modules 292, Dialects 234, LanguageSdk.Generic 62, LanguageSdk 167, PlanFuzz 41 и 10 isolated integration cases. Перенос 58 generic implementation tests между owner-specific suites не уменьшает покрытие; 4 ранее существовавших Wist-free generic tests вместе с ними образуют 62-test canonical generic suite в Linux/Windows contract. Дополнительные regressions фиксируют реальную `Syntax -> Semantic -> Bytecode` границу, stage-local lifetime, plan-owned lowering/fail-closed activation, phase-owned module ordering, detached optimizer-contract provenance, скрытые `UNIVERSAL -> WIST_PRODUCT` friend edges и документированный rollout-scoring facade path. Canonical build/test gate обязан подтвердить 0 failed и 0 skipped на exact candidate revision; более старые workflow receipts не подменяют exact-head verification.
 
 Baseline-bearing package gate проверяет девять package identities, exact `.nuspec` metadata, monotonic version/content provenance, Wist public API delta, physical package surface, clean external consumers и detached integrity manifest. GitHub aggregate CI остаётся отдельным обязательным gate.
 
 ## Не является частью candidate
 
 - publish packages;
-- merge в `master`;
-- release promotion;
+- создание GitHub Release;
+- создание/push release tag;
 - sandboxing claim;
 - secure secret scrubbing claim;
 - thread-safety claim для одного `WistEngine`;

--- a/Tools/check-wist-release-readiness-docs.py
+++ b/Tools/check-wist-release-readiness-docs.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def parse_number(value: str) -> int:
+    return int(value.replace(',', ''))
+
+
+def main() -> int:
+    errors: list[str] = []
+
+    test_counts_path = ROOT / 'eng' / 'test-counts.json'
+    release_state_path = ROOT / 'eng' / 'documentation-release-state.json'
+    recipe_path = ROOT / 'docs' / 'start' / 'use-case-recipes.md'
+    recipe_test_path = (
+        ROOT
+        / 'UniversalToolchain'
+        / 'UniversalToolchain.Dialects.Tests'
+        / 'Wist'
+        / 'PublicFacade'
+        / 'WistUseCaseRecipeTests.cs'
+    )
+
+    test_counts = json.loads(test_counts_path.read_text(encoding='utf-8'))
+    expected_total = int(test_counts['totalPassed'])
+    release_state = json.loads(release_state_path.read_text(encoding='utf-8'))
+
+    stability_path = ROOT / release_state['stabilityDocument']
+    stability_text = stability_path.read_text(encoding='utf-8')
+    stability_match = re.search(
+        r'(?i)exact repository test manifest of\s+([0-9][0-9,]*)\s+tests\b',
+        stability_text,
+    )
+    if stability_match is None:
+        errors.append(
+            f'{stability_path.relative_to(ROOT).as_posix()}: '
+            'missing exact repository test-manifest claim'
+        )
+    else:
+        claimed_total = parse_number(stability_match.group(1))
+        if claimed_total != expected_total:
+            errors.append(
+                f'{stability_path.relative_to(ROOT).as_posix()}: '
+                f'stale test total {claimed_total}; expected {expected_total} from eng/test-counts.json'
+            )
+
+    recipe_text = recipe_path.read_text(encoding='utf-8')
+    formula_marker = re.search(
+        r'<!--\s*wist-rollout-formula-contract:\s*(.*?)\s*-->',
+        recipe_text,
+    )
+    score_marker = re.search(
+        r'<!--\s*wist-rollout-expected-score:\s*([0-9]+(?:\.[0-9]+)?)\s*-->',
+        recipe_text,
+    )
+    test_text = recipe_test_path.read_text(encoding='utf-8')
+    test_formula = re.search(
+        r'DocumentedRolloutFormula\s*=\s*"([^"]+)"\s*;',
+        test_text,
+        re.MULTILINE,
+    )
+    test_score = re.search(
+        r'DocumentedRolloutExpectedScore\s*=\s*([0-9]+(?:\.[0-9]+)?)\s*;',
+        test_text,
+    )
+
+    if formula_marker is None:
+        errors.append('docs/start/use-case-recipes.md: rollout formula contract marker is missing')
+    if score_marker is None:
+        errors.append('docs/start/use-case-recipes.md: rollout expected-score contract marker is missing')
+    if test_formula is None:
+        errors.append('WistUseCaseRecipeTests.cs: documented rollout formula constant is missing')
+    if test_score is None:
+        errors.append('WistUseCaseRecipeTests.cs: documented rollout expected-score constant is missing')
+
+    if formula_marker is not None and test_formula is not None:
+        documented_formula = formula_marker.group(1).strip()
+        regression_formula = test_formula.group(1)
+        if documented_formula != regression_formula:
+            errors.append(
+                'rollout recipe drift: documentation formula and public-facade regression differ'
+            )
+        if f'"{documented_formula}"' not in recipe_text:
+            errors.append(
+                'docs/start/use-case-recipes.md: rollout contract marker is not used by the copy-ready C# snippet'
+            )
+
+    if score_marker is not None and test_score is not None:
+        documented_score = float(score_marker.group(1))
+        regression_score = float(test_score.group(1))
+        if documented_score != regression_score:
+            errors.append(
+                'rollout recipe drift: documentation expected score and regression expected score differ'
+            )
+
+    if errors:
+        print('Wist release-readiness documentation check failed:', file=sys.stderr)
+        for error in errors:
+            print(f'- {error}', file=sys.stderr)
+        return 1
+
+    print(
+        'Wist release-readiness documentation check passed: '
+        f'test total {expected_total}, rollout recipe synchronized.'
+    )
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/Tools/smoke-published-wist-package.ps1
+++ b/Tools/smoke-published-wist-package.ps1
@@ -2,15 +2,12 @@
 param(
     [Parameter(Mandatory = $true, Position = 0)]
     [ValidateNotNullOrEmpty()]
-    [string]$PackageVersion,
-
-    [Parameter()]
-    [ValidateNotNullOrEmpty()]
-    [string]$NuGetSource = "https://api.nuget.org/v3/index.json"
+    [string]$PackageVersion
 )
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
+$NuGetSource = "https://api.nuget.org/v3/index.json"
 
 $smokeDir = Join-Path ([System.IO.Path]::GetTempPath()) ("wist-published-smoke-" + [Guid]::NewGuid().ToString("N"))
 
@@ -159,7 +156,7 @@ Console.WriteLine($"RESULT={score:R}");
     }
     $metadata = Get-Content -LiteralPath $metadataPath -Raw
     if (-not $metadata.Contains($NuGetSource, [StringComparison]::Ordinal)) {
-        throw "Published-package smoke failed at stage 'package-source': package metadata does not record the requested public feed."
+        throw "Published-package smoke failed at stage 'package-source': package metadata does not record the public NuGet.org feed."
     }
 
     Write-Host "Published UniversalToolchain.Wist $PackageVersion smoke passed."

--- a/Tools/smoke-published-wist-package.ps1
+++ b/Tools/smoke-published-wist-package.ps1
@@ -1,0 +1,171 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true, Position = 0)]
+    [ValidateNotNullOrEmpty()]
+    [string]$PackageVersion,
+
+    [Parameter()]
+    [ValidateNotNullOrEmpty()]
+    [string]$NuGetSource = "https://api.nuget.org/v3/index.json"
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$smokeDir = Join-Path ([System.IO.Path]::GetTempPath()) ("wist-published-smoke-" + [Guid]::NewGuid().ToString("N"))
+
+function Invoke-Stage {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Stage,
+        [Parameter(Mandatory = $true)]
+        [scriptblock]$Action
+    )
+
+    try {
+        & $Action
+        if ($LASTEXITCODE -ne 0) {
+            throw "command exited with code $LASTEXITCODE"
+        }
+    }
+    catch {
+        throw "Published-package smoke failed at stage '$Stage': $($_.Exception.Message)"
+    }
+}
+
+try {
+    New-Item -ItemType Directory -Path $smokeDir -Force | Out-Null
+
+    $env:NUGET_PACKAGES = Join-Path $smokeDir "packages"
+    $env:NUGET_HTTP_CACHE_PATH = Join-Path $smokeDir "http-cache"
+    $env:DOTNET_CLI_HOME = Join-Path $smokeDir "dotnet-home"
+    $env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE = "1"
+    $env:DOTNET_NOLOGO = "1"
+    $env:NuGetAudit = "false"
+
+    $nugetConfig = Join-Path $smokeDir "NuGet.Config"
+    @"
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="$NuGetSource" protocolVersion="3" />
+  </packageSources>
+</configuration>
+"@ | Set-Content -Path $nugetConfig -Encoding utf8
+
+    Invoke-Stage "project-create" {
+        dotnet new console --framework net10.0 --output $smokeDir --force | Out-Null
+    }
+
+    $projectPath = Join-Path $smokeDir ((Split-Path $smokeDir -Leaf) + ".csproj")
+    Invoke-Stage "package-reference" {
+        dotnet add $projectPath package UniversalToolchain.Wist --version $PackageVersion --source $NuGetSource --no-restore | Out-Null
+    }
+
+    $programPath = Join-Path $smokeDir "Program.cs"
+    @'
+using UniversalToolchain.Wist;
+
+using var rules = WistEngine.CreateRestrictedArithmetic();
+
+var validFormula = "usage * 0.7 + reliability * 0.3 - incidents * 15.0";
+var validation = rules.Validate(
+    validFormula,
+    new
+    {
+        usage = 100.0,
+        reliability = 90.0,
+        incidents = 1.0
+    });
+if (!validation.IsValid)
+{
+    throw new InvalidOperationException(
+        "stage=validation: expected the restricted numeric formula to validate successfully.");
+}
+
+var rejected = rules.Validate(
+    "let total = usage * 0.7\ntotal",
+    new { usage = 100.0 });
+if (rejected.IsValid)
+{
+    throw new InvalidOperationException(
+        "stage=validation: expected the restricted preset to reject statement-style syntax.");
+}
+Console.WriteLine("STAGE=validation PASS");
+
+WistProgram<Func<double, double, double, double>> compiled;
+try
+{
+    compiled = rules.Compile<Func<double, double, double, double>>(
+        validFormula,
+        "usage",
+        "reliability",
+        "incidents");
+}
+catch (Exception exception)
+{
+    throw new InvalidOperationException("stage=compile: public facade compilation failed.", exception);
+}
+Console.WriteLine("STAGE=compile PASS");
+
+double score;
+try
+{
+    score = compiled.CompiledDelegate(100.0, 90.0, 1.0);
+}
+catch (Exception exception)
+{
+    throw new InvalidOperationException("stage=invocation: compiled delegate invocation failed.", exception);
+}
+Console.WriteLine("STAGE=invocation PASS");
+Console.WriteLine($"RESULT={score:R}");
+'@ | Set-Content -Path $programPath -Encoding utf8
+
+    Invoke-Stage "restore" {
+        dotnet restore $projectPath --configfile $nugetConfig --no-cache --force | Out-Null
+    }
+
+    Invoke-Stage "build" {
+        dotnet build $projectPath -c Release --no-restore | Out-Null
+    }
+
+    $runOutput = $null
+    Invoke-Stage "validation/compile/invocation" {
+        $script:runOutput = @(dotnet run --project $projectPath -c Release --no-build --no-restore)
+    }
+
+    foreach ($marker in @("STAGE=validation PASS", "STAGE=compile PASS", "STAGE=invocation PASS")) {
+        if ($runOutput -notcontains $marker) {
+            throw "Published-package smoke failed at stage '$($marker.Split('=')[1].Split(' ')[0])': success marker was not emitted."
+        }
+    }
+
+    $resultLine = $runOutput | Where-Object { $_ -like "RESULT=*" } | Select-Object -Last 1
+    if ($null -eq $resultLine) {
+        throw "Published-package smoke failed at stage 'expected-output': RESULT marker was not emitted."
+    }
+
+    $actual = [double]::Parse(
+        $resultLine.Substring("RESULT=".Length),
+        [System.Globalization.CultureInfo]::InvariantCulture)
+    if ([Math]::Abs($actual - 82.0) -gt 1e-9) {
+        throw "Published-package smoke failed at stage 'expected-output': expected 82, got $actual."
+    }
+
+    $metadataPath = Join-Path $env:NUGET_PACKAGES "universaltoolchain.wist/$PackageVersion/.nupkg.metadata"
+    if (-not (Test-Path -LiteralPath $metadataPath)) {
+        throw "Published-package smoke failed at stage 'package-source': NuGet metadata was not found for exact version $PackageVersion."
+    }
+    $metadata = Get-Content -LiteralPath $metadataPath -Raw
+    if (-not $metadata.Contains($NuGetSource, [StringComparison]::Ordinal)) {
+        throw "Published-package smoke failed at stage 'package-source': package metadata does not record the requested public feed."
+    }
+
+    Write-Host "Published UniversalToolchain.Wist $PackageVersion smoke passed."
+}
+finally {
+    if (Test-Path -LiteralPath $smokeDir) {
+        Remove-Item -LiteralPath $smokeDir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}

--- a/Tools/test-wist-release-readiness-doc-mutants.py
+++ b/Tools/test-wist-release-readiness-doc-mutants.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+EXCLUDED = shutil.ignore_patterns(
+    '.git', 'artifacts', 'bin', 'obj', 'node_modules', 'packages', '.cache'
+)
+
+
+def run_validator(root: Path) -> int:
+    return subprocess.run(
+        ['python3', str(root / 'Tools' / 'check-wist-release-readiness-docs.py')],
+        cwd=root,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+    ).returncode
+
+
+def clone_for_mutant() -> tuple[tempfile.TemporaryDirectory[str], Path]:
+    temporary = tempfile.TemporaryDirectory(prefix='wist-readiness-mutant-')
+    mutant_root = Path(temporary.name) / 'repo'
+    shutil.copytree(ROOT, mutant_root, ignore=EXCLUDED)
+    return temporary, mutant_root
+
+
+def stale_release_evidence_total_must_fail() -> None:
+    temporary, mutant_root = clone_for_mutant()
+    try:
+        release_state = json.loads(
+            (mutant_root / 'eng' / 'documentation-release-state.json').read_text(encoding='utf-8')
+        )
+        stability = mutant_root / release_state['stabilityDocument']
+        text = stability.read_text(encoding='utf-8')
+        canonical_total = json.loads(
+            (mutant_root / 'eng' / 'test-counts.json').read_text(encoding='utf-8')
+        )['totalPassed']
+        formatted = f'{canonical_total:,}'
+        if formatted not in text:
+            raise RuntimeError('test setup failed: canonical total is not present in stability evidence')
+        stability.write_text(text.replace(formatted, '9,999', 1), encoding='utf-8')
+        if run_validator(mutant_root) == 0:
+            raise RuntimeError('Wist release-readiness mutant survived: stale-release-evidence-total')
+        print('SURVIVOR=0 mutant=stale-release-evidence-total')
+    finally:
+        temporary.cleanup()
+
+
+def rollout_formula_drift_must_fail() -> None:
+    temporary, mutant_root = clone_for_mutant()
+    try:
+        recipe = mutant_root / 'docs' / 'start' / 'use-case-recipes.md'
+        text = recipe.read_text(encoding='utf-8')
+        original = 'wist-rollout-formula-contract: usage * 0.7 + reliability * 0.3 - incidents * 15.0'
+        mutant = 'wist-rollout-formula-contract: usage * 0.6 + reliability * 0.4 - incidents * 15.0'
+        if original not in text:
+            raise RuntimeError('test setup failed: rollout formula marker is not present')
+        recipe.write_text(text.replace(original, mutant, 1), encoding='utf-8')
+        if run_validator(mutant_root) == 0:
+            raise RuntimeError('Wist release-readiness mutant survived: rollout-formula-drift')
+        print('SURVIVOR=0 mutant=rollout-formula-drift')
+    finally:
+        temporary.cleanup()
+
+
+def main() -> int:
+    stale_release_evidence_total_must_fail()
+    rollout_formula_drift_must_fail()
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/Wist/PublicFacade/WistUseCaseRecipeTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/Wist/PublicFacade/WistUseCaseRecipeTests.cs
@@ -7,6 +7,7 @@ public sealed class WistUseCaseRecipeTests
 {
     private const string DocumentedRolloutFormula =
         "usage * 0.7 + reliability * 0.3 - incidents * 15.0";
+    private const double DocumentedRolloutExpectedScore = 82.0;
 
     [Test]
     public void RolloutScoreRecipe_UsesDocumentedFormulaThroughPublicFacade()
@@ -33,7 +34,7 @@ public sealed class WistUseCaseRecipeTests
         {
             Assert.That(validation.IsValid, Is.True);
             Assert.That(validation.Diagnostics, Is.Empty);
-            Assert.That(score, Is.EqualTo(82.0).Within(1e-9));
+            Assert.That(score, Is.EqualTo(DocumentedRolloutExpectedScore).Within(1e-9));
         });
     }
 }

--- a/UniversalToolchain/UniversalToolchain.Dialects.Tests/Wist/PublicFacade/WistUseCaseRecipeTests.cs
+++ b/UniversalToolchain/UniversalToolchain.Dialects.Tests/Wist/PublicFacade/WistUseCaseRecipeTests.cs
@@ -1,0 +1,39 @@
+using UniversalToolchain.Wist;
+
+namespace UniversalToolchain.Dialects.Tests.Wist.PublicFacade;
+
+[TestFixture]
+public sealed class WistUseCaseRecipeTests
+{
+    private const string DocumentedRolloutFormula =
+        "usage * 0.7 + reliability * 0.3 - incidents * 15.0";
+
+    [Test]
+    public void RolloutScoreRecipe_UsesDocumentedFormulaThroughPublicFacade()
+    {
+        using var rules = WistEngine.CreateRestrictedArithmetic();
+
+        var validation = rules.Validate(
+            DocumentedRolloutFormula,
+            new
+            {
+                usage = 100.0,
+                reliability = 90.0,
+                incidents = 1.0
+            });
+
+        var rolloutScore = rules.Compile<Func<double, double, double, double>>(
+            DocumentedRolloutFormula,
+            "usage",
+            "reliability",
+            "incidents");
+        var score = rolloutScore.CompiledDelegate(100.0, 90.0, 1.0);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(validation.IsValid, Is.True);
+            Assert.That(validation.Diagnostics, Is.Empty);
+            Assert.That(score, Is.EqualTo(82.0).Within(1e-9));
+        });
+    }
+}

--- a/VERIFICATION.md
+++ b/VERIFICATION.md
@@ -2,7 +2,7 @@
 
 ## Environment and authority
 
-- Record refreshed: 2026-08-15.
+- Record refreshed: 2026-08-18.
 - Target CI environment: GitHub Actions Ubuntu 24.04, Linux x64.
 - SDK policy: `UniversalToolchain/global.json` with .NET 10 feature-band roll-forward.
 - Ordinary integration command: `./build.sh --skip-docs --skip-pack`.
@@ -41,7 +41,10 @@ The repository implements and continuously verifies:
 - Wist-free generic implementation tests whose internal friend edges remain `UNIVERSAL -> UNIVERSAL`;
 - PlanFuzz fresh-process replay, evidence-complete classification and exact-fingerprint reduction;
 - a separate production-boundary B0/B1/B2 contract experiment;
-- a separately reported post-freeze review-derived holdout set.
+- a separately reported post-freeze review-derived holdout set;
+- public Wist rollout-scoring recipe parity between documentation and focused facade regression;
+- Linux and Windows clean-room smoke coverage for the currently published Wist package;
+- release-evidence test-count drift detection with a negative mutant.
 
 The retained product boundary remains a contribution/pass/route/runtime SDK rather than a declarative grammar, binder or type-system workbench. PlanFuzz and the contract experiments are non-packable research layers and do not extend the public Wist NuGet surface.
 
@@ -61,14 +64,14 @@ Parallel graph traversal and shared compilation are the default. `--jobs`, `--se
 |---|---:|---:|---:|
 | `Tests` | 500 | 0 | 0 |
 | `UniversalToolchain.Modules.Tests` | 292 | 0 | 0 |
-| `UniversalToolchain.Dialects.Tests` | 233 | 0 | 0 |
+| `UniversalToolchain.Dialects.Tests` | 234 | 0 | 0 |
 | `UniversalToolchain.LanguageSdk.Generic.Tests` | 62 | 0 | 0 |
 | `UniversalToolchain.LanguageSdk.Tests` | 167 | 0 | 0 |
 | `UniversalToolchain.PlanFuzz.Tests` | 41 | 0 | 0 |
 | `UniversalToolchain.PlanFuzz.IntegrationTests` | 10 | 0 | 0 |
-| **Total** | **1,305** | **0** | **0** |
+| **Total** | **1,306** | **0** | **0** |
 
-The current candidate adds focused regressions for the real `Syntax -> Semantic -> Bytecode` boundary, syntax-mutation isolation, canonical Add convergence, independent stage-local activation, exact planned lowering fail-closed behavior, phase-owned module ordering, detached optimizer-contract provenance and hidden `UNIVERSAL -> WIST_PRODUCT` friend edges. Fifty-eight implementation-internal generic tests were moved out of mixed Wist-owned test assemblies rather than regaining forbidden friendship; together with the four existing generic ownership tests they form the 62-test Wist-free suite. The exact manifest is owned by `eng/test-counts.json`; provider-backed exact-head results are recorded against their commit/run identities rather than inferred from an older local TRX snapshot.
+The current candidate adds focused regressions for the real `Syntax -> Semantic -> Bytecode` boundary, syntax-mutation isolation, canonical Add convergence, independent stage-local activation, exact planned lowering fail-closed behavior, phase-owned module ordering, detached optimizer-contract provenance, hidden `UNIVERSAL -> WIST_PRODUCT` friend edges and the documented rollout-scoring public-facade path. Fifty-eight implementation-internal generic tests were moved out of mixed Wist-owned test assemblies rather than regaining forbidden friendship; together with the four existing generic ownership tests they form the 62-test Wist-free suite. The exact manifest is owned by `eng/test-counts.json`; provider-backed exact-head results are recorded against their commit/run identities rather than inferred from an older local TRX snapshot.
 
 ## Production-boundary contract experiment
 
@@ -149,7 +152,7 @@ The baseline-aware package gate verifies:
 - clean Wist consumer, template consumer and cross-package consumer;
 - detached release-integrity manifest and mutation tests.
 
-The package candidate is not published by verification. NuGet publication, merge and release remain separately authorized actions.
+The package candidate is not published by verification. NuGet publication, GitHub Release and release-tag creation remain separately authorized actions.
 
 ## PlanFuzz evidence boundary
 

--- a/docs/evidence/current-verification.md
+++ b/docs/evidence/current-verification.md
@@ -27,14 +27,14 @@ The documentation guard requires this table to mirror the repository's current e
 |---|---:|---:|---:|
 | `Tests` | 500 | 0 | 0 |
 | `UniversalToolchain.Modules.Tests` | 292 | 0 | 0 |
-| `UniversalToolchain.Dialects.Tests` | 233 | 0 | 0 |
+| `UniversalToolchain.Dialects.Tests` | 234 | 0 | 0 |
 | `UniversalToolchain.LanguageSdk.Generic.Tests` | 62 | 0 | 0 |
 | `UniversalToolchain.LanguageSdk.Tests` | 167 | 0 | 0 |
 | `UniversalToolchain.PlanFuzz.Tests` | 41 | 0 | 0 |
 | `UniversalToolchain.PlanFuzz.IntegrationTests` | 10 | 0 | 0 |
-| **Total** | **1,305** | **0** | **0** |
+| **Total** | **1,306** | **0** | **0** |
 
-The exact manifest belongs to `eng/test-counts.json`. The current candidate adds focused regressions for the real syntax/semantic/lowering boundary, stage-local lifetime, plan-owned lowering activation, phase-owned module ordering, detached optimizer-contract provenance and hidden ownership edges. Fifty-eight generic implementation tests were moved from mixed Wist-owned suites into the Wist-free generic project rather than restoring forbidden friend edges; together with its four existing ownership tests the canonical generic suite now contains 62 tests. `.NET CI` run `31049607823` completed the canonical entrypoint for the pinned historical commit; that receipt corresponds only to its own earlier manifest. A current revision is green only when its own exact manifest is verified.
+The exact manifest belongs to `eng/test-counts.json`. The current candidate adds focused regressions for the real syntax/semantic/lowering boundary, stage-local lifetime, plan-owned lowering activation, phase-owned module ordering, detached optimizer-contract provenance, hidden ownership edges and the documented rollout-scoring public-facade path. Fifty-eight generic implementation tests were moved from mixed Wist-owned suites into the Wist-free generic project rather than restoring forbidden friend edges; together with its four existing ownership tests the canonical generic suite contains 62 tests. `.NET CI` run `31049607823` completed the canonical entrypoint for the pinned historical commit; that receipt corresponds only to its own earlier manifest. A current revision is green only when its own exact manifest is verified.
 
 ## Workflow set
 

--- a/docs/evidence/wist-stability-v0.1.0-alpha.7.md
+++ b/docs/evidence/wist-stability-v0.1.0-alpha.7.md
@@ -3,7 +3,7 @@ title: Wist 0.1.0-alpha.7 Candidate Stability
 description: Source-candidate contract for Wist architecture and production hardening over the canonical LanguagePlan runtime.
 audience: wist-application-developer
 status: source-candidate
-lastVerifiedAgainst: architecture-production-hardening-2026-08-12
+lastVerifiedAgainst: wist-release-readiness-2026-08-18
 ---
 
 # Wist 0.1.0-alpha.7 candidate stability
@@ -68,7 +68,7 @@ One `WistEngine` instance is not advertised as concurrently reentrant. Overlappi
 
 ## Verification boundary
 
-The hardening branch declares an exact repository test manifest of 1,290 tests across the canonical suites and keeps the existing benchmark smoke, PlanFuzz regression, architecture guards/mutants, package-surface and clean-consumer gates. The baseline-bearing package gate is required because package payload identities changed.
+The source tree declares an exact repository test manifest of 1,306 tests across the canonical suites and keeps the existing benchmark smoke, PlanFuzz regression, architecture guards/mutants, package-surface and clean-consumer gates. The baseline-bearing package gate is required because package payload identities changed.
 
 This document does **not** claim those gates are green for the final revision until the exact final commit has completed them. The pinned [verification snapshot](/evidence/current-verification) and the integration-review report are authoritative for the exact revision that was actually checked.
 

--- a/docs/start/first-program.md
+++ b/docs/start/first-program.md
@@ -3,7 +3,7 @@ title: First Program
 description: Run the smallest useful Wist program from a published package or repository checkout.
 audience: wist-application-developer
 status: current
-lastVerifiedAgainst: wist-release-state-2026-08-06
+lastVerifiedAgainst: wist-release-readiness-2026-08-18
 ---
 
 # First Program
@@ -44,6 +44,47 @@ Console.WriteLine(result); // 95
 `Compile<TDelegate>` validates and compiles once. For expected invalid author input, use `Validate` or `TryCompile` and keep the last-known-good program active.
 
 The repository source may define a newer candidate than the published package. That does not make the candidate installable from NuGet.org.
+
+## Structured diagnostics for invalid formulas
+
+For configuration or admin UIs, consume the stable public fields on `WistDiagnostic` instead of parsing exception text. This example intentionally submits statement-style syntax to the restricted arithmetic preset:
+
+```csharp
+using UniversalToolchain.Wist;
+
+using var wist = WistEngine.CreateRestrictedArithmetic();
+
+var validation = wist.Validate(
+    "let score = usage * 0.7\nscore",
+    new { usage = 100.0 });
+
+if (validation.IsValid)
+{
+    throw new InvalidOperationException("Expected the restricted formula to be rejected.");
+}
+
+foreach (var diagnostic in validation.Diagnostics)
+{
+    Console.WriteLine($"code: {diagnostic.Code}");
+    Console.WriteLine($"severity: {diagnostic.Severity}");
+    Console.WriteLine($"stage: {diagnostic.Stage}");
+    Console.WriteLine($"source: {diagnostic.SourceName}");
+
+    if (diagnostic.Span is { } span)
+    {
+        Console.WriteLine(
+            $"span: {span.StartLine}:{span.StartColumn}-{span.EndLine}:{span.EndColumn}");
+    }
+
+    Console.WriteLine($"message: {diagnostic.Message}");
+    foreach (var hint in diagnostic.Hints)
+    {
+        Console.WriteLine($"hint: {hint.Message}");
+    }
+}
+```
+
+A diagnostic may have no `Span`; treat location as optional in stored records and UI models. `Code`, `Severity`, `Stage`, `SourceName`, optional `Span`, `Message` and `Hints` are the public structured contract to preserve. Validation or policy rejection means the selected language surface rejected the input; it is **not** OS/process isolation and does not turn the preset into a security sandbox. See [Diagnostics](/reference/diagnostics) for the deeper contract.
 
 ## Trusted C# interop example
 

--- a/docs/start/installation.md
+++ b/docs/start/installation.md
@@ -3,7 +3,7 @@ title: Installation
 description: Install the published Wist package or prepare the current repository source safely.
 audience: wist-application-developer
 status: current
-lastVerifiedAgainst: wist-release-state-2026-08-12
+lastVerifiedAgainst: wist-release-readiness-2026-08-18
 ---
 
 # Installation
@@ -36,10 +36,18 @@ The package page is <https://www.nuget.org/packages/UniversalToolchain.Wist>.
 
 ### Clean-room published-package check
 
-The repository smoke script creates a temporary `net10.0` project, isolates NuGet caches, restores only from NuGet.org, compiles and evaluates formulas and verifies a rejected statement-style rule:
+The repository smoke scripts create a temporary `net10.0` project, isolate NuGet caches, restore only from NuGet.org, compile and evaluate formulas and verify a rejected statement-style rule. They test the published package boundary, not a sandbox/security boundary.
+
+Linux/macOS:
 
 ```bash ci-run=false
 ./Tools/smoke-published-wist-package.sh 0.1.0-alpha.1
+```
+
+Windows with PowerShell 7:
+
+```powershell
+pwsh -File .\Tools\smoke-published-wist-package.ps1 -PackageVersion 0.1.0-alpha.1
 ```
 
 Expected final line:
@@ -47,6 +55,8 @@ Expected final line:
 ```text
 Published UniversalToolchain.Wist 0.1.0-alpha.1 smoke passed.
 ```
+
+Both scripts require the exact version explicitly and use an isolated temporary NuGet cache plus the public NuGet.org feed. The PowerShell script reports the failing stage and removes its temporary project in `finally` on both success and failure.
 
 ## Current source candidate
 

--- a/docs/start/use-case-recipes.md
+++ b/docs/start/use-case-recipes.md
@@ -3,7 +3,7 @@ title: Use-case Recipes
 description: Copy-ready Wist examples for pricing, rollout scoring and LMS scoring.
 audience: wist-application-developer
 status: current
-lastVerifiedAgainst: wist-release-state-2026-08-06
+lastVerifiedAgainst: wist-release-readiness-2026-08-18
 ---
 
 # Use-case Recipes
@@ -50,6 +50,9 @@ The rule returns a number. The host still owns payment creation, authorization, 
 
 Keep rollout policy configurable without letting the formula enable a feature directly:
 
+<!-- wist-rollout-formula-contract: usage * 0.7 + reliability * 0.3 - incidents * 15.0 -->
+<!-- wist-rollout-expected-score: 82.0 -->
+
 ```csharp
 using UniversalToolchain.Wist;
 
@@ -60,7 +63,7 @@ var rolloutScore = rules.Compile<Func<double, double, double, double>>(
     "usage",
     "reliability",
     "incidents");
-double score = rolloutScore.CompiledDelegate(100.0, 90.0, 1.0);
+double score = rolloutScore.CompiledDelegate(100.0, 90.0, 1.0); // 82
 bool enableNewDashboard = score >= 80.0;
 ```
 
@@ -126,4 +129,4 @@ Do not use the restricted arithmetic preset when you need arbitrary C# execution
 
 ## Next
 
-Read the [Wist `0.1.0-alpha.6` source-candidate stability record](/evidence/wist-stability-v0.1.0-alpha.6), the pinned [verification snapshot](/evidence/current-verification), the [Performance Model](/reference/performance-model) and [Security](/SECURITY) before moving beyond the currently published package.
+Read the [Wist `0.1.0-alpha.7` source-candidate stability record](/evidence/wist-stability-v0.1.0-alpha.7), the pinned [verification snapshot](/evidence/current-verification), the [Performance Model](/reference/performance-model) and [Security](/SECURITY) before moving beyond the currently published package.

--- a/eng/test-counts.json
+++ b/eng/test-counts.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "totalPassed": 1305,
+  "totalPassed": 1306,
   "main": [
     {
       "label": "Core",
@@ -24,7 +24,7 @@
       "runner": "project",
       "path": "UniversalToolchain/UniversalToolchain.Dialects.Tests/UniversalToolchain.Dialects.Tests.csproj",
       "timeoutSeconds": 600,
-      "expectedPassed": 233
+      "expectedPassed": 234
     },
     {
       "label": "LanguageSdk.Generic",

--- a/package.json
+++ b/package.json
@@ -5,10 +5,12 @@
     "docs:build": "vitepress build docs",
     "docs:preview": "vitepress preview docs --host 0.0.0.0",
     "docs:release-state": "python3 Tools/check_documentation_release_state.py",
+    "docs:readiness": "python3 Tools/check-wist-release-readiness-docs.py",
+    "docs:readiness-mutants": "python3 Tools/test-wist-release-readiness-doc-mutants.py",
     "docs:first-contact": "python3 -c \"from pathlib import Path; Path('UniversalToolchain/packages').mkdir(parents=True, exist_ok=True)\" && python3 Tools/check-wist-documentation-first-contact.py",
-    "docs:status": "python3 Tools/check_documentation_status.py && npm run docs:release-state",
+    "docs:status": "python3 Tools/check_documentation_status.py && npm run docs:release-state && npm run docs:readiness",
     "docs:links": "python3 Tools/check_documentation_links.py",
-    "docs:check": "npm run docs:status && npm run docs:links && npm run docs:first-contact && npm run docs:build"
+    "docs:check": "npm run docs:status && npm run docs:readiness-mutants && npm run docs:links && npm run docs:first-contact && npm run docs:build"
   },
   "devDependencies": {
     "vitepress": "1.6.4"


### PR DESCRIPTION
## Scope

Completes the release-readiness cleanup for the unpublished `UniversalToolchain.Wist 0.1.0-alpha.7` candidate.

- adds the focused public-facade regression for the documented rollout formula;
- adds PowerShell 7 clean-room published-package smoke and a Windows Actions job;
- adds the copy-ready structured diagnostics example;
- synchronizes the canonical test contract to 1,306 tests;
- makes alpha.7 release-evidence test-count drift and rollout docs/test drift fail mechanically, with negative mutants;
- preserves `publishedVersion = 0.1.0-alpha.1` and does not claim alpha.7 is published;
- makes Package Compatibility Review run on `master` pushes so the final package gate is built from the exact post-merge source revision.

No NuGet publication, GitHub Release, or release tag is performed by this PR.

Closes #282 after acceptance criteria and CI are verified.
Closes #283 after Windows published-package smoke is verified.
Closes #284 after docs/facade checks are verified.
#362 will be closed separately only after its existing phase-boundary regression and Linux/Windows CI are reverified.
#298 remains an open research scope.